### PR TITLE
Alert only commit author on note

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,6 +13,7 @@ class NotesController < ApplicationController
     @note = @project.notes.new(params[:note])
     @note.author = current_user
     @note.notify = true if params[:notify] == '1'
+    @note.notify_author = true if params[:notify_author] == '1'
     @note.save
 
     respond_to do |format|

--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -28,6 +28,7 @@ class Notify < ActionMailer::Base
     @note = note
     @project = note.project
     @commit = @project.repo.commits(note.noteable_id).first
+    return unless ( note.notify or ( note.notify_author and @commit.author.email == @user.email ) )
     mail(:to => @user.email, :subject => "gitlab | #{@note.project.name} ")
   end
   

--- a/app/models/mailer_observer.rb
+++ b/app/models/mailer_observer.rb
@@ -27,7 +27,7 @@ class MailerObserver < ActiveRecord::Observer
     end
 
     def new_note(note)
-      return unless note.notify
+      return unless note.notify or note.notify_author
       note.project.users.reject { |u| u.id == current_user.id } .each do |u|
         case note.noteable_type
         when "Commit" then

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -14,6 +14,7 @@ class Note < ActiveRecord::Base
 
   attr_protected :author, :author_id
   attr_accessor :notify
+  attr_accessor :notify_author
 
   validates_presence_of :project
 
@@ -39,6 +40,10 @@ class Note < ActiveRecord::Base
 
   def notify
     @notify ||= false
+  end
+
+  def notify_author
+    @notify_author ||= false
   end
 end
 # == Schema Information

--- a/app/views/notes/_form.html.haml
+++ b/app/views/notes/_form.html.haml
@@ -23,8 +23,12 @@
       %br
       = f.file_field :attachment
 
-      = check_box_tag :notify, 1, true
+      = check_box_tag :notify, 1, @note.noteable_type != "Commit"
       = label_tag :notify, "Notify project team about your note"
+
+      -if @note.noteable_type == "Commit"
+        = check_box_tag :notify_author, 1 , @note.noteable_type == "Commit"
+        = label_tag :notify_author, "Notify commit author about your note"
 
     .clear
     %br


### PR DESCRIPTION
Allows to alert only the commit author when a new note is added on a commit, useful when gitlabhq is used for code reviews, allows less noise with mails...
Default value on commit's note is alert only commiter.
