### PR TITLE
Visual update for merge requests

### DIFF
--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -31,9 +31,13 @@
 }
 
 /**
- * MR -> show: Automerge widget
+ * MR -> show
  *
  */
+.main_box .merge-branches {
+  line-height: 36px;
+  margin: 15px;
+}
 .automerge_widget { 
   &.can_be_merged { 
     background: #DFF0D8;
@@ -97,5 +101,12 @@ li.merge_request {
   p { 
     padding: 0px;
     padding-bottom: 2px;
+  }
+  .notes-count {
+    margin-top: 4px;
+  }
+  .merge-branches {
+    display: inline-block;
+    line-height: 36px;
   }
 }

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -85,9 +85,14 @@
 
 li.merge_request { 
   padding:7px 10px;
-  img.avatar { 
-    width: 32px;
+  strong.gfm-id {
+    color: #999999;
+    font-size: 24px;
+    line-height: 36px;
+    float: left;
+    width: 64px;
     margin-top: 4px;
+    margin-right: 4px;
   }
   p { 
     padding: 0px;

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -7,13 +7,13 @@
             %i.icon-ok
             = "MERGED"
       - if merge_request.notes.any?
-        %span.btn.small.disabled.grouped
+        .notes-count.btn.small.disabled.grouped
           %i.icon-comment
           = merge_request.notes.count
-      %span.btn.small.disabled.grouped
-        = merge_request.source_branch
+      .merge-branches
+        %span.pretty_label.branch= merge_request.source_branch
         &rarr;
-        = merge_request.target_branch
+        %span.pretty_label.branch= merge_request.target_branch
   %strong.gfm-id !#{merge_request.id}
 
   %p= link_to_gfm truncate(merge_request.title, :length => 80), project_merge_request_path(merge_request.project, merge_request), :class => "row_title"

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -14,13 +14,14 @@
         = merge_request.source_branch
         &rarr;
         = merge_request.target_branch
-  = image_tag gravatar_icon(merge_request.author_email), :class => "avatar"
+  %strong.gfm-id !#{merge_request.id}
 
   %p= link_to_gfm truncate(merge_request.title, :length => 80), project_merge_request_path(merge_request.project, merge_request), :class => "row_title"
 
   %span.update-author
-    %small.cdark= "##{merge_request.id}"
-    authored by #{merge_request.author_name}
+    by
+    = image_tag gravatar_icon(merge_request.author_email), :width => 16, :class => "lil_av"
+    %strong.author= link_to_merge_request_author(merge_request)
     = time_ago_in_words(merge_request.created_at)
     ago
     - if merge_request.upvotes > 0

--- a/app/views/merge_requests/show/_mr_box.html.haml
+++ b/app/views/merge_requests/show/_mr_box.html.haml
@@ -1,4 +1,8 @@
 .main_box
+  .merge-branches.right
+    %span.pretty_label.branch= @merge_request.source_branch
+    &rarr;
+    %span.pretty_label.branch= @merge_request.target_branch
   .top_box_content
     %h4
       - if @merge_request.closed

--- a/app/views/merge_requests/show/_mr_title.html.haml
+++ b/app/views/merge_requests/show/_mr_title.html.haml
@@ -1,5 +1,6 @@
 %h3.page_title
-  = "Merge Request ##{@merge_request.id}:"
+  Merge Request
+  %strong.gfm-id !#{@merge_request.id}
   &nbsp;
   %span.pretty_label.branch= @merge_request.source_branch
   &rarr;

--- a/app/views/merge_requests/show/_mr_title.html.haml
+++ b/app/views/merge_requests/show/_mr_title.html.haml
@@ -1,10 +1,6 @@
 %h3.page_title
   Merge Request
   %strong.gfm-id !#{@merge_request.id}
-  &nbsp;
-  %span.pretty_label.branch= @merge_request.source_branch
-  &rarr;
-  %span.pretty_label.branch= @merge_request.target_branch
 
   %span.right
     - if @merge_request.merged?


### PR DESCRIPTION
This is a try to update how merge requests are displayed with regard to consistency and feature interoperability.

It changes the following things:
- use GFM style notation for MR ids (i.e. "Merge Request !123" instead of "Merge Request #123")
- make GFM ids more prominent (especially on the index page)
- make it clearer that the avatar image is associated with the author not with the MR (on the index page)
- make the author a link (on the index page as it already is on the show page)
- the source and target branch displays look the same on the index and show pages
