### PR TITLE
Fixed Redundant UTF-8 Sequence error

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,3 +1,5 @@
+require "iconv"
+
 class Commit
 
   attr_accessor :commit
@@ -22,7 +24,8 @@ class Commit
   end
 
   def safe_message
-    message
+    iconv = Iconv.new("UTF-8//IGNORE", "UTF-8")
+    iconv.iconv(message + ' ')[0..-2]
   end
 
   def created_at

--- a/lib/graph_commit.rb
+++ b/lib/graph_commit.rb
@@ -102,7 +102,7 @@ class GraphCommit
     h[:refs]    = refs.collect{|r|r.name}.join(" ") unless refs.nil?
     h[:id]      = sha
     h[:date]    = date
-    h[:message] = message.force_encoding("UTF-8")
+    h[:message] = safe_message.force_encoding("UTF-8")
     h[:login]   = author.email
     h
   end


### PR DESCRIPTION
When Tree or Network page is opened and commit log's encoding is non-UTF-8, may be occur "Redundant UTF-8 Sequence" error.
This patch fixes the error.
