### PR TITLE
Add comments to Wiki pages

### DIFF
--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -14,7 +14,8 @@
   border-bottom:1px solid #aaa;
 }
 
-.issue_notes {
+.issue_notes,
+.wiki_notes {
   .note_content {
     float:left;
     width:400px;

--- a/app/controllers/admin/mailer_controller.rb
+++ b/app/controllers/admin/mailer_controller.rb
@@ -18,6 +18,8 @@ class Admin::MailerController < ApplicationController
     when "Issue" then
       @issue = Issue.first
       render :file => 'notify/note_issue_email', :layout => 'notify'
+    when "Wiki" then
+      render :file => 'notify/note_wiki_email', :layout => 'notify'
     else
       render :file => 'notify/note_wall_email', :layout => 'notify'
     end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -52,7 +52,7 @@ class NotesController < ApplicationController
              when "merge_request"
                then project.merge_requests.find(params[:target_id]).notes.inc_author.order("created_at DESC").limit(20)
              when "wiki"
-               then project.wikis.find(params[:target_id]).notes.order("created_at DESC").limit(20)
+               then project.wikis.reverse.map {|w| w.notes.fresh }.flatten[0..20]
              end
 
     @notes = if params[:last_id]

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -51,6 +51,8 @@ class NotesController < ApplicationController
                then project.issues.find(params[:target_id]).notes.inc_author.order("created_at DESC").limit(20)
              when "merge_request"
                then project.merge_requests.find(params[:target_id]).notes.inc_author.order("created_at DESC").limit(20)
+             when "wiki"
+               then project.wikis.find(params[:target_id]).notes.order("created_at DESC").limit(20)
              end
 
     @notes = if params[:last_id]

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -17,6 +17,8 @@ class WikisController < ApplicationController
       return render_404 unless can?(current_user, :write_wiki, @project)
     end
 
+    @note = @project.notes.new(:noteable => @wiki)
+
     respond_to do |format|
       if @wiki
         format.html

--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -46,6 +46,13 @@ class Notify < ActionMailer::Base
     mail(:to => recipient.email, :subject => "gitlab | note for issue #{@issue.id} | #{@note.project_name} ")
   end
 
+  def note_wiki_email(recipient_id, note_id)
+    recipient = User.find(recipient_id)
+    @note = Note.find(note_id)
+    @wiki = @note.noteable
+    mail(:to => recipient.email, :subject => "gitlab | note for wiki | #{@note.project_name}")
+  end
+
   def new_merge_request_email(merge_request_id)
     @merge_request = MergeRequest.find(merge_request_id)
     mail(:to => @merge_request.assignee_email, :subject => "gitlab | new merge request | #{@merge_request.title} ")

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,6 +1,7 @@
 class Wiki < ActiveRecord::Base
   belongs_to :project
   belongs_to :user
+  has_many :notes, :as => :noteable, :dependent => :destroy
 
   validates :content, :title, :user_id, :presence => true
   validates :title, :length => 1..250

--- a/app/observers/mailer_observer.rb
+++ b/app/observers/mailer_observer.rb
@@ -34,6 +34,7 @@ class MailerObserver < ActiveRecord::Observer
       case note.noteable_type
       when "Commit"; Notify.note_commit_email(u.id, note.id).deliver
       when "Issue";  Notify.note_issue_email(u.id, note.id).deliver
+      when "Wiki";  Notify.note_wiki_email(u.id, note.id).deliver
       when "MergeRequest"; Notify.note_merge_request_email(u.id, note.id).deliver
       when "Snippet"; true
       else

--- a/app/views/notify/note_wiki_email.html.haml
+++ b/app/views/notify/note_wiki_email.html.haml
@@ -1,0 +1,24 @@
+%td.content{:align => "left", :style => "font-family: Helvetica, Arial, sans-serif; padding: 20px 0 0;", :valign => "top", :width => "600"}
+  %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :style => "color: #717171; font: normal 11px Helvetica, Arial, sans-serif; margin: 0; padding: 0;", :width => "600"}
+    %tr
+      %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
+      %td{:align => "left", :style => "padding: 20px 0 0;"}
+        %h2{:style => "color:#646464 !important; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
+          New comment -
+          = link_to project_issue_url(@wiki.project, @wiki, :anchor => "note_#{@note.id}") do
+            = "Wiki ##{@wiki.title.to_s}"
+      %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
+    %tr
+      %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
+      %td{:style => "padding: 15px 0 15px;", :valign => "top"}
+        %p{:style => "color:#767676; font-weight: normal; margin: 0; padding: 0; line-height: 20px; font-size: 12px;font-family: Helvetica, Arial, sans-serif; "}
+          %a{:href => "#", :style => "color: #0eb6ce; text-decoration: none;"} #{@note.author_name}
+          commented on Wiki page:
+        %br
+          %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :width => "558"}
+            %tr
+              %td{:valign => "top"}
+                %div{ :style => "background:#f5f5f5; padding:20px;border:1px solid #ddd" }
+                  = markdown(@note.note)
+      %td{:style => "font-size: 1px; line-height: 1px;", :width => "21"}
+

--- a/app/views/wikis/show.html.haml
+++ b/app/views/wikis/show.html.haml
@@ -15,3 +15,5 @@
 - if can? current_user, :admin_wiki, @project
   = link_to project_wiki_path(@project, @wiki), :confirm => "Are you sure you want to delete this page?", :method => :delete do
     Delete this page
+
+.wiki_notes#notes= render "notes/notes", :tid => @wiki.id, :tt => "wiki"

--- a/spec/requests/wikis_notes_spec.rb
+++ b/spec/requests/wikis_notes_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe "Wikis" do
+  let(:project) { Factory :project }
+
+  before do
+    login_as :user
+    project.add_access(@user, :read, :write)
+  end
+
+  describe "add new note", :js => true do
+    before do
+      visit project_wiki_path(project, :index)
+      
+      fill_in "Title", :with => 'Test title'
+      fill_in "Content", :with => '[link test](test)'
+      click_on "Save"
+      
+      page.should have_content("Test title")
+      
+      fill_in "note_note", :with => "Comment on wiki!"
+      click_button "Add Comment"
+    end
+
+    it "should contain the new note" do
+      page.should have_content("Comment on wiki!")
+    end
+  end
+end


### PR DESCRIPTION
Implements comments for wiki pages as mentioned in issue #845. Two questions:
1. The comments reference a Wiki object which changes with each edit. Should they point at the project's last Wiki object?
2. Are the email notifications I added unnecessary?

Let me know if there is anything else. Thanks.
