### PR TITLE
Features/linguist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ gem "pygments.rb",   :git => "https://github.com/gitlabhq/pygments.rb.git",     
 gem "omniauth-ldap", :git => "https://github.com/gitlabhq/omniauth-ldap.git",   :ref => "f038dd852d7bd473a557e385d5d7c2fd5dc1dc2e"
 gem 'yaml_db',       :git => "https://github.com/gitlabhq/yaml_db.git"
 gem 'grack',         :git => "https://github.com/gitlabhq/grack.git"
-gem "linguist", "~> 1.0.0", :git => "https://github.com/gitlabhq/linguist.git"
+
+# Language detection
+gem "github-linguist", "~> 2.3.3"
 
 # API
 gem "grape", "~> 0.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'yaml_db',       :git => "https://github.com/gitlabhq/yaml_db.git"
 gem 'grack',         :git => "https://github.com/gitlabhq/grack.git"
 
 # Language detection
-gem "github-linguist", "~> 2.3.3"
+gem "github-linguist", "~> 2.3.3" , :require => "linguist"
 
 # API
 gem "grape", "~> 0.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,16 +31,6 @@ GIT
       posix-spawn (~> 0.3.6)
 
 GIT
-  remote: https://github.com/gitlabhq/linguist.git
-  revision: c3d6fc5af8cf9d67afa572bba363bf0db256a900
-  specs:
-    linguist (1.0.0)
-      charlock_holmes (~> 0.6.6)
-      escape_utils (~> 0.2.3)
-      mime-types (~> 1.18)
-      pygments.rb (~> 0.2.11)
-
-GIT
   remote: https://github.com/gitlabhq/omniauth-ldap.git
   revision: f038dd852d7bd473a557e385d5d7c2fd5dc1dc2e
   ref: f038dd852d7bd473a557e385d5d7c2fd5dc1dc2e
@@ -178,6 +168,11 @@ GEM
     gherkin (2.11.0)
       json (>= 1.4.6)
     git (1.2.5)
+    github-linguist (2.3.3)
+      charlock_holmes (~> 0.6.6)
+      escape_utils (~> 0.2.3)
+      mime-types (~> 1.19)
+      pygments.rb (>= 0.2.13)
     gitlab_meta (2.9)
     grape (0.2.1)
       hashie (~> 1.2)
@@ -396,6 +391,7 @@ DEPENDENCIES
   ffaker
   foreman
   git
+  github-linguist (~> 2.3.3)
   gitlab_meta (= 2.9)
   gitolite!
   grack!
@@ -409,7 +405,6 @@ DEPENDENCIES
   kaminari
   launchy
   letter_opener
-  linguist (~> 1.0.0)!
   modernizr (= 2.5.3)
   mysql2
   omniauth-ldap!

--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -20,9 +20,19 @@
           a {
             display:block;
             .project_name {
+              float:left;
+              width:50%;
               color:#4fa2bd;
               font-size:14px;
               line-height:18px;
+            }
+            .language_name {
+              float: left;
+              width:35%;
+              color:black;
+              text-align:right;
+              font-size:12px;
+              line-height:20px;
             }
             .arrow {
               float:right;

--- a/app/roles/push_observer.rb
+++ b/app/roles/push_observer.rb
@@ -107,11 +107,11 @@ module PushObserver
     # Discover the default branch, but only if it hasn't already been set to
     # something else
     if default_branch.nil?
-      update_attributes(default_branch: discover_default_branch)
+      self.default_branch = discover_default_branch
     end
 
     # Update project's language field
-    update_attributes(language: detect_repo_language)
-
+    self.language = detect_repo_language
+    save
   end
 end

--- a/app/roles/push_observer.rb
+++ b/app/roles/push_observer.rb
@@ -109,5 +109,9 @@ module PushObserver
     if default_branch.nil?
       update_attributes(default_branch: discover_default_branch)
     end
+
+    # Update project's language field
+    update_attributes(language: detect_repo_language)
+
   end
 end

--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -61,6 +61,10 @@ module Repository
     File.join(Gitlab.config.git_base_path, "#{path}.git")
   end
 
+  def path_to_work_tree
+    File.join(Gitlab.config.git_base_path, path)
+  end
+
   def update_repository
     git_host.update_repository(self)
   end
@@ -149,6 +153,12 @@ module Repository
     end
 
     file_path
+  end
+
+  def detect_repo_language
+    if(File.exist?(path_to_work_tree))
+      Linguist::Repository.from_directory(path_to_work_tree).language.name
+    end
   end
 
   def ssh_url_to_repo

--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -157,7 +157,7 @@ module Repository
 
   def detect_repo_language
     if(File.exist?(path_to_work_tree))
-      Linguist::Repository.from_directory(path_to_work_tree).language.name
+      Linguist::Repository.from_directory(path_to_work_tree).language.try(:name)
     end
   end
 

--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -156,7 +156,7 @@ module Repository
   end
 
   def detect_repo_language
-    if(File.exist?(path_to_work_tree))
+    if File.exist?(path_to_work_tree)
       Linguist::Repository.from_directory(path_to_work_tree).language.try(:name)
     end
   end

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -24,6 +24,7 @@
             %li.wll
               = link_to project_path(project), class: dom_class(project) do
                 %strong.project_name= truncate(project.name, length: 25)
+                %strong.language_name= project.language ||= "Plain Text"
                 %span.arrow
                   &rarr;
                 %span.last_activity

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -24,7 +24,7 @@
             %li.wll
               = link_to project_path(project), class: dom_class(project) do
                 %strong.project_name= truncate(project.name, length: 25)
-                %strong.language_name= project.language ||= "Plain Text"
+                %strong.language_name= project.language || "Plain Text"
                 %span.arrow
                   &rarr;
                 %span.last_activity

--- a/db/migrate/20120908101117_add_language_to_projects.rb
+++ b/db/migrate/20120908101117_add_language_to_projects.rb
@@ -1,0 +1,5 @@
+class AddLanguageToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :language, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120905043334) do
+ActiveRecord::Schema.define(:version => 20120908101117) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(:version => 20120905043334) do
     t.boolean  "wall_enabled",           :default => true, :null => false
     t.boolean  "merge_requests_enabled", :default => true, :null => false
     t.boolean  "wiki_enabled",           :default => true, :null => false
+    t.string   "language"
   end
 
   create_table "protected_branches", :force => true do |t|

--- a/lib/hooks/post-receive
+++ b/lib/hooks/post-receive
@@ -9,4 +9,8 @@ do
   pwd=`pwd`
   reponame=`basename "$pwd" | cut -d. -f1`
   env -i redis-cli rpush "resque:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$reponame\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
+  # export GIT_WORK_TREE variable for Language detection
+  export GIT_WORK_TREE="`dirname $pwd`/$reponame"
+  mkdir -p $GIT_WORK_TREE
+  git checkout -f
 done


### PR DESCRIPTION
use github-linguist to instead of gitlab linguist.

add detect language feature.

![image](http://f.cl.ly/items/1S0n3r1y0U0v3m2g1P2t/Screen%20Shot%202012-09-08%20at%2011.45.11%20PM.png)
### Important:

`post-receive` need to export `git_work_tree` variable. that is why we can detect language.

projects added a `language` field. the default language is `Plain Text`
### Next:

we can checkout `gl-pages` branch to a folder too. so , we can have our gitlab pages!. 
