### PR TITLE
Fix encoding error in refs/blame page

### DIFF
--- a/app/views/refs/blame.html.haml
+++ b/app/views/refs/blame.html.haml
@@ -38,7 +38,7 @@
               = preserve do
                 %pre
                   - lines.each do |line|
-                    = line
+                    = Gitlab::Encode.utf8(line)
 
 :javascript
   $(function(){


### PR DESCRIPTION
refs/blame page raises encoding error when the file contains non-ASCII characters.

ex) /master/blame/config/locales/ja.yml

fix it
