### PR TITLE
This makes gitlabhq compatible with more LDAP servers (specifically OpenLDAP).

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,8 +2,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
  
   def ldap
     # We only find ourselves here if the authentication to LDAP was successful.
-    omniauth = request.env["omniauth.auth"]["extra"]["raw_info"]
-    @user = User.find_for_ldap_auth(omniauth)
+    info = request.env["omniauth.auth"]["info"]
+    @user = User.find_for_ldap_auth(info)
     if @user.persisted?
       @user.remember_me = true
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,15 +67,15 @@ class User < ActiveRecord::Base
     (0...8).map{ ('a'..'z').to_a[rand(26)] }.join
   end 
 
-  def self.find_for_ldap_auth(omniauth)
-    username = omniauth.sAMAccountName[0]
-    email = omniauth.userprincipalname[0]
+  def self.find_for_ldap_auth(omniauth_info)
+    name = omniauth_info.name
+    email = omniauth_info.email
     
     if @user = User.find_by_email(email)
       @user
     else
       password = generate_random_password
-      @user = User.create(:name => username,
+      @user = User.create(:name => name,
         :email => email,
         :password => password,
         :password_confirmation => password


### PR DESCRIPTION
This helps with compatibility with more LDAP providers as the implementation
doesn't depend on the exact names of the LDAP fields. The LDAP strategy
helps maps the attributes to the fields in the info object and we use the
info object to get the email and name.

This makes the LDAP auth compatible with most OpenLDAP servers as well.
