### PR TITLE
Enable directories of repos

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -72,7 +72,7 @@ class Project < ActiveRecord::Base
   validates :path,
             :uniqueness => true,
             :presence => true,
-            :format => { :with => /^[a-zA-Z][a-zA-Z0-9_\-\.]*$/,
+            :format => { :with => /^[a-zA-Z][a-zA-Z0-9_\-\.\/]*$/,
                          :message => "only letters, digits & '_' '-' '.' allowed. Letter should be first" },
             :length   => { :within => 0..255 }
 
@@ -82,7 +82,7 @@ class Project < ActiveRecord::Base
   validates :code,
             :presence => true,
             :uniqueness => true,
-            :format => { :with => /^[a-zA-Z][a-zA-Z0-9_\-\.]*$/,
+            :format => { :with => /^[a-zA-Z][a-zA-Z0-9_\-\.\/]*$/,
                          :message => "only letters, digits & '_' '-' '.' allowed. Letter should be first"  },
             :length   => { :within => 1..255 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Gitlab::Application.routes.draw do
     project_root: Gitlab.config.git_base_path,
     upload_pack:  Gitlab.config.git_upload_pack,
     receive_pack: Gitlab.config.git_receive_pack
-  }), at: '/:path', constraints: { path: /[\w-]+\.git/ }
+  }), at: '/:path', constraints: { path: /[-\/\w]+\.git/ }
 
   #
   # Help
@@ -39,7 +39,7 @@ Gitlab::Application.routes.draw do
         put :unblock
       end
     end
-    resources :projects, :constraints => { :id => /[^\/]+/ } do
+    resources :projects, :id => /[a-zA-Z.\/0-9_\-]+/ do
       member do
         get :team
         put :team_update
@@ -75,14 +75,14 @@ Gitlab::Application.routes.draw do
   get "dashboard/issues", :to => "dashboard#issues"
   get "dashboard/merge_requests", :to => "dashboard#merge_requests"
 
-  resources :projects, :constraints => { :id => /[^\/]+/ }, :only => [:new, :create]
+  resources :projects, :only => [:new, :create], :id => /[a-zA-Z.\/0-9_\-]+/
 
   devise_for :users, :controllers => { :omniauth_callbacks => :omniauth_callbacks }
 
   #
   # Project Area
   #
-  resources :projects, :constraints => { :id => /[^\/]+/ }, :except => [:new, :create, :index], :path => "/" do
+  resources :projects, :except => [:new, :create, :index], :path => "/", :id => /[a-zA-Z.\/0-9_\-]+/ do
     member do
       get "team"
       get "wall"


### PR DESCRIPTION
This seems to work for me. It's not ideal but we use subdirectories to organize
our many, many git repos so it's necessary if I want to replace our hand-rolled
git server.

I saw a note in a closed issue about plans to have github style user directories, but that isn't quite what I need and is not available in any case. This solves the need for now and doesn't seem to break anything.
