### PR TITLE
Adding consolas font-family in commit.css and highlight.css

### DIFF
--- a/app/assets/stylesheets/commits.css.scss
+++ b/app/assets/stylesheets/commits.css.scss
@@ -20,7 +20,7 @@
     background:#fff;
     color:#333;
     font-size: 12px;
-    font-family: 'Courier New', 'andale mono','lucida console',monospace;
+    font-family: Consolas,'Courier New', 'andale mono','lucida console',monospace;
   }
   .diff_file_content_image {
     background:#eee;
@@ -49,6 +49,7 @@
     border:none;
     background:#F7F7F7;
     color:#aaa;
+    line-height: 18px;
     padding: 0px 5px;
     border-right: 1px solid #ccc;
     text-align:right;

--- a/app/assets/stylesheets/highlight.css.scss
+++ b/app/assets/stylesheets/highlight.css.scss
@@ -54,7 +54,7 @@ td.code .highlight {
 table.highlighttable pre{
   padding:0;
   margin:0;
-  font-family: 'Courier New', 'andale mono','lucida console',monospace;
+  font-family: Consolas,'Courier New', 'andale mono','lucida console',monospace;
   color: #333;
   text-align:left;
 }
@@ -68,7 +68,7 @@ table.highlighttable pre{
     padding:0;
     line-height:2.0;
     margin:0;
-    font-family: 'Courier New', 'andale mono','lucida console',monospace;
+    font-family: Consolas,'Courier New', 'andale mono','lucida console',monospace;
     color: #333;
     text-align:left;}
   }


### PR DESCRIPTION
Fix issue number #311 ugly font family on OS X. 
