### PR TITLE
Truncate the "Signed-off-by" part of commit messages throughout site.

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -24,7 +24,7 @@ module DashboardHelper
     title = case klass
             when "Note" then markdown(object.note)
             when "Issue" then object.title
-            when "Commit" then object.safe_message
+            when "Commit" then object.safe_message_no_signoff
             else return "Project Wall"
             end
 

--- a/app/views/commits/_commits.html.haml
+++ b/app/views/commits/_commits.html.haml
@@ -17,7 +17,7 @@
               = image_tag "no_avatar.png", :class => "left", :width => 40, :style => "padding-right:5px;"
             %span.commit-title
               %strong
-                = truncate(commit.safe_message, :length => fixed_mode? ? 60 : 120)
+                = truncate(commit.safe_message_no_signoff, :length => fixed_mode? ? 60 : 120)
             %span.commit-author
               %strong= commit.author_name
               = time_ago_in_words(commit.committed_date)

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -1,5 +1,5 @@
 %h3
-  = "[ #{@commit.author_name} ]  #{truncate(@commit.safe_message, :length => 70)}"
+  = "[ #{@commit.author_name} ]  #{truncate(@commit.safe_message_no_signoff, :length => 70)}"
 -#= link_to 'Back', project_commits_path(@project), :class => "button"
 %table.round-borders
   %tr
@@ -15,7 +15,7 @@
     %td Message
     %td
       %pre.commit_message
-        = preserve @commit.safe_message
+        = preserve @commit.safe_message_no_signoff
   %tr
     %td Tree
     %td= link_to 'Browse Code', tree_project_path(@project, :commit_id => @commit.id)

--- a/app/views/projects/_recent_commits.html.haml
+++ b/app/views/projects/_recent_commits.html.haml
@@ -22,7 +22,7 @@
           - else
             = image_tag "no_avatar.png", :class => "left", :width => 40, :style => "padding-right:5px;"
           .title
-            %p= link_to truncate(commit.safe_message, :length => fixed_mode? ? 40 : 100), project_commit_path(@project, :id => commit.id)
+            %p= link_to truncate(commit.safe_message_no_signoff, :length => fixed_mode? ? 40 : 100), project_commit_path(@project, :id => commit.id)
 
           %span
             %span.author

--- a/app/views/projects/_tree_item.html.haml
+++ b/app/views/projects/_tree_item.html.haml
@@ -12,7 +12,7 @@
     = time_ago_in_words(content_commit.committed_date)
     ago
   %td.commit
-    = link_to truncate(content_commit.safe_message, :length => fixed_mode? ? 40 : 80), project_commit_path(@project, content_commit), :class => "tree-commit-link"
+    = link_to truncate(content_commit.safe_message_no_signoff, :length => fixed_mode? ? 40 : 80), project_commit_path(@project, content_commit), :class => "tree-commit-link"
     - tm = @project.team_member_by_name_or_email(content_commit.author_email, content_commit.author_name)
     - if tm
       = link_to "[#{tm.user_name}]", project_team_member_path(@project, tm)

--- a/lib/commit_ext.rb
+++ b/lib/commit_ext.rb
@@ -9,6 +9,14 @@ module CommitExt
     "-- invalid encoding for commit message"
   end
 
+  def safe_message_no_signoff
+    if safe_message.include? 'Signed-off-by:'
+      safe_message[0..safe_message.index('Signed-off-by:')-2]
+    else
+      safe_message
+    end
+  end
+
   def created_at
     committed_date
   end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -23,7 +23,7 @@ describe "Dashboard" do
     it "should have news feed" do
       within "#news-feed"  do 
         page.should have_content(@project.commit.author.name)
-        page.should have_content(@project.commit.safe_message)
+        page.should have_content(@project.commit.safe_message_no_signoff)
       end
     end
   end


### PR DESCRIPTION
All instances of commit.safe_message (including dashboard spec) replaced
by mew method commit.safe_message_no_signoff; you may wish to simply
incorporate the changes into safe_message itself... but that's up to you :)

Signed-off-by: Dean Rollins deano.dinosaur@gmail.com
