### PR TITLE
Adapt to new web_hook_data method. fixes #509

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -32,7 +32,7 @@ class HooksController < ApplicationController
   def test
     @hook = @project.web_hooks.find(params[:id])
     commits = @project.commits(@project.default_branch, nil, 3)
-    data = @project.web_hook_data(commits.last.id, commits.first.id, "refs/heads/#{@project.default_branch}")
+    data = @project.web_hook_data(commits.last.id, commits.first.id, "refs/heads/#{@project.default_branch}", current_user.keys.first.identifier)
     @hook.execute(data)
 
     redirect_to :back


### PR DESCRIPTION
Uses the first key that the user has for testing post receive hook. fixes issue #509
