### PR TITLE
Rescue from CharlockHolmes failures.

### DIFF
--- a/lib/gitlabhq/encode.rb
+++ b/lib/gitlabhq/encode.rb
@@ -3,7 +3,7 @@ module Gitlabhq
     extend self
 
     def utf8 message
-      hash = CharlockHolmes::EncodingDetector.detect(message)
+      hash = CharlockHolmes::EncodingDetector.detect(message) rescue {}
       if hash[:encoding]
         CharlockHolmes::Converter.convert(message, hash[:encoding], 'UTF-8')
       else


### PR DESCRIPTION
A workaround to keep GitLab working if CharlockHolmes failes.
