### PR TITLE
Display Milestones without a due date as active

### DIFF
--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -6,7 +6,7 @@ class Milestone < ActiveRecord::Base
   validates_presence_of :title
 
   def self.active
-    where("due_date > ? ", Date.today)
+    where("due_date > ? OR due_date IS NULL", Date.today)
   end
 
   def percent_complete


### PR DESCRIPTION
Milestones appear to currently set due_date as NULL in the milestones table if you do not specifically pick a date in the calendar on milestone creation. 

This small change would make due_date optional and show milestones without a due_date set in the active tab rather then only show them in the ALL view.

This is the first time I've done a pull request on github, as small as this might be, let me know if I've done anything wrong.

Thanks.
