### PR TITLE
FIX: Empty string in commit message

### DIFF
--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -16,7 +16,7 @@ class CommitDecorator < ApplicationDecorator
   # In case this first line is longer than 80 characters, it is cut off
   # after 70 characters and ellipses (`&hellp;`) are appended.
   def title
-    return no_commit_message unless safe_message
+    return no_commit_message unless safe_message && !safe_message.strip.empty?
 
     title_end = safe_message.index(/\n/)
     if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)

--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -16,7 +16,7 @@ class CommitDecorator < ApplicationDecorator
   # In case this first line is longer than 80 characters, it is cut off
   # after 70 characters and ellipses (`&hellp;`) are appended.
   def title
-    return no_commit_message unless safe_message && !safe_message.strip.empty?
+    return no_commit_message if safe_message.blank?
 
     title_end = safe_message.index(/\n/)
     if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -11,7 +11,7 @@ module GitlabMarkdownHelper
   # explicitly produce the correct linking behavior (i.e.
   # "<a>outer text </a><a>gfm ref</a><a> more outer text</a>").
   def link_to_gfm(body, url, html_options = {})
-    return "" unless body && !body.strip.empty?
+    return "" if body.blank?
     
     gfm_body = gfm(body, html_options)
 

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -11,6 +11,8 @@ module GitlabMarkdownHelper
   # explicitly produce the correct linking behavior (i.e.
   # "<a>outer text </a><a>gfm ref</a><a> more outer text</a>").
   def link_to_gfm(body, url, html_options = {})
+    return "" unless body && !body.strip.empty?
+    
     gfm_body = gfm(body, html_options)
 
     gfm_body.gsub!(%r{<a.*?>.*?</a>}m) do |match|


### PR DESCRIPTION
Fixed commit title when commit message is an empty string and ensured that link_to_gfm helper doesn't break on empty body.

This one is related to https://github.com/gitlabhq/gitlabhq/pull/1343, it breaks the commits project page. The previous solution didn't cover the situation where commit message is an empty string. In that case, the #title decorator method would return nil for the title, and the link_to_gfm helper would break.

Unfortunately, the "empty string" messages are a remnant of TFS repositories being converted. But, it could also be an issue with new commits (-m "").

Wasn't sure on how to approach since empty string is not nil, should it be considered a commit message or not. Chose to make it a "non message". Maybe you can change the decorator like this too:

``` ruby
  def title
    return no_commit_message unless safe_message

    title_end = safe_message.index(/\n/)
    if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
      safe_message[0..69] << "&hellip;".html_safe
    else
      safe_message.split(/\n/, 2).first || ""
    end
  end
```

As for the helper, it is just a minor update, to ensure that at least it won't break if somehow empty/nil string is passed into it.
