### PR TITLE
Automagically fills the email on add ssh key page

### DIFF
--- a/app/views/keys/new.html.haml
+++ b/app/views/keys/new.html.haml
@@ -1,3 +1,14 @@
 %h3 New key
 %hr
 = render 'form'
+
+:javascript
+  $('#key_key').on('keyup', function(){
+    var title = $('#key_title'),
+        val      = $('#key_key').val(),
+        key_mail = val.match(/([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+|\.[a-zA-Z0-9._-]+)/gi);
+
+    if( key_mail && key_mail.length > 0 && title.val() == '' ){
+      $('#key_title').val( key_mail );
+    }
+  });


### PR DESCRIPTION
Finally had some spare time to do this on it's own branch :) 

When you add a new ssh key, the title field automatically fills with the email (if is present in the key sting)
