### PR TITLE
Break up links with nested formating (rebased)

### DIFF
--- a/app/assets/stylesheets/gitlab_bootstrap.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap.scss
@@ -381,7 +381,6 @@ form {
   min-height: 20px;
   border-bottom: 1px solid #eee;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  cursor:pointer;
   &.smoke { 
     background-color:#f5f5f5;
   }
@@ -516,7 +515,8 @@ form {
   .row_title { 
     font-weight:bold;
     color:#444;
-    &:hover { 
+    &:hover {
+      color:#444;
       text-decoration:underline;
     }
   }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -34,7 +34,7 @@
       width:32px;
       margin-top:4px;
     }
-    p.row_title { 
+    .row_title {
       padding:0px;
       padding-bottom:2px;
     }

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -2,16 +2,15 @@
   .browse_code_link_holder
     %p
       %strong= link_to "Browse Code »", tree_project_ref_path(@project, commit.id), :class => "right"
-  = link_to project_commit_path(@project, :id => commit.id) do
-    %p
-      %code.left= commit.short_id
-      %strong.cgray= commit.author_name
-      &ndash;
-      = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      %span.row_title= truncate(commit.title, :length => 50)
+  %p
+    %code.left= link_to commit.short_id, project_commit_path(@project, :id => commit.id)
+    %strong.cgray= commit.author_name
+    &ndash;
+    = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
+    = link_to truncate(commit.title, :length => 50), project_commit_path(@project, :id => commit.id), :class => "row_title"
 
-      %span.committed_ago
-        = time_ago_in_words(commit.committed_date)
-        ago
-        &nbsp;
+    %span.committed_ago
+      = time_ago_in_words(commit.committed_date)
+      ago
+      &nbsp;
 

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -1,10 +1,9 @@
 - commit = CommitDecorator.decorate(commit)
 %li.wll.commit
-  = link_to project_commit_path(project, :id => commit.id) do
-    %p
-      %code.left= link_to commit.short_id, project_commit_path(project, :id => commit.id)
-      %strong.cgray= commit.author_name
-      &ndash;
-      = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      = link_to truncate(commit.title, :length => 50), project_commit_path(project, :id => commit.id), :class => "row_title" rescue "--broken encoding"
+  %p
+    %code.left= link_to commit.short_id, project_commit_path(project, :id => commit.id)
+    %strong.cgray= commit.author_name
+    &ndash;
+    = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
+    = link_to truncate(commit.title, :length => 50), project_commit_path(project, :id => commit.id), :class => "row_title" rescue "--broken encoding"
 

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -2,9 +2,9 @@
 %li.wll.commit
   = link_to project_commit_path(project, :id => commit.id) do
     %p
-      %code.left= commit.short_id
+      %code.left= link_to commit.short_id, project_commit_path(project, :id => commit.id)
       %strong.cgray= commit.author_name
       &ndash;
       = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-      %span.row_title= truncate(commit.title, :length => 50) rescue "--broken encoding"
+      = link_to truncate(commit.title, :length => 50), project_commit_path(project, :id => commit.id), :class => "row_title" rescue "--broken encoding"
 

--- a/app/views/issues/_show.html.haml
+++ b/app/views/issues/_show.html.haml
@@ -24,8 +24,7 @@
   - else
     = image_tag "no_avatar.png", :class => "avatar"
 
-  = link_to project_issue_path(issue.project, issue) do
-    %p.row_title= truncate(issue.title, :length => 100)
+  %p= link_to truncate(issue.title, :length => 100), project_issue_path(issue.project, issue), :class => "row_title"
 
   %span.update-author
     %small.cdark= "##{issue.id}"

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -46,9 +46,7 @@
     - if @issue.milestone
       - milestone = @issue.milestone
       %cite.cgray and attached to milestone
-      = link_to project_milestone_path(milestone.project, milestone) do
-        %strong
-          = truncate(milestone.title, :length => 20)
+      %strong= link_to truncate(milestone.title, :length => 20), project_milestone_path(milestone.project, milestone)
 
     .right
       - @issue.labels.each do |label|

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -16,8 +16,7 @@
         = merge_request.target_branch
   = image_tag gravatar_icon(merge_request.author_email), :class => "avatar"
 
-  = link_to project_merge_request_path(merge_request.project, merge_request) do
-    %p.row_title= truncate(merge_request.title, :length => 80)
+  %p= link_to truncate(merge_request.title, :length => 80), project_merge_request_path(merge_request.project, merge_request), :class => "row_title"
 
   %span.update-author
     %small.cdark= "##{merge_request.id}"

--- a/app/views/milestones/_milestone.html.haml
+++ b/app/views/milestones/_milestone.html.haml
@@ -6,14 +6,13 @@
       = link_to 'Browse Issues', project_issues_path(milestone.project, :milestone_id => milestone.id), :class => "btn small grouped"
     - if can? current_user, :admin_milestone, milestone.project
       = link_to 'Edit', edit_project_milestone_path(milestone.project, milestone), :class => "btn small edit-milestone-link grouped"
-  = link_to project_milestone_path(milestone.project, milestone) do
-    %h4.row_title
-      = truncate(milestone.title, :length => 100)
-      %small
-        = milestone.expires_at
-      %br
-      .progress.progress-success.span3
-        .bar{:style => "width: #{milestone.percent_complete}%;"}
+  %h4
+    = link_to truncate(milestone.title, :length => 100), project_milestone_path(milestone.project, milestone), :class => "row_title"
+    %small
+      = milestone.expires_at
+    %br
+    .progress.progress-success.span3
+      .bar{:style => "width: #{milestone.percent_complete}%;"}
 
 
   &nbsp;

--- a/app/views/milestones/show.html.haml
+++ b/app/views/milestones/show.html.haml
@@ -50,8 +50,8 @@
           %td
             = link_to [@project, issue] do
               %span.badge.badge-info ##{issue.id}
-              &ndash;
-              = truncate issue.title, :length => 60
+            &ndash;
+            = link_to truncate(issue.title, :length => 60), [@project, issue]
     %br
     = paginate @issues, :theme => "gitlab"
 

--- a/app/views/refs/blame.html.haml
+++ b/app/views/refs/blame.html.haml
@@ -32,9 +32,8 @@
               = commit.author_name
             %td.blame_commit
               &nbsp;
-              = link_to project_commit_path(@project, :id => commit.id) do
-                %code= commit.short_id
-                %span.row_title= truncate(commit.title, :length => 30) rescue "--broken encoding"
+              %code= link_to commit.short_id, project_commit_path(@project, :id => commit.id)
+              = link_to truncate(commit.title, :length => 30), project_commit_path(@project, :id => commit.id), :class => "row_title" rescue "--broken encoding"
             %td.lines
               = preserve do
                 %pre


### PR DESCRIPTION
Breaks up "block links" to be simpler and contain less "structure" (i.e. HTML) so that the structure is outside and the links encapsulate only the text.

Rebased #1130.
This is also in preparation for changes regarding #527.
