### PR TITLE
Updated MySQL docs and Ubuntu auto-install script

### DIFF
--- a/doc/debian_ubuntu.sh
+++ b/doc/debian_ubuntu.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get upgrade
 
-sudo apt-get install -y git git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-gplv2-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server python-dev python-pip libyaml-dev
+sudo apt-get install -y git git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-gplv2-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server python-dev python-pip libyaml-dev sendmail
 
 wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz
 tar xfvz ruby-1.9.3-p194.tar.gz

--- a/doc/debian_ubuntu.sh
+++ b/doc/debian_ubuntu.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get upgrade
 
-sudo apt-get install -y git git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-gplv2-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server python-dev python-pip libyaml-dev sendmail
+sudo apt-get install -y git git-core wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline-gplv2-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server python-dev python-pip libyaml-dev postfix
 
 wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz
 tar xfvz ruby-1.9.3-p194.tar.gz

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -153,8 +153,22 @@ Permissions:
 
     # Or 
     # Mysql
+    # Install MySQL as directed in Step #1
+    
+    # Login to MySQL
+    $ mysql -u root -p 
+    
+    # Create the gitlabhq production database
+    mysql> CREATE DATABASE IF NOT EXISTS `gitlabhq_production` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_unicode_ci`;
+    
+    # Create the MySQL User change $password to a real password
+    mysql> CREATE USER 'gitlab'@'localhost' IDENTIFIED BY '$password'; 
+    
+    # Grant proper permissions to the MySQL User
+    mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON `gitlabhq_production`.* TO 'gitlab'@'localhost';
+    
+    # Exit MySQL Server and copy the example config, make sure to update username/password in config/database.yml
     sudo -u gitlab cp config/database.yml.example config/database.yml
-    # Change username/password of config/database.yml  to real one
 
 #### Install gems
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -60,7 +60,7 @@ Also read the [Read this before you submit an issue](https://github.com/gitlabhq
     sudo apt-get update
     sudo apt-get upgrade
 
-    sudo apt-get install -y wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip libyaml-dev sendmail
+    sudo apt-get install -y wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip libyaml-dev postfix
     
     # If you want to use MySQL:
     sudo apt-get install -y mysql-server mysql-client libmysqlclient-dev

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -215,8 +215,9 @@ Application can be started with next command:
     sudo -u gitlab bundle exec rake environment resque:work QUEUE=* RAILS_ENV=production BACKGROUND=yes
 
     # Gitlab start script
-    ./resque.sh
-
+    sudo -u gitlab ./resque.sh
+    # if you run this as root /home/gitlab/gitlab/tmp/pids/resque_worker.pid will be owned by root
+    # causing the resque worker not to start via init script on next boot/service restart
 
 **Ok - we have a working application now. **
 **But keep going - there are some thing that should be done **


### PR DESCRIPTION
Hello,

Please pull this one as it is based on the current master branch.  Sorry for the confusion.

I have added some additional instruction for MySQL installation/configuration that I think others may find helpful.

Additionally, I ran into an issue where running ./resque.sh as root the first time creates a PID file /home/gitlab/gitlab/tmp/pids/resque_worker.pid owned by root and prevents the service from starting/stopping via init script as the gitlab user cannot write to the PID file. Prepending a sudo -u gitlab resolves this issue and makes this command look uniform with all the other commands in the install instructions.

Finally, I noticed in the instructions, the first line to install all the packages includes sendmail while the install script (https://raw.github.com/gitlabhq/gitlabhq/master/doc/debian_ubuntu.sh) does not. As such, I added sendmail to the install line in the debian_ubuntu.sh install script.

Thanks,
Jon
