### PR TITLE
GFM Refactoring

### DIFF
--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -1,4 +1,14 @@
 module GitlabMarkdownHelper
+  REFERENCE_PATTERN = %r{
+    (\W)?              # Prefix (1)
+    (                  # Reference (2)
+      @([\w\._]+)    | # User name (3)
+      [#!$](\d+)     | # Issue/MR/Snippet ID (4)
+      [\h]{6,40}       # Commit ID (2)
+    )
+    (\W)?              # Suffix (5)
+  }x.freeze
+
   def gfm(text, html_options = {})
     return text if text.nil?
     return text if @project.nil?
@@ -12,53 +22,21 @@ module GitlabMarkdownHelper
       "{gfm-extraction-#{md5}}"
     end
 
-    # match     1    2 3               4     5            6
-    text.gsub!(/(\W)?(@([\w\._]+)|[#!$](\d+)|([\h]{6,40}))(\W)?/) do |match|
-      prefix    = $1
-      reference = $2
-      user_name = $3
-      issue_id  = $4
-      merge_request_id = $4
-      snippet_id = $4
-      commit_id = $5
-      suffix    = $6
+    text.gsub!(REFERENCE_PATTERN) do |match|
+      vals = {
+        prefix:       $1,
+        reference:    $2,
+        user_name:    $3,
+        reference_id: $4,
+        suffix:       $5
+      }
 
-      # TODO: add popups with additional information
-      ref_link = case reference
-
-                  # team member: @foo
-                  when /^@/
-                    user = @project.users.where(name: user_name).first
-                    member = @project.users_projects.where(user_id: user).first if user
-                    link_to("@#{user_name}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
-
-                  # issue: #123
-                  when /^#/
-                    # avoid HTML entities
-                    unless prefix.try(:end_with?, "&") && suffix.try(:start_with?, ";")
-                      issue = @project.issues.where(id: issue_id).first
-                      link_to("##{issue_id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}")) if issue
-                    end
-
-                  # merge request: !123
-                  when /^!/
-                    merge_request = @project.merge_requests.where(id: merge_request_id).first
-                    link_to("!#{merge_request_id}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}")) if merge_request
-
-                  # snippet: $123
-                  when /^\$/
-                    snippet = @project.snippets.where(id: snippet_id).first
-                    link_to("$#{snippet_id}", project_snippet_path(@project, snippet), html_options.merge(title: "Snippet: #{snippet.title}", class: "gfm gfm-snippet #{html_options[:class]}")) if snippet
-
-                  # commit: 123456...
-                  when /^\h/
-                    commit = @project.commit(commit_id)
-                    link_to(commit_id, project_commit_path(@project, id: commit.id), html_options.merge(title: "Commit: #{commit.author_name} - #{CommitDecorator.new(commit).title}", class: "gfm gfm-commit #{html_options[:class]}")) if commit
-
-                  end # case
-
-      ref_link.nil? ? match : "#{prefix}#{ref_link}#{suffix}"
-    end # gsub
+      if ref_link = reference_link(vals, html_options)
+        sprintf('%s%s%s', vals[:prefix], ref_link, vals[:suffix])
+      else
+        match
+      end
+    end
 
     # Insert pre block extractions
     text.gsub!(/\{gfm-extraction-(\h{32})\}/) do
@@ -92,5 +70,43 @@ module GitlabMarkdownHelper
     })
 
     @__renderer.render(text).html_safe
+  end
+
+  private
+
+  def reference_link(vals, html_options)
+    # TODO: add popups with additional information
+    case vals[:reference]
+
+      # team member: @foo
+    when /^@/
+      user = @project.users.where(name: vals[:user_name]).first
+      member = @project.users_projects.where(user_id: user).first if user
+      link_to("@#{user.name}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
+
+    # issue: #123
+    when /^#/
+      # avoid HTML entities
+      unless vals[:prefix].try(:end_with?, "&") && vals[:suffix].try(:start_with?, ";")
+        issue = @project.issues.where(id: vals[:reference_id]).first
+        link_to("##{issue.id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}")) if issue
+      end
+
+    # merge request: !123
+    when /^!/
+      merge_request = @project.merge_requests.where(id: vals[:reference_id]).first
+      link_to("!#{merge_request.id}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}")) if merge_request
+
+    # snippet: $123
+    when /^\$/
+      snippet = @project.snippets.where(id: vals[:reference_id]).first
+      link_to("$#{snippet.id}", project_snippet_path(@project, snippet), html_options.merge(title: "Snippet: #{snippet.title}", class: "gfm gfm-snippet #{html_options[:class]}")) if snippet
+
+    # commit: 123456...
+    when /^\h/
+      commit = @project.commit(vals[:reference])
+      link_to(vals[:reference], project_commit_path(@project, id: commit.id), html_options.merge(title: "Commit: #{commit.author_name} - #{CommitDecorator.new(commit).title}", class: "gfm gfm-commit #{html_options[:class]}")) if commit
+
+    end
   end
 end

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -1,14 +1,4 @@
 module GitlabMarkdownHelper
