### PR TITLE
Add to schema.rb the increased MR text column size.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define(:version => 20120413135904) do
     t.boolean  "closed",                              :default => false, :null => false
     t.datetime "created_at",                                             :null => false
     t.datetime "updated_at",                                             :null => false
-    t.text     "st_commits",    :limit => 2147483647
-    t.text     "st_diffs",      :limit => 2147483647
+    t.text     "st_commits",    :limit => 4294967295
+    t.text     "st_diffs",      :limit => 4294967295
     t.boolean  "merged",                              :default => false, :null => false
     t.integer  "state",                               :default => 1,     :null => false
   end


### PR DESCRIPTION
This change was made in a migration in commit 17a88bb6a21cc8b6125bd2e36c1f62f4bd13300e.
Because the schema.rb is checked in, the column size increase should
be here, too.
