### PR TITLE
internally 'public' projects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,8 @@ class ApplicationController < ActionController::Base
   end
 
   def project
-    @project ||= current_user.projects.find_by_code(params[:project_id])
+    @project ||= current_user.projects.find_by_code(params[:project_id]) ||
+      Project.find_by_code_and_private_flag(params[:project_id], false)
     @project || render_404
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -13,6 +13,7 @@ class ProjectsController < ApplicationController
   def index
     @projects = current_user.projects
     @projects = @projects.select(&:last_activity_date).sort_by(&:last_activity_date).reverse
+    @public_projects = Project.find_all_by_private_flag(false) - @projects
     @events = Event.where(:project_id => @projects.map(&:id)).recent.limit(20)
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,13 +25,13 @@ class Ability
       :write_project,
       :write_issue,
       :write_note
-    ] if project.guest_access_for?(user)
+    ] if project.guest_access_for?(user) || project.public?
 
     rules << [
       :download_code,
       :write_merge_request,
       :write_snippet
-    ] if project.report_access_for?(user)
+    ] if project.report_access_for?(user) || project.public?
 
     rules << [
       :write_wiki
@@ -50,7 +50,6 @@ class Ability
       :admin_note,
       :admin_wiki
     ] if project.master_access_for?(user) || project.owner == user
-
 
     rules.flatten
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,7 +21,7 @@ class Project < ActiveRecord::Base
   has_many :wikis,          :dependent => :destroy
   has_many :protected_branches, :dependent => :destroy
 
-  attr_protected :private_flag, :owner_id
+  attr_protected :owner_id
 
   scope :public_only, where(:private_flag => false)
   scope :without_user, lambda { |user|  where("id not in (:ids)", :ids => user.projects.map(&:id) ) }

--- a/app/models/project/permissions_trait.rb
+++ b/app/models/project/permissions_trait.rb
@@ -22,7 +22,7 @@ module Project::PermissionsTrait
     def repository_readers
       keys = Key.joins({:user => :users_projects}).
         where("users_projects.project_id = ? AND users_projects.project_access = ?", id, UsersProject::REPORTER)
-      keys.map(&:identifier) + deploy_keys.map(&:identifier)
+      keys.map(&:identifier) + deploy_keys.map(&:identifier) + (public? ? ['@all'] : [])
     end
 
     def repository_writers

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -48,6 +48,10 @@
         = f.label :wall_enabled, "Wall"
         .input= f.check_box :wall_enabled
 
+      .clearfix
+        = f.label :private_flag, "Private"
+        .input= f.check_box :private_flag
+
   .clearfix
     = f.label :description
     .input= f.text_area :description, :class => "xxlarge"

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -46,6 +46,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
     
+      .clearfix
+        = f.label :private_flag, "Private"
+        .input= f.check_box :private_flag
+
   .clearfix
     = f.label :description
     .input

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -17,7 +17,7 @@
     .span4.right
       %div.leftbar.ui-box
         %h5
-          Projects
+          My Projects
           %small
             (#{@projects.count})
           - if current_user.can_create_project?
@@ -26,6 +26,19 @@
                 New Project
         .content_list
           - @projects.each do |project|
+            = link_to project_path(project), :class => dom_class(project) do
+              %h4
+                %span.ico.project
+                = truncate(project.name, :length => 25)
+                %span.right
+                  &rarr;
+      %div.leftbar.ui-box
+        %h5
+          Public Projects
+          %small
+            (#{@public_projects.count})
+        .content_list
+          - @public_projects.each do |project|
             = link_to project_path(project), :class => dom_class(project) do
               %h4
                 %span.ico.project


### PR DESCRIPTION
ability to share projects internally without a need to add permission for every user. convenient to share readonly projects.
