### PR TITLE
Update rails version to 3.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails", "3.2.3"
+gem "rails", "3.2.5"
 
 gem "sqlite3"
 gem "mysql2"
@@ -8,7 +8,6 @@ gem "devise", "~> 1.5"
 gem "stamp"
 gem "kaminari"
 gem "haml-rails"
-gem "jquery-rails"
 gem "grit", :git => "https://github.com/gitlabhq/grit.git", :ref => "9536f306645f2d6b1f993ae02d3a29893ba8881f"
 gem "gitolite", :git => "https://github.com/gitlabhq/gitolite-client.git", :ref => "9b715ca8bab6529f6c92204a25f84d12f25a6eb0"
 gem "carrierwave"
@@ -29,18 +28,20 @@ gem "httparty"
 gem "charlock_holmes"
 gem "foreman"
 gem "omniauth-ldap"
-gem 'bootstrap-sass', "2.0.3"
+gem 'bootstrap-sass', "2.0.3.1"
 gem "colored"
 gem 'yaml_db', :git => "https://github.com/gitlabhq/yaml_db.git"
 gem 'modularity'
 gem 'resque_mailer'
 gem 'chosen-rails'
-gem 'modernizr'
-gem 'graphael-rails'
-gem 'jquery-ui-rails'
+
+gem "jquery-rails",    "2.0.2"
+gem "jquery-ui-rails", "0.5.0"
+gem "modernizr",       "2.5.3"
+gem "graphael-rails",  "0.1.4"
 
 group :assets do
-  gem "sass-rails",   "3.2.3"
+  gem "sass-rails",   "3.2.5"
   gem "coffee-rails", "3.2.2"
   gem "uglifier",     "1.0.3"
   gem "therubyracer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,32 +49,32 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    ZenTest (4.8.0)
-    actionmailer (3.2.3)
-      actionpack (= 3.2.3)
+    ZenTest (4.8.1)
+    actionmailer (3.2.5)
+      actionpack (= 3.2.5)
       mail (~> 2.4.4)
-    actionpack (3.2.3)
-      activemodel (= 3.2.3)
-      activesupport (= 3.2.3)
+    actionpack (3.2.5)
+      activemodel (= 3.2.5)
+      activesupport (= 3.2.5)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.1)
       rack (~> 1.4.0)
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
-      sprockets (~> 2.1.2)
-    activemodel (3.2.3)
-      activesupport (= 3.2.3)
+      sprockets (~> 2.1.3)
+    activemodel (3.2.5)
+      activesupport (= 3.2.5)
       builder (~> 3.0.0)
-    activerecord (3.2.3)
-      activemodel (= 3.2.3)
-      activesupport (= 3.2.3)
+    activerecord (3.2.5)
+      activemodel (= 3.2.5)
+      activesupport (= 3.2.5)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activeresource (3.2.3)
-      activemodel (= 3.2.3)
-      activesupport (= 3.2.3)
-    activesupport (3.2.3)
+    activeresource (3.2.5)
+      activemodel (= 3.2.5)
+      activesupport (= 3.2.5)
+    activesupport (3.2.5)
       i18n (~> 0.6)
       multi_json (~> 1.0)
     acts-as-taggable-on (2.1.1)
@@ -90,7 +90,7 @@ GEM
     awesome_print (1.0.2)
     bcrypt-ruby (3.0.1)
     blankslate (2.1.2.4)
-    bootstrap-sass (2.0.3)
+    bootstrap-sass (2.0.3.1)
     builder (3.0.0)
     capybara (1.1.2)
       mime-types (>= 1.16)
@@ -115,11 +115,11 @@ GEM
     coffee-script (2.2.0)
       coffee-script-source
       execjs
-    coffee-script-source (1.3.1)
+    coffee-script-source (1.3.3)
     colored (1.2)
     crack (0.3.1)
     daemons (1.1.8)
-    database_cleaner (0.7.2)
+    database_cleaner (0.8.0)
     devise (1.5.3)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)
@@ -132,16 +132,16 @@ GEM
     erubis (2.7.0)
     escape_utils (0.2.4)
     eventmachine (0.12.10)
-    execjs (1.3.2)
+    execjs (1.4.0)
       multi_json (~> 1.0)
     ffaker (1.14.0)
     ffi (1.0.11)
-    foreman (0.46.0)
+    foreman (0.47.0)
       thor (>= 0.13.6)
     git (1.2.5)
     graphael-rails (0.1.4)
       jeweler
-    haml (3.1.4)
+    haml (3.1.6)
     haml-rails (0.3.4)
       actionpack (~> 3.0)
       activesupport (~> 3.0)
@@ -163,10 +163,10 @@ GEM
     jquery-rails (2.0.2)
       railties (>= 3.2.0, < 5.0)
       thor (~> 0.14)
