### PR TITLE
Autolinks to issues in commit message (see #155)

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -20,7 +20,7 @@ module CommitsHelper
   def more_commits_link
     offset = params[:offset] || 0
     limit = params[:limit] || 100
-    link_to "More", project_commits_path(project, :offset =>  offset.to_i + limit.to_i, :limit => limit),
+    link_to "More", project_commits_path(@project, :offset =>  offset.to_i + limit.to_i, :limit => limit),
       :remote => true, :class => "lite_button vm", :style => "text-align:center; width:930px; ", :id => "more-commits-link"
   end
 

--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -23,4 +23,23 @@ module CommitsHelper
     link_to "More", project_commits_path(@project, :offset =>  offset.to_i + limit.to_i, :limit => limit),
       :remote => true, :class => "lite_button vm", :style => "text-align:center; width:930px; ", :id => "more-commits-link"
   end
+
+  def commit_msg_with_link_to_issues
+    out = ""
+    @commit.safe_message.split(/(#[0-9]+)/m).each do |m|
+      if m =~ /(#([0-9]+))/m
+        begin
+          issue = Issue.find($2)
+          raise Exception('Issue not belonging to current project, not creating link !') unless issue.project_id == @project.id
+          out+=link_to($1, project_issue_path(@project, $2))
+        rescue
+          out+=$1
+        end
+      else
+        out+= m
+      end
+    end
+    out
+  end
+
 end

--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -20,26 +20,27 @@ module CommitsHelper
   def more_commits_link
     offset = params[:offset] || 0
     limit = params[:limit] || 100
-    link_to "More", project_commits_path(@project, :offset =>  offset.to_i + limit.to_i, :limit => limit),
+    link_to "More", project_commits_path(project, :offset =>  offset.to_i + limit.to_i, :limit => limit),
       :remote => true, :class => "lite_button vm", :style => "text-align:center; width:930px; ", :id => "more-commits-link"
   end
 
-  def commit_msg_with_link_to_issues
-    out = ""
-    @commit.safe_message.split(/(#[0-9]+)/m).each do |m|
+  def commit_msg_with_link_to_issues(project, message)
+    return '' unless message
+    out = ''
+    message.split(/(#[0-9]+)/m).each do |m|
       if m =~ /(#([0-9]+))/m
         begin
           issue = Issue.find($2)
-          raise Exception('Issue not belonging to current project, not creating link !') unless issue.project_id == @project.id
-          out+=link_to($1, project_issue_path(@project, $2))
+          raise Exception('Issue not belonging to current project, not creating link !') unless issue.project_id == project.id
+          out += link_to($1, project_issue_path(project, $2))
         rescue
-          out+=$1
+          out += $1
         end
       else
-        out+= m
+        out += m
       end
     end
-    out
+    preserve out
   end
 
 end

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -18,7 +18,7 @@
 
 %hr
 %pre.commit_message
-  = preserve get_commit_message_with_link_to_issues
+  = preserve commit_msg_with_link_to_issues
 .clear
 %br
 

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -18,7 +18,7 @@
 
 %hr
 %pre.commit_message
-  = preserve commit_msg_with_link_to_issues
+  = commit_msg_with_link_to_issues(@project, @commit.safe_message)
 .clear
 %br
 

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -18,8 +18,7 @@
 
 %hr
 %pre.commit_message
-  = preserve @commit.safe_message
-
+  = preserve get_commit_message_with_link_to_issues
 .clear
 %br
 

--- a/spec/helpers/commit_helper_spec.rb
+++ b/spec/helpers/commit_helper_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+include Haml::Helpers
+
+describe CommitsHelper do
+
+  before do
+    @project = Factory :project
+    @other_project = Factory :project, :path => "OtherPath", :code => "OtherCode"
+    @fake_user = Factory :user
+    @valid_issue = Factory :issue, :assignee => @fake_user, :author => @fake_user, :project => @project
+    @invalid_issue = Factory :issue, :assignee => @fake_user, :author => @fake_user, :project => @other_project
+  end
+
+  it "should provides return message untouched if no issue number present" do
+    message = "Dummy message without issue number"
+
+    commit_msg_with_link_to_issues(@project, message).should eql message
+  end
+
+  it "should returns message handled by preserve" do
+    message = "My brand new
+    Commit on multiple
+    lines !"
+
+    #\n are converted to &#x000A as specified in preserve_rspec
+    expected = "My brand new&#x000A;    Commit on multiple&#x000A;    lines !"
+
+    commit_msg_with_link_to_issues(@project, message).should eql expected
+  end
+
+  it "should returns empty string if message undefined" do
+    commit_msg_with_link_to_issues(@project, nil).should eql ''
+  end
+
+  it "should returns link_to issue for one valid issue in message" do
+    issue_id = @valid_issue.id
+    message = "One commit message ##{issue_id}"
+    expected = "One commit message <a href=\"/#{@project.code}/issues/#{issue_id}\">##{issue_id}</a>"
+
+    commit_msg_with_link_to_issues(@project, message).should eql expected
+  end
+
+  it "should returns message untouched for one invalid issue in message" do
+    issue_id = @invalid_issue.id
+    message = "One commit message ##{issue_id}"
+
+    commit_msg_with_link_to_issues(@project, message).should eql message
+  end
+
+  it "should handle multiple issue references in commit message" do
+    issue_id = @valid_issue.id
+    invalid_issue_id = @invalid_issue.id
+
+    message = "One big commit message with a valid issue ##{issue_id} and an invalid one ##{invalid_issue_id}.
+    We reference valid ##{issue_id} multiple times (##{issue_id}) as the invalid ##{invalid_issue_id} is also
+    referenced another time (##{invalid_issue_id})"
+
+    expected = "One big commit message with a valid issue <a href=\"/#{@project.code}/issues/#{issue_id}\">##{issue_id}</a>"+
+        " and an invalid one ##{invalid_issue_id}.&#x000A;    "+
+        "We reference valid <a href=\"/#{@project.code}/issues/#{issue_id}\">##{issue_id}</a> multiple times "+
+        "(<a href=\"/#{@project.code}/issues/#{issue_id}\">##{issue_id}</a>) "+
+        "as the invalid ##{invalid_issue_id} is also&#x000A;    referenced another time (##{invalid_issue_id})"
+
+    commit_msg_with_link_to_issues(@project, message).should eql expected
+  end
+
+end


### PR DESCRIPTION
It matches #[0-9]+ in commit messages.
For example
- Fix for #12
- Code review for #56
- Test for #15, Review on #54, Fix for #42
  
  It only links to valid issues (existing and belonging to the current project)
  It does not add any link to the commit in the issue page, it only consists in parsing the commit message when displayed.
  
  This can be considered as a primary work for the issue #155 on gitlabhq/gitlabhq.
