### PR TITLE
Fix admin_all_repo behaviour in Gitlabhq::Gitolite

### DIFF
--- a/lib/gitlabhq/gitolite.rb
+++ b/lib/gitlabhq/gitolite.rb
@@ -133,7 +133,7 @@ module Gitlabhq
       #
       begin 
         repo = conf.get_repo("gitolite-admin")
-        owner_name = repo.permissions[0]["RW+"][""][0]
+        owner_name = repo.permissions[0]["RW+"][""].select { |x| x == 'gitlab' }.first
         raise StandardError if owner_name.blank?
       rescue => ex
         puts "Cant determine gitolite-admin owner".red


### PR DESCRIPTION
`admin_all_repo` expects that gitlab is the only user with access to `gitolite-admin`.

**This may break on some installations**
Having more than just the gitlab user in the `gitolite-admin` configuration seems to be possible, as the `gitolite-admin` configuration will always be kept as is (where other repos will just be rewritten from the database).

**Reproduce**
Pull your `gitolite-admin` repository and change `conf/gitolite.conf` to list another user in `RW+` before gitlab, i.e.

```
repo    gitolite-admin
  RW+                            = foobar gitlab
```

Now run `gitlab:app:enable_automerge` and get rejected by gitolite (for user `gitlab`).
