### PR TITLE
Generate consistent gravatar hash values as per documentation.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,8 @@ module ApplicationHelper
 
   def gravatar_icon(user_email, size = 40)
     gravatar_host = request.ssl? ? "https://secure.gravatar.com" :  "http://www.gravatar.com"
-    "#{gravatar_host}/avatar/#{Digest::MD5.hexdigest(user_email)}?s=#{size}&d=identicon"
+    user_email.strip!
+    "#{gravatar_host}/avatar/#{Digest::MD5.hexdigest(user_email.downcase)}?s=#{size}&d=identicon"
   end
 
   def fixed_mode?


### PR DESCRIPTION
The gravatar documentation on implementing the hash specifies that leading
and trailing whitespace must be trimmed and all characters should be forced
to lowercase.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
