### PR TITLE
Project destroy relationship speed fix

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,7 +93,11 @@ class ProjectsController < ApplicationController
   end
 
   def destroy
+    # Disable the UsersProject update_repository call, otherwise it will be
+    # called once for every person removed from the project
+    UsersProject.skip_callback(:destroy, :after, :update_repository)
     project.destroy
+    UsersProject.set_callback(:destroy, :after, :update_repository)
 
     respond_to do |format|
       format.html { redirect_to projects_url }


### PR DESCRIPTION
Removes destroy callback for UsersProjects when a project is destroyed. Previously, the after_destroy hook for UsersProjects would be called for every user on the project, causing a delay of about 2 seconds per user when destroying a project.

This works because the gitolite config will be updated at at the end to remove the entry entirely, thereby removing the users anyway.
