### PR TITLE
fix commit events on dashboard

### DIFF
--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -5,5 +5,5 @@
     %strong.cdark= commit.author_name
     &ndash;
     = image_tag gravatar_icon(commit.author_email), :class => "avatar", :width => 16
-    = gfm truncate(commit.title, :length => 50), project_commit_path(project, :id => commit.id) rescue "--broken encoding"
+    = gfm truncate(commit.title, :length => 50) rescue "--broken encoding"
 


### PR DESCRIPTION
Hello,

Commit events on dashboard are still broken, it happens only when the commit message contains GFM and it displays "--broken encoding" instead of the commit message.

This patch fixes it. 

![Alt text](https://github.com/downloads/jouve/gitlabhq/gitlab_diff.png)
