### PR TITLE
fix merge request form

### DIFF
--- a/app/controllers/merge_requests_controller.rb
+++ b/app/controllers/merge_requests_controller.rb
@@ -103,10 +103,12 @@ class MergeRequestsController < ApplicationController
 
   def branch_from
     @commit = project.commit(params[:ref])
+    @commit = CommitDecorator.decorate(@commit)
   end
 
   def branch_to
     @commit = project.commit(params[:ref])
+    @commit = CommitDecorator.decorate(@commit)
   end
 
   protected


### PR DESCRIPTION
Hello,

on the form to create a merge request, we should see the last commit when we select from branch and to branch. That was the behavior before 34cea1cb broke it.

Exemple :
![before_after](https://github.com/downloads/jouve/gitlabhq/fix_mr.png)
