### PR TITLE
Add libyaml-dev to the apt-get install string.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -55,7 +55,7 @@ The installation consists of 6 steps:
     sudo apt-get update
     sudo apt-get upgrade
 
-    sudo apt-get install -y git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip sendmail
+    sudo apt-get install -y git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip libyaml-dev sendmail
 
 # 2. Install ruby
 


### PR DESCRIPTION
If libyaml headers are not installed, YAML will not be correctly compiled (either not at all, or using Syck instead of Psych).

This caused some weird YAML serialization errors for me when creating merge requests in gitlab.
