### PR TITLE
Add initializer for pygments to fix crash on Mac OS X.

### DIFF
--- a/config/initializers/gitlabhq/30_pygments.rb
+++ b/config/initializers/gitlabhq/30_pygments.rb
@@ -1,0 +1,4 @@
+require 'pygments'
+
+Pygments.start
+


### PR DESCRIPTION
The pygments module loads Python lazily on first use, which in turn causes
CoreFoundation to be loaded (if using the system's default Python interpreter).
CoreFoundation has an initialization function that must run on the main thread.

By adding an initialization module which simply calls Pygments.start, Python
is loaded when the rails application loads, on the main thread.

Issue: #244
