### PR TITLE
Fix URL for "resque info" iframe

### DIFF
--- a/app/views/admin/resque/show.html.haml
+++ b/app/views/admin/resque/show.html.haml
@@ -1,2 +1,2 @@
 %h3 Resque
-%iframe{src: "/info/resque", width: 1168, height: 600, style: "border: none"}
+%iframe{src: "#{ENV['RAILS_RELATIVE_URL_ROOT']}/info/resque", width: 1168, height: 600, style: "border: none"}


### PR DESCRIPTION
Prepend the URL with #{ENV['RAILS_RELATIVE_URL_ROOT']} to make it work
when gitlab's path isn't / on the web server.

This URL fixes the Resque page in the admin area for people running Gitlab on a subdirectory in their webserver, eg. www.example.com/gitlab
