### PR TITLE
Preview window is not closed after post

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,7 +74,7 @@ $(document).ready(function(){
    * Note markdown preview
    *
    */
-  $('#preview-link').on('click', function(e) {
+  $(document).on('click', '#preview-link', function(e) {
     $('#preview-note').text('Loading...');
 
     var previewLinkText = ($(this).text() == 'Preview' ? 'Edit' : 'Preview');

--- a/app/views/notes/_create_common.js.haml
+++ b/app/views/notes/_create_common.js.haml
@@ -1,7 +1,9 @@
 - if note.valid?
   :plain
-    $("#new_note .errors").remove();
+    $("#new_note .error").remove();
     $('#new_note textarea').val("");
+    $('#preview-link').text('Preview');
+    $('#preview-note').hide(); $('#note_note').show();
     NoteList.prepend(#{note.id}, "#{escape_javascript(render partial: "notes/show", locals: {note: note})}");
 - else
   :plain


### PR DESCRIPTION
Note preview added in #1198 is great.
But it does not remove preview `div` after the comment is sent.
