### PR TITLE
Remove vestigial comma from project_spec.

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -75,7 +75,7 @@ describe Project do
     let(:project) { Factory :project }
 
     before do
-      @issue = Factory :issue, :project => project,
+      @issue = Factory :issue, :project => project
     end
 
     it { project.last_activity.should == Event.last }


### PR DESCRIPTION
Needed to remove this extraneous comma from spec/models/project_spec.rb to get specs to even run. Not sure why TravisCI is green with what appears to be a dangling comma.

I started [a thread](https://groups.google.com/d/topic/gitlabhq/y1kAy3Afr4I/discussion) on the mailing list about this.
