### PR TITLE
When the email address is empty gitlab will give a 500 error

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,7 @@ module ApplicationHelper
 
   def gravatar_icon(user_email, size = 40)
     gravatar_host = request.ssl? ? "https://secure.gravatar.com" :  "http://www.gravatar.com"
+    user_email ||= ''
     user_email.strip!
     "#{gravatar_host}/avatar/#{Digest::MD5.hexdigest(user_email.downcase)}?s=#{size}&d=identicon"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,8 @@
 require 'digest/md5'
 module ApplicationHelper
 
-  def gravatar_icon(user_email, size = 40)
+  def gravatar_icon(user_email = '', size = 40)
     gravatar_host = request.ssl? ? "https://secure.gravatar.com" :  "http://www.gravatar.com"
-    user_email ||= ''
     user_email.strip!
     "#{gravatar_host}/avatar/#{Digest::MD5.hexdigest(user_email.downcase)}?s=#{size}&d=identicon"
   end


### PR DESCRIPTION
Since some conversion tools do commits with an empty commiters email
address gitlab will fail with a 500 error
