### PR TITLE
Speed up the "Project Network Graph" cucumber feature

### DIFF
--- a/features/projects/network.feature
+++ b/features/projects/network.feature
@@ -4,9 +4,7 @@ Feature: Project Network Graph
   Background:
     Given I signin as a user
     And I own project "Shop"
-    And I visit project "Shop" network page 
+    And I visit project "Shop" network page
 
   Scenario: I should see project network
     Then page should have network graph
-    
-

--- a/features/step_definitions/project/projects_steps.rb
+++ b/features/step_definitions/project/projects_steps.rb
@@ -57,6 +57,11 @@ end
 
 Given /^I visit project "(.*?)" network page$/ do |arg1|
   project = Project.find_by_name(arg1)
+
+  # Stub out find_all to speed this up (10 commits vs. 650)
+  commits = Grit::Commit.find_all(project.repo, nil, {max_count: 10})
+  Grit::Commit.stub(:find_all).and_return(commits)
+
   visit graph_project_path(project)
 end
 
@@ -67,8 +72,9 @@ end
 Given /^page should have network graph$/ do
   page.should have_content "Project Network Graph"
   within ".graph" do
-    page.should have_content "stable"
-    page.should have_content "notes_refacto..."
+    page.should have_content "master"
+    page.should have_content "github"
+    page.should have_content "scss_refactor..."
   end
 end
 

--- a/features/step_definitions/project/projects_steps.rb
+++ b/features/step_definitions/project/projects_steps.rb
@@ -73,7 +73,6 @@ Given /^page should have network graph$/ do
   page.should have_content "Project Network Graph"
   within ".graph" do
     page.should have_content "master"
-    page.should have_content "github"
     page.should have_content "scss_refactor..."
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -44,3 +44,5 @@ require 'headless'
 
 headless = Headless.new
 headless.start
+
+require 'cucumber/rspec/doubles'


### PR DESCRIPTION
This change involves stubbing out the call to `Grit::Commit.find_all`
and limiting the number of commits to 10 vs. the standard of 650 used by
`Gitlab::GraphCommit.to_graph`.

Prior to this change, this single feature required almost 3 minutes of
running time and over 2 GB of memory on my machine. Now it takes less
than 3 seconds.
