### PR TITLE
Fix create repo

### DIFF
--- a/lib/tasks/gitlab/enable_automerge.rake
+++ b/lib/tasks/gitlab/enable_automerge.rake
@@ -2,10 +2,6 @@ namespace :gitlab do
   namespace :app do
     desc "GITLAB | Enable auto merge"
     task :enable_automerge => :environment  do
-      Gitlab::GitHost.system.new.configure do |git|
-        git.admin_all_repo
-      end
-
       Project.find_each do |project|
         if project.repo_exists? && !project.satellite.exists?
           puts "Creating satellite for #{project.name}...".green

--- a/lib/tasks/gitlab/fix_post_receive.rake
+++ b/lib/tasks/gitlab/fix_post_receive.rake
@@ -1,0 +1,11 @@
+namespace :gitlab do
+  namespace :app do
+    desc "GITLAB | Fix post receive"
+    task :fix_post_receive => :environment do
+      Gitlab::GitHost.system.new.configure do |c|
+        c.update_projects(Project.all)
+      end
+      puts "Done!".green
+    end
+  end
+end


### PR DESCRIPTION
Hello,

this request fixes #1257.

This bug happens because gitolite does not create the bare repository in /home/git/repositories if we only add the repo line to the gitolite.conf file. It also need a line with rights + key.
ex, just adding : 

```
repo    toto
```

gitolite won't create the repository but with :

```
repo    toto
  RW+    = somekey
```

gitolite will create a bare repository : /home/git/repositories/toto.git.

If a user creates a repo and he has no ssh key, the first case apply, gitolite does not create a repo and of course gitlab can't see the post-receive file.
To fix that, we must add a default key to the repo.

First commit does this by adding gitlab's key with RW+ rights to each repo. This is not a problem because gitlab is already admin of all repos.

Second commit provide a task to fix existing repositories.
