### PR TITLE
Use of -p option of mkdir command to avoid message telling tmp/pids directory already exists...

### DIFF
--- a/resque.sh
+++ b/resque.sh
@@ -1,2 +1,2 @@
-mkdir tmp/pids
+mkdir -p tmp/pids
 nohup bundle exec rake environment resque:work QUEUE=* RAILS_ENV=production PIDFILE=tmp/pids/resque_worker.pid & >> log/resque_worker.log 2>&1


### PR DESCRIPTION
...at every GitLab (re)start. It ensures that all directories on the path exists so it can create tmp directory if its not there for some reason.
