### PR TITLE
Fix installation instructions for running gitlab_status

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -158,7 +158,7 @@ Permissions:
     
 Checking status:
 
-    sudo -u gitlab bundle exec rake gitlab_status
+    sudo -u gitlab bundle exec rake gitlab_status RAILS_ENV=production
 
 
     # OUTPUT EXAMPLE


### PR DESCRIPTION
When running `rake gitlab_status` to check if it's safe to continue on installation in step 4, you need to use `RAILS_ENV=production` or else you will receive an error about "permission denied for user root@localhost..."
