### PR TITLE
Fixes Timeout When Adding an SSH key with Many Projects 

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -21,20 +21,14 @@ class Key < ActiveRecord::Base
   def update_repository
     Gitlabhq::GitHost.system.new.configure do |c|
       c.update_keys(identifier, key)
-
-      projects.each do |project|
-        c.update_project(project.path, project)
-      end
+      c.update_projects(projects)
     end
   end
 
   def repository_delete_key
     Gitlabhq::GitHost.system.new.configure do |c|
       c.delete_key(identifier)
-
-      projects.each do |project|
-        c.update_project(project.path, project)
-      end
+      c.update_projects(projects)
     end
   end
 


### PR DESCRIPTION
Users with many projects (>100) will hit the 20 second timeout when updating the gitolite config. This fix batches those changes into a single update to the file, causing an order of magnitude speed increase which finishes well below the 20 second timeout.

Fixes gitlabhq/gitlabhq#220