-  REFERENCE_PATTERN = %r{
-    ([^\w&;])?         # Prefix (1)
-    (                  # Reference (2)
-      @([\w\._]+)    | # User name (3)
-      [#!$](\d+)     | # Issue/MR/Snippet ID (4)
-      [\h]{6,40}       # Commit ID (2)
-    )
-    ([^\w&;])?         # Suffix (5)
-  }x.freeze
-
   def gfm(text, html_options = {})
     return text if text.nil?
     return text if @project.nil?
@@ -22,21 +12,10 @@ module GitlabMarkdownHelper
       "{gfm-extraction-#{md5}}"
     end
 
-    text.gsub!(REFERENCE_PATTERN) do |match|
-      vals = {
-        prefix:       $1,
-        reference:    $2,
-        user_name:    $3,
-        reference_id: $4,
-        suffix:       $5
-      }
+    # TODO: add popups with additional information
 
-      if ref_link = reference_link(vals, html_options)
-        sprintf('%s%s%s', vals[:prefix], ref_link, vals[:suffix])
-      else
-        match
-      end
-    end
+    parser = Gitlab::Markdown.new(@project, html_options)
+    text = parser.parse(text)
 
     # Insert pre block extractions
     text.gsub!(/\{gfm-extraction-(\h{32})\}/) do
@@ -70,40 +49,5 @@ module GitlabMarkdownHelper
     })
 
     @__renderer.render(text).html_safe
