### PR TITLE
improve visibility of shortened commit id's

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -205,5 +205,8 @@
     @extend .lined;
     min-width:65px;
     font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
+    background-color: #F2F291;
+    padding: 2px 5px 1px 5px;
+    border-radius: 3px;
   }
 }


### PR DESCRIPTION
resulting effect: 
![http://puu.sh/Y4gH.png](http://puu.sh/Y4gH.png)

makes it a bit easier to work with IMO, without being too loud and disrupting the focus away from everything else.
