### PR TITLE
Allow dots in project names

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,7 +25,7 @@ class Project < ActiveRecord::Base
   validates :path,
             :uniqueness => true,
             :presence => true,
-            :format => { :with => /^[a-zA-Z0-9_\-]*$/,
+            :format => { :with => /^[a-zA-Z0-9_\-\.]*$/,
                          :message => "only letters, digits & '_' '-' allowed" },
             :length   => { :within => 0..255 }
 
@@ -35,7 +35,7 @@ class Project < ActiveRecord::Base
   validates :code,
             :presence => true,
             :uniqueness => true,
-            :format => { :with => /^[a-zA-Z0-9_\-]*$/,
+            :format => { :with => /^[a-zA-Z0-9_\-\.]*$/,
                          :message => "only letters, digits & '_' '-' allowed"  },
             :length   => { :within => 3..255 }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ActiveRecord::Base
             :uniqueness => true,
             :presence => true,
             :format => { :with => /^[a-zA-Z0-9_\-\.]*$/,
-                         :message => "only letters, digits & '_' '-' allowed" },
+                         :message => "only letters, digits & '_' '-' '.' allowed" },
             :length   => { :within => 0..255 }
 
   validates :description,
@@ -36,7 +36,7 @@ class Project < ActiveRecord::Base
             :presence => true,
             :uniqueness => true,
             :format => { :with => /^[a-zA-Z0-9_\-\.]*$/,
-                         :message => "only letters, digits & '_' '-' allowed"  },
+                         :message => "only letters, digits & '_' '-' '.' allowed"  },
             :length   => { :within => 3..255 }
 
   validates :owner,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Gitlab::Application.routes.draw do
 
   namespace :admin do
     resources :users
-    resources :projects
+    resources :projects, :constraints => { :id => /[^\/]+/ }
     resources :team_members
     get 'emails', :to => 'mailer#preview'
     get 'mailer/preview_note'
@@ -28,12 +28,12 @@ Gitlab::Application.routes.draw do
 
   #get "profile/:id", :to => "profile#show"
 
-  resources :projects, :only => [:new, :create, :index]
+  resources :projects, :constraints => { :id => /[^\/]+/ }, :only => [:new, :create, :index]
   resources :keys
 
   devise_for :users
 
-  resources :projects, :except => [:new, :create, :index], :path => "/" do
+  resources :projects, :constraints => { :id => /[^\/]+/ }, :except => [:new, :create, :index], :path => "/" do
     member do
       get "team"
       get "wall"


### PR DESCRIPTION
Many IDE and packaging systems rely on dots in the name of the repository. This patch allows for dots in both the project and code url. I have tested it locally with a few projects and it seems to function well.
