### PR TITLE
Be more resilient in the case of missing omniauth settings

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -121,19 +121,19 @@ class Settings < Settingslogic
     end
 
     def ldap_enabled?
-      ldap['enabled']
-    rescue
+      ldap && ldap['enabled']
+    rescue Settingslogic::MissingSetting
       false
     end
 
     def omniauth_enabled?
       omniauth && omniauth['enabled']
-    rescue
+    rescue Settingslogic::MissingSetting
       false
     end
 
     def omniauth_providers
-      omniauth['providers'] || []
+      (omniauth_enabled? && omniauth['providers']) || []
     end
 
     def disable_gravatar?

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -17,7 +17,7 @@ module Gitlab
       end
     end
 
-    def create_from_omniauth auth, ldap = false
+    def create_from_omniauth(auth, ldap = false)
       provider = auth.provider
       uid = auth.info.uid || auth.uid
       name = auth.info.name.force_encoding("utf-8")
@@ -39,7 +39,7 @@ module Gitlab
         password_confirmation: password,
         projects_limit: Gitlab.config.default_projects_limit,
       )
-      if Gitlab.config.omniauth.block_auto_created_users && !ldap
+      if Gitlab.config.omniauth['block_auto_created_users'] && !ldap
         @user.blocked = true
       end
       @user.save!
@@ -52,7 +52,7 @@ module Gitlab
       if @user = User.find_by_provider_and_extern_uid(provider, uid)
         @user
       else
-        if Gitlab.config.omniauth.allow_single_sign_on
+        if Gitlab.config.omniauth['allow_single_sign_on']
           @user = create_from_omniauth(auth)
           @user
         end

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -4,6 +4,8 @@ describe Gitlab::Auth do
   let(:gl_auth) { Gitlab::Auth.new }
 
   before do
+    Gitlab.config.stub(omniauth: {})
+
     @info = mock(
       uid: '12djsak321',
       name: 'John',
@@ -64,7 +66,7 @@ describe Gitlab::Auth do
     end
 
     it "should create user if single_sing_on"do
-      Gitlab.config.omniauth.stub allow_single_sign_on: true
+      Gitlab.config.omniauth['allow_single_sign_on'] = true
       User.stub find_by_provider_and_extern_uid: nil
       gl_auth.should_receive :create_from_omniauth
       gl_auth.find_or_new_for_omniauth(@auth)


### PR DESCRIPTION
Should no longer freak out when omniauth settings aren't present in gitlab.yml. People who aren't using it shouldn't even have to put a 'false' entry in their config for it (and probably wouldn't, after an upgrade).

Should prevent a few future support requests where people who have no interest in using Omniauth and don't bother to update their config settings and suddenly get errors.

Also I _hate_ method definitions that have arguments but no parenthesis, and rescuing from all exceptions when you really only needed one, so I changed those.
