### PR TITLE
Download button: put files into a directory

### DIFF
--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -133,10 +133,13 @@ module Repository
     storage_path = File.join(Rails.root, "tmp", "repositories", self.code)
     file_path = File.join(storage_path, file_name)
 
+    # Put files into a directory before archiving
+    prefix = self.code + "/"
+
     # Create file if not exists
     unless File.exists?(file_path)
       FileUtils.mkdir_p storage_path
-      file = self.repo.archive_to_file(ref, nil,  file_path)
+      file = self.repo.archive_to_file(ref, prefix,  file_path)
     end
 
     file_path


### PR DESCRIPTION
Currently, when you try to unpack archive downloaded from gitlab it will mess right into your working directory. This is not very conventional. Common approach is to put all files inside a directory with the same name as tarball. The patch brings such behaviour to gitlab.

To see the difference you may need to do

```
rm -rf tmp/repositories/*
```
