### PR TITLE
Adding rake to Gemfile. Fixes #48

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 gem "rails", "3.1.1"
 
 gem "sqlite3"
+gem "rake", "0.9.2.2"
 gem "devise", "1.5.0"
 gem "stamp"
 gem "kaminari"


### PR DESCRIPTION
From issue comments...

I had to add rake@0.9.2.2 to the Gemfile because I wanted to run gitlab via an upstart script on Ubuntu, which looks something like...

```
exec sudo -u www-data sh -c "bundle exec rails s -e production -d >> /var/log/gitlab/gitlab.log 2>&1"
```

When running bundle/rails from this command, it's unable to find the correct rake dependency and rails will never start.
