### PR TITLE
Fixing MySQL syntax error

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -159,7 +159,7 @@ namespace :gitlab do
         print "- Dumping table #{tbl}... "
         count = 1
         File.open(File.join(backup_path_db, tbl + ".yml"), "w+") do |file|
-          ActiveRecord::Base.connection.select_all("SELECT * FROM #{tbl}").each do |line|
+          ActiveRecord::Base.connection.select_all("SELECT * FROM `#{tbl}`").each do |line|
             line.delete_if{|k,v| v.blank?}
             output = {tbl + '_' + count.to_s => line}
             file << output.to_yaml.gsub(/^---\n/,'') + "\n"


### PR DESCRIPTION
This fixes a MySQL syntax error I experienced when running the backup script. MySQL version is 5.5.24-0ubuntu0.12.04.1. (Original pull request contained accidental commit onto master branch, so am creating a new one)
