### PR TITLE
Must ensure that the lock is always removed.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ActiveRecord::Base
             :uniqueness => true,
             :format => { :with => /^[a-zA-Z0-9_\-]*$/,
                          :message => "only letters, digits & '_' '-' allowed"  },
-            :length   => { :within => 3..16 }
+            :length   => { :within => 3..255 }
 
   validates :owner,
             :presence => true

--- a/lib/gitosis.rb
+++ b/lib/gitosis.rb
@@ -27,13 +27,16 @@ class Gitosis
   def configure
     status = Timeout::timeout(20) do
       File.open(File.join(Dir.tmpdir,"gitlabhq-gitosis.lock"), "w+") do |f|
-        f.flock(File::LOCK_EX)
+        begin
+          f.flock(File::LOCK_EX)
 
-        pull
-        yield(self)
-        push
+          pull
+          yield(self)
+          push
 
-        f.flock(File::LOCK_UN)
+        ensure
+          f.flock(File::LOCK_UN)
+        end
       end
     end
   rescue Exception => ex


### PR DESCRIPTION
I got into a state where the file existed but was still locked. Ensuring the unlock guarantees the file will be unlocked even if an exception arises in the block.

Also, Timeout::timeout(20) can be called like Timeout::timeout(20, Gitosis::AccessDenied) to cast timeout exceptions automatically. This will prevent exceptions in yield from being recast to Gitosis specific exceptions.

Also, you might want to consider removing the file after the lock.
