### PR TITLE
use resque mailer to send mail background

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'bootstrap-sass', "2.0.2"
 gem "colored"
 gem 'yaml_db', :git => "https://github.com/gitlabhq/yaml_db.git"
 gem 'modularity'
+gem 'resque_mailer'
 
 group :assets do
   gem "sass-rails",   "3.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,9 @@ GEM
       redis-namespace (~> 1.0.2)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque_mailer (2.0.3)
+      actionmailer (>= 3.0.0)
+      resque (>= 1.2.3)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
       rspec-expectations (~> 2.8.0)
@@ -348,6 +351,7 @@ DEPENDENCIES
   rake
   redcarpet (~> 2.1.1)
   resque (~> 1.20.0)
+  resque_mailer
   rspec-rails
   sass-rails (= 3.2.3)
   seed-fu

--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -1,4 +1,5 @@
 class Notify < ActionMailer::Base
+  include Resque::Mailer
   add_template_helper ApplicationHelper
 
   default_url_options[:host] = EMAIL_OPTS["host"]
@@ -9,68 +10,68 @@ class Notify < ActionMailer::Base
   def new_user_email(user, password)
     @user = user
     @password = password
-    mail(:to => @user.email, :subject => "gitlab | Account was created for you")
+    mail(:to => @user['email'], :subject => "gitlab | Account was created for you")
   end
 
   def new_issue_email(issue)
-    @user = issue.assignee
-    @project = issue.project
-    @issue = issue
+    @issue = Issue.find(issue['id'])
+    @user = @issue.assignee
+    @project = @issue.project
 
     mail(:to => @user.email, :subject => "gitlab | New Issue was created")
   end
 
   def note_wall_email(user, note)
     @user = user
-    @note = note
-    @project = note.project
-    mail(:to => @user.email, :subject => "gitlab | #{@note.project.name} ")
+    @note = Note.find(note['id'])
+    @project = @note.project
+    mail(:to => @user['email'], :subject => "gitlab | #{@note.project.name} ")
   end
 
   def note_commit_email(user, note)
     @user = user
-    @note = note
-    @project = note.project
+    @note = Note.find(note['id'])
+    @project = @note.project
     @commit = @note.target
-    mail(:to => @user.email, :subject => "gitlab | note for commit | #{@note.project.name} ")
+    mail(:to => @user['email'], :subject => "gitlab | note for commit | #{@note.project.name} ")
   end
   
   def note_merge_request_email(user, note)
     @user = user
-    @note = note
-    @project = note.project
-    @merge_request = note.noteable
-    mail(:to => @user.email, :subject => "gitlab | note for merge request | #{@note.project.name} ")
+    @note = Note.find(note['id'])
+    @project = @note.project
+    @merge_request = @note.noteable
+    mail(:to => @user['email'], :subject => "gitlab | note for merge request | #{@note.project.name} ")
   end
 
   def note_issue_email(user, note)
     @user = user
-    @note = note
-    @project = note.project
-    @issue = note.noteable
-    mail(:to => @user.email, :subject => "gitlab | note for issue #{@issue.id} | #{@note.project.name} ")
+    @note = Note.find(note['id'])
+    @project = @note.project
+    @issue = @note.noteable
+    mail(:to => @user['email'], :subject => "gitlab | note for issue #{@issue.id} | #{@note.project.name} ")
   end
   
   def new_merge_request_email(merge_request)
-    @user = merge_request.assignee
-    @merge_request = merge_request
-    @project = merge_request.project
+    @merge_request = MergeRequest.find(merge_request['id'])
+    @user = @merge_request.assignee
+    @project = @merge_request.project
     mail(:to => @user.email, :subject => "gitlab | new merge request | #{@merge_request.title} ")
   end
   
   def changed_merge_request_email(user, merge_request)
     @user = user
-    @assignee_was ||= User.find(merge_request.assignee_id_was)
-    @merge_request = merge_request
-    @project = merge_request.project
-    mail(:to => @user.email, :subject => "gitlab | merge request changed | #{@merge_request.title} ")
+    @merge_request = MergeRequest(merge_request.id)
+    @assignee_was ||= User.find(@merge_request.assignee_id_was)
+    @project = @merge_request.project
+    mail(:to => @user['email'], :subject => "gitlab | merge request changed | #{@merge_request.title} ")
   end
   
   def changed_issue_email(user, issue)
+    @issue = Issue.find(issue['id'])
     @user = user
-    @assignee_was ||= User.find(issue.assignee_id_was)
-    @issue = issue
-    @project = issue.project
-    mail(:to => @user.email, :subject => "gitlab | changed issue | #{@issue.title} ")
+    @assignee_was ||= User.find(@issue.assignee_id_was)
+    @project = @issue.project
+    mail(:to => @user['email'], :subject => "gitlab | changed issue | #{@issue.title} ")
   end
 end

--- a/app/views/notify/new_user_email.html.haml
+++ b/app/views/notify/new_user_email.html.haml
@@ -4,7 +4,7 @@
       %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
       %td{:align => "left", :style => "padding: 20px 0 0;"}
         %h2{:style => "color:#646464; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
-          Hi #{@user.name}!
+          Hi #{@user['name']}!
         %p{:style => "color:#767676; font-weight: normal; margin: 0; padding: 0; line-height: 20px; font-size: 12px;font-family: Helvetica, Arial, sans-serif; "}
           Administrator created account for you. Now you are a member of company gitlab application.
       %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
@@ -13,7 +13,7 @@
       %td{:style => "padding: 15px 0 15px;", :valign => "top"}
         %p{:style => "color:#767676; font-weight: normal; margin: 0; padding: 0; line-height: 28px; font-size: 16px;font-family: Helvetica, Arial, sans-serif; "}
           login..........................................
-          %code= @user.email
+          %code= @user['email']
         %p{:style => "color:#767676; font-weight: normal; margin: 0; padding: 0; line-height: 28px; font-size: 16px;font-family: Helvetica, Arial, sans-serif; "}
           password..................................
           %code= @password

--- a/resque.sh
+++ b/resque.sh
@@ -1,2 +1,2 @@
 mkdir -p tmp/pids
-bundle exec rake environment resque:work QUEUE=post_receive RAILS_ENV=production PIDFILE=tmp/pids/resque_worker.pid BACKGROUND=yes
+bundle exec rake environment resque:work QUEUE=* RAILS_ENV=production PIDFILE=tmp/pids/resque_worker.pid BACKGROUND=yes


### PR DESCRIPTION
I change rails configure to send mail via smtp, not sendmail. It's very slow. The user has to wait for a long time after click. The patch use resque mailer to send mail background, no waiting anymore. It can work fine with :smtp.
