### PR TITLE
Double Grit timeout to 20 seconds.

### DIFF
--- a/app/models/project/repository_trait.rb
+++ b/app/models/project/repository_trait.rb
@@ -57,6 +57,7 @@ module Project::RepositoryTrait
     end
 
     def repo
+      Grit::Git.with_timeout(20)
       @repo ||= Grit::Repo.new(path_to_repo)
     end
 


### PR DESCRIPTION
In one repository I have some large commits (>600 files), in the default settings Grit times out after 10 seconds, this increases the timeout to 20 seconds.
