### PR TITLE
Move OmniAuth configuration details into a non-revision controlled file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ Vagrantfile
 .vagrant
 config/gitlab.yml
 config/database.yml
+config/initializers/omniauth.rb
 db/data.yml

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -195,18 +195,9 @@ Devise.setup do |config|
   config.sign_out_via = :delete
 
   # ==> OmniAuth
-  # Add a new OmniAuth provider. Check the wiki for more information on setting
-  # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-
-  #config.omniauth :ldap, 
-  #    :host => 'YOUR_LDAP_SERVER',
-  #    :base => 'THE_BASE_WHERE_YOU_SEARCH_FOR_USERS',
-  #    :uid => 'sAMAccountName',
-  #    :port => 389,
-  #    :method => :plain,
-  #    :bind_dn => 'THE_FULL_DN_OF_THE_USER_YOU_WILL_BIND_WITH',
-  #    :password => 'THE_PASSWORD_OF_THE_BIND_USER'
+  # To configure a new OmniAuth provider copy and edit omniauth.rb.sample
+  # selecting the provider you require.
+  # Check the wiki for more information on setting up on your models
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/omniauth.rb.sample
+++ b/config/initializers/omniauth.rb.sample
@@ -1,0 +1,15 @@
+# Copy this file to 'omniauth.rb' and configure it as necessary.
+# The wiki has further details on configuring each provider.
+
+Devise.setup do |config|
+  # config.omniauth :github 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+
+  # config.omniauth :ldap, 
+  #     :host => 'YOUR_LDAP_SERVER',
+  #     :base => 'THE_BASE_WHERE_YOU_SEARCH_FOR_USERS',
+  #     :uid => 'sAMAccountName',
+  #     :port => 389,
+  #     :method => :plain,
+  #     :bind_dn => 'THE_FULL_DN_OF_THE_USER_YOU_WILL_BIND_WITH',
+  #     :password => 'THE_PASSWORD_OF_THE_BIND_USER'
+end


### PR DESCRIPTION
Provide an omniauth.rb.sample file to avoid encouraging end-users to commit
their provider access details (passwords or api tokens) into their git
repositories.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
