### PR TITLE
As per request: Post-receive hook should be owned by gitlab user, not git.

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -142,8 +142,12 @@ namespace :gitlab do
         print "- Restoring repository #{project.first}... "
         FileUtils.rm_rf(project.second) if File.dirname(project.second) # delet old stuff
         if Kernel.system("cd #{File.dirname(project.second)} > /dev/null 2>&1 && git clone --bare #{backup_path_repo}/#{project.first}.bundle #{project.first}.git > /dev/null 2>&1")
-          Kernel.system("sudo chmod -R g+rwX #{Gitlab.config.git_base_path}")
-          Kernel.system("sudo chown -R #{Gitlab.config.ssh_user}:#{Gitlab.config.ssh_user} #{Gitlab.config.git_base_path}")
+          permission_commands = [
+            "sudo chmod -R g+rwX #{Gitlab.config.git_base_path}",
+            "sudo chown -R #{Gitlab.config.ssh_user}:#{Gitlab.config.ssh_user} #{Gitlab.config.git_base_path}",
+            "sudo chown gitlab:gitlab /home/git/repositories/**/hooks/post-receive"
+          ]
+          permission_commands.each { |command| Kernel.system(command) }
           puts "[DONE]".green
         else
           puts "[FAILED]".red


### PR DESCRIPTION
As per request: Post-receive hook should be owned by gitlab user, not git.

Ref: https://github.com/gitlabhq/gitlabhq/pull/1129#issuecomment-7298317

This might be why the restore functionality wasn't working properly. I'll give it another shot using this.
