### PR TITLE
Allow short project names

### DIFF
--- a/app/models/project/validations_trait.rb
+++ b/app/models/project/validations_trait.rb
@@ -20,7 +20,7 @@ module Project::ValidationsTrait
               :uniqueness => true,
               :format => { :with => /^[a-zA-Z0-9_\-\.]*$/,
                            :message => "only letters, digits & '_' '-' '.' allowed"  },
-              :length   => { :within => 3..255 }
+              :length   => { :within => 1..255 }
 
     validates :owner, :presence => true
     validate :check_limit


### PR DESCRIPTION
We have some projects which a length of 2.
With this I lower the minimum lenght to 1.
As I could not found a specific reason why it is set to 3...
