### PR TITLE
HTTP 500 when no commit message

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -7,15 +7,13 @@ class Commit
   attr_accessor :head
   attr_accessor :refs
 
-  delegate :message,
-    :authored_date,
+  delegate :authored_date,
     :committed_date,
     :parents,
     :sha,
     :date,
     :committer,
     :author,
-    :message,
     :diffs,
     :tree,
     :id,
@@ -116,6 +114,16 @@ class Commit
 
   def short_id(length = 10)
     id.to_s[0..length]
+  end
+
+  def message=(val)
+    self.commit.message
+  end
+
+  def message
+    # If has no commit message then shows a warning
+    # Fix Nil Exception in link_to_gfm
+    self.commit.message.blank? ? '[NO COMMIT MESSAGE]' : self.commit.message
   end
 
   def safe_message


### PR DESCRIPTION
I just migrate a repo from SVN to Git, some commits did not have message and gitlab shows HTTP 500 when it loads commits index view.

```
Added an "if" to check Nil and show a warning instead of HTTP 500.
```
