### PR TITLE
Add Fedora/CentOS 'yum' for Ruby wiki page

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -60,8 +60,11 @@ Also read the [Read this before you submit an issue](https://github.com/gitlabhq
     sudo apt-get update
     sudo apt-get upgrade
 
+    # Ubuntu/Debian
     sudo apt-get install -y git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip libyaml-dev sendmail
-    
+    # Fedora/CentOS
+    sudo yum install wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev
+
     # If you want to use MySQL:
     sudo apt-get install -y mysql-server mysql-client libmysqlclient-dev
 


### PR DESCRIPTION
Add the fedora line so that this page https://github.com/gitlabhq/gitlabhq/wiki/Ruby can be deleted from wiki and information is in only one place
