### PR TITLE
Modified the login screen for primarily LDAP authentication

### DIFF
--- a/app/views/devise/sessions/_new_ldap.html.erb
+++ b/app/views/devise/sessions/_new_ldap.html.erb
@@ -1,0 +1,40 @@
+<%#= form_for(resource, :as => resource_name, :url => user_omniauth_callback_path(:ldap), :html => { :class => "login-box", :id => 'new_ldap_user' }) do |f| %>
+<%= form_tag(user_omniauth_callback_path(:ldap), :class => "login-box", :id => 'new_ldap_user' ) do %>
+  <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
+
+  <%= text_field_tag :username, nil, {:class => "text top", :placeholder => "LDAP Login"} %>
+  <%= password_field_tag :password, nil, {:class => "text bottom", :placeholder => "Password"} %>
+
+  <br/>
+  <%= submit_tag "LDAP Sign in", :class => "primary btn" %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- (resource_class.omniauth_providers - [:ldap]).each do |provider| %>
+      <hr/>
+      <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn primary" %><br />
+    <% end -%>
+  <% end -%>
+
+  <hr/>
+  <a href="#" id="other_form_toggle" onclick="javascript:$('#new_user').toggle();">Other Sign in</a>
+  <!-- inline for right now just to illustrate -->
+  <script type="text/javascript">
+    $(function() {
+      $('#new_user').toggle();
+    });
+  </script>
+<% end %>
+
+
+<%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f| %>
+  <%= f.text_field :email, :class => "text top", :placeholder => "Email" %>
+  <%= f.password_field :password, :class => "text bottom", :placeholder => "Password"  %>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="clearfix inputs-list"> <label class="checkbox remember_me" for="user_remember_me"><%= f.check_box :remember_me %><span>Remember me</span></label></div>
+  <% end -%>
+  <br/>
+  <%= f.submit "Sign in", :class => "primary btn" %>
+  <div class="right"> <%= render :partial => "devise/shared/links" %></div>
+
+<% end %>

--- a/app/views/devise/sessions/_new_ldap.html.erb
+++ b/app/views/devise/sessions/_new_ldap.html.erb
@@ -1,4 +1,3 @@
-<%#= form_for(resource, :as => resource_name, :url => user_omniauth_callback_path(:ldap), :html => { :class => "login-box", :id => 'new_ldap_user' }) do |f| %>
 <%= form_tag(user_omniauth_callback_path(:ldap), :class => "login-box", :id => 'new_ldap_user' ) do %>
   <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,48 +1,27 @@
-<% if ldap_enable? -%>
-  <%= form_for(resource, :as => resource_name, :url => user_omniauth_callback_path(:ldap), :html => { :class => "login-box", :id => 'new_ldap_user' }) do |f| %>
+<% unless ldap_enable? -%>
+
+  <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f| %>
     <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
 
-    <%= text_field_tag :username, nil, {:class => "text top", :placeholder => "LDAP Login"} %>
-    <%= password_field_tag :password, nil, {:class => "text bottom", :placeholder => "Password"} %>
+    <%= f.text_field :email, :class => "text top", :placeholder => "Email" %>
+    <%= f.password_field :password, :class => "text bottom", :placeholder => "Password"  %>
 
     <% if devise_mapping.rememberable? -%>
       <div class="clearfix inputs-list"> <label class="checkbox remember_me" for="user_remember_me"><%= f.check_box :remember_me %><span>Remember me</span></label></div>
     <% end -%>
     <br/>
-    <%= f.submit "LDAP Sign in", :class => "primary btn" %>
-    <hr/>
-    <a href="#" id="admin_form_toggle" onclick="javascript:$('#new_user').toggle();">Admin Sign in</a>
-    <!-- inline right just to illustrate -->
-    <script type="text/javascript">
-      $(function() {
-        $('#new_user').toggle();
-      });
-    </script>
-  <% end %>
-<% end %>
+    <%= f.submit "Sign in", :class => "primary btn" %>
+    <div class="right"> <%= render :partial => "devise/shared/links" %></div>
 
-<%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f| %>
-  <% unless ldap_enable? %>
-    <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
-  <% else %>
-    <!-- <a href="#" id="ldap_form_toggle" onclick="javascript:$('#new_ldap_user').toggle();">LDAP Sign in</a> -->
-  <% end %>
-
-  <%= f.text_field :email, :class => "text top", :placeholder => "Email" %>
-  <%= f.password_field :password, :class => "text bottom", :placeholder => "Password"  %>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="clearfix inputs-list"> <label class="checkbox remember_me" for="user_remember_me"><%= f.check_box :remember_me %><span>Remember me</span></label></div>
-  <% end -%>
-  <br/>
-  <%= f.submit "Sign in", :class => "primary btn" %>
-  <div class="right"> <%= render :partial => "devise/shared/links" %></div>
-
-  <%- if devise_mapping.omniauthable? %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <hr/>
-      <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn primary" %><br />
+    <%- if devise_mapping.omniauthable? %>
+      <%- resource_class.omniauth_providers.each do |provider| %>
+        <hr/>
+        <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn primary" %><br />
+      <% end -%>
     <% end -%>
-  <% end -%>
 
+  <% end %>
+
+<% else %>
+  <%= render :partial => 'devise/sessions/new_ldap' %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,33 @@
+<% if ldap_enable? -%>
+  <%= form_for(resource, :as => resource_name, :url => user_omniauth_callback_path(:ldap), :html => { :class => "login-box", :id => 'new_ldap_user' }) do |f| %>
+    <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
+
+    <%= text_field_tag :username, nil, {:class => "text top", :placeholder => "LDAP Login"} %>
+    <%= password_field_tag :password, nil, {:class => "text bottom", :placeholder => "Password"} %>
+
+    <% if devise_mapping.rememberable? -%>
+      <div class="clearfix inputs-list"> <label class="checkbox remember_me" for="user_remember_me"><%= f.check_box :remember_me %><span>Remember me</span></label></div>
+    <% end -%>
+    <br/>
+    <%= f.submit "LDAP Sign in", :class => "primary btn" %>
+    <hr/>
+    <a href="#" id="admin_form_toggle" onclick="javascript:$('#new_user').toggle();">Admin Sign in</a>
+    <!-- inline right just to illustrate -->
+    <script type="text/javascript">
+      $(function() {
+        $('#new_user').toggle();
+      });
+    </script>
+  <% end %>
+<% end %>
+
 <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f| %>
-  <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
+  <% unless ldap_enable? %>
+    <%= image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo" %>
+  <% else %>
+    <!-- <a href="#" id="ldap_form_toggle" onclick="javascript:$('#new_ldap_user').toggle();">LDAP Sign in</a> -->
+  <% end %>
+
   <%= f.text_field :email, :class => "text top", :placeholder => "Email" %>
   <%= f.password_field :password, :class => "text bottom", :placeholder => "Password"  %>
 
@@ -16,7 +44,5 @@
       <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn primary" %><br />
     <% end -%>
   <% end -%>
-  <% if ldap_enable? -%>
-    <p><%= link_to "via LDAP", user_omniauth_authorize_path(:ldap)%></p>
-  <% end -%>
+
 <% end %>


### PR DESCRIPTION
Before I went too far I wanted to see your opinion on modifying the login screen for LDAP authenticated systems.  Most times if LDAP is used it would be the primary and before it was a bit removed from the main login flow before in the extra click and not styled screen.  I maintained the local sign on, but hid it unless it's really needed.

If this is acceptable I can remove the javascript in the page out to a .js file to match the rest of the project.

thanks.
