### PR TITLE
Ensure LDAP provided email is always compared case-insensitively.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
 
   def self.find_for_ldap_auth(omniauth_info)
     name = omniauth_info.name
-    email = omniauth_info.email
+    email = omniauth_info.email.downcase
     
     if @user = User.find_by_email(email)
       @user


### PR DESCRIPTION
LDAP databases may store email addresses in mixed case so
ensure we only work with a lower case version to avoid missing
a valid account after LDAP login.

[PT: this commit resolves github issue #455]

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
