### PR TITLE
update launchy to fix an NoMethodError on development and test mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     acts-as-taggable-on (2.1.1)
       rails
     acts_as_list (0.1.4)
-    addressable (2.2.6)
+    addressable (2.2.8)
     ansi (1.4.2)
     arel (3.0.2)
     autotest (4.4.6)
@@ -148,7 +148,7 @@ GEM
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
     kgio (2.7.2)
-    launchy (2.0.5)
+    launchy (2.1.0)
       addressable (~> 2.2.6)
     letter_opener (0.0.2)
       launchy


### PR DESCRIPTION
``` ruby
sh: xprop: not found
/home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/detect/runner.rb:41:in `shell_commands': undefined method `shellsplit' for nil:NilClass (NoMethodError)
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/detect/runner.rb:104:in `block in wet_run'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/detect/runner.rb:103:in `fork'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/detect/runner.rb:103:in `wet_run'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/detect/runner.rb:61:in `run'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/application.rb:58:in `run'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy/applications/browser.rb:76:in `open'
    from /home/vagrant/.rvm/gems/ruby-1.9.3-p194/gems/launchy-2.0.5/lib/launchy.rb:30:in `open'
    ...
```
