### PR TITLE
Fix #1009 Replace all special characters in user's identity

### DIFF
--- a/app/roles/account.rb
+++ b/app/roles/account.rb
@@ -1,6 +1,6 @@
 module Account 
   def identifier
-    email.gsub /[@.]/, "_"
+    email.gsub /[^[:alnum:]]/, "_"
   end
 
   def is_admin?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,11 @@ describe User do
     user.identifier.should == "test_mail_com"
   end
 
+  it "should return identifier without + sign" do
+    user = User.new(:email => "test+foo@mail.com")
+    user.identifier.should == "test_foo_mail_com"
+  end
+
   it "should execute callback when force_random_password specified" do
     user = User.new(:email => "test@mail.com", :force_random_password => true)
     user.should_receive(:generate_password)


### PR DESCRIPTION
This seems to be naive, but `identity` should be always available for file names.

Therefore I prefer generating a safer identity to patching the key's name.
