### PR TITLE
Patch 1 - Fix for gitlab doesn't start on boot

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -274,7 +274,9 @@ Adding permission:
 
 Gitlab autostart:
 
-    sudo update-rc.d gitlab defaults
+    # 70 30 causes gitlab to start after redis-server
+    # leaving 70 30 off causes gitlab to not start (tested in Ubuntu Server 12.04 LTS)
+    sudo update-rc.d gitlab defaults 70 30
 
 Now you can start/restart/stop gitlab like:
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,4 +1,4 @@
-## Platform requirements: 
+## Platform requirements:
 
 **The project is designed for the Linux operating system.**
 
@@ -22,7 +22,7 @@ You might have some luck using these, but no guarantees:
 
 Gitlab does **not** run on Windows and we have no plans of making Gitlab compatible.
 
-## This installation guide created for Debian/Ubuntu and properly tested. 
+## This installation guide created for Debian/Ubuntu and properly tested.
 
 The installation consists of 6 steps:
 
@@ -43,14 +43,20 @@ Also read the [Read this before you submit an issue](https://github.com/gitlabhq
 
 > - - -
 > First 3 steps can be easily skipped with simply install script:
-> 
->     # Install curl and sudo 
+>
+>     # Install curl and sudo
 >     apt-get install curl sudo
->     
+>
 >     # 3 steps in 1 command :)
->     curl https://raw.github.com/gitlabhq/gitlabhq/master/doc/debian_ubuntu.sh | sh
-> 
-> Now you can go to step 4"
+>     curl https://raw.github.com/gitlabhq/gitlab-recipes/master/install/debian_ubuntu.sh | sh
+>
+> Now you can go to [Step 4](#4-install-gitlab-and-configuration-check-status-configuration)
+>
+> Or if you are installing on Amazon Web Services using Ubuntu 12.04 you can do all steps (1 to 6) at once with:
+>
+>     curl https://raw.github.com/gitlabhq/gitlab-recipes/master/install/debian_ubuntu_aws.sh | sh
+>
+> for more detailed instructions read the HOWTO section of [the script](https://github.com/gitlabhq/gitlab-recipes/blob/master/install/debian_ubuntu_aws.sh)
 > - - -
 
 # 1. Install packages
@@ -61,15 +67,15 @@ Also read the [Read this before you submit an issue](https://github.com/gitlabhq
     sudo apt-get upgrade
 
     sudo apt-get install -y wget curl gcc checkinstall libxml2-dev libxslt-dev sqlite3 libsqlite3-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev libicu-dev redis-server openssh-server git-core python-dev python-pip libyaml-dev postfix
-    
+
     # If you want to use MySQL:
     sudo apt-get install -y mysql-server mysql-client libmysqlclient-dev
 
 # 2. Install ruby
 
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz
-    tar xzfv ruby-1.9.2-p290.tar.gz
-    cd ruby-1.9.2-p290
+    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz
+    tar xfvz ruby-1.9.3-p194.tar.gz
+    cd ruby-1.9.3-p194
     ./configure
     make
     sudo make install
@@ -77,7 +83,7 @@ Also read the [Read this before you submit an issue](https://github.com/gitlabhq
 # 3. Install gitolite
 
 Create user for git:
-    
+
     sudo adduser \
       --system \
       --shell /bin/sh \
@@ -90,7 +96,7 @@ Create user for git:
 Create user for gitlab:
 
     # ubuntu/debian
-    sudo adduser --disabled-login --gecos 'gitlab system' gitlab    
+    sudo adduser --disabled-login --gecos 'gitlab system' gitlab
 
 Add your user to git group:
 
@@ -103,7 +109,7 @@ Generate key:
 Get gitolite source code:
 
     cd /home/git
-    sudo -H -u git git clone git://github.com/gitlabhq/gitolite /home/git/gitolite    
+    sudo -H -u git git clone git://github.com/gitlabhq/gitolite /home/git/gitolite
 
 Setup:
 
@@ -114,20 +120,20 @@ Setup:
 
     sudo -u git -H sed -i 's/0077/0007/g' /home/git/share/gitolite/conf/example.gitolite.rc
     sudo -u git -H sh -c "PATH=/home/git/bin:$PATH; gl-setup -q /home/git/gitlab.pub"
-    
+
 Permissions:
 
     sudo chmod -R g+rwX /home/git/repositories/
     sudo chown -R git:git /home/git/repositories/
 
 #### CHECK: Logout & login again to apply git group to your user
-    
+
     # clone admin repo to add localhost to known_hosts
     # & be sure your user has access to gitolite
-    sudo -u gitlab -H git clone git@localhost:gitolite-admin.git /tmp/gitolite-admin 
+    sudo -u gitlab -H git clone git@localhost:gitolite-admin.git /tmp/gitolite-admin
 
     # if succeed  you can remove it
-    sudo rm -rf /tmp/gitolite-admin 
+    sudo rm -rf /tmp/gitolite-admin
 
 **IMPORTANT! If you cant clone `gitolite-admin` repository - DONT PROCEED INSTALLATION**
 
@@ -139,7 +145,7 @@ Permissions:
     cd /home/gitlab
     sudo -H -u gitlab git clone -b stable git://github.com/gitlabhq/gitlabhq.git gitlab
     cd gitlab
-    
+
     sudo -u gitlab mkdir tmp
 
     # Rename config files
@@ -150,22 +156,22 @@ Permissions:
     # SQLite
     sudo -u gitlab cp config/database.yml.sqlite config/database.yml
 
-    # Or 
+    # Or
     # Mysql
     # Install MySQL as directed in Step #1
-    
+
     # Login to MySQL
-    $ mysql -u root -p 
-    
+    $ mysql -u root -p
+
     # Create the gitlabhq production database
     mysql> CREATE DATABASE IF NOT EXISTS `gitlabhq_production` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_unicode_ci`;
-    
+
     # Create the MySQL User change $password to a real password
-    mysql> CREATE USER 'gitlab'@'localhost' IDENTIFIED BY '$password'; 
-    
+    mysql> CREATE USER 'gitlab'@'localhost' IDENTIFIED BY '$password';
+
     # Grant proper permissions to the MySQL User
     mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON `gitlabhq_production`.* TO 'gitlab'@'localhost';
-    
+
     # Exit MySQL Server and copy the example config, make sure to update username/password in config/database.yml
     sudo -u gitlab cp config/database.yml.example config/database.yml
 
@@ -181,7 +187,7 @@ Permissions:
 
     sudo cp ./lib/hooks/post-receive /home/git/share/gitolite/hooks/common/post-receive
     sudo chown git:git /home/git/share/gitolite/hooks/common/post-receive
-    
+
 Checking status:
 
     sudo -u gitlab bundle exec rake gitlab:app:status RAILS_ENV=production
@@ -202,13 +208,13 @@ Checking status:
     UMASK for .gitolite.rc is 0007? ............YES
     /home/git/share/gitolite/hooks/common/post-receive exists? ............YES
 
-If you got all YES - congrats! You can go to next step.  
+If you got all YES - congrats! You can go to next step.
 
 # 5. Server up
 
 Application can be started with next command:
 
-    # For test purposes 
+    # For test purposes
     sudo -u gitlab bundle exec rails s -e production
 
     # As daemon
@@ -244,42 +250,15 @@ You can login via web using admin generated with setup:
     sudo -u gitlab cp config/unicorn.rb.orig config/unicorn.rb
     sudo -u gitlab bundle exec unicorn_rails -c config/unicorn.rb -E production -D
 
-Edit /etc/nginx/nginx.conf. In the *http* section add:
+Add GitLab to nginx sites & change with your host specific settings
 
-    upstream gitlab {
-        server unix:/home/gitlab/gitlab/tmp/sockets/gitlab.socket;
-    }
+    sudo wget https://raw.github.com/gitlabhq/gitlab-recipes/master/nginx/gitlab -P /etc/nginx/sites-available/
+    sudo ln -s /etc/nginx/sites-available/gitlab /etc/nginx/sites-enabled/gitlab
 
-    server {
-        listen YOUR_SERVER_IP:80;         # e.g., listen 192.168.1.1:80;
-        server_name YOUR_SERVER_FQDN;     # e.g., server_name source.example.com;
-        root /home/gitlab/gitlab/public;
-        
-        # individual nginx logs for this gitlab vhost
-        access_log  /var/log/nginx/gitlab_access.log;
-        error_log   /var/log/nginx/gitlab_error.log;
-        
-        location / {
-            # serve static files from defined root folder;.
-            # @gitlab is a named location for the upstream fallback, see below
-            try_files $uri $uri/index.html $uri.html @gitlab;
-        }
-        
-        # if a file, which is not found in the root folder is requested, 
-        # then the proxy pass the request to the upsteam (gitlab unicorn)
-        location @gitlab {
-          proxy_redirect     off;
-          
-          # you need to change this to "https", if you set "ssl" directive to "on"
-          proxy_set_header   X-FORWARDED_PROTO http;
-          proxy_set_header   Host              $http_host;
-          proxy_set_header   X-Real-IP         $remote_addr;
-        
-          proxy_pass http://gitlab;
-        }
-    }
-
-Change **YOUR_SERVER_IP** and **YOUR_SERVER_FQDN** to the IP address and fully-qualified domain name of the host serving GitLab.
+    # Change **YOUR_SERVER_IP** and **YOUR_SERVER_FQDN**
+    # to the IP address and fully-qualified domain name
+    # of the host serving GitLab.
+    sudo vim /etc/nginx/sites-enabled/gitlab
 
 Restart nginx:
 
@@ -287,60 +266,7 @@ Restart nginx:
 
 Create init script in /etc/init.d/gitlab:
 
-    #! /bin/bash
-    ### BEGIN INIT INFO
-    # Provides:          gitlab
-    # Required-Start:    $local_fs $remote_fs $network $syslog redis-server
-    # Required-Stop:     $local_fs $remote_fs $network $syslog
-    # Default-Start:     2 3 4 5
-    # Default-Stop:      0 1 6
-    # Short-Description: GitLab git repository management
-    # Description:       GitLab git repository management
-    ### END INIT INFO
-    
-    DAEMON_OPTS="-c /home/gitlab/gitlab/config/unicorn.rb -E production -D"
-    NAME=unicorn
-    DESC="Gitlab service"
-    PID=/home/gitlab/gitlab/tmp/pids/unicorn.pid
-    RESQUE_PID=/home/gitlab/gitlab/tmp/pids/resque_worker.pid
-
-    case "$1" in
-      start)
-            CD_TO_APP_DIR="cd /home/gitlab/gitlab"
-            START_DAEMON_PROCESS="bundle exec unicorn_rails $DAEMON_OPTS"
-            START_RESQUE_PROCESS="./resque.sh"
-
-            echo -n "Starting $DESC: "
-            if [ `whoami` = root ]; then
-              sudo -u gitlab sh -l -c "$CD_TO_APP_DIR > /dev/null 2>&1 && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS"
-            else
-              $CD_TO_APP_DIR > /dev/null 2>&1 && $START_DAEMON_PROCESS && $START_RESQUE_PROCESS
-            fi
-            echo "$NAME."
-            ;;
-      stop)
-            echo -n "Stopping $DESC: "
-            kill -QUIT `cat $PID`
-            kill -QUIT `cat $RESQUE_PID`
-            echo "$NAME."
-            ;;
-      restart)
-            echo -n "Restarting $DESC: "
-            kill -USR2 `cat $PID`
-            echo "$NAME."
-            ;;
-      reload)
-            echo -n "Reloading $DESC configuration: "
-            kill -HUP `cat $PID`
-            echo "$NAME."
-            ;;
-      *)
-            echo "Usage: $NAME {start|stop|restart|reload}" >&2
-            exit 1
-            ;;
-    esac
-
-    exit 0
+    sudo wget https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab -P /etc/init.d/
 
 Adding permission:
 


### PR DESCRIPTION
gitlab doesn't start on boot if you follow the install instructions on Ubuntu (12.04 LTS Server - probably others). Turns out gitlab requires redis-server to be running for gitlab to be able to start. Startup script S20redis-server isn't run until after S20gitlab so gitlab fails to start on boot. Webserver will be up, bad gateway 502 error is usually seen/reported. Starting gitlab manually works (because redis-server has started). This change makes gitlab start after redis-server.

sudo update-rc.d gitlab defaults 70 30
