### PR TITLE
Incompatible character encodings: ASCII-8BIT and UTF-8 in _text_file.html.haml

### DIFF
--- a/app/views/commits/_text_file.html.haml
+++ b/app/views/commits/_text_file.html.haml
@@ -4,14 +4,14 @@
       - if type == "match"
         %td.old_line= "..."
         %td.new_line= "..."
-        %td.line_content.matched= line
+        %td.line_content.matched= line.force_encoding('UTF-8')
       - else 
         %td.old_line
           = link_to raw(type == "new" ? "&nbsp;" : line_old), "##{line_code}", :id => line_code
           - if @comments_allowed
             = link_to "", "#", :class => "line_note_link", "line_code" => line_code, :title => "Add note for this line" 
         %td.new_line= link_to raw(type == "old" ? "&nbsp;" : line_new) , "##{line_code}", :id => line_code
-        %td.line_content{:class => "noteable_line #{type} #{line_code}", "line_code" => line_code}= raw "#{line} &nbsp;"
+        %td.line_content{:class => "noteable_line #{type} #{line_code}", "line_code" => line_code}= raw "#{line.force_encoding('UTF-8')} &nbsp;"
         
         - if @comments_allowed
           - comments = @line_notes.select { |n| n.line_code == line_code }.sort_by(&:created_at).reverse


### PR DESCRIPTION
Force diff line to UTF-8 encoding to prevent 'incompatible character encodings' error while rendering text file diff in compare view.
