### PR TITLE
Add CSS class for closed tickets in ticket list.

### DIFF
--- a/app/views/issues/_show.html.haml
+++ b/app/views/issues/_show.html.haml
@@ -1,4 +1,4 @@
-%li.wll{ :id => dom_id(issue), :class => "issue #{issue.critical ? "critical" : ""}", :url => project_issue_path(issue.project, issue) }
+%li.wll{ :id => dom_id(issue), :class => "issue #{issue.critical ? "critical" : ""} #{issue.closed ? "closed" : ""}", :url => project_issue_path(issue.project, issue) }
   .right
     - if issue.notes.any?
       %span.btn.small.disabled.padded= pluralize issue.notes.count, 'note'


### PR DESCRIPTION
This is a first step for #745.

It adds a CSS class to closed tickets in the ticket list. I haven't yet figured out where the best place for the CSS changes would be. Maybe app/assets/stylesheets/main.scss?
