### PR TITLE
Hide admin menu for non-admins

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -359,6 +359,9 @@ header nav{border-radius: 4px; box-shadow: 0 1px 2px black; width: 294px; margin
   margin-top: 2px;
   height:30px
 }
+header nav.shorter_nav{
+  width: 207px;
+}
 header nav a{padding: 8px 12px 8px 34px; display: inline-block; color: #D6DADF; border-right: 1px solid #31363E; position: relative; box-shadow: 1px 0 0 rgba(255,255,255,.1); margin: 0}
 header nav a span{width: 20px; height: 20px; display: inline-block; background: red; position: absolute; left: 8px; top: 6px;}
 header nav a:last-child {border: 0; box-shadow: none}
@@ -382,7 +385,7 @@ header nav a.dashboard {
   border-bottom-left-radius: 4px;
 }
 
-header nav a.admin{
+header nav a.last_elem{
   -webkit-border-top-right-radius: 4px;
   -webkit-border-bottom-right-radius: 4px;
   -moz-border-radius-topright: 4px;

--- a/app/views/layouts/_head_panel.html.erb
+++ b/app/views/layouts/_head_panel.html.erb
@@ -21,16 +21,18 @@
     <%= text_field_tag "search", nil, :placeholder => "Search", :class => "search-input"  %>
   </div>
   <!-- .login-top -->
-  <nav>
-    <%= link_to dashboard_path, :class => current_page?(root_path) ? "current dashboard" : "dashboard" do %>
+  <nav class="<%= 'shorter_nav' unless current_user.is_admin? %>">
+    <%= link_to dashboard_path, :class => "#{'current' if current_page?(root_path)} dashboard" do %>
       <span></span>Dashboard
     <% end %>
-    <%= link_to projects_path, :class => current_page?(projects_path) ? "current project" : "project" do %>
+    <%= link_to projects_path, :class =>"#{'current' if current_page?(projects_path)} project #{'last_elem' unless current_user.is_admin?}" do %>
       <span></span>Projects
     <% end %>
-    <%= link_to((current_user.is_admin? ? admin_root_path : "#"), :class => (admin_namespace? ? "current admin" : "admin")) do %>
-      <span></span>Admin
-    <% end  %>
+    <% if current_user.is_admin? %>
+      <%= link_to((current_user.is_admin? ? admin_root_path : "#"), :class => "#{'current' if admin_namespace?} admin last_elem") do %>
+        <span></span>Admin
+      <% end  %>
+    <% end %>
   </nav>
 
 </header>


### PR DESCRIPTION
Hi,

I've created small fix, that will not show "admin" item in top menu for non-admins. 
