### PR TITLE
Don't install development and test gems in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ echo "USERNAME ALL = (git) NOPASSWD: /bin/rm" | sudo tee -a /etc/sudoers
 
 sudo gem install bundler
 
-bundle
+bundle install --without development test
 
 bundle exec rake db:setup RAILS_ENV=production
 


### PR DESCRIPTION
Hi,

I think it should be better to not install development and test gems in production. In particular, linecache19 is not available for Ruby 1.9.3-p0 for the moment, so it can be a blocker.
