### PR TITLE
fix inline forms

### DIFF
--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -35,6 +35,7 @@
     .btn {
       padding:6px;
       margin-left:10px;
+      margin-bottom:8px;
     }
   }
 }

--- a/app/views/admin/hooks/index.html.haml
+++ b/app/views/admin/hooks/index.html.haml
@@ -5,7 +5,7 @@
     Read more about system hooks
     %strong #{link_to "here", help_system_hooks_path, class: "vlink"}
 
-= form_for @hook, as: :hook, url: admin_hooks_path do |f|
+= form_for @hook, as: :hook, url: admin_hooks_path, html: { class: 'form-inline' } do |f|
   -if @hook.errors.any?
     .alert-message.block-message.error
       - @hook.errors.full_messages.each do |msg|

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -2,7 +2,7 @@
   Projects
   = link_to 'New Project', new_admin_project_path, class: "btn small right"
 %br
-= form_tag admin_projects_path, method: :get do 
+= form_tag admin_projects_path, method: :get, class: 'form-inline' do
   = text_field_tag :name, params[:name], class: "xlarge"
   = submit_tag "Search", class: "btn submit primary"
 

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -3,7 +3,7 @@
   = link_to 'New User', new_admin_user_path, class: "btn small right"
 %br
 
-= form_tag admin_users_path, method: :get do 
+= form_tag admin_users_path, method: :get, class: 'form-inline' do
   = text_field_tag :name, params[:name], class: "xlarge"
   = submit_tag "Search", class: "btn submit primary"
 %ul.nav.nav-pills

--- a/app/views/hooks/index.html.haml
+++ b/app/views/hooks/index.html.haml
@@ -8,7 +8,7 @@
       Read more about web hooks
       %strong #{link_to "here", help_web_hooks_path, class: "vlink"}
 
-= form_for [@project, @hook], as: :hook, url: project_hooks_path(@project) do |f|
+= form_for [@project, @hook], as: :hook, url: project_hooks_path(@project), html: { class: 'form-inline' } do |f|
   -if @hook.errors.any?
     .alert-message.block-message.error
       - @hook.errors.full_messages.each do |msg|

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -1,4 +1,4 @@
-= form_tag search_path, method: :get do |f|
+= form_tag search_path, method: :get, class: 'form-inline' do |f|
   .padded
     = label_tag :search do
       %strong Looking for


### PR DESCRIPTION
Hello,

on inline forms, the text input is misaligned with the submit input. This patch aligns them.

Exemples : 
![before_after](https://github.com/downloads/jouve/gitlabhq/fix_inline_form.png)
