### PR TITLE
Display both author and committer in commits list

### DIFF
--- a/app/assets/stylesheets/commits.css.scss
+++ b/app/assets/stylesheets/commits.css.scss
@@ -79,8 +79,8 @@ pre.commit_message {
 /** COMMIT BLOCK **/
 .commit-title{display: block;}
 .commit-title{margin-bottom: 10px}
-.commit-author{color: #999; font-weight: normal; font-style: italic;}
-.commit-author strong{font-weight: bold; font-style: normal;}
+.commit-author, .commit-committer{display: block;color: #999; font-weight: normal; font-style: italic;}
+.commit-author strong, .commit-committer strong{font-weight: bold; font-style: normal;}
 
 /** bordered list **/
 ul.bordered-list { 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -5,10 +5,12 @@ class Commit
   attr_accessor :refs
 
   delegate :message,
+    :authored_date,
     :committed_date,
     :parents,
     :sha,
     :date,
+    :committer,
     :author,
     :message,
     :diffs,
@@ -35,6 +37,14 @@ class Commit
 
   def author_name
     author.name
+  end
+
+  def committer_name
+    committer.name
+  end
+
+  def committer_email
+    committer.email
   end
 
   def prev_commit

--- a/app/views/commits/_commits.html.haml
+++ b/app/views/commits/_commits.html.haml
@@ -19,6 +19,15 @@
               %strong
                 = truncate(commit.safe_message, :length => 70)
             %span.commit-author
+              Authored by
+              &nbsp;
               %strong= commit.author_name
-              = time_ago_in_words(commit.committed_date)
+              = time_ago_in_words(commit.authored_date)
               ago
+            - if commit.author_name != commit.committer_name or commit.author_email != commit.committer_email or commit.authored_date != commit.committed_date
+              %span.commit-committer
+                Committed by
+                &nbsp;
+                %strong= commit.committer_name
+                = time_ago_in_words(commit.committed_date)
+                ago


### PR DESCRIPTION
This patch makes gitlab behave more like githab by displaying commit author as well as committer.
