### PR TITLE
Corrected line for running gl-system-install

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -108,7 +108,7 @@ Get gitolite source code:
 Setup:
 
     sudo -u git sh -c 'echo -e "PATH=\$PATH:/home/git/bin\nexport PATH" > /home/git/.profile'
-    sudo -u git -i -H /home/git/gitolite/src/gl-system-install
+    sudo -u git -H sh -c "PATH=/home/git/bin:$PATH; /home/git/gitolite/src/gl-system-install"
     sudo cp /home/gitlab/.ssh/id_rsa.pub /home/git/gitlab.pub
     sudo chmod 777 /home/git/gitlab.pub
 


### PR DESCRIPTION
This fixes the command to run the gl-system-install correctly.  The previous command produced a warning about the file not being in the path
