### PR TITLE
Due to Ubuntu bug #259671, need to use bash instead of sh, otherwise the...

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -107,7 +107,7 @@ Get gitolite source code:
 
 Setup:
 
-    sudo -u git sh -c 'echo -e "PATH=\$PATH:/home/git/bin\nexport PATH" > /home/git/.profile'
+    sudo -u git bash -c 'echo -e "PATH=\$PATH:/home/git/bin\nexport PATH" > /home/git/.profile'
     sudo -u git -i -H /home/git/gitolite/src/gl-system-install
     sudo cp /home/gitlab/.ssh/id_rsa.pub /home/git/gitlab.pub
     sudo chmod 777 /home/git/gitlab.pub


### PR DESCRIPTION
... -e will appear in the output.

https://bugs.launchpad.net/ubuntu/+source/dash/+bug/259671

To see, on Ubuntu 12.04 try:
mike@git:~$ sh -c 'echo -e "foo"'
-e foo
mike@git:~$ echo -e "foo"
foo
