### PR TITLE
Remove the .git extension instead of taking the first field from the cut

### DIFF
--- a/lib/post-receive-hook
+++ b/lib/post-receive-hook
@@ -7,6 +7,6 @@ while read oldrev newrev ref
 do
   # For every branch or tag that was pushed, create a Resque job in redis.
   pwd=`pwd`
-  reponame=`basename "$pwd" | cut -d. -f1`
+  reponame=`basename "$pwd" .git`
   env -i redis-cli rpush "resque:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$reponame\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
 done


### PR DESCRIPTION
This fixes gitlabhq/gitlabhq#945 where repositories with a period don't properly get their events tracked.
