### PR TITLE
Separate user and issue observation from mail observer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,5 @@ group :test do
   gem "simplecov", :require => false
   gem "shoulda-matchers"
   gem 'email_spec'
+  gem 'resque_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,9 @@ GEM
     resque_mailer (2.0.3)
       actionmailer (>= 3.0.0)
       resque (>= 1.2.3)
+    resque_spec (0.11.0)
+      resque (>= 1.19.0)
+      rspec (>= 2.5.0)
     rspec (2.10.0)
       rspec-core (~> 2.10.0)
       rspec-expectations (~> 2.10.0)
@@ -391,6 +394,7 @@ DEPENDENCIES
   redcarpet (~> 2.1.1)
   resque (~> 1.20.0)
   resque_mailer
+  resque_spec
   rspec-rails
   sass-rails (= 3.2.5)
   seed-fu

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -56,11 +56,6 @@ class Issue < ActiveRecord::Base
     today? && created_at == updated_at
   end
 
-  # Return the number of +1 comments (upvotes)
-  def upvotes
-    notes.select(&:upvote?).size
-  end
-
   def is_being_reassigned?
     assignee_id_changed?
   end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -64,6 +64,10 @@ class Issue < ActiveRecord::Base
   def is_being_reassigned?
     assignee_id_changed?
   end
+
+  def is_being_closed?
+    closed_changed? && closed
+  end
 end
 # == Schema Information
 #

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -27,7 +27,7 @@ class Issue < ActiveRecord::Base
   validates :title,
             :presence => true,
             :length   => { :within => 0..255 }
-            
+
   validates :description,
             :length   => { :within => 0..2000 }
 
@@ -54,6 +54,15 @@ class Issue < ActiveRecord::Base
 
   def new?
     today? && created_at == updated_at
+  end
+
+  # Return the number of +1 comments (upvotes)
+  def upvotes
+    notes.select(&:upvote?).size
+  end
+
+  def is_being_reassigned?
+    assignee_id_changed?
   end
 end
 # == Schema Information

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -68,6 +68,10 @@ class Issue < ActiveRecord::Base
   def is_being_closed?
     closed_changed? && closed
   end
+
+  def is_being_reopened?
+    closed_changed? && !closed
+  end
 end
 # == Schema Information
 #

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -5,9 +5,10 @@ class IssueObserver < ActiveRecord::Observer
     Notify.new_issue_email(issue.id) if issue.assignee != current_user
   end
 
-  def after_change(issue)
+  def after_update(issue)
     send_reassigned_email(issue) if issue.is_being_reassigned?
     Note.create_status_change_note(issue, current_user, 'closed') if issue.is_being_closed?
+    Note.create_status_change_note(issue, current_user, 'reopened') if issue.is_being_reopened?
   end
 
   def send_reassigned_email(issue)

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -2,7 +2,7 @@ class IssueObserver < ActiveRecord::Observer
   cattr_accessor :current_user
 
   def after_create(issue)
-    Notify.new_issue_email(issue.id) if issue.assignee != current_user
+    Notify.new_issue_email(issue.id).deliver if issue.assignee != current_user
   end
 
   def after_update(issue)
@@ -15,7 +15,7 @@ class IssueObserver < ActiveRecord::Observer
     recipient_ids = [issue.assignee_id, issue.assignee_id_was].keep_if {|id| id != current_user.id }
 
     recipient_ids.each do |recipient_id|
-      Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was)
+      Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was).deliver
     end
   end
 end

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -6,12 +6,15 @@ class IssueObserver < ActiveRecord::Observer
   end
 
   def after_change(issue)
-    if issue.assignee_id_changed?
-      recipient_ids = [issue.assignee_id, issue.assignee_id_was].keep_if {|id| id != current_user.id }
+    send_reassigned_email(issue) if issue.is_being_reassigned?
+  end
 
-      recipient_ids.each do |recipient_id|
-        Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was)
-      end
+  def send_reassigned_email(issue)
+    recipient_ids = [issue.assignee_id, issue.assignee_id_was].keep_if {|id| id != current_user.id }
+
+    recipient_ids.each do |recipient_id|
+      Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was)
     end
   end
