### PR TITLE
Added note when issue status changed (closed / reopened)

### DIFF
--- a/app/models/mailer_observer.rb
+++ b/app/models/mailer_observer.rb
@@ -71,5 +71,11 @@ class MailerObserver < ActiveRecord::Observer
         end
       end
 
-    end
+      if issue.closed_changed?
+        note = Note.new(:noteable => issue, :project => issue.project)
+        note.author = current_user
+        note.note = "_Status changed to #{issue.closed ? 'closed' : 'reopened'}_"
+        note.save()
+      end
+  end
 end


### PR DESCRIPTION
Allows to trace when an issue is closed / reopened by adding a note in the issue history

Contrary to pull request #250, implementation is correctly done through observer.
