### PR TITLE
Fixed a typo by the third n in 'commit'.

### DIFF
--- a/app/views/notify/note_commit_email.html.haml
+++ b/app/views/notify/note_commit_email.html.haml
@@ -4,7 +4,7 @@
       %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
       %td{:align => "left", :style => "padding: 20px 0 0;"}
         %h2{:style => "color:#646464; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
-          New comment for commmit
+          New comment for commit
           = link_to truncate(@commit.id.to_s, :length => 16), project_commit_url(@project, :id => @commit.id, :anchor => "note_#{@note.id}")
       %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
     %tr


### PR DESCRIPTION
The template for notifying a committer that a note has been created spells commit as "commmit". This simply fixes the spelling.