+
 end

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -7,6 +7,7 @@ class IssueObserver < ActiveRecord::Observer
 
   def after_change(issue)
     send_reassigned_email(issue) if issue.is_being_reassigned?
+    Note.create_status_change_note(issue, current_user, 'closed') if issue.is_being_closed?
   end
 
   def send_reassigned_email(issue)
@@ -16,5 +17,4 @@ class IssueObserver < ActiveRecord::Observer
       Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was)
     end
   end
-
 end

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -1,0 +1,17 @@
+class IssueObserver < ActiveRecord::Observer
+  cattr_accessor :current_user
+
+  def after_create(issue)
+    Notify.new_issue_email(issue.id) if issue.assignee != current_user
+  end
+
+  def after_change(issue)
+    if issue.assignee_id_changed?
+      recipient_ids = [issue.assignee_id, issue.assignee_id_was].keep_if {|id| id != current_user.id }
+
+      recipient_ids.each do |recipient_id|
+        Notify.reassigned_issue_email(recipient_id, issue.id, issue.assignee_id_was)
+      end
+    end
+  end
+end

--- a/app/models/issue_observer.rb
+++ b/app/models/issue_observer.rb
@@ -11,6 +11,8 @@ class IssueObserver < ActiveRecord::Observer
     Note.create_status_change_note(issue, current_user, 'reopened') if issue.is_being_reopened?
   end
 
+  protected
+
   def send_reassigned_email(issue)
     recipient_ids = [issue.assignee_id, issue.assignee_id_was].keep_if {|id| id != current_user.id }
 

--- a/app/models/mailer_observer.rb
+++ b/app/models/mailer_observer.rb
@@ -3,7 +3,6 @@ class MailerObserver < ActiveRecord::Observer
   cattr_accessor :current_user
 
   def after_create(model)
-    new_issue(model) if model.kind_of?(Issue)
     new_user(model) if model.kind_of?(User)
     new_note(model) if model.kind_of?(Note)
     new_merge_request(model) if model.kind_of?(MergeRequest)
@@ -11,16 +10,9 @@ class MailerObserver < ActiveRecord::Observer
 
   def after_update(model)
     changed_merge_request(model) if model.kind_of?(MergeRequest)
-    changed_issue(model) if model.kind_of?(Issue)
   end
 
   protected
-
-  def new_issue(issue)
-    if issue.assignee != current_user
-      Notify.new_issue_email(issue.id).deliver
-    end
-  end
 
   def new_user(user)
     Notify.new_user_email(user.id, user.password).deliver
@@ -65,12 +57,8 @@ class MailerObserver < ActiveRecord::Observer
     status_notify_and_comment merge_request, :reassigned_merge_request_email
   end
 
-  def changed_issue(issue)
-    status_notify_and_comment issue, :reassigned_issue_email
-  end
-
   # This method used for Issues & Merge Requests
-  # 
+  #
   # It create a comment for Issue or MR if someone close/reopen.
   # It also notify via email if assignee was changed 
   #

--- a/app/models/mailer_observer.rb
+++ b/app/models/mailer_observer.rb
@@ -1,9 +1,8 @@
 class MailerObserver < ActiveRecord::Observer
-  observe :issue, :user, :note, :merge_request
+  observe :issue, :note, :merge_request
   cattr_accessor :current_user
 
   def after_create(model)
-    new_user(model) if model.kind_of?(User)
     new_note(model) if model.kind_of?(Note)
     new_merge_request(model) if model.kind_of?(MergeRequest)
   end
@@ -13,10 +12,6 @@ class MailerObserver < ActiveRecord::Observer
   end
 
   protected
-
-  def new_user(user)
-    Notify.new_user_email(user.id, user.password).deliver
-  end
 
   def new_note(note)
     if note.notify

--- a/app/models/mailer_observer.rb
+++ b/app/models/mailer_observer.rb
@@ -1,5 +1,5 @@
 class MailerObserver < ActiveRecord::Observer
-  observe :issue, :note, :merge_request
+  observe :note, :merge_request
   cattr_accessor :current_user
 
   def after_create(model)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -42,6 +42,14 @@ class Note < ActiveRecord::Base
 
   mount_uploader :attachment, AttachmentUploader
 
