### PR TITLE
The indents errors of pre blocks in haml

### DIFF
--- a/app/views/errors/gitolite.html.haml
+++ b/app/views/errors/gitolite.html.haml
@@ -14,5 +14,6 @@
       %p
         Try:
       %pre
-        sudo chmod -R 770 /home/git/repositories/
-        sudo chown -R git:git /home/git/repositories/
+        = preserve do
+          sudo chmod -R 770 /home/git/repositories/
+          sudo chown -R git:git /home/git/repositories/

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -42,7 +42,8 @@
       
   - if @issue.description.present?
     .bottom_box_content
-      = markdown @issue.description
+      = preserve do
+        = markdown @issue.description
 
 
 .issue_notes#notes= render "notes/notes", :tid => @issue.id, :tt => "issue"

--- a/app/views/merge_requests/_how_to_merge.html.haml
+++ b/app/views/merge_requests/_how_to_merge.html.haml
@@ -4,11 +4,12 @@
     %h3 How To Merge
   .modal-body
     %pre
-      :erb
-        git checkout <%= @merge_request.target_branch %>
-        git fetch origin
-        git merge origin/<%= @merge_request.source_branch %>
-        git push origin <%= @merge_request.target_branch %>
+      = preserve do
+        :erb
+          git checkout <%= @merge_request.target_branch %>
+          git fetch origin
+          git merge origin/<%= @merge_request.source_branch %>
+          git push origin <%= @merge_request.target_branch %>
 
 
 :javascript

--- a/app/views/milestones/show.html.haml
+++ b/app/views/milestones/show.html.haml
@@ -39,7 +39,8 @@
 
   - if @milestone.description.present?
     .bottom_box_content
-      = markdown @milestone.description
+      = preserve do
+        = markdown @milestone.description
 
 
 :javascript

--- a/app/views/notes/_show.html.haml
+++ b/app/views/notes/_show.html.haml
@@ -9,7 +9,8 @@
       %strong= link_to "Remove", [@project, note], :confirm => 'Are you sure?', :method => :delete, :remote => true, :class => "cred delete-note btn small"
 
   %div.note-title
-    = markdown(note.note)
+    = preserve do
+      = markdown(note.note)
     - if note.attachment.url
       .right
         %div.file

--- a/app/views/projects/empty.html.haml
+++ b/app/views/projects/empty.html.haml
@@ -15,7 +15,8 @@
   %h3 Git global setup:
   - setup_str = ["git config --global user.name \"#{current_user.name}\"", 
     "git config --global user.email  \"#{current_user.email}\""].join("\n")
-  = raw bash_lexer.highlight(setup_str, :lexer => 'bash', :options => {:encoding => 'utf-8'})
+  = preserve do
+    = raw bash_lexer.highlight(setup_str, :lexer => 'bash', :options => {:encoding => 'utf-8'})
 
   %br
   %br
@@ -29,7 +30,8 @@
     "git remote add origin #{@project.url_to_repo}",
     "git push -u origin master"].join("\n")
 
-  = raw bash_lexer.highlight(repo_setup_str)
+  = preserve do
+    = raw bash_lexer.highlight(repo_setup_str)
 
   %br
   %br
@@ -37,7 +39,8 @@
   - exist_repo_setup_str = ["cd existing_git_repo",
     "git remote add origin #{@project.url_to_repo}",
     "git push -u origin master"].join("\n")
-  = raw bash_lexer.highlight(exist_repo_setup_str)
+  = preserve do
+    = raw bash_lexer.highlight(exist_repo_setup_str)
 
   - if can? current_user, :admin_project, @project
     .alert-message.block-message.error.prepend-top-20

--- a/app/views/refs/_tree.html.haml
+++ b/app/views/refs/_tree.html.haml
@@ -41,7 +41,8 @@
         %h3= content.name
         .readme
           - if content.name =~ /\.(md|markdown)$/i
-            = markdown(content.data)
+            = preserve do
+              = markdown(content.data)
           - else
             = simple_format(content.data)
 

--- a/app/views/wikis/show.html.haml
+++ b/app/views/wikis/show.html.haml
@@ -8,7 +8,8 @@
         Edit
 %hr
 .wiki_content
-  = markdown_to_html @wiki.content
+  = preserve do
+    = markdown_to_html @wiki.content
 
 %p.time Last edited by #{@wiki.user.name}, in #{time_ago_in_words @wiki.created_at}
 - if can? current_user, :admin_wiki, @project


### PR DESCRIPTION
You should use the preserve helper to keep the proper indent of raw code blocks in haml.

The current indent of pre blocks are broken like the screenshot below.
http://gyazo.com/a26e805f962d7cbb9ae4a568a13601b3

However, the indent should be actually like this.
http://gyazo.com/b9385d3faa3544c9678b4ab2a4fe2064

These errors occur all multi line pre blocks such as error/init/merge instructions as well as most of markdown rendered statements in the entire project .

I fixed all of these errors which I found.
Please check my commits and merge them to fix the indent errors.
