### PR TITLE
Look for 'gitolite_admin_uri' in the right section of 'gitlab.yml'.

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -95,7 +95,7 @@ class Settings < Settingslogic
     end
 
     def gitolite_admin_uri
-      git['admin_uri'] || 'git@localhost:gitolite-admin'
+      git_host['admin_uri'] || 'git@localhost:gitolite-admin'
     end
 
     def default_projects_limit


### PR DESCRIPTION
gitlabhq\config\initializers\1_settings.rb looks for
'gitolite_admin_uri' in the 'git' section of 'gitlab.yml'

Actually, that setting is in the 'git_host' section.
If not fixed, the 'gitolite_admin_uri' would always be equals to
'git@localhost:gitolite-admin', even if the administrator wants
to have another user than 'git' in charge of that repo.
