### PR TITLE
Internal public projects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,7 +76,7 @@ class ApplicationController < ActionController::Base
   end
 
   def project
-    @project ||= current_user.projects.find_by_code(params[:project_id])
+    @project ||= current_user.projects.find_by_code(params[:project_id]) || Project.find_by_code_and_private_flag(params[:project_id], false)
     @project || render_404
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,6 +3,7 @@ class DashboardController < ApplicationController
 
   def index
     @projects = current_user.projects_with_events.page(params[:page]).per(40)
+    @public_projects = Project.find_all_by_private_flag(false) - @projects
     @events = Event.recent_for_user(current_user).limit(20).offset(params[:offset] || 0)
     @last_push = current_user.recent_push
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,7 +4,8 @@ class DashboardController < ApplicationController
   def index
     @projects = current_user.projects_with_events.page(params[:page]).per(40)
     @public_projects = Project.find_all_by_private_flag(false) - @projects
-    @events = Event.recent_for_user(current_user).limit(20).offset(params[:offset] || 0)
+    #@events = Event.recent_for_user(current_user).limit(20).offset(params[:offset] || 0)
+    @events = Event.recent_for_projects(@projects + @public_projects).limit(20).offset(params[:offset] || 0)
     @last_push = current_user.recent_push
 
     respond_to do |format|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,13 +25,13 @@ class Ability
       :write_project,
       :write_issue,
       :write_note
-    ] if project.guest_access_for?(user)
+    ] if project.guest_access_for?(user) || project.public?
 
     rules << [
       :download_code,
       :write_merge_request,
       :write_snippet
-    ] if project.report_access_for?(user)
+    ] if project.report_access_for?(user) || project.public?
 
     rules << [
       :write_wiki

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,10 @@ class Event < ActiveRecord::Base
     where(project_id: user.projects.map(&:id)).recent
   end
 
+  def self.recent_for_projects projects
+    where(project_id: projects.map(&:id)).recent
+  end
+
   # Next events currently enabled for system
   #  - push 
   #  - new issue

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ActiveRecord::Base
   # 
   # Protected attributes
   #
-  attr_protected :private_flag, :owner_id
+  attr_protected :owner_id
 
   # 
   # Scopes

--- a/app/roles/authority.rb
+++ b/app/roles/authority.rb
@@ -21,7 +21,7 @@ module Authority
   def repository_readers
     keys = Key.joins({user: :users_projects}).
       where("users_projects.project_id = ? AND users_projects.project_access = ?", id, UsersProject::REPORTER)
-    keys.map(&:identifier) + deploy_keys.map(&:identifier)
+    keys.map(&:identifier) + deploy_keys.map(&:identifier) + (public? ? ['@all'] : [])
   end
 
   def repository_writers

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -61,6 +61,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix	
+        = f.label :private_flag, "Private"	
+        .input= f.check_box :private_flag
+
   - unless project.new_record?
     .actions
       = f.submit 'Save Project', class: "btn primary"

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-- if @projects.any?
+- if @projects.any? || @public_projects.any?
   .projects
     .activities.span8
       = render 'shared/no_ssh'
@@ -11,7 +11,7 @@
       = render "events/event_last_push", event: @last_push
       .projects_box
         %h5
-          Projects
+          My Projects
           %small
             (#{@projects.total_count})
           - if current_user.can_create_project?
@@ -27,6 +27,25 @@
               %span.right
                 &rarr;
         .bottom= paginate @projects, theme: "gitlab"
+
+      = render "events/event_last_push", event: @last_push
+      .projects_box
+        %h5
+          Public Projects
+          %small
+            (#{@public_projects.count})
+        - if @public_projects.any?
+          - @public_projects.each do |project|
+            = link_to project_path(project), class: dom_class(project) do
+              %h4
+                %span.ico.project
+                = truncate(project.name, length: 25)
+                %span.right
+                  &rarr;
+        - else
+          %h4
+            .project No Public Projects
+        .bottom
 
       %hr
       %div

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -53,6 +53,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix
+        = f.label :private_flag, "Private"
+        .input= f.check_box :private_flag
+
   %br
 
   .actions


### PR DESCRIPTION
The topic of internal public projects was brought up in pull request #680 a few months ago with the outcome being the creation of teams support in issue #739. When I installed GitLab this past weekend I still wanted internally public projects rather than adding all users to a team. Thus, I took the commits from pull request #680 and modified them slightly to work with version 2.8 of GitLab. I understand that the teams issue is supposed to take care of the need for internally public projects, so this pull request is mainly just to provide an interim solution for internally public repos for those that want them. Feel free to close this request.

Patches are also available on my blog at: http://shanetully.com/2012/08/gitlab-internally-public-projects/
