### PR TITLE
server ip not needed in nginx configuration

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -223,7 +223,7 @@ Edit /etc/nginx/nginx.conf. Add in **http** section:
     }
 
     server {
-        listen YOUR_SERVER_IP:80;
+        listen 80;
         server_name gitlab.YOUR_DOMAIN.com;
         root /home/gitlab/gitlab/public;
         


### PR DESCRIPTION
server ip in nginx configuration not needed.
