### PR TITLE
Fix many encoding problems

### DIFF
--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -1,4 +1,5 @@
 class RefsController < ApplicationController
+  include Gitlabhq::Encode
   before_filter :project
 
   # Authorize
@@ -49,9 +50,16 @@ class RefsController < ApplicationController
 
   def blob
     if @tree.is_blob?
+      if @tree.text?
+        encoding = detect_encoding(@tree.data)
+        mime_type = encoding ? "text/plain; charset=#{encoding}" : "text/plain"
+      else
+        mime_type = @tree.mime_type
+      end
+
       send_data(
         @tree.data,
-        :type => @tree.text? ? "text/plain" : @tree.mime_type,
+        :type => mime_type,
         :disposition => 'inline',
         :filename => @tree.name
       )

--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -44,8 +44,6 @@ class RefsController < ApplicationController
         no_cache_headers
       end
     end
-  rescue
-    return render_404
   end
 
   def blob
@@ -66,8 +64,6 @@ class RefsController < ApplicationController
     else
       head(404)
     end
-  rescue
-    return render_404
   end
 
   def blame

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -8,7 +8,7 @@
       %strong.cgray= commit.author_name
       &ndash;
       = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      %span.row_title= truncate(commit.safe_message, :length => 50) rescue "--broken encoding"
+      %span.row_title= truncate(commit.safe_message, :length => 50)
 
       %span.right.cgray
         = time_ago_in_words(commit.committed_date)

--- a/app/views/refs/_tree.html.haml
+++ b/app/views/refs/_tree.html.haml
@@ -42,9 +42,9 @@
         .readme
           - if content.name =~ /\.(md|markdown)$/i
             = preserve do
-              = markdown(content.data.force_encoding('UTF-8'))
+              = markdown(content.data.detect_encoding!)
           - else
-            = simple_format(content.data.force_encoding('UTF-8'))
+            = simple_format(content.data.detect_encoding!)
 
 - if params[:path]
   - history_path = tree_file_project_ref_path(@project, @ref, params[:path])

--- a/app/views/refs/_tree_file.html.haml
+++ b/app/views/refs/_tree_file.html.haml
@@ -13,7 +13,7 @@
       #tree-readme-holder
         .readme
           = preserve do
-            = markdown(file.data.force_encoding('UTF-8'))
+            = markdown(file.data.detect_encoding!)
     - else
       .view_file_content
         - unless file.empty?

--- a/lib/gitlabhq/encode.rb
+++ b/lib/gitlabhq/encode.rb
@@ -1,3 +1,6 @@
+# Patch Strings to enable detect_encoding! on views
+require 'charlock_holmes/string'
+
 module Gitlabhq
   module Encode 
     extend self

--- a/lib/gitlabhq/encode.rb
+++ b/lib/gitlabhq/encode.rb
@@ -12,7 +12,7 @@ module Gitlabhq
 
       # It's better to default to UTF-8 as sometimes it's wrongly detected as another charset
       if detect[:encoding] && detect[:confidence] == 100
-        CharlockHolmes::Converter.convert(message, encoding, 'UTF-8')
+        CharlockHolmes::Converter.convert(message, detect[:encoding], 'UTF-8')
       else
         message
       end.force_encoding("utf-8")

--- a/lib/gitlabhq/encode.rb
+++ b/lib/gitlabhq/encode.rb
@@ -8,16 +8,19 @@ module Gitlabhq
     def utf8 message
       return nil unless message
 
-      encoding = detect_encoding(message)
-      if encoding
+      detect = CharlockHolmes::EncodingDetector.detect(message) rescue {}
+
+      # It's better to default to UTF-8 as sometimes it's wrongly detected as another charset
+      if detect[:encoding] && detect[:confidence] == 100
         CharlockHolmes::Converter.convert(message, encoding, 'UTF-8')
       else
         message
       end.force_encoding("utf-8")
+
     # Prevent app from crash cause of 
     # encoding errors
     rescue
-      ""
+      "--broken encoding: #{encoding}"
     end
 
     def detect_encoding message

--- a/lib/gitlabhq/encode.rb
+++ b/lib/gitlabhq/encode.rb
@@ -5,9 +5,9 @@ module Gitlabhq
     def utf8 message
       return nil unless message
 
-      hash = CharlockHolmes::EncodingDetector.detect(message) rescue {}
-      if hash[:encoding]
-        CharlockHolmes::Converter.convert(message, hash[:encoding], 'UTF-8')
+      encoding = detect_encoding(message)
+      if encoding
+        CharlockHolmes::Converter.convert(message, encoding, 'UTF-8')
       else
         message
       end.force_encoding("utf-8")
@@ -15,6 +15,13 @@ module Gitlabhq
     # encoding errors
     rescue
       ""
+    end
+
+    def detect_encoding message
+      return nil unless message
+
+      hash = CharlockHolmes::EncodingDetector.detect(message) rescue {}
+      return hash[:encoding] ? hash[:encoding] : nil
     end
   end
 end


### PR DESCRIPTION
I've appended bug fixes for #725, #782, #648, #782 with a better solution then
force_encoding to UTF-8 as it will not fix every case. A proper reading
of Yehuda Katz's article about 1.9 encoding is a must to fully
understand the problem:
http://yehudakatz.com/2010/05/05/ruby-1-9-encodings-a-primer-and-the-solution-for-rails/.

This also fixes a unreported problem with plain/text blobs being sent
without charset being informed on HTTP HEADER.