+  def self.create_status_change_note(noteable, author, status)
+    create({ :noteable => noteable,
+             :project => noteable.project,
+             :author => author,
+             :note => "_Status changed to #{status}_" },
+          :without_protection => true)
+  end
+
   def notify
     @notify ||= false
   end

--- a/app/models/user_observer.rb
+++ b/app/models/user_observer.rb
@@ -1,0 +1,5 @@
+class UserObserver < ActiveRecord::Observer
+  def after_create(user)
+    Notify.new_user_email(user.id, user.password).deliver
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Gitlab
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
 
     # Activate observers that should always be running.
-    config.active_record.observers = :mailer_observer, :activity_observer, :project_observer, :key_observer, :issue_observer
+    config.active_record.observers = :mailer_observer, :activity_observer, :project_observer, :key_observer, :issue_observer, :user_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Gitlab
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
 
     # Activate observers that should always be running.
-    config.active_record.observers = :mailer_observer, :activity_observer, :project_observer, :key_observer
+    config.active_record.observers = :mailer_observer, :activity_observer, :project_observer, :key_observer, :issue_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/initializers/resque_mailer.rb
+++ b/config/initializers/resque_mailer.rb
@@ -1,0 +1,1 @@
+Resque::Mailer.excluded_environments = []

--- a/spec/models/activity_observer_spec.rb
+++ b/spec/models/activity_observer_spec.rb
@@ -9,9 +9,11 @@ describe ActivityObserver do
   end
 
   describe "Merge Request created" do 
-    before do 
-      @merge_request = Factory :merge_request, :project => project
-      @event = Event.last
+    before do
+      MergeRequest.observers.enable :activity_observer do
+        @merge_request = Factory :merge_request, :project => project
+        @event = Event.last
+      end
     end
 
     it_should_be_valid_event
@@ -20,9 +22,11 @@ describe ActivityObserver do
   end
 
   describe "Issue created" do 
-    before do 
-      @issue = Factory :issue, :project => project
-      @event = Event.last
+    before do
+      Issue.observers.enable :activity_observer do
+        @issue = Factory :issue, :project => project
+        @event = Event.last
+      end
     end
 
     it_should_be_valid_event

--- a/spec/models/issue_observer_spec.rb
+++ b/spec/models/issue_observer_spec.rb
@@ -13,7 +13,10 @@ describe IssueObserver do
 
     it 'is called when an issue is created' do
       subject.should_receive(:after_create)
-      Factory.create(:issue, :project => Factory.create(:project))
+
+      Issue.observers.enable :issue_observer do
+        Factory.create(:issue, :project => Factory.create(:project))
+      end
     end
 
     it 'sends an email to the assignee' do
@@ -40,8 +43,11 @@ describe IssueObserver do
     it 'is called when an issue is changed' do
       changed = Factory.create(:issue, :project => Factory.create(:project))
       subject.should_receive(:after_update)
-      changed.description = 'I changed'
-      changed.save
+
+      Issue.observers.enable :issue_observer do
+        changed.description = 'I changed'
+        changed.save
+      end
     end
 
     context 'a reassigned email' do

