### PR TITLE
Ignore chef dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ config/unicorn.rb
 db/data.yml
 .idea
 .DS_Store
-
+.chef


### PR DESCRIPTION
.chef is the default directory to add chef configuration that should not be checked into version control.
