### PR TITLE
send notify email to author and cc to project team

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -27,26 +27,26 @@ class Notify < ActionMailer::Base
     mail(to: recipient(recipient_id), subject: subject)
   end
 
-  def note_commit_email(recipient_id, note_id)
+  def note_commit_email(recipient_emails, cc_emails, note_id)
     @note = Note.find(note_id)
     @commit = @note.target
     @commit = CommitDecorator.decorate(@commit)
     @project = @note.project
-    mail(to: recipient(recipient_id), subject: subject("note for commit #{@commit.short_id}", @commit.title))
+    mail(to: recipient_emails, cc: cc_emails, subject: subject("note for commit #{@commit.short_id}", @commit.title))
   end
 
-  def note_merge_request_email(recipient_id, note_id)
+  def note_merge_request_email(recipient_ids, cc_ids, note_id)
     @note = Note.find(note_id)
     @merge_request = @note.noteable
     @project = @note.project
-    mail(to: recipient(recipient_id), subject: subject("note for merge request !#{@merge_request.id}"))
+    mail(to: recipient(recipient_ids), cc: recipient(cc_ids), subject: subject("note for merge request !#{@merge_request.id}"))
   end
 
-  def note_issue_email(recipient_id, note_id)
+  def note_issue_email(recipient_ids, cc_ids, note_id)
     @note = Note.find(note_id)
     @issue = @note.noteable
     @project = @note.project
-    mail(to: recipient(recipient_id), subject: subject("note for issue ##{@issue.id}"))
+    mail(to: recipient(recipient_ids), cc: recipient(cc_ids), subject: subject("note for issue ##{@issue.id}"))
   end
 
   def note_wiki_email(recipient_id, note_id)
@@ -83,9 +83,17 @@ class Notify < ActionMailer::Base
   # recipient_id - User ID
   #
   # Returns a String containing the User's email address.
-  def recipient(recipient_id)
-    if recipient = User.find(recipient_id)
-      recipient.email
+  def recipient(recipient_ids)
+    if recipient_ids.class == Array
+      recipient_ids.collect do |rid|
+        if ruser = User.find(rid)
+          ruser.email
+        end
+      end
+    else  
+      if recipient = User.find(recipient_ids)
+        recipient.email
+      end
     end
   end
 

--- a/app/observers/mailer_observer.rb
+++ b/app/observers/mailer_observer.rb
@@ -28,18 +28,31 @@ class MailerObserver < ActiveRecord::Observer
 
   def notify_note note
     # reject author of note from mail list
-    users = note.project.users.reject { |u| u.id == current_user.id }
+    all_users = note.project.users.reject { |u| u.id == current_user.id }
+    all_users_ids = all_users.collect{ |u| u.id }
 
-    users.each do |u|
-      case note.noteable_type
-      when "Commit"; Notify.note_commit_email(u.id, note.id).deliver
-      when "Issue";  Notify.note_issue_email(u.id, note.id).deliver
-      when "Wiki";  Notify.note_wiki_email(u.id, note.id).deliver
-      when "MergeRequest"; Notify.note_merge_request_email(u.id, note.id).deliver
-      when "Snippet"; true
-      else
-        Notify.note_wall_email(u.id, note.id).deliver
-      end
+    case note.noteable_type
+    when "Commit"
+      ci = note.project.commit(noteable_id)
+      # author email may not belong to any user, so use email directly.
+      to_users_emails = [ci.author_email, ci.committer_email].uniq
+      all_users_emails = all_users.collect{ |u| u.email }
+      cc_users_emails = all_users_emails - to_users_emails
+      Notify.note_commit_email(to_users_emails, cc_users_emails, note.id).deliver
+    when "Issue"
+      to_users_ids = [note.noteable.assignee_id, note.noteable.author_id].uniq
+      cc_users_ids = all_users_ids - to_users_ids
+      Notify.note_issue_email(to_users_ids, cc_users_ids, note.id).deliver
+    when "Wiki"
+      Notify.note_wiki_email(u.id, note.id).deliver
+    when "MergeRequest"
+      to_users_ids = [note.noteable.assignee_id, note.noteable.author_id].uniq
+      cc_users_ids = all_users_ids - to_users_ids
+      Notify.note_merge_request_email(to_users_ids, cc_users_ids, note.id).deliver
+    when "Snippet"
+      true
+    else
+      Notify.note_wall_email(u.id, note.id).deliver
     end
   end
 


### PR DESCRIPTION
project team members will receive many comments mails, the patch send these comments mails to relative members and cc to others. project memebers can filter them in mail client.
