### PR TITLE
Use GitHub::Markup to parse markup files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "seed-fu"
 
 # Markdown to HTML
 gem "redcarpet", "~> 2.1.1"
+gem 'github-markup'
 
 # Servers
 gem "thin"

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ gem "ffaker"
 gem "seed-fu"
 
 # Markdown to HTML
-gem "redcarpet", "~> 2.1.1"
-gem 'github-markup'
+gem "redcarpet",     "~> 2.1.1"
+gem "github-markup", "~> 0.7.4"
 
 # Servers
 gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     gherkin (2.11.0)
       json (>= 1.4.6)
     git (1.2.5)
+    github-markup (0.7.4)
     gitlab_meta (2.9)
     grape (0.2.1)
       hashie (~> 1.2)
@@ -396,6 +397,7 @@ DEPENDENCIES
   ffaker
   foreman
   git
+  github-markup
   gitlab_meta (= 2.9)
   gitolite!
   grack!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,7 +397,7 @@ DEPENDENCIES
   ffaker
   foreman
   git
-  github-markup
+  github-markup (~> 0.7.4)
   gitlab_meta (= 2.9)
   gitolite!
   grack!

--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -1,3 +1,5 @@
+require 'github/markup'
+
 class RefsController < ApplicationController
   include Gitlab::Encode
   before_filter :project

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -24,4 +24,14 @@ module TreeHelper
       content.name
     end
   end
+
+  # Public: Determines if a given filename is compatible with GitHub::Markup.
+  #
+  # filename - Filename string to check
+  #
+  # Returns boolean
+  def markup?(filename)
+    filename.end_with?(*%w(.mdown .md .markdown .textile .rdoc .org .creole
+                          .mediawiki .rst .asciidoc .pod))
+  end
 end

--- a/app/views/refs/_tree.html.haml
+++ b/app/views/refs/_tree.html.haml
@@ -43,11 +43,7 @@
           %i.icon-file
           = content.name
         .file_content.wiki
-          - if content.name =~ /\.(md|markdown)$/i
-            = preserve do
-              = markdown(content.data)
-          - else
-            = simple_format(content.data)
+          = raw GitHub::Markup.render(content.name, content.data)
 
 :javascript
   $(function(){

--- a/app/views/refs/_tree_file.html.haml
+++ b/app/views/refs/_tree_file.html.haml
@@ -9,10 +9,9 @@
       = link_to "history", project_commits_path(@project, path: params[:path], ref: @ref), class: "btn very_small"
       = link_to "blame", blame_file_project_ref_path(@project, @ref, path: params[:path]), class: "btn very_small"
   - if file.text?
-    - if name =~ /\.(md|markdown)$/i
+    - if markup?(name)
       .file_content.wiki
-        = preserve do
-          = markdown(file.data)
+        = raw GitHub::Markup.render(name, file.data)
     - else
       .file_content.code
         - unless file.empty?

--- a/spec/helpers/tree_helper_spec.rb
+++ b/spec/helpers/tree_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe TreeHelper do
+  describe '#markup?' do
+    %w(mdown md markdown textile rdoc org creole mediawiki rst asciidoc pod).each do |type|
+      it "returns true for #{type} files" do
+        markup?("README.#{type}").should be_true
+      end
+    end
+
+    it "returns false when given a non-markup filename" do
+      markup?('README.rb').should_not be_true
+    end
+  end
+end


### PR DESCRIPTION
Parses files like README.rdoc on the root "Files" page as well as when
viewing the blob.

Closes #1382
