### PR TITLE
Adds refs to gitolite.conf with $ at the end

### DIFF
--- a/lib/gitlab/gitolite.rb
+++ b/lib/gitlab/gitolite.rb
@@ -106,13 +106,13 @@ module Gitlab
       name_writers = project.repository_writers
       name_masters = project.repository_masters
 
-      pr_br = project.protected_branches.map(&:name).join(" ")
+      pr_br = project.protected_branches.map(&:name).join("$ ")
 
       repo.clean_permissions
 
       # Deny access to protected branches for writers
       unless name_writers.blank? || pr_br.blank?
-        repo.add_permission("-", pr_br, name_writers)
+        repo.add_permission("-", pr_br.strip + "$ ", name_writers)
       end
 
       # Add read permissions


### PR DESCRIPTION
Can't push branch with name that starts with prefix which matches one of the names from the protected branch list

Example: if we have protected branch "release", developer can't push branch "release.task1" to main repo.
Fixes [#927](https://github.com/gitlabhq/gitlabhq/issues/927).
