### PR TITLE
Do not install ruby-debug on travis-ci.org, it only wastes time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,9 @@ group :development, :test do
   gem 'capybara'
   gem 'autotest'
   gem 'autotest-rails'
-  gem 'ruby-debug19', :require => 'ruby-debug'
+  unless ENV["CI"]
+    gem 'ruby-debug19', :require => 'ruby-debug'
+  end
   gem 'awesome_print'
   gem 'database_cleaner'
   gem 'launchy'


### PR DESCRIPTION
See http://about.travis-ci.org/docs/user/languages/ruby/ (the "Exclude non-essential gems like ruby-debug" section) for reasoning.
