### PR TITLE
Network graph fix (#909)

### DIFF
--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -79,10 +79,10 @@ function branchGraph(holder) {
                     .attr({stroke: colors[c.space], "stroke-width": 2});
 
                 } else if (c.space < commits[i].space) {
-                    r.path(["M", x - 5, y + .0001, "l-5-2,0,4,5,-2C",x-5,y,x -17, y+2, x -20, y-10,"L", cx,y-10,cx , cy])
+                    r.path(["M", x - 5, y + .0001, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y + 2, x - 20, y - 10, "L", cx, y - 10, cx, cy])
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 } else {
-                    r.path(["M", x-5, y, "l-5-2,0,4,5,-2C",x-5,y,x -17, y-2, x -20, y+10,"L", cx,y+10,cx , cy])
+                    r.path(["M", x - 5, y, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y - 2, x - 20, y + 10, "L", cx, y + 10, cx, cy])
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 }
             }

--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -82,7 +82,7 @@ function branchGraph(holder) {
                     r.path(["M", x - 5, y + .0001, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y + 2, x - 20, y - 5, "L", cx, y - 5, cx, cy])
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 } else {
-                    r.path(["M", x - 3, y + 4, "l-4,3,3,2,1,-4L", x - 10, y + 14, "L", x - 10, cy, cx, cy])
+                    r.path(["M", x - 3, y + 6, "l-4,3,4,2,0,-5L", x - 10, y + 20, "L", x - 10, cy, cx, cy])
                     .attr({stroke: colors[c.space], "stroke-width": 2});
                 }
             }

--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -79,10 +79,10 @@ function branchGraph(holder) {
                     .attr({stroke: colors[c.space], "stroke-width": 2});
 
                 } else if (c.space < commits[i].space) {
-                    r.path(["M", x - 5, y + .0001, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y + 2, x - 20, y - 10, "L", cx, y - 10, cx, cy])
+                    r.path(["M", x - 5, y + .0001, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y + 2, x - 20, y - 5, "L", cx, y - 5, cx, cy])
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 } else {
-                    r.path(["M", x - 5, y, "l-5-2,0,4,5,-2C", x - 5, y, x - 17, y - 2, x - 20, y + 10, "L", cx, y + 10, cx, cy])
+                    r.path(["M", x - 3, y + 4, "l-4,3,3,2,1,-4L", x - 10, y + 14, "L", x - 10, cy, cx, cy])
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 }
             }

--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -83,7 +83,7 @@ function branchGraph(holder) {
                     .attr({stroke: colors[commits[i].space], "stroke-width": 2});
                 } else {
                     r.path(["M", x - 3, y + 4, "l-4,3,3,2,1,-4L", x - 10, y + 14, "L", x - 10, cy, cx, cy])
-                    .attr({stroke: colors[commits[i].space], "stroke-width": 2});
+                    .attr({stroke: colors[c.space], "stroke-width": 2});
                 }
             }
         }


### PR DESCRIPTION
Fixes #909.
to be short: this patch turns this http://rghost.net/38755422/image.png into this http://rghost.net/38755441/image.png

In the ruby part it is just a new algorithm which properly places branches. I'm not a big ruby programmer, so this  code may require some style fixing.

Javascript part replaces original lines placing with more practical github-like. This part may require some aesthetic revision.

All in all this patch still makes a good boost for gitlab's network graph usability.
