### PR TITLE
fix invalid encoding error at Network Graph

### DIFF
--- a/lib/graph_commit.rb
+++ b/lib/graph_commit.rb
@@ -96,13 +96,13 @@ class GraphCommit
     h[:parents] = self.parents.collect do |p|
       [p.id,0,0]
     end
-    h[:author]  = author.name.force_encoding("UTF-8")
+    h[:author]  = author.name.force_encoding("UTF-8").encode("UTF-16BE", :invalid => :replace, :undef => :replace, :replace => '?').encode("UTF-8")
     h[:time]    = time
     h[:space]   = space
     h[:refs]    = refs.collect{|r|r.name}.join(" ") unless refs.nil?
     h[:id]      = sha
     h[:date]    = date
-    h[:message] = message.force_encoding("UTF-8")
+    h[:message] = message.force_encoding("UTF-8").encode("UTF-16BE", :invalid => :replace, :undef => :replace, :replace => '?').encode("UTF-8")
     h[:login]   = author.email
     h
   end


### PR DESCRIPTION
fix issue #525 invalid byte sequence error.

I had same problem issue #525.
Cause of problem in  own case, mix in two encoding, latin1 and UTF-8.

I have mistake mix in a string <E9>(maybe latin1 é, not UTF-8).
But usualy I use Japanage at UTF-8.
so, <E9> string fail to recognize on UTF-8 encoding.

Because I fixed invalid string convert to '?'.

Please merge this fix?

sorry for broken my English. ;)
Regard.
