### PR TITLE
Adds mysql2 adapter support for production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ group :development, :test do
   gem "webmock"
 end
 
+group :production do
+  gem "mysql2"
+end
+
 group :test do
   gem "turn", :require => false
   gem "simplecov", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     mime-types (1.17.2)
     multi_json (1.0.3)
     multi_xml (0.4.1)
+    mysql2 (0.3.11)
     nokogiri (1.5.0)
     orm_adapter (0.0.5)
     polyglot (0.3.3)
@@ -306,6 +307,7 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
+  mysql2
   pygments.rb (= 0.2.4)
   rails (= 3.1.1)
   rails-footnotes (~> 3.7.5)

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,11 @@ test:
   timeout: 5000
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: gitlab_production
   pool: 5
-  timeout: 5000
+  username: root
+  password:
+  host: localhost


### PR DESCRIPTION
I think it could be useful to have mysql support hardcoded in the project.

At least could be useful having the mysql2 gem required in production (I'm using chef and it's kind of complicated to require a gem which is not in the Gemfile).