--- a/spec/models/issue_observer_spec.rb
+++ b/spec/models/issue_observer_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe IssueObserver do
+  let(:some_user) { Factory.new(:user, :id => 1) }
+  let(:assignee) { Factory.new(:user, :id => 2) }
+  let(:issue)    { Factory.new(:issue, :id => 42, :assignee => assignee) }
+
+  before(:each) { subject.stub(:current_user).and_return(some_user) }
+
+  subject { IssueObserver.instance }
+
+  context 'when an issue is created' do
+
+    it 'sends an email to the assignee' do
+      Notify.should_receive(:new_issue_email).with(issue.id)
+
+      subject.after_create(issue)
+    end
+
+    it 'does not send an email to the assignee if assignee created the issue' do
+      subject.stub(:current_user).and_return(assignee)
+      Notify.should_not_receive(:new_issue_email)
+
+      subject.after_create(issue)
+    end
+  end
+
+  context 'when an issue is modified' do
+    it 'but not reassigned, does not send a reassigned email' do
+      issue.stub(:assignee_id_changed?).and_return(false)
+      Notify.should_not_receive(:reassigned_issue_email)
+
+      subject.after_change(issue)
+    end
+
+    context 'and is reassigned' do
+      let(:previous_assignee) { Factory.new(:user, :id => 3) }
+
+      before(:each) do
+        issue.stub(:assignee_id_changed?).and_return(true)
+        issue.stub(:assignee_id_was).and_return(previous_assignee.id)
+      end
+
+      it 'sends a reassigned email to the previous and current assignees' do
+        Notify.should_receive(:reassigned_issue_email).with(assignee.id, issue.id, previous_assignee.id)
+        Notify.should_receive(:reassigned_issue_email).with(previous_assignee.id, issue.id, previous_assignee.id)
+
+        subject.after_change(issue)
+      end
+
+      context 'does not send an email to the user who made the reassignment' do
+        it 'if the user is the assignee' do
+          subject.stub(:current_user).and_return(assignee)
+          Notify.should_not_receive(:reassigned_issue_email).with(assignee.id, issue.id, previous_assignee.id)
+
+          subject.after_change(issue)
+        end
+        it 'if the user is the previous assignee' do
+          subject.stub(:current_user).and_return(previous_assignee)
+          Notify.should_not_receive(:reassigned_issue_email).with(previous_assignee.id, issue.id, previous_assignee.id)
+
+          subject.after_change(issue)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/issue_observer_spec.rb
+++ b/spec/models/issue_observer_spec.rb
@@ -121,7 +121,7 @@ describe IssueObserver do
       it_sends_a_reassigned_email_to assignee.id
       it_sends_a_reassigned_email_to previous_assignee.id
 
-      subject.send_reassigned_email(issue)
+      subject.send(:send_reassigned_email, issue)
     end
 
     context 'does not send an email to the user who made the reassignment' do
@@ -130,14 +130,14 @@ describe IssueObserver do
         it_sends_a_reassigned_email_to previous_assignee.id
         it_does_not_send_a_reassigned_email_to assignee.id
 
-        subject.send_reassigned_email(issue)
+        subject.send(:send_reassigned_email, issue)
       end
       it 'if the user is the previous assignee' do
         subject.stub(:current_user).and_return(previous_assignee)
         it_sends_a_reassigned_email_to assignee.id
         it_does_not_send_a_reassigned_email_to previous_assignee.id
 
-        subject.send_reassigned_email(issue)
+        subject.send(:send_reassigned_email, issue)
       end
     end
   end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -55,6 +55,26 @@ describe Issue do
     end
   end
 
