### PR TITLE
Fix a minor typo in example configuration file

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -10,7 +10,7 @@ email:
   # Value can be http or https
   protocol: http # or https
 
-# Git Hosting congiguration
+# Git Hosting configuration
 git_host:
   system: gitolite
   admin_uri: git@localhost:gitolite-admin


### PR DESCRIPTION
This fixes the sample example configuration file, which had a small typo misspelling "configuration".
