### PR TITLE
Fixed identification of users with extern auth provider (LDAP)

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -15,8 +15,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
  
   def ldap
     # We only find ourselves here if the authentication to LDAP was successful.
-    info = request.env["omniauth.auth"]["info"]
-    @user = User.find_for_ldap_auth(info)
+    @user = User.find_for_ldap_auth(request.env["omniauth.auth"], current_user)
     if @user.persisted?
       @user.remember_me = true
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,7 +91,7 @@ class User < ActiveRecord::Base
     provider = auth.provider
     name = auth.info.name.force_encoding("utf-8")
     email = auth.info.email.downcase unless auth.info.email.nil?
-    raise OmniAuth::Error, "LDAP accounts must provide an uid and email address" if uid.nil? and email.nil?
+    raise OmniAuth::Error, "LDAP accounts must provide an uid and email address" if uid.nil? or email.nil?
 
     if @user = User.find_by_extern_uid_and_provider(uid, provider)
       @user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,8 +95,13 @@ class User < ActiveRecord::Base
 
     if @user = User.find_by_extern_uid_and_provider(uid, provider)
       @user
+    # workaround for backward compatibility
+    elsif @user = User.find_by_email(email)
+      logger.info "Updating legacy LDAP user #{email} with extern_uid => #{uid}"
+      @user.update_attributes(:extern_uid => uid, :provider => provider)
+      @user
     else
-      logger.info "Creating user from LDAP login; uid = #{uid}, name = #{name}, email = #{email}"
+      logger.info "Creating user from LDAP login {uid => #{uid}, name => #{name}, email => #{email}}"
       password = Devise.friendly_token[0, 8].downcase
       @user = User.create(
         :extern_uid => uid,

--- a/db/migrate/20120729131232_add_extern_auth_provider_to_users.rb
+++ b/db/migrate/20120729131232_add_extern_auth_provider_to_users.rb
@@ -1,0 +1,8 @@
+class AddExternAuthProviderToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :extern_uid, :string
+    add_column :users, :provider, :string
+
+    add_index :users, [:extern_uid, :provider], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120712080407) do
+ActiveRecord::Schema.define(:version => 20120729131232) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -171,9 +171,12 @@ ActiveRecord::Schema.define(:version => 20120712080407) do
     t.boolean  "blocked",                               :default => false, :null => false
     t.integer  "failed_attempts",                       :default => 0
     t.datetime "locked_at"
+    t.string   "extern_uid"
+    t.string   "provider"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
+  add_index "users", ["extern_uid", "provider"], :name => "index_users_on_extern_uid_and_provider", :unique => true
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
   create_table "users_projects", :force => true do |t|


### PR DESCRIPTION
We cannot use email as identification of user when using LDAP. When user decides to change his e-mail address in Gitlab (but not in LDAP), he loses his account and new one with the new e-mail address is created.

I added new user attributes extern_uid and provider and changed User.find_for_ldap_auth() to find user by these attributes instead of email.