+
+  describe '#is_being_reopened?' do
+    it 'returns true if the closed attribute has changed and is now false' do
+      issue = Factory.create(:issue,
+                             :closed => true,
+                             :author => Factory(:user),
+                             :assignee => Factory(:user),
+                             :project => Factory.create(:project))
+      issue.closed = false
+      issue.is_being_reopened?.should be_true
+    end
+    it 'returns false if the closed attribute has changed and is now true' do
+      subject.closed = true
+      subject.is_being_reopened?.should be_false
+    end
+    it 'returns false if the closed attribute has not changed' do
+      subject.is_being_reopened?.should be_false
+    end
+  end
+
   describe "plus 1" do
     let(:project) { Factory(:project) }
     subject {
@@ -86,6 +106,7 @@ describe Issue do
       subject.upvotes.should == 2
     end
   end
+
 end
 # == Schema Information
 #

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -20,10 +20,21 @@ describe Issue do
     it { Issue.should respond_to :opened }
   end
 
-  it { Factory.create(:issue,
-                      :author => Factory(:user),
-                      :assignee => Factory(:user),
-                      :project => Factory.create(:project)).should be_valid }
+  subject { Factory.create(:issue,
+                           :author => Factory(:user),
+                           :assignee => Factory(:user),
+                           :project => Factory.create(:project)) }
+  it { should be_valid }
+
+  describe '#is_being_reassigned?' do
+    it 'returns true if the issue assignee has changed' do
+      subject.assignee = Factory(:user)
+      subject.is_being_reassigned?.should be_true
+    end
+    it 'returns false if the issue assignee has not changed' do
+      subject.is_being_reassigned?.should be_false
+    end
+  end
 
   describe "plus 1" do
     let(:project) { Factory(:project) }

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -36,6 +36,25 @@ describe Issue do
     end
   end
 
+  describe '#is_being_closed?' do
+    it 'returns true if the closed attribute has changed and is now true' do
+      subject.closed = true
+      subject.is_being_closed?.should be_true
+    end
+    it 'returns false if the closed attribute has changed and is now false' do
+      issue = Factory.create(:issue,
+                             :closed => true,
+                             :author => Factory(:user),
+                             :assignee => Factory(:user),
+                             :project => Factory.create(:project))
+      issue.closed = false
+      issue.is_being_closed?.should be_false
+    end
+    it 'returns false if the closed attribute has not changed' do
+      subject.is_being_closed?.should be_false
+    end
+  end
+
   describe "plus 1" do
     let(:project) { Factory(:project) }
     subject {

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -70,6 +70,25 @@ describe Note do
     end
   end
 
+  describe '#create_status_change_note' do
+    let(:project)  { Factory.create(:project) }
+    let(:thing)    { Factory.create(:issue, :project => project) }
+    let(:author)   { Factory(:user) }
+    let(:status)   { 'new_status' }
+
+    subject { Note.create_status_change_note(thing, author, status) }
+
+    it 'creates and saves a Note' do
+      should be_a Note
+      subject.id.should_not be_nil
+    end
+
+    its(:noteable) { should == thing }
+    its(:project)  { should == thing.project }
+    its(:author)   { should == author }
+    its(:note)     { should =~ /Status changed to #{status}/ }
+  end
+
   describe :authorization do
     before do
       @p1 = project

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -72,16 +72,29 @@ describe Project do
   end
 
   describe "last_activity" do
-    let(:project) { Factory :project }
+    let(:project)    { Factory :project }
+    let(:last_event) { double }
 
     before do
-      @issue = Factory :issue, :project => project
+      project.stub(:events).and_return( [ double, double, last_event ] )
     end
 
-    it { project.last_activity.should == Event.last }
-    it { project.last_activity_date.to_s.should == Event.last.created_at.to_s }
+    it { project.last_activity.should == last_event }
   end
 
+  describe 'last_activity_date' do
+    let(:project)    { Factory :project }
+
+    it 'returns the creation date of the project\'s last event if present' do
+      last_event = double(:created_at => 'now')
+      project.stub(:events).and_return( [double, double, last_event] )
+      project.last_activity_date.should == last_event.created_at
+    end
+
+    it 'returns the project\'s last update date if it has no events' do
+      project.last_activity_date.should == project.updated_at
+    end
+  end
   describe "fresh commits" do
     let(:project) { Factory :project }
 

--- a/spec/models/user_observer_spec.rb
+++ b/spec/models/user_observer_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe UserObserver do
+  subject { UserObserver.instance }
+
+  it 'calls #after_create when new users are created' do
+    new_user = Factory.new(:user)
+    subject.should_receive(:after_create).with(new_user)
+
+    User.observers.enable :user_observer do
+      new_user.save
+    end
+  end
+
+  context 'when a new user is created' do
+    let(:user) { double(:user, id: 42, password: 'P@ssword!') }
+    let(:notification) { double :notification }
+
+    it 'sends an email' do
+      notification.should_receive(:deliver)
+      Notify.should_receive(:new_user_email).with(user.id, user.password).and_return(notification)
+
+      subject.after_create(user)
+    end
+  end
+end

--- a/spec/requests/admin/admin_projects_spec.rb
+++ b/spec/requests/admin/admin_projects_spec.rb
@@ -88,6 +88,7 @@ describe "Admin::Projects" do
       fill_in 'Name', :with => 'NewProject'
       fill_in 'Code', :with => 'NPR'
       fill_in 'Path', :with => 'gitlabhq_1'
+      fill_in 'Description', :with => 'New Project Description'
       expect { click_button "Save" }.to change { Project.count }.by(1)
       @project = Project.last
     end

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -45,7 +45,9 @@ describe "Admin::Users" do
     end
 
     it "should send valid email to user with email & password" do
-      click_button "Save"
+      with_resque do
+        click_button "Save"
+      end
       user = User.last
       email = ActionMailer::Base.deliveries.last
       email.subject.should have_content("Account was created")

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -40,19 +40,23 @@ describe "Admin::Users" do
     end
 
     it "should call send mail" do
-      Notify.should_receive(:new_user_email).and_return(stub(:deliver => true))
-      click_button "Save"
+      User.observers.enable :mailer_observer do
+        Notify.should_receive(:new_user_email).and_return(stub(:deliver => true))
+        click_button "Save"
+      end
     end
 
     it "should send valid email to user with email & password" do
-      with_resque do
-        click_button "Save"
+      User.observers.enable :mailer_observer do
+        with_resque do
+          click_button "Save"
+        end
+        user = User.last
+        email = ActionMailer::Base.deliveries.last
+        email.subject.should have_content("Account was created")
+        email.body.should have_content(user.email)
+        email.body.should have_content(@password)
       end
-      user = User.last
-      email = ActionMailer::Base.deliveries.last
-      email.subject.should have_content("Account was created")
-      email.body.should have_content(user.email)
-      email.body.should have_content(@password)
     end
   end
 

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -40,14 +40,15 @@ describe "Admin::Users" do
     end
 
     it "should call send mail" do
-      User.observers.enable :mailer_observer do
-        Notify.should_receive(:new_user_email).and_return(stub(:deliver => true))
+      Notify.should_receive(:new_user_email).and_return(stub(:deliver => true))
+
+      User.observers.enable :user_observer do
         click_button "Save"
       end
     end
 
     it "should send valid email to user with email & password" do
-      User.observers.enable :mailer_observer do
+      User.observers.enable :user_observer do
         with_resque do
           click_button "Save"
         end

--- a/spec/requests/issues_spec.rb
+++ b/spec/requests/issues_spec.rb
@@ -133,7 +133,9 @@ describe "Issues" do
         end
 
         it "should send valid email to user" do
-          click_button "Submit new issue"
+          with_resque do
+            click_button "Submit new issue"
+          end
           issue = Issue.last
           email = ActionMailer::Base.deliveries.last
           email.subject.should have_content("New Issue was created")

--- a/spec/requests/issues_spec.rb
+++ b/spec/requests/issues_spec.rb
@@ -128,18 +128,22 @@ describe "Issues" do
         end
 
         it "should call send mail" do
-          Notify.should_receive(:new_issue_email).and_return(stub(:deliver => true))
-          click_button "Submit new issue"
+          Issue.observers.enable :issue_observer do
+            Notify.should_receive(:new_issue_email).and_return(stub(:deliver => true))
+            click_button "Submit new issue"
+          end
         end
 
         it "should send valid email to user" do
-          with_resque do
-            click_button "Submit new issue"
+          Issue.observers.enable :issue_observer do
+            with_resque do
+              click_button "Submit new issue"
+            end
+            issue = Issue.last
+            email = ActionMailer::Base.deliveries.last
+            email.subject.should have_content("New Issue was created")
+            email.body.should have_content(issue.title)
           end
-          issue = Issue.last
-          email = ActionMailer::Base.deliveries.last
-          email.subject.should have_content("New Issue was created")
-          email.body.should have_content(issue.title)
         end
 
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
     DatabaseCleaner.start
 
     WebMock.disable_net_connect!(allow_localhost: true)
+    ActiveRecord::Base.observers.disable :all
   end
 
   config.after do


### PR DESCRIPTION
#### Submitted for review, do not merge without discussion!

It seems like I made a lot of changes in this. I only split out two of the four classes MailerObserver observes: User and Issue. If you like what is here, I can do the other two.

All observers are turned off by default when running specs. Observers are turned back on when their actual behavior is being tested.

Because we moved to resque_mailer, I added the resque_spec gem to turn queues on and off when needed under test.

For changed issues, I split the logic of sending a reassigned email from the logic of creating a status change note.

The implementation of creating a Note that is a status change was moved to a Note.create_status_change_note method. This could be reused by a MergeRequestObserver if you like the observers in this pull request.

And there are tests in this one. It's Ruby, fellas; I'm back on firmer ground.
