### PR TITLE
Start the merge diff from the merge base.

### DIFF
--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -72,9 +72,12 @@ class MergeRequest < ActiveRecord::Base
     diffs
   end
 
+  def merge_base
+    project.repo.git.native(:merge_base, {}, [target_branch, source_branch]).strip
+  end
+
   def unmerged_diffs
-    commits = project.repo.commits_between(target_branch, source_branch).map {|c| Commit.new(c)}
-    diffs = project.repo.diff(commits.first.prev_commit.id, commits.last.id) rescue []
+    project.repo.diff(merge_base, source_branch)
   end
 
   def last_commit


### PR DESCRIPTION
This shows **correct** merge diffs, exactly in the way git will later
handle merges.

The previous method sometimes showed changes in the diff that were just
wrong.

(Basically, the diff shows now the output of `git diff
target_branch…source_branch`).
