### PR TITLE
Fixed 502 problem with nginx

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -214,7 +214,7 @@ Application can be started with next command:
 Edit /etc/nginx/nginx.conf. Add next code to **http** section:
 
     upstream gitlab {
-        server unix:/tmp/gitlab.socket;
+        server unix:/home/gitlab/gitlab/tmp/gitlab.socket;
     }
 
     server {


### PR DESCRIPTION
using this new nginx conf you will not get the 502 error on nginx because it cant fint its socet descriptor.
