### PR TITLE
Fix bug: missing call to MergeRequest.find in Notify#changed_merge_request_email

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -61,7 +61,7 @@ class Notify < ActionMailer::Base
   
   def changed_merge_request_email(user, merge_request)
     @user = user
-    @merge_request = MergeRequest(merge_request.id)
+    @merge_request = MergeRequest.find(merge_request.id)
     @assignee_was ||= User.find(@merge_request.assignee_id_was)
     @project = @merge_request.project
     mail(:to => @user['email'], :subject => "gitlab | merge request changed | #{@merge_request.title} ")


### PR DESCRIPTION
Bug in the move to resque_mailer. I found this while adding mailer specs for Notify. Would you guys be interested in my submitting the specs in a pull request?
