### PR TITLE
fix web hooks help view commit count off by one

### DIFF
--- a/app/views/hooks/_data_ex.html.erb
+++ b/app/views/hooks/_data_ex.html.erb
@@ -37,7 +37,7 @@
             }
         }
     ],
-   total_commits_count => 3
+   total_commits_count => 4
 }
 eos
 %>


### PR DESCRIPTION
Commits with zero based ids would have reached a count of four by the time the index gets to 3 as in the example.