-    jquery-ui-rails (0.4.0)
+    jquery-ui-rails (0.5.0)
       jquery-rails
       railties (>= 3.1.0)
-    json (1.7.1)
+    json (1.7.3)
     kaminari (0.13.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -188,11 +188,11 @@ GEM
     modernizr (2.5.3)
       sprockets (~> 2.0)
     modularity (0.6.1)
-    multi_json (1.3.4)
+    multi_json (1.3.6)
     multi_xml (0.5.1)
     mysql2 (0.3.11)
     net-ldap (0.2.2)
-    nokogiri (1.5.2)
+    nokogiri (1.5.3)
     omniauth (1.1.0)
       hashie (~> 1.2)
       rack
@@ -218,24 +218,24 @@ GEM
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
-    rails (3.2.3)
-      actionmailer (= 3.2.3)
-      actionpack (= 3.2.3)
-      activerecord (= 3.2.3)
-      activeresource (= 3.2.3)
-      activesupport (= 3.2.3)
+    rails (3.2.5)
+      actionmailer (= 3.2.5)
+      actionpack (= 3.2.5)
+      activerecord (= 3.2.5)
+      activeresource (= 3.2.5)
+      activesupport (= 3.2.5)
       bundler (~> 1.0)
-      railties (= 3.2.3)
+      railties (= 3.2.5)
     rails-footnotes (3.7.8)
       rails (>= 3.0.0)
-    railties (3.2.3)
-      actionpack (= 3.2.3)
-      activesupport (= 3.2.3)
+    railties (3.2.5)
+      actionpack (= 3.2.5)
+      activesupport (= 3.2.5)
       rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       rdoc (~> 3.4)
-      thor (~> 0.14.6)
-    raindrops (0.8.0)
+      thor (>= 0.14.6, < 2.0)
+    raindrops (0.9.0)
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
@@ -255,7 +255,7 @@ GEM
       rspec-core (~> 2.10.0)
       rspec-expectations (~> 2.10.0)
       rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.0)
+    rspec-core (2.10.1)
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
@@ -265,25 +265,26 @@ GEM
       railties (>= 3.0)
       rspec (~> 2.10.0)
     rubyntlm (0.1.1)
-    rubypython (0.6.1)
+    rubypython (0.6.2)
       blankslate (>= 2.1.2.3)
       ffi (~> 1.0.7)
     rubyzip (0.9.8)
-    sass (3.1.17)
-    sass-rails (3.2.3)
-      railties (~> 3.2.0.beta)
+    sass (3.1.19)
+    sass-rails (3.2.5)
+      railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
     seed-fu (2.2.0)
       activerecord (~> 3.1)
       activesupport (~> 3.1)
-    selenium-webdriver (2.21.2)
+    selenium-webdriver (2.22.2)
       childprocess (>= 0.2.5)
       ffi (~> 1.0)
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    shoulda-matchers (1.0.0)
+    shoulda-matchers (1.1.0)
+      activesupport (>= 3.0.0)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
@@ -306,7 +307,7 @@ GEM
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    thor (0.14.6)
+    thor (0.15.2)
     tilt (1.3.3)
     treetop (1.4.10)
       polyglot
@@ -325,7 +326,7 @@ GEM
       rack (>= 1.0.0)
     warden (1.2.0)
       rack (>= 1.0)
-    webmock (1.8.6)
+    webmock (1.8.7)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
     xpath (0.1.4)
@@ -341,7 +342,7 @@ DEPENDENCIES
   autotest
   autotest-rails
   awesome_print
-  bootstrap-sass (= 2.0.3)
+  bootstrap-sass (= 2.0.3.1)
   capybara
   carrierwave
   charlock_holmes
@@ -356,29 +357,29 @@ DEPENDENCIES
   foreman
   git
   gitolite!
-  graphael-rails
+  graphael-rails (= 0.1.4)
   grit!
   haml-rails
   httparty
-  jquery-rails
-  jquery-ui-rails
+  jquery-rails (= 2.0.2)
+  jquery-ui-rails (= 0.5.0)
   kaminari
   launchy
   letter_opener
   linguist (~> 1.0.0)!
-  modernizr
+  modernizr (= 2.5.3)
   modularity
   mysql2
   omniauth-ldap
   pry
   pygments.rb (= 0.2.12)!
-  rails (= 3.2.3)
+  rails (= 3.2.5)
   rails-footnotes
   redcarpet (~> 2.1.1)
   resque (~> 1.20.0)
   resque_mailer
   rspec-rails
-  sass-rails (= 3.2.3)
+  sass-rails (= 3.2.5)
   seed-fu
   shoulda-matchers
   simplecov


### PR DESCRIPTION
closes #883
closes #882

582 examples, 0 failures

And I've got 2 deprecation warnings about "link_to_function" in app/views/merge_requests/_commits.html.haml:12

It will removed from Rails 4.0, details here: https://gist.github.com/rails/rails/pull/5922
