### PR TITLE
Add redis-server init.d dependency - fixes #598

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -262,13 +262,13 @@ Create init script in /etc/init.d/gitlab:
 
     #! /bin/bash
     ### BEGIN INIT INFO
-    # Provides:          unicorn
-    # Required-Start:    $local_fs $remote_fs $network $syslog
+    # Provides:          gitlab
+    # Required-Start:    $local_fs $remote_fs $network $syslog redis-server
     # Required-Stop:     $local_fs $remote_fs $network $syslog
     # Default-Start:     2 3 4 5
     # Default-Stop:      0 1 6
-    # Short-Description: starts the unicorn web server
-    # Description:       starts unicorn
+    # Short-Description: GitLab git repository management
+    # Description:       GitLab git repository management
     ### END INIT INFO
     
     DAEMON_OPTS="-c /home/gitlab/gitlab/config/unicorn.rb -E production -D"
@@ -323,7 +323,7 @@ Adding permission:
 
 When server is rebooted then gitlab must starting:
 
-    sudo update-rc.d gitlab defaults
+    sudo insserv gitlab
 
 Now you can start/restart/stop gitlab like:
 


### PR DESCRIPTION
The documentation's example init.d script apparently will fail on system startup if redis-server isn't started first (see #598).  I added a startup dependency for redis-server to fix this (also replaced unicorn meta info with gitlab while I was there).

However, the init.d script will have to be added to system boot using `insserv` instead of `update-rc.d` to take advantage of [dependency resolution](http://wiki.debian.org/LSBInitScripts/DependencyBasedBoot).
