### PR TITLE
Nicer commit headers

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -94,7 +94,12 @@ $hover: #FDF5D9;
 @import "common.scss";
 
 /**
- * This scss file redefine chozen selectbox styles for 
+ * Styles related to displaying commits
+ */
+@import "sections/commits.scss";
+
+/**
+ * This scss file redefine chozen selectbox styles for
  * project Branch/Tag select element
  */
 @import "ref_select.scss";

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -1,0 +1,33 @@
+.commit-head {
+  @extend .well;
+
+  padding: 14px;
+  padding-bottom: 8px;
+
+  .browse-button {
+    @extend .btn;
+    @extend .btn-small;
+    float: right;
+  }
+
+  .commit-title {
+    line-height: 26px;
+  }
+
+  .commit-description {
+    background-color: white;
+  }
+
+  .sha-block {
+    float: right;
+    margin-left: 10px
+  }
+
+  .committer {
+    padding-left: 32px;
+  }
+
+  .avatar {
+    margin-right: 4px;
+  }
+}

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -1,6 +1,5 @@
 .commit-head {
-  @extend .well;
-  @extend .clearfix;
+  @extend .main_box;
 
   padding: 14px;
   padding-bottom: 8px;
@@ -17,7 +16,27 @@
   }
 
   .commit-description {
+    font-size: 14px;
+    padding: 0px;
+    padding-bottom: 4px;
+    border: none;
     background-color: white;
+  }
+
+  .commit-info {
+    @extend .middle_box_content;
+    @extend .clearfix;
+
+    padding-bottom: 8px;
+    padding-top: 8px;
+
+    margin-left: -14px;
+    margin-right: -14px;
+    margin-bottom: -8px;
+
+    .author .name, .committer .name {
+      font-weight: bold;
+    }
   }
 
   .sha-block {

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -1,8 +1,10 @@
 .commit-head {
   @extend .well;
+  @extend .clearfix;
 
   padding: 14px;
   padding-bottom: 8px;
+  line-height: 24px;
 
   .browse-button {
     @extend .btn;
@@ -21,6 +23,10 @@
   .sha-block {
     float: right;
     margin-left: 10px
+  }
+
+  &.merge-commit .sha-block {
+    clear: right;
   }
 
   .committer {

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -106,6 +106,41 @@ class Commit
     utf8 author.name
   end
 
+  # Returns the commits title.
+  #
+  # Usually, the commit title is the first line of the commit message.
+  # In case this first line is longer than 80 characters, it is cut off
+  # after 70 characters and ellipses (`&hellp;`) are appended.
+  #
+  # @todo This might be better placed in a view helper.
+  def title
+    title_end = safe_message.index(/\n/)
+    if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
+      safe_message[0..69] << "&hellip;".html_safe
+    else
+      safe_message.split(/\n/, 2).first
+    end
+  end
+
+  # Returns the commits description
+  #
+  # cut off, ellipses (`&hellp;`) are prepended to the commit message.
+  #
+  # @todo This might be better placed in a view helper.
+  def description
+    title_end = safe_message.index(/\n/)
+    if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
+      "&hellip;".html_safe << safe_message[70..-1]
+    else
+      safe_message.split(/\n/, 2)[1].try(:chomp)
+    end
+  end
+
+  # Was this commit committed by a different person than the original author?
+  def different_committer?
+    author_name != committer_name || author_email != committer_email
+  end
+
   def committer_name
     utf8 committer.name
   end

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -5,23 +5,23 @@
   - if @commit.description.present?
     %pre.commit-description
       = commit_msg_with_link_to_issues(@project, @commit.description)
-  %span.sha-block
-    commit
-    %code= @commit.id
-  %span.sha-block
-    = pluralize(@commit.parents.count, "parent")
-    - @commit.parents.each do |parent|
-      %code= link_to parent.id, project_commit_path(@project, parent)
   .commit-info
+    %span.sha-block
+      commit
+      %code= @commit.id
+    %span.sha-block
+      = pluralize(@commit.parents.count, "parent")
+      - @commit.parents.each do |parent|
+        %code= link_to parent.id, project_commit_path(@project, parent)
     .author
       = image_tag gravatar_icon(@commit.author_email, 24), :class => "avatar", :height => 24, :width => 24
-      = @commit.author_name
+      %span.name= @commit.author_name
       authored
       %time{title: @commit.authored_date.stamp("Aug 21, 2011 9:23pm")}
         #{time_ago_in_words(@commit.authored_date)} ago
     - if @commit.different_committer?
       .committer
-        = @commit.committer_name
+        %span.name= @commit.committer_name
         committed
         %time{title: @commit.committed_date.stamp("Aug 21, 2011 9:23pm")}
           #{time_ago_in_words(@commit.committed_date)} ago

--- a/app/views/commits/show.html.haml
+++ b/app/views/commits/show.html.haml
@@ -1,26 +1,31 @@
-.main_box
-  .top_box_content
-    .right
-      - unless @notes_count.zero?
-        %span.btn.small.disabled.padded= pluralize @notes_count, 'note'
-
-      = link_to tree_project_ref_path(@project, @commit.id), :class => "btn small" do 
-        Browse Code »
-    = image_tag gravatar_icon(@commit.author_email), :class => "avatar"
-    %code= @commit.id.to_s
-    %h5
+.commit-head{class: @commit.parents.count > 1 ? "merge-commit" : ""}
+  = link_to "Browse Code »", tree_project_ref_path(@project, @commit.id), :class => "browse-button"
+  %h3.commit-title
+    = commit_msg_with_link_to_issues(@project, @commit.title)
+  - if @commit.description.present?
+    %pre.commit-description
+      = commit_msg_with_link_to_issues(@project, @commit.description)
+  %span.sha-block
+    commit
+    %code= @commit.id
+  %span.sha-block
+    = pluralize(@commit.parents.count, "parent")
+    - @commit.parents.each do |parent|
+      %code= link_to parent.id, project_commit_path(@project, parent)
+  .commit-info
+    .author
+      = image_tag gravatar_icon(@commit.author_email, 24), :class => "avatar", :height => 24, :width => 24
       = @commit.author_name
-      %small= @commit.created_at.stamp("Aug 21, 2011 9:23pm")
-      - if @commit.author_name != @commit.committer_name or @commit.author_email != @commit.committer_email or @commit.authored_date != @commit.committed_date 
-        &ndash;
-        %cite committed by
+      authored
+      %time{title: @commit.authored_date.stamp("Aug 21, 2011 9:23pm")}
+        #{time_ago_in_words(@commit.authored_date)} ago
+    - if @commit.different_committer?
+      .committer
         = @commit.committer_name
-        %small= @commit.committed_date.stamp("Aug 21, 2011 9:23pm")
+        committed
+        %time{title: @commit.committed_date.stamp("Aug 21, 2011 9:23pm")}
+          #{time_ago_in_words(@commit.committed_date)} ago
 
-  .middle_box_content
-    %pre.commit_message
-      = commit_msg_with_link_to_issues(@project, @commit.safe_message)
-%br
 = render "commits/diffs", :diffs => @commit.diffs
 = render "notes/notes", :tid => @commit.id, :tt => "commit"
 = render "notes/per_line_form"


### PR DESCRIPTION
This changes the commit headers to look nicer:
- The header takes less space.
- Parent commit ids and links are included.
- Committer information is only shown if the commit was authored by a different person than it was committed, instead of all the time.
- Different styling for the commit title and the commit description.

Examples:
![First Example](http://i.imgur.com/3JigN.png)
![Second Example](http://i.imgur.com/XewKO.png)
