### PR TITLE
Use CommitDecorator more

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -17,6 +17,7 @@ class CommitsController < ApplicationController
     @limit, @offset = (params[:limit] || 40), (params[:offset] || 0)
 
     @commits = @project.commits(@ref, params[:path], @limit, @offset)
+    @commits = CommitDecorator.decorate(@commits)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -143,5 +143,6 @@ class MergeRequestsController < ApplicationController
     # Get commits from repository 
     # or from cache if already merged
     @commits = @merge_request.commits
+    @commits = CommitDecorator.decorate(@commits)
   end
 end

--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -51,7 +51,8 @@ class RefsController < ApplicationController
     @logs = contents.map do |content|
       file = params[:path] ? File.join(params[:path], content.name) : content.name
       last_commit = @project.commits(@commit.id, file, 1).last
-      { 
+      last_commit = CommitDecorator.decorate(last_commit)
+      {
         :file_name => content.name, 
         :commit => last_commit
       }

--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -1,6 +1,10 @@
 class CommitDecorator < ApplicationDecorator
   decorates :commit
 
+  def short_id(length = 10)
+    id.to_s[0..length]
+  end
+
   # Returns the commits title.
   #
   # Usually, the commit title is the first line of the commit message.

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -4,11 +4,11 @@
       %strong= link_to "Browse Code »", tree_project_ref_path(@project, commit.id), :class => "right"
   = link_to project_commit_path(@project, :id => commit.id) do
     %p
-      %code.left= commit.id.to_s[0..10]
+      %code.left= commit.short_id
       %strong.cgray= commit.author_name
       &ndash;
       = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      %span.row_title= truncate(commit.safe_message, :length => 50)
+      %span.row_title= truncate(commit.title, :length => 50)
 
       %span.committed_ago
         = time_ago_in_words(commit.committed_date)

--- a/app/views/commits/index.atom.builder
+++ b/app/views/commits/index.atom.builder
@@ -10,14 +10,14 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://sear
     xml.entry do
       xml.id      project_commit_url(@project, :id => commit.id)
       xml.link    :href => project_commit_url(@project, :id => commit.id)
-      xml.title   truncate(commit.safe_message, :length => 80)
+      xml.title   truncate(commit.title, :length => 80)
       xml.updated commit.committed_date.strftime("%Y-%m-%dT%H:%M:%SZ")
       xml.media   :thumbnail, :width => "40", :height => "40", :url => gravatar_icon(commit.author_email)
       xml.author do |author|
         xml.name commit.author_name
         xml.email commit.author_email
       end
-      xml.summary commit.safe_message
+      xml.summary commit.description
     end
   end
 end

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -1,9 +1,10 @@
+- commit = CommitDecorator.decorate(commit)
 %li.wll.commit
   = link_to project_commit_path(project, :id => commit.id) do
     %p
-      %code.left= commit.id.to_s[0..10]
+      %code.left= commit.short_id
       %strong.cgray= commit.author_name
       &ndash;
       = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      %span.row_title= truncate(commit.safe_message, :length => 50) rescue "--broken encoding"
+      %span.row_title= truncate(commit.title, :length => 50) rescue "--broken encoding"
 

--- a/app/views/refs/_tree_commit.html.haml
+++ b/app/views/refs/_tree_commit.html.haml
@@ -1,3 +1,3 @@
 - if tm
   %strong= link_to "[#{tm.user_name}]", project_team_member_path(@project, tm)
-= link_to truncate(content_commit.safe_message, :length => tm ? 30 : 50), project_commit_path(@project, content_commit.id), :class => "tree-commit-link"
+= link_to truncate(content_commit.title, :length => tm ? 30 : 50), project_commit_path(@project, content_commit.id), :class => "tree-commit-link"

--- a/app/views/refs/blame.html.haml
+++ b/app/views/refs/blame.html.haml
@@ -25,6 +25,7 @@
       %table
         - @blame.each do |commit, lines|
           - commit = Commit.new(commit)
+          - commit = CommitDecorator.decorate(commit)
           %tr
             %td.author
               = image_tag gravatar_icon(commit.author_email, 16)
@@ -32,8 +33,8 @@
             %td.blame_commit
               &nbsp;
               = link_to project_commit_path(@project, :id => commit.id) do
-                %code= commit.id.to_s[0..10]
-                %span.row_title= truncate(commit.safe_message, :length => 30) rescue "--broken encoding"
+                %code= commit.short_id
+                %span.row_title= truncate(commit.title, :length => 30) rescue "--broken encoding"
             %td.lines
               = preserve do
                 %pre

--- a/app/views/repositories/_branch.html.haml
+++ b/app/views/repositories/_branch.html.haml
@@ -1,3 +1,5 @@
+- commit = Commit.new(branch.commit)
+- commit = CommitDecorator.decorate(commit)
 %tr
   %td
     = link_to project_commits_path(@project, :ref => branch.name) do
@@ -5,14 +7,14 @@
       - if branch.name == @project.root_ref
         %span.label default
   %td
-    = link_to project_commit_path(@project, :id => branch.commit.id) do
-      %code= branch.commit.id.to_s[0..10]
+    = link_to project_commit_path(@project, :id => commit.id) do
+      %code= commit.short_id
 
-    = image_tag gravatar_icon(Commit.new(branch.commit).author_email), :class => "", :width => 16
-    = truncate(Commit.new(branch.commit).safe_message, :length => 40)
+    = image_tag gravatar_icon(commit.author_email), :class => "", :width => 16
+    = truncate(commit.title, :length => 40)
   %td
     %span.update-author.right
-      = time_ago_in_words(branch.commit.committed_date)
+      = time_ago_in_words(commit.committed_date)
       ago
   %td
     - if can? current_user, :download_code, @project

--- a/app/views/repositories/_feed.html.haml
+++ b/app/views/repositories/_feed.html.haml
@@ -1,4 +1,5 @@
 - commit = update
+- commit = CommitDecorator.new(commit)
 %tr
   %td
     = link_to project_commits_path(@project, :ref => commit.head.name) do
@@ -10,9 +11,9 @@
   %td
     %div
       = link_to project_commits_path(@project, commit.id) do
-        %code= commit.id.to_s[0..10]
+        %code= commit.short_id
       = image_tag gravatar_icon(commit.author_email), :class => "", :width => 16
-      = truncate(commit.safe_message, :length => 40)
+      = truncate(commit.title, :length => 40)
   %td
     %span.right.cgray
       = time_ago_in_words(commit.committed_date)

--- a/app/views/repositories/tags.html.haml
+++ b/app/views/repositories/tags.html.haml
@@ -9,14 +9,15 @@
         %th
     - @tags.each do |tag|
       - commit = Commit.new(tag.commit)
+      - commit = CommitDecorator.decorate(commit)
       %tr
         %td
           %strong= link_to tag.name, project_commits_path(@project, :ref => tag.name), :class => ""
         %td
           = link_to project_commit_path(@project, commit.id) do
-            %code= commit.id.to_s[0..10]
+            %code= commit.short_id
           = image_tag gravatar_icon(commit.author_email), :class => "", :width => 16
-          = truncate(commit.safe_message, :length => 40)
+          = truncate(commit.title, :length => 40)
         %td
           %span.update-author.right
             = time_ago_in_words(commit.committed_date)

--- a/spec/requests/commits_spec.rb
+++ b/spec/requests/commits_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Commits" do
   let(:project) { Factory :project }
-  let!(:commit) { project.commit }
+  let!(:commit) { CommitDecorator.decorate(project.commit) }
   before do
     login_as :user
     project.add_access(@user, :read)
@@ -22,8 +22,8 @@ describe "Commits" do
     end
 
     it "should list commits" do
-      page.should have_content(commit.message)
-      page.should have_content(commit.id.to_s[0..5])
+      page.should have_content(commit.description)
+      page.should have_content(commit.short_id)
     end
 
     it "should render atom feed" do
@@ -32,7 +32,7 @@ describe "Commits" do
       page.response_headers['Content-Type'].should have_content("application/atom+xml")
       page.body.should have_selector("title", :text => "Recent commits to #{project.name}")
       page.body.should have_selector("author email", :text => commit.author_email)
-      page.body.should have_selector("entry summary", :text => commit.message)
+      page.body.should have_selector("entry summary", :text => commit.description)
     end
 
     it "should render atom feed via private token" do
@@ -42,7 +42,7 @@ describe "Commits" do
       page.response_headers['Content-Type'].should have_content("application/atom+xml")
       page.body.should have_selector("title", :text => "Recent commits to #{project.name}")
       page.body.should have_selector("author email", :text => commit.author_email)
-      page.body.should have_selector("entry summary", :text => commit.message)
+      page.body.should have_selector("entry summary", :text => commit.description)
     end
   end
 


### PR DESCRIPTION
Especially separating the commit title (first line) from the description (rest) makes for nicer and more consistent commit lists.

This is also in preparation for changes regarding #527
