### PR TITLE
Removed hardcoded SSH Username on project create/edit form: fixes #493

### DIFF
--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -13,7 +13,7 @@
       Path
     .input
       .input-prepend
-        %span.add-on= "git@#{GIT_HOST["host"]}:"
+        %span.add-on= "#{GIT_HOST["git_user"]}@#{GIT_HOST["host"]}:"
         = f.text_field :path, :placeholder => "example_project", :disabled => !@admin_project.new_record?
   .clearfix
     = f.label :code do 

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -12,7 +12,7 @@
       Path
     .input
       .input-prepend
-        %span.add-on= "git@#{GIT_HOST["host"]}:"
+        %span.add-on= "#{GIT_HOST["git_user"]}@#{GIT_HOST["host"]}:"
         = f.text_field :path, :placeholder => "example_project", :disabled => !@project.new_record?
   .clearfix
     = f.label :code do 


### PR DESCRIPTION
The SSH Username was hardcoded to "git". Changing that to the git_user variable from the config file.
Issue was raised here: #493
