### PR TITLE
upgrade selenium-webdriver for firefox 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 
 group :development, :test do
   gem 'rspec-rails'
-  gem 'capybara'
+  gem 'capybara', '~> 1.1.2'
   gem 'autotest'
   gem 'autotest-rails'
   gem 'ruby-debug19', :require => 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     bcrypt-ruby (3.0.1)
     blankslate (2.1.2.4)
     builder (3.0.0)
-    capybara (1.0.1)
+    capybara (1.1.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -115,8 +115,7 @@ GEM
     jquery-rails (1.0.14)
       railties (~> 3.0)
       thor (~> 0.14)
-    json_pure (1.5.4)
-      spruz (~> 0.2.8)
+    json_pure (1.6.1)
     kaminari (0.12.4)
       rails (>= 3.0.0)
     launchy (2.0.5)
@@ -200,9 +199,9 @@ GEM
       railties (~> 3.1.0)
       sass (>= 3.1.4)
       tilt (~> 1.3.2)
-    selenium-webdriver (2.5.0)
+    selenium-webdriver (2.12.2)
       childprocess (>= 0.2.1)
-      ffi (>= 1.0.7)
+      ffi (~> 1.0.9)
       json_pure
       rubyzip
     shoulda (3.0.0.beta2)
@@ -219,7 +218,6 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    spruz (0.2.13)
     sqlite3 (1.3.4)
     stamp (0.1.6)
     therubyracer (0.9.4)
@@ -254,7 +252,7 @@ DEPENDENCIES
   autotest
   autotest-rails
   awesome_print
-  capybara
+  capybara (~> 1.1.2)
   carrierwave
   coffee-rails (~> 3.1.0)
   database_cleaner


### PR DESCRIPTION
it would hang on firefox 8 when run the specs.

because selenium-webdriver version is too old. 
