### PR TITLE
Preselected milestone and assignee while create new issue

### DIFF
--- a/app/assets/javascripts/issues.js
+++ b/app/assets/javascripts/issues.js
@@ -80,6 +80,10 @@ function issuesPage(){
     $(this).closest("form").submit();
   });
 
+  $("#new_issue_link").click(function(){
+    updateNewIssueURL();
+  });
+
   $('body').on('ajax:success', '.close_issue, .reopen_issue, #new_issue', function(){
     var t = $(this),
         totalIssues,
@@ -126,3 +130,20 @@ function issuesCheckChanged() {
     $('.issues_filters').show();
   }
 }
+
+function updateNewIssueURL(){
+  var new_issue_link = $("#new_issue_link");
+  var milestone_id = $("#milestone_id").val();
+  var assignee_id = $("#assignee_id").val();
+  var new_href = "";
+  if(milestone_id){
+    new_href = "milestone_id=" + milestone_id + "&";
+  }
+  if(assignee_id){
+    new_href = new_href + "assignee_id=" + assignee_id;
+  }
+  if(new_href.length){
+    new_href = new_issue_link.attr("href") + "?" + new_href;
+    new_issue_link.attr("href", new_href);
+  }
+};

--- a/app/assets/javascripts/issues.js
+++ b/app/assets/javascripts/issues.js
@@ -137,10 +137,10 @@ function updateNewIssueURL(){
   var assignee_id = $("#assignee_id").val();
   var new_href = "";
   if(milestone_id){
-    new_href = "milestone_id=" + milestone_id + "&";
+    new_href = "issue[milestone_id]=" + milestone_id + "&";
   }
   if(assignee_id){
-    new_href = new_href + "assignee_id=" + assignee_id;
+    new_href = new_href + "issue[assignee_id]=" + assignee_id;
   }
   if(new_href.length){
     new_href = new_issue_link.attr("href") + "?" + new_href;

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -38,6 +38,7 @@ class IssuesController < ApplicationController
 
   def new
     @issue = @project.issues.new
+    @issue.milestone_id = params[:milestone_id] if params[:milestone_id].present?
     respond_with(@issue)
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -37,9 +37,7 @@ class IssuesController < ApplicationController
   end
 
   def new
-    @issue = @project.issues.new
-    @issue.milestone_id = params[:milestone_id] if params[:milestone_id].present?
-    @issue.assignee_id = params[:assignee_id] if params[:assignee_id].present?
+    @issue = @project.issues.new(params[:issue])
     respond_with(@issue)
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -39,6 +39,7 @@ class IssuesController < ApplicationController
   def new
     @issue = @project.issues.new
     @issue.milestone_id = params[:milestone_id] if params[:milestone_id].present?
+    @issue.assignee_id = params[:assignee_id] if params[:assignee_id].present?
     respond_with(@issue)
   end
 

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -6,7 +6,7 @@
     .right
       .span5
         - if can? current_user, :write_issue, @project
-          = link_to new_project_issue_path(@project), class: "right btn", title: "New Issue", remote: true do
+          = link_to new_project_issue_path(@project), class: "right btn", title: "New Issue", remote: true, id: "new_issue_link" do
             %i.icon-plus
             New Issue
         = form_tag search_project_issues_path(@project), method: :get, remote: true, id: "issue_search_form", class: :right  do

--- a/features/projects/issues/issues.feature
+++ b/features/projects/issues/issues.feature
@@ -75,7 +75,6 @@ Feature: Issues
     Then I should see selected milestone with title "v3.0"
 
   @javascript
-  @current
   Scenario: I create Issue with pre-selected assignee
     When I select first assignee from "Shop" project
     And I click link "New Issue"

--- a/features/projects/issues/issues.feature
+++ b/features/projects/issues/issues.feature
@@ -66,7 +66,6 @@ Feature: Issues
     And I should see "Release 0.3" in issues
 
   @javascript
-  @current
   Scenario: I create Issue with pre-selected milestone
     Given project "Shop" has milestone "v2.2"
     And project "Shop" has milestone "v3.0"
@@ -74,3 +73,11 @@ Feature: Issues
     When I select milestone "v3.0"
     And I click link "New Issue"
     Then I should see selected milestone with title "v3.0"
+
+  @javascript
+  @current
+  Scenario: I create Issue with pre-selected assignee
+    When I select first assignee from "Shop" project
+    And I click link "New Issue"
+    Then I should see first assignee from "Shop" as selected assignee
+

--- a/features/projects/issues/issues.feature
+++ b/features/projects/issues/issues.feature
@@ -64,3 +64,13 @@ Feature: Issues
     And I fill in issue search with ""
     Then I should see "Release 0.4" in issues
     And I should see "Release 0.3" in issues
+
+  @javascript
+  @current
+  Scenario: I create Issue with pre-selected milestone
+    Given project "Shop" has milestone "v2.2"
+    And project "Shop" has milestone "v3.0"
+    And I visit project "Shop" issues page
+    When I select milestone "v3.0"
+    And I click link "New Issue"
+    Then I should see selected milestone with title "v3.0"

--- a/features/step_definitions/project/project_issues_steps.rb
+++ b/features/step_definitions/project/project_issues_steps.rb
@@ -55,3 +55,15 @@ Given /^I fill in issue search with "(.*?)"$/ do |arg1|
   end
   fill_in 'issue_search', with: arg1
 end
+
+When /^I select milestone "(.*?)"$/ do |milestone_title|
+  select milestone_title, from: "milestone_id"
+end
+
+Then /^I should see selected milestone with title "(.*?)"$/ do |milestone_title|
+  issues_milestone_selector = "#issue_milestone_id_chzn/a"
+  wait_until{
+    page.has_content?("Details") 
+  }
+  page.find(issues_milestone_selector).should have_content(milestone_title)
+end

--- a/features/step_definitions/project/project_issues_steps.rb
+++ b/features/step_definitions/project/project_issues_steps.rb
@@ -57,14 +57,25 @@ Given /^I fill in issue search with "(.*?)"$/ do |arg1|
 end
 
 When /^I select milestone "(.*?)"$/ do |milestone_title|
-  #puts page.body
   select milestone_title, from: "milestone_id"
 end
 
 Then /^I should see selected milestone with title "(.*?)"$/ do |milestone_title|
   issues_milestone_selector = "#issue_milestone_id_chzn/a"
-  wait_until{
-    page.has_content?("Details") 
-  }
+  wait_until{ page.has_content?("Details") }
   page.find(issues_milestone_selector).should have_content(milestone_title)
+end
+
+When /^I select first assignee from "(.*?)" project$/ do |project_name|
+  project = Project.find_by_name project_name
+  first_assignee = project.users.first
+  select first_assignee.name, from: "assignee_id"
+end
+
+Then /^I should see first assignee from "(.*?)" as selected assignee$/ do |project_name|
+  issues_assignee_selector = "#issue_assignee_id_chzn/a"
+  wait_until{ page.has_content?("Details") }
+  project = Project.find_by_name project_name
+  assignee_name = project.users.first.name
+  page.find(issues_assignee_selector).should have_content(assignee_name)
 end

--- a/features/step_definitions/project/project_issues_steps.rb
+++ b/features/step_definitions/project/project_issues_steps.rb
@@ -57,6 +57,7 @@ Given /^I fill in issue search with "(.*?)"$/ do |arg1|
 end
 
 When /^I select milestone "(.*?)"$/ do |milestone_title|
+  #puts page.body
   select milestone_title, from: "milestone_id"
 end
 


### PR DESCRIPTION
Solution for #1199.

Pre-selected labels is not implemented (yet?), but it works fine with milestone and/or assignee.

Does anybody need this feature? If yes, then I could implement this, but later.
