### PR TITLE
fix gfm for commit events on dashboard

### DIFF
--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -1,9 +1,10 @@
 - commit = CommitDecorator.decorate(commit)
+- @project = project
 %li.wll.commit
   %p
     = link_to commit.short_id(8), project_commit_path(project, :id => commit.id), :class => "commit_short_id" 
     %strong.cdark= commit.author_name
     &ndash;
     = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-    = gfm truncate(commit.title, :length => 50), project_commit_path(project, :id => commit.id) rescue "--broken encoding"
+    = gfm truncate(commit.title, :length => 50) rescue "--broken encoding"
 


### PR DESCRIPTION
We on dashboard, commit events are displayed incorrectly by gfm : it displays "--broken encoding" instead of the actual commit message. 

This patch fix it. 
