### PR TITLE
Set post-receive hook permissions to gitlab user on install. Fixes #933

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -119,7 +119,7 @@ Permissions:
 
     sudo chmod -R g+rwX /home/git/repositories/
     sudo chown -R git:git /home/git/repositories/
-    find /home/git/repositories/ -maxdepth 3 -mindepth 3 -name "post-receive" | xargs chown gitlab:gitlab
+    find /home/git/repositories/ -maxdepth 3 -mindepth 3 -name "post-receive" -print0 | xargs -0 chown gitlab:gitlab
 
 #### CHECK: Logout & login again to apply git group to your user
     

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -119,6 +119,7 @@ Permissions:
 
     sudo chmod -R g+rwX /home/git/repositories/
     sudo chown -R git:git /home/git/repositories/
+    find /home/git/repositories/ -maxdepth 3 -mindepth 3 -name "post-receive" | xargs chown gitlab:gitlab
 
 #### CHECK: Logout & login again to apply git group to your user
     


### PR DESCRIPTION
The issue seems to be with one of the install instructions that sets the owner of all the hooks to the `git` user, when apparently the `gitlab` user should own the post-receive hook.
