### PR TITLE
Add configurable default for projects_limit

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -34,7 +34,7 @@ class Admin::UsersController < ApplicationController
 
 
   def new
-    @admin_user = User.new(:projects_limit => 10)
+    @admin_user = User.new(:projects_limit => GITLAB_OPTS["default_projects_limit"])
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,8 @@ class User < ActiveRecord::Base
         :name => name,
         :email => email,
         :password => password,
-        :password_confirmation => password
+        :password_confirmation => password,
+        :projects_limit => GITLAB_OPTS["default_projects_limit"]
       )
     end
   end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -27,3 +27,7 @@ git:
   git_max_size: 5242880 # 5.megabytes
   # Git timeout to read commit, in seconds
   git_timeout: 10
+
+# Gitlab settings
+gitlab:
+  default_projects_limit: 10

--- a/config/initializers/00_before_all.rb
+++ b/config/initializers/00_before_all.rb
@@ -1,3 +1,4 @@
 GIT_HOST = YAML.load_file("#{Rails.root}/config/gitlab.yml")["git_host"]
 EMAIL_OPTS = YAML.load_file("#{Rails.root}/config/gitlab.yml")["email"]
 GIT_OPTS = YAML.load_file("#{Rails.root}/config/gitlab.yml")["git"]
+GITLAB_OPTS = YAML.load_file("#{Rails.root}/config/gitlab.yml")["gitlab"]


### PR DESCRIPTION
Add configurable default for projects_limit, used in manual and automatic (LDAP) user creation. I've also added a gitlab section in gitlab.yml, which can be useful for others global settings like this.