-  end
-
-  private
-
-  def reference_link(vals, html_options)
-    # TODO: add popups with additional information
-    case vals[:reference]
-
-      # team member: @foo
-    when /^@/
-      user = @project.users.where(name: vals[:user_name]).first
-      member = @project.users_projects.where(user_id: user).first if user
-      link_to("@#{user.name}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
-
-    # issue: #123
-    when /^#/
-      issue = @project.issues.where(id: vals[:reference_id]).first
-      link_to("##{issue.id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}")) if issue
-
-    # merge request: !123
-    when /^!/
-      merge_request = @project.merge_requests.where(id: vals[:reference_id]).first
-      link_to("!#{merge_request.id}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}")) if merge_request
-
-    # snippet: $123
-    when /^\$/
-      snippet = @project.snippets.where(id: vals[:reference_id]).first
-      link_to("$#{snippet.id}", project_snippet_path(@project, snippet), html_options.merge(title: "Snippet: #{snippet.title}", class: "gfm gfm-snippet #{html_options[:class]}")) if snippet
-
-    # commit: 123456...
-    when /^\h/
-      commit = @project.commit(vals[:reference])
-      link_to(vals[:reference], project_commit_path(@project, id: commit.id), html_options.merge(title: "Commit: #{commit.author_name} - #{CommitDecorator.new(commit).title}", class: "gfm gfm-commit #{html_options[:class]}")) if commit
-
-    end
   end
 end

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -1,12 +1,12 @@
 module GitlabMarkdownHelper
   REFERENCE_PATTERN = %r{
-    (\W)?              # Prefix (1)
+    ([^\w&;])?         # Prefix (1)
     (                  # Reference (2)
       @([\w\._]+)    | # User name (3)
       [#!$](\d+)     | # Issue/MR/Snippet ID (4)
       [\h]{6,40}       # Commit ID (2)
     )
-    (\W)?              # Suffix (5)
+    ([^\w&;])?         # Suffix (5)
   }x.freeze
 
   def gfm(text, html_options = {})
@@ -86,11 +86,8 @@ module GitlabMarkdownHelper
 
     # issue: #123
     when /^#/
-      # avoid HTML entities
-      unless vals[:prefix].try(:end_with?, "&") && vals[:suffix].try(:start_with?, ";")
-        issue = @project.issues.where(id: vals[:reference_id]).first
-        link_to("##{issue.id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}")) if issue
-      end
+      issue = @project.issues.where(id: vals[:reference_id]).first
+      link_to("##{issue.id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}")) if issue
 
     # merge request: !123
     when /^!/

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -1,0 +1,98 @@
+module Gitlab
+  # Custom parsing for Gitlab-flavored Markdown
+  #
+  # Examples
+  #
+  #   >> m = Markdown.new(...)
+  #
+  #   >> m.parse("Hey @david, can you fix this?")
+  #   => "Hey <a href="/gitlab/team_members/1">@david</a>, can you fix this?"
+  #
+  #   >> m.parse("Commit 35d5f7c closes #1234")
+  #   => "Commit <a href="/gitlab/commits/35d5f7c">35d5f7c</a> closes <a href="/gitlab/issues/1234">#1234</a>"
+  class Markdown
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers
+
+    REFERENCE_PATTERN = %r{
+      ([^\w&;])?      # Prefix (1)
+      (               # Reference (2)
+        @([\w\._]+)   # User name (3)
+        |[#!$](\d+)   # Issue/MR/Snippet ID (4)
+        |([\h]{6,40}) # Commit ID (5)
+      )
+      ([^\w&;])?      # Suffix (6)
+    }x.freeze
+
+    attr_reader :html_options
+
+    def initialize(project, html_options = {})
+      @project      = project
+      @html_options = html_options
+    end
+
+    def parse(text)
+      text.gsub(REFERENCE_PATTERN) do |match|
+        prefix     = $1 || ''
+        reference  = $2
+        identifier = $3 || $4 || $5
+        suffix     = $6 || ''
+
+        if ref_link = reference_link(reference, identifier)
+          prefix + ref_link + suffix
+        else
+          match
+        end
+      end
+    end
+
+    private
+
+    # Private: Dispatches to a dedicated processing method based on reference
+    #
+    # reference  - Object reference ("@1234", "!567", etc.)
+    # identifier - Object identifier (Issue ID, SHA hash, etc.)
+    #
+    # Returns string rendered by the processing method
+    def reference_link(reference, identifier)
+      case reference
+      when /^@/  then reference_user(identifier)
+      when /^#/  then reference_issue(identifier)
+      when /^!/  then reference_merge_request(identifier)
+      when /^\$/ then reference_snippet(identifier)
+      when /^\h/ then reference_commit(identifier)
+      end
+    end
+
+    def reference_user(identifier)
+      if user = @project.users.where(name: identifier).first
+        member = @project.users_projects.where(user_id: user).first
+        link_to("@#{user.name}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
+      end
+    end
+
+    def reference_issue(identifier)
+      if issue = @project.issues.where(id: identifier).first
+        link_to("##{issue.id}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}"))
+      end
+    end
+
+    def reference_merge_request(identifier)
+      if merge_request = @project.merge_requests.where(id: identifier).first
+        link_to("!#{merge_request.id}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}"))
+      end
+    end
+
+    def reference_snippet(identifier)
+      if snippet = @project.snippets.where(id: identifier).first
+        link_to("$#{snippet.id}", project_snippet_path(@project, snippet), html_options.merge(title: "Snippet: #{snippet.title}", class: "gfm gfm-snippet #{html_options[:class]}"))
+      end
+    end
+
+    def reference_commit(identifier)
+      if commit = @project.commit(identifier)
+        link_to(identifier, project_commit_path(@project, id: commit.id), html_options.merge(title: "Commit: #{commit.author_name} - #{CommitDecorator.new(commit).title}", class: "gfm gfm-commit #{html_options[:class]}"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
According to [cane](https://github.com/square/cane), the `gfm` helper method was by far the most complex method in the entire project, so I tried to refactor it a bit.

I think the new one is a bit easier to understand and will be easier to maintain, especially for the regex pattern.

This also shows that there's still lots of room for improvement, particularly removing the duplication from dealing with `html_options` and the various link classes. I'll reply to this with some ideas.
