### PR TITLE
Add step to make sure tmp directory exists in /home/gitlab/gitlab/

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -139,6 +139,8 @@ Permissions:
     cd /home/gitlab
     sudo -H -u gitlab git clone -b stable git://github.com/gitlabhq/gitlabhq.git gitlab
     cd gitlab
+    
+    sudo -u gitlab mkdir tmp
 
     # Rename config files
     sudo -u gitlab cp config/gitlab.yml.example config/gitlab.yml


### PR DESCRIPTION
since the step "Setup DB" fails if tmp doesn't exist (or is not writable). see issue #1038 for more details.
