### PR TITLE
Add support for custom SSH ports

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -22,7 +22,11 @@ class Repository
   end
 
   def url_to_repo
-    "#{GITOSIS["git_user"]}@#{GITOSIS["host"]}:#{path}.git"
+    if !GITOSIS["port"] or GITOSIS["port"] == 22
+      "#{GITOSIS["git_user"]}@#{GITOSIS["host"]}:#{path}.git"
+    else
+      "ssh://#{GITOSIS["git_user"]}@#{GITOSIS["host"]}:#{GITOSIS["port"]}/#{path}.git"
+    end
   end
 
   def path_to_repo

--- a/config/gitosis.yml
+++ b/config/gitosis.yml
@@ -2,3 +2,4 @@ admin_uri: git@localhost:gitosis-admin.git
 base_path: /home/git/repositories/
 host: localhost
 git_user: git
+# port: 22


### PR DESCRIPTION
For security reasons, I use a non-standard SSH port.
Specify the port in the gitosis.yml file to get clone urls like

```
ssh://git@gitlabhq.com:1234/path/to/repo.git
```
