### PR TITLE
Defaults commit.title to "" instead of nil

### DIFF
--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -11,7 +11,7 @@ class CommitDecorator < ApplicationDecorator
     if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
       safe_message[0..69] << "&hellip;".html_safe
     else
-      safe_message.split(/\n/, 2).first
+      safe_message.split(/\n/, 2).first || ""
     end
   end
 


### PR DESCRIPTION
When there's no commit message, commit.title was returning nil
instead of "".  Might help some people that have #1210
