### PR TITLE
Initial Admin Access for Projects

### DIFF
--- a/app/views/projects/_new_form.html.haml
+++ b/app/views/projects/_new_form.html.haml
@@ -27,3 +27,13 @@
         .input-prepend
           %span.add-on= web_app_url
           = f.text_field :code, :placeholder => "example"
+    .clearfix
+      = f.label :project_access do
+        Initial Access for Admins
+      .input
+        .input-prepend
+          - access_options_w_none = {"none"=>0}.merge(Project.access_options)
+          = select_tag :project_access, options_for_select(access_options_w_none, access_options_w_none[Gitlab.config.default_project_access]), :class => "project-access-select", :name => "project[access]"
+          %br
+          Read more about project permissions
+          %strong= link_to "here", help_permissions_path, :class => "vlink"

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -23,6 +23,8 @@ app:
   default_projects_limit: 10 
   # backup_path: "/vol/backups"   # default: Rails.root + backups/
   # backup_keep_time: 604800      # default: 0 (forever) (in seconds)
+  # Can use any of the settings in UsersProject.access_roles, or 'none'
+  default_project_access: Reporter
 
 
 # 

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -102,6 +102,10 @@ class Settings < Settingslogic
       app['default_projects_limit'] || 10
     end
 
+    def default_project_access
+      app['default_project_access'] || 'none'
+    end
+
     def backup_path
       t = app['backup_path'] || "backups/"
       t = /^\//.match(t) ? t : File.join(Rails.root + t)

--- a/features/projects/create_project.feature
+++ b/features/projects/create_project.feature
@@ -9,3 +9,13 @@ Feature: Create Project
     And fill project form with valid data
     Then I should see project page
     And I should see empty project instuctions
+
+  Scenario: User create a project, changing the initial access
+    Given I signin as a user
+    And gitlab admin "Sam"
+    When I visit new project page
+    And fill project form with valid data and change initial access
+    Then I should see project page for "NewOpenProject"
+    When I visit project "NewOpenProject" team page
+    Then I should see myself in team list as "Master"
+    Then I should see "Sam" in team list as "Developer"

--- a/features/step_definitions/project_team_steps.rb
+++ b/features/step_definitions/project_team_steps.rb
@@ -2,6 +2,10 @@ Given /^gitlab user "(.*?)"$/ do |arg1|
   Factory :user, :name => arg1
 end
 
+Given /^gitlab admin "(.*?)"$/ do |arg1|
+  Factory :admin, :name => arg1
+end
+
 Given /^"(.*?)" is "(.*?)" developer$/ do |arg1, arg2|
   user = User.find_by_name(arg1)
   project = Project.find_by_name(arg2)
@@ -40,6 +44,11 @@ Then /^I should see "(.*?)" in team list as "(.*?)"$/ do |arg1, arg2|
   user = User.find_by_name(arg1)
   role_id = find(".user_#{user.id} #team_member_project_access").value
   role_id.should == UsersProject.access_roles[arg2].to_s
+end
+
+Then /^I should see myself in team list as "(.*?)"$/ do |arg1|
+  role_id = find(".user_#{@user.id} #team_member_project_access").value
+  role_id.should == UsersProject.access_roles[arg1].to_s
 end
 
 Given /^I change "(.*?)" role to "(.*?)"$/ do |arg1, arg2|

--- a/features/step_definitions/projects_steps.rb
+++ b/features/step_definitions/projects_steps.rb
@@ -15,9 +15,22 @@ When /^fill project form with valid data$/ do
   click_button "Create project"
 end
 
+When /^fill project form with valid data and change initial access$/ do
+  fill_in 'project_name',   :with => 'NewOpenProject'
+  fill_in 'project_code',   :with => 'NOPR'
+  fill_in 'project_path',   :with => 'newopenproject'
+  select  'Developer',      :from => 'project_access'
+  click_button "Create project"
+end
+
 Then /^I should see project page$/ do
   current_path.should == project_path(Project.last)
   page.should have_content('NewProject')
+end
+
+Then /^I should see project page for "(.*?)"$/ do |arg1|
+  current_path.should == project_path(Project.last)
+  page.should have_content(arg1)
 end
 
 Then /^I should see empty project instuctions$/ do


### PR DESCRIPTION
This new feature allows one to set an initial access for admins when
creating a new project. The default choice can be set in
config/gitlab.yml, under 'default_project_access'. Cucumber test
included.

I welcome discussion around what the Gitlab team might actually want, related to this feature. For example:
- _all_ users instead of admins? Admins just worked for my team.
- different default, like 'none'?
