### PR TITLE
Consolidate functionality shared between Issue and MergeRequest

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -4,56 +4,15 @@ class Issue < ActiveRecord::Base
 
   acts_as_taggable_on :labels
 
-  belongs_to :project
   belongs_to :milestone
-  belongs_to :author, :class_name => "User"
-  belongs_to :assignee, :class_name => "User"
-  has_many :notes, :as => :noteable, :dependent => :destroy
-
-  attr_protected :author, :author_id, :project, :project_id
-  attr_accessor :author_id_of_changes
-
-  validates_presence_of :project_id
-  validates_presence_of :author_id
-
-  delegate :name,
-           :email,
-           :to => :author,
-           :prefix => true
-
-  delegate :name,
-           :email,
-           :to => :assignee,
-           :allow_nil => true,
-           :prefix => true
-
-  validates :title,
-            :presence => true,
-            :length   => { :within => 0..255 }
 
   validates :description,
             :length   => { :within => 0..2000 }
-
-  scope :opened, where(:closed => false)
-  scope :closed, where(:closed => true)
-  scope :assigned, lambda { |u| where(:assignee_id => u.id)}
 
   acts_as_list
 
   def self.open_for(user)
     opened.assigned(user)
-  end
-
-  def self.search query
-    where("title like :query", :query => "%#{query}%")
-  end
-
-  def today?
-    Date.today == created_at.to_date
-  end
-
-  def new?
-    today? && created_at == updated_at
   end
 
   def is_assigned?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,4 +1,5 @@
 class Issue < ActiveRecord::Base
+  include IssueCommonality
   include Upvote
 
   acts_as_taggable_on :labels

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1,6 +1,7 @@
 require File.join(Rails.root, "app/models/commit")
 
 class MergeRequest < ActiveRecord::Base
+  include IssueCommonality
   include Upvote
 
   BROKEN_DIFF = "--broken-diff"

--- a/app/roles/issue_commonality.rb
+++ b/app/roles/issue_commonality.rb
@@ -1,0 +1,3 @@
+# Contains common functionality shared between Issues and MergeRequests
+module IssueCommonality
+end

--- a/app/roles/issue_commonality.rb
+++ b/app/roles/issue_commonality.rb
@@ -36,8 +36,10 @@ module IssueCommonality
     attr_accessor :author_id_of_changes
   end
 
-  def self.search query
-    where("title like :query", :query => "%#{query}%")
+  module ClassMethods
+    def search(query)
+      where("title like :query", :query => "%#{query}%")
+    end
   end
 
   def today?

--- a/app/roles/issue_commonality.rb
+++ b/app/roles/issue_commonality.rb
@@ -1,3 +1,50 @@
 # Contains common functionality shared between Issues and MergeRequests
 module IssueCommonality
+  extend ActiveSupport::Concern
+
+  included do
+    attr_protected :author, :author_id, :project, :project_id
+
+    belongs_to :project
+    belongs_to :author, :class_name => "User"
+    belongs_to :assignee, :class_name => "User"
+    has_many :notes, :as => :noteable, :dependent => :destroy
+
+    validates_presence_of :project_id
+    validates_presence_of :author_id
+
+    validates :title,
+              :presence => true,
+              :length   => { :within => 0..255 }
+
+
+    scope :opened, where(:closed => false)
+    scope :closed, where(:closed => true)
+    scope :assigned, lambda { |u| where(:assignee_id => u.id)}
+
+    delegate :name,
+             :email,
+             :to => :author,
+             :prefix => true
+
+    delegate :name,
+             :email,
+             :to => :assignee,
+             :allow_nil => true,
+             :prefix => true
+
+    attr_accessor :author_id_of_changes
+  end
+
+  def self.search query
+    where("title like :query", :query => "%#{query}%")
+  end
+
+  def today?
+    Date.today == created_at.to_date
+  end
+
+  def new?
+    today? && created_at == updated_at
+  end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -106,6 +106,14 @@ describe Issue do
     end
   end
 
+  describe ".search" do
+    let!(:issue) { Factory.create(:issue, :title => "Searchable issue",
+                                 :project => Factory.create(:project)) }
+
+    it "matches by title" do
+      Issue.search('able').all.should == [issue]
+    end
+  end
 end
 # == Schema Information
 #

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -56,6 +56,15 @@ describe MergeRequest do
       subject.upvotes.should == 2
     end
   end
+
+  describe ".search" do
+    let!(:issue) { Factory.create(:issue, :title => "Searchable issue",
+                                 :project => Factory.create(:project)) }
+
+    it "matches by title" do
+      Issue.search('able').all.should == [issue]
+    end
+  end
 end
 # == Schema Information
 #


### PR DESCRIPTION
### Summary

Any associations, validations, delegates, scopes and methods that were exactly the same in both Issue and MergeRequest models have been moved to a new IssueCommonality module (role) that gets included by each class.

There was actually quite a bit of duplication, because MergeRequests are basically just specialized Issues.
### "IssueCommonality"?

I had a bit of a hard time coming up with a name for the module, and I'm still not entirely satisfied with it, but I think it does a good enough job of describing what it does without being too verbose.

> commonality |ˌkämənˈalitē|
> noun ( pl. commonalities )
> 1 the state of sharing features or attributes: a commonality of interest ensures cooperation.
### Specs?

First, there's probably now a bit of duplication in the model specs for these two classes, but I haven't done anything with that yet.

Second, I was unable to get a full development environment running that actually passed all the tests _before_ I made these changes. I did run the two model specs, and those passed, but a quick "Developer Bootstrap" guide on the wiki or something would be much appreciated, and probably get the project some more contributors.
