### PR TITLE
View project pages without master branch

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -23,11 +23,11 @@ class Commit
 
 
   class << self 
-    def find_or_first(repo, commit_id = nil)
+    def find_or_first(repo, commit_id = nil, root_ref)
       commit = if commit_id
                  repo.commit(commit_id)
                else
-                 repo.commits.first
+                 repo.commits(root_ref).first
                end
       Commit.new(commit) if commit
     end

--- a/app/models/project/repository_trait.rb
+++ b/app/models/project/repository_trait.rb
@@ -8,7 +8,7 @@ module Project::RepositoryTrait
     end
 
     def commit(commit_id = nil)
-      Commit.find_or_first(repo, commit_id)
+      Commit.find_or_first(repo, commit_id, root_ref)
     end
 
     def fresh_commits(n = 10)


### PR DESCRIPTION
Project pages will not show up unless a master branch exists as find_or_first (without a commit id) will look for the first commit on the master branch by default - causing require_non_empty_project to do the redirection, even though the project is not empty.  This changes find_or_first (without commit id) to look on the default branch instead.
