### PR TITLE
Unbreak migrations for PostgreSQL

### DIFF
--- a/db/migrate/20120405211750_increase_mr_text_column_size.rb
+++ b/db/migrate/20120405211750_increase_mr_text_column_size.rb
@@ -1,8 +1,10 @@
 class IncreaseMrTextColumnSize < ActiveRecord::Migration
   def up
     # MYSQL LARGETEXT for merge request
-    change_column :merge_requests, :st_diffs, :text, :limit => 4294967295
-    change_column :merge_requests, :st_commits, :text, :limit => 4294967295
+    unless connection.adapter_name == 'PostgreSQL'
+      change_column :merge_requests, :st_diffs, :text, :limit => 4294967295
+      change_column :merge_requests, :st_commits, :text, :limit => 4294967295
+    end
   end
 
   def down


### PR DESCRIPTION
I'm not sure it is good idea to mess with existing migrations, but it is easiest way. Is it applicable?
