### PR TITLE
Fix gl-setup PATH warning when executing gl-system-install.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -101,7 +101,8 @@ Get gitolite source code:
 
 Setup:
 
-    sudo -u git -H /home/git/gitolite/src/gl-system-install
+    sudo -u git sh -c 'echo "PATH=\$PATH:/home/git/bin\nexport PATH" > /home/git/.profile'
+    sudo -u git -i -H /home/git/gitolite/src/gl-system-install
     sudo cp /home/gitlab/.ssh/id_rsa.pub /home/git/gitlab.pub
     sudo chmod 777 /home/git/gitlab.pub
 


### PR DESCRIPTION
My git user uses bash (so .profile), but I think it should work the same for sh shell.

Full warning message:

```
                ***** WARNING *****
gl-setup is not in your $PATH.

Since gl-setup MUST be run from the PATH (and not as src/gl-setup or such),
you must fix this before running gl-setup.  The simplest way is to add

    PATH=/home/git/bin:$PATH

to the end of your bashrc or similar file.  You can even simply run that
command manually each time you log in and want to run a gitolite command.

Run /home/git/gitolite/src/gl-system-install -h for a detailed usage message.
```
