### PR TITLE
Use secure.gravatar.com when running over SSL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,9 @@
 require 'digest/md5'
 module ApplicationHelper
+
   def gravatar_icon(user_email)
-    "http://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(user_email)}?s=40&d=identicon"
+    gravatar_host = request.ssl? ? "https://secure.gravatar.com" :  "http://www.gravatar.com"
+    "#{gravatar_host}/avatar/#{Digest::MD5.hexdigest(user_email)}?s=40&d=identicon"
   end
 
   def fixed_mode?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+  context ".gravatar_icon" do
+    context "over http" do
+      it "returns the correct URL to www.gravatar.com" do
+        expected = "http://www.gravatar.com/avatar/f7daa65b2aa96290bb47c4d68d11fe6a?s=40&d=identicon"
+
+        # Pretend we're running over HTTP
+        helper.stub(:request) do
+          request = double('request')
+          request.stub(:ssl?) { false }
+          request
+        end
+
+        helper.gravatar_icon("admin@local.host").should == expected
+      end
+    end
+
+    context "over https" do
+      it "returns the correct URL to secure.gravatar.com" do
+        expected = "https://secure.gravatar.com/avatar/f7daa65b2aa96290bb47c4d68d11fe6a?s=40&d=identicon"
+
+        # Pretend we're running over HTTPS
+        helper.stub(:request) do
+          request = double('request')
+          request.stub(:ssl?) { true }
+          request
+        end
+
+        helper.gravatar_icon("admin@local.host").should == expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
This relates to issue #64. When you run Gitlab over SSL you get warnings because gravatars are loaded over HTTP.

This fix uses `http:/www.gravatar.com` for normal requests and `https://secure.gravatar.com` for secure SSL requests.

Helper tests included.
