### PR TITLE
Fix resque worker becoming paused on restarts

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -299,13 +299,11 @@ Create init script in /etc/init.d/gitlab:
       restart)
             echo -n "Restarting $DESC: "
             kill -USR2 `cat $PID`
-            kill -USR2 `cat $RESQUE_PID`
             echo "$NAME."
             ;;
       reload)
             echo -n "Reloading $DESC configuration: "
             kill -HUP `cat $PID`
-            kill -HUP `cat $RESQUE_PID`
             echo "$NAME."
             ;;
       *)


### PR DESCRIPTION
My resque worker would not run jobs after doing a `/etc/init.d/gitlab restart`.  I finally noticed that looking at the process status in `ps` showed that it said `Paused`.  I looked up the [signals for resque](https://github.com/defunkt/resque/blob/master/lib/resque/worker.rb#L264) and it turns out that the `USR2` signal the init.d script is sending is specifically for pausing the worker (to unpause, use the `CONT` signal).

Instead of adding an extra `kill -CONT` step, I think that it makes more sense to just to take out the resque kill codes as I believe the [Unicorn signals](http://unicorn.bogomips.org/SIGNALS.html) page shows that `kill -USR2` is a non-blocking operation, so you would effectively immediately pause and unpause your resque worker for no reason.

If the script gets cleaned up to properly restart Unicorn it would probably make sense to put in `kill -USR2 $RESQUE_PID; <restart Unicorn>; kill -CONT $RESQUE_PID`.
