### PR TITLE
cleanup the wording of the notification footer

### DIFF
--- a/app/views/layouts/notify.html.haml
+++ b/app/views/layouts/notify.html.haml
@@ -33,4 +33,7 @@
               %td{:align => "center", :style => "padding: 5px 0 10px; font-size: 11px; color:#7d7a7a; margin: 0; line-height: 1.2;font-family: Helvetica, Arial, sans-serif;", :valign => "top"}
                 %br
                   %p{:style => "font-size: 11px; color:#7d7a7a; margin: 0; padding: 0; font-family: Helvetica, Arial, sans-serif;"}
-                    You're receiving this newsletter because you are in project team.
+                    You're receiving this notification because you are a member of the
+                    - if @project
+                      #{@project.name} 
+                    project team.


### PR DESCRIPTION
This cleans up the wording of the message in the notification footer, and also adds the project name (if available).

_Old message:_

> You're receiving this newsletter because you are in project team.

_New message:_

> You're receiving this notification because you are a member of the _[project name]_ project team.
