### PR TITLE
Display configured git repository location on error page

### DIFF
--- a/app/views/errors/gitolite.html.haml
+++ b/app/views/errors/gitolite.html.haml
@@ -15,5 +15,5 @@
         Try:
       %pre
         = preserve do
-          sudo chmod -R 770 /home/git/repositories/
-          sudo chown -R git:git /home/git/repositories/
+          sudo chmod -R 770 #{Gitlab.config.git_base_path}
+          sudo chown -R git:git #{Gitlab.config.git_base_path}


### PR DESCRIPTION
(this is partially addressing issue #1072)
