### PR TITLE
Incorrect line numbering in diff

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -61,12 +61,12 @@ module CommitsHelper
       full_line = html_escape(line.gsub(/\n/, '')).force_encoding("UTF-8")
 
       if line.match(/^@@ -/)
-        next if line_old == 1 && line_new == 1
         type = "match"
 
         line_old = line.match(/\-[0-9]*/)[0].to_i.abs rescue 0
         line_new = line.match(/\+[0-9]*/)[0].to_i.abs rescue 0
-
+                
+        next if line_old == 1 && line_new == 1
         yield(line, type, nil, nil, nil)
         next
       else


### PR DESCRIPTION
When displaying a diff, the line number always starts at one, even if the first diff is not at the first line
Fixes this to display correct line numbering on first diff
