### PR TITLE
Add missing header gradient for Opera

### DIFF
--- a/app/assets/stylesheets/top_panel.scss
+++ b/app/assets/stylesheets/top_panel.scss
@@ -58,6 +58,7 @@ body header {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFF', endColorstr='#EAEAEA'); /* for IE */
   background: -webkit-gradient(linear, left top, left bottom, from(#FFFFFF), to(#EAEAEA)); /* for webkit browsers */
   background: -moz-linear-gradient(top,  #FFFFFF,  #EAEAEA); /* for firefox 3.6+ */ 
+  background: -o-linear-gradient(top,  #FFFFFF,  #EAEAEA); /* for firefox 3.6+ */ 
   border-bottom: 1px solid #ccc; 
 
   height:50px;


### PR DESCRIPTION
I found one place where a prefixed css directive for opera was missing. You should really use https://github.com/thoughtbot/bourbon sass mixins. They automatically create all needed prefixes.
