### PR TITLE
Bash path in post-receive-hook

### DIFF
--- a/lib/post-receive-hook
+++ b/lib/post-receive-hook
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file was placed here by Gitlab. It makes sure that your pushed commits
 # will be processed properly.


### PR DESCRIPTION
This change fixes the bash path to a more general form and allows the correct execution of the hook on systems where bash is not installed as /bin/bash

This pull request fixes issue #796
