### PR TITLE
Hook url should be able to contain http basic authentication

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -11,7 +11,16 @@ class WebHook < ActiveRecord::Base
               message: "should be a valid url" }
 
   def execute(data)
-    WebHook.post(url, body: data.to_json, headers: { "Content-Type" => "application/json" })
+    parsed_url = URI.parse(url)
+    if parsed_url.userinfo.blank?
+      WebHook.post(url, body: data.to_json, headers: { "Content-Type" => "application/json" })
+    else
+      post_url = url.gsub(parsed_url.userinfo+"@", "")
+      WebHook.post(post_url,
+                   body: data.to_json,
+                   headers: { "Content-Type" => "application/json" }, 
+                   basic_auth: {username: parsed_url.user, password: parsed_url.password})
+    end
   end
   
 end


### PR DESCRIPTION
Currently hook url doesn't work if it contain http basic authentication username and password  

```
http://username:password@url.com
```

This patch added http basic authentication in hook url  
