### PR TITLE
Issue status changed notifications

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -83,6 +83,14 @@ class Notify < ActionMailer::Base
          subject: subject("access to project was granted"))
   end
 
+  def issue_status_changed_email(recipient_id, issue_id, status, updated_by_user_id)
+    @issue = Issue.find issue_id
+    @issue_status = status
+    @updated_by = User.find updated_by_user_id
+    mail(to: recipient(recipient_id),
+        subject: subject("changed issue ##{@issue.id}", @issue.title))
+  end
+
   private
 
   # Look up a User by their ID and return their email address

--- a/app/observers/issue_observer.rb
+++ b/app/observers/issue_observer.rb
@@ -10,17 +10,13 @@ class IssueObserver < ActiveRecord::Observer
   def after_update(issue)
     send_reassigned_email(issue) if issue.is_being_reassigned?
 
-    if issue.is_being_closed?
-      Note.create_status_change_note(issue, current_user, 'closed') 
+    status = nil
+    status = 'closed' if issue.is_being_closed?
+    status = 'reopened' if issue.is_being_reopened?
+    if status
+      Note.create_status_change_note(issue, current_user, status) 
       [issue.author, issue.assignee].compact.each do |recipient| 
-        Notify.issue_status_changed_email(recipient.id, issue.id, 'closed', current_user)
-      end
-    end
-
-    if issue.is_being_reopened?
-      Note.create_status_change_note(issue, current_user, 'reopened')
-      [issue.author, issue.assignee].compact.each do |recipient| 
-        Notify.issue_status_changed_email(recipient.id, issue.id, 'reopened', current_user)
+        Notify.issue_status_changed_email(recipient.id, issue.id, status, current_user)
       end
     end
   end

--- a/app/views/notify/issue_status_changed_email.html.haml
+++ b/app/views/notify/issue_status_changed_email.html.haml
@@ -1,0 +1,16 @@
+%td.content{align: "left", style: "font-family: Helvetica, Arial, sans-serif; padding: 20px 0 0;", valign: "top", width: "600"}
+  %table{border: "0", cellpadding: "0", cellspacing: "0", style: "color: #717171; font: normal 11px Helvetica, Arial, sans-serif; margin: 0; padding: 0;", width: "600"}
+    %tr
+      %td{style: "font-size: 1px; line-height: 1px;", width: "21"}
+      %td{align: "left", style: "padding: 20px 0 0;"}
+        %h2{style: "color:#646464; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
+          = "Issue was #{@issue_status} by #{@updated_by.name}"
+      %td{style: "font-size: 1px; line-height: 1px;", width: "21"}
+    %tr
+      %td{style: "font-size: 1px; line-height: 1px;", width: "21"}
+      %td{align: "left", style: "padding: 20px 0 0;"}
+        %h2{style: "color:#646464 !important; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
+          = "Issue ##{@issue.id}"
+          = link_to_gfm truncate(@issue.title, length: 45), project_issue_url(@issue.project, @issue), title: @issue.title
+        %br
+

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -91,6 +91,29 @@ describe Notify do
             should have_body_text /#{project_issue_path project, issue}/
           end
         end
+
+        describe 'status changed' do
+          let(:current_user) { Factory.create :user, email: "current@email.com" }
+          let(:status) { 'closed' }
+          subject { Notify.issue_status_changed_email(recipient.id, issue.id, status, current_user) }
+        
+          it 'has the correct subject' do
+            should have_subject /changed issue ##{issue.id} \| #{issue.title}/i
+          end
+
+          it 'contains the new status' do
+            should have_body_text /#{status}/i
+          end
+
+          it 'contains the user name' do
+            should have_body_text /#{current_user.name}/i
+          end
+
+          it 'contains a link to the issue' do
+            should have_body_text /#{project_issue_path project, issue}/
+          end
+        end
+
       end
 
       context 'for merge requests' do


### PR DESCRIPTION
Automatically send email notifications to author and/or assignee if issue is being closed or reopened.
