### PR TITLE
Added syntax color for Drupal files (.inc, .module and .install)

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -28,7 +28,7 @@ module Utils
 
     def handle_file_type(file_name, mime_type = nil)
       case file_name
-      when /(\.pl|\.scala|\.java|\.haml|\.jade|\.scaml|\.html|\.sass|\.scss|\.php|\.erb)$/
+      when /(\.pl|\.scala|\.java|\.haml|\.jade|\.scaml|\.html|\.sass|\.scss|\.php|\.inc|\.erb|\.install|\.module)$/
         $1[1..-1].to_sym
       when /(\.c|\.h|\.idc)$/
         :c


### PR DESCRIPTION
I'm using gitlab mainly for drupal projects. Because I've not the knowledge to do something cleaner (like detect the language file) I just added the extension in the file.
