### PR TITLE
Update Fonts to include good Windows Default monospaced font, too.

### DIFF
--- a/app/assets/stylesheets/highlight/white.scss
+++ b/app/assets/stylesheets/highlight/white.scss
@@ -51,7 +51,7 @@ td.code .highlight {
 table.highlighttable pre{
   padding:0;
   margin:0;
-  font-family: 'Menlo', 'Liberation Mono', 'Courier New', 'andale mono','lucida console',monospace;
+  font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
   color: #333;
   text-align:left;
 }
@@ -61,7 +61,7 @@ table.highlighttable pre{
     padding:15px;
     line-height:2.0;
     margin:0;
-    font-family: 'Menlo', 'Courier New', 'andale mono','lucida console',monospace;
+    font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
     color: #333;
     text-align:left;}
   }

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -81,7 +81,7 @@
     background:#fff;
     color:#333;
     font-size: 12px;
-    font-family: 'Menlo', 'Liberation Mono', 'Courier New', 'andale mono','lucida console',monospace;
+    font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
   }
   .diff_file_content_image {
     background:#eee;


### PR DESCRIPTION
This pull request just updates the fonts to include the "good" Windows monospace font, Consolas.  You've already got Mac and Linux covered with Menlo and Linux Liberation, so let's round it out with Consolas.  I also updated another <pre> css definition to be consistent with the code preview.
