### PR TITLE
Remove admin_uri from gitlab.yml

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -31,7 +31,6 @@ app:
 
 # Git Hosting configuration
 git_host:
-  admin_uri: git@localhost:gitolite-admin
   base_path: /home/git/repositories/
   # host: localhost
   git_user: git

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -94,10 +94,6 @@ class Settings < Settingslogic
       git['git_timeout'] || 10
     end
 
-    def gitolite_admin_uri
-      git_host['admin_uri'] || 'git@localhost:gitolite-admin'
-    end
-
     def default_projects_limit
       app['default_projects_limit'] || 10
     end

--- a/lib/gitlab/git_host.rb
+++ b/lib/gitlab/git_host.rb
@@ -7,7 +7,7 @@ module Gitlab
     end
 
     def self.admin_uri
-      Gitlab.config.git_host.admin_uri
+      url_to_repo "gitolite-admin"
     end
 
     def self.url_to_repo(path)

--- a/lib/tasks/gitlab/status.rake
+++ b/lib/tasks/gitlab/status.rake
@@ -38,7 +38,7 @@ namespace :gitlab do
       end
 
       begin
-        `git clone #{Gitlab.config.gitolite_admin_uri} /tmp/gitolite_gitlab_test`
+        `git clone #{Gitlab::GitHost.admin_uri} /tmp/gitolite_gitlab_test`
         FileUtils.rm_rf("/tmp/gitolite_gitlab_test")
         print "Can clone gitolite-admin?............"
         puts "YES".green 


### PR DESCRIPTION
We must give options for git twice in git_host section of gitlab.yml :
- for the gitolite-admin repo, we have admin_uri (Gitlab.config.gitolite_admin_uri)
- for all other repo, we have git_user, host and port (Gitlab.config.ssh_path)

This is confusing and redondant because admin_uri is easily calculated with Gitlab.config.ssh_path + "gitolite-admin"
