### PR TITLE
link "GITLAB" logo to root_url instead of '/'

### DIFF
--- a/app/views/layouts/_head_panel.html.erb
+++ b/app/views/layouts/_head_panel.html.erb
@@ -1,7 +1,7 @@
 <!-- Page Header -->
 <header>
   <h1 class="logo">
-    <a href="/">GITLAB</a>
+    <%= link_to "GITLAB", root_url %>
   </h1>
   <div class="account-box">
     <%= link_to profile_path, :class => "pic" do %>


### PR DESCRIPTION
If using multiple Rails apps in subfolders, the upper left "GITLAB" button links to '/' and thats kinda wrong.
This fix creates a link to the root_url instead, which works in every case.
