### PR TITLE
Move Unicorn unix socket out of /tmp

### DIFF
--- a/config/unicorn.rb.orig
+++ b/config/unicorn.rb.orig
@@ -13,7 +13,7 @@ timeout 30
 
 #listen 8080 # listen to port 8080 on all TCP interfaces
 #listen "127.0.0.1:8080"  # listen to port 8080 on the loopback interface
-listen "/tmp/gitlab.socket"
+listen "#{app_dir}/tmp/sockets/gitlab.socket"
 
 pid "#{app_dir}/tmp/pids/unicorn.pid"
 stderr_path "#{app_dir}/log/unicorn.stderr.log"

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -220,7 +220,7 @@ Application can be started with next command:
 Edit /etc/nginx/nginx.conf. Add next code to **http** section:
 
     upstream gitlab {
-        server unix:/tmp/gitlab.socket;
+        server unix:/home/gitlab/gitlab/tmp/sockets/gitlab.socket;
     }
 
     server {


### PR DESCRIPTION
Seems like it would be more secure in the app's folder (I see there's a `tmp/sockets` directory already there), instead of the global `/tmp`.
