### PR TITLE
Minor headers styles in readme fix: increased line-height for h1..h4.

### DIFF
--- a/app/assets/stylesheets/tree.scss
+++ b/app/assets/stylesheets/tree.scss
@@ -194,6 +194,12 @@
   #tree-readme-holder .readme { 
     @include shade;
     margin-bottom:20px;
+    h1, h2 {  
+      line-height: 56px;  
+ 	  }  
+    h3, h4 {  
+ 	    line-height: 46px;  
+ 	  }  
   }
 
   a.tree-commit-link { 


### PR DESCRIPTION
Minor style change to make headers in readme more readable.
