### PR TITLE
Gemfile cleanup

### DIFF
--- a/.rails_footnotes
+++ b/.rails_footnotes
@@ -1,3 +1,0 @@
-#this code temporarily disables notes for all controllers
-# Footnotes::Filter.notes = []
-

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,6 @@ end
 
 group :development do
   gem "letter_opener"
-  gem "rails-footnotes"
   gem "annotate", :git => "https://github.com/ctran/annotate_models.git"
   gem 'rack-mini-profiler'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -111,8 +111,6 @@ end
 
 group :test do
   gem 'cucumber-rails', :require => false
-  gem 'minitest', ">= 2.10"
-  gem "turn", :require => false
   gem "simplecov", :require => false
   gem "shoulda-matchers"
   gem 'email_spec'

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ gem 'settingslogic'
 # Misc
 gem "foreman"
 gem "git"
-gem "gitlab_meta", '2.8'
 
 group :assets do
   gem "sass-rails",   "3.2.5"
@@ -119,4 +118,8 @@ group :test do
   gem 'email_spec'
   gem 'resque_spec'
   gem "webmock"
+end
+
+group :production do
+  gem "gitlab_meta", '2.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,8 +259,6 @@ GEM
       activesupport (= 3.2.8)
       bundler (~> 1.0)
       railties (= 3.2.8)
-    rails-footnotes (3.7.8)
-      rails (>= 3.0.0)
     railties (3.2.8)
       actionpack (= 3.2.8)
       activesupport (= 3.2.8)
@@ -417,7 +415,6 @@ DEPENDENCIES
   pygments.rb!
   rack-mini-profiler
   rails (= 3.2.8)
-  rails-footnotes
   raphael-rails (= 1.5.2)
   redcarpet (~> 2.1.1)
   resque (~> 1.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ GEM
     acts-as-taggable-on (2.3.1)
       rails (~> 3.0)
     addressable (2.2.8)
-    ansi (1.4.2)
     arel (3.0.2)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
@@ -219,7 +218,6 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.7.1)
     mime-types (1.19)
-    minitest (3.1.0)
     modernizr (2.5.3)
       sprockets (~> 2.0)
     multi_json (1.3.6)
@@ -348,8 +346,6 @@ GEM
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
-    turn (0.9.5)
-      ansi
     tzinfo (0.3.33)
     uglifier (1.0.3)
       execjs (>= 0.3.0)
@@ -407,7 +403,6 @@ DEPENDENCIES
   launchy
   letter_opener
   linguist (~> 1.0.0)!
-  minitest (>= 2.10)
   modernizr (= 2.5.3)
   mysql2
   omniauth-ldap!
@@ -431,7 +426,6 @@ DEPENDENCIES
   stamp
   therubyracer
   thin
-  turn
   uglifier (= 1.0.3)
   unicorn
   webmock

--- a/config/initializers/rails_footnotes.rb
+++ b/config/initializers/rails_footnotes.rb
@@ -1,3 +1,0 @@
-#if defined?(Footnotes) && Rails.env.development?
-  #Footnotes.run! # first of all
-#end


### PR DESCRIPTION
Removes some gems that no longer appear to be used and moves gitlab_meta
to a `:production` group as we discussed.
