### PR TITLE
Fix current class for hooks tab in admin section

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,7 +110,7 @@ module ApplicationHelper
              when :admin_root;     controller.controller_name == "dashboard"
              when :admin_users;    controller.controller_name == 'users'
              when :admin_projects; controller.controller_name == "projects"
-             when :admin_emails;   controller.controller_name == 'mailer'
+             when :admin_hooks;    controller.controller_name == 'hooks'
              when :admin_resque;   controller.controller_name == 'resque'
              when :admin_logs;   controller.controller_name == 'logs'
 

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -14,7 +14,7 @@
           = link_to "Users", admin_users_path
         %li{class: tab_class(:admin_logs)}
           = link_to "Logs", admin_logs_path
-        %li{class: tab_class(:admin_emails)}
+        %li{class: tab_class(:admin_hooks)}
           = link_to "Hooks", admin_hooks_path
         %li{class: tab_class(:admin_resque)}
           = link_to "Resque", admin_resque_path


### PR DESCRIPTION
Just a simple fix to have the css "current" class when the tab "hooks" is
active in the admin section.

Signed-off-by: Martin Bastien martin.bastien@studiofrenetic.com
