### PR TITLE
use high level api and compatibility with Passenger

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -12,21 +12,22 @@ module Grack
       # Pass Gitolite update hook
       ENV['GL_BYPASS_UPDATE_HOOK'] = "true"
 
-      # Need this patch because the rails mount
-      @env['PATH_INFO'] = @env['REQUEST_PATH']
+      # Need this patch due to the rails mount
+      @env['PATH_INFO'] = @request.path
+      @env['SCRIPT_NAME'] = ""
 
       # Find project by PATH_INFO from env
-      if m = /^\/([\w-]+).git/.match(@env['PATH_INFO']).to_a
+      if m = /^\/([\w-]+).git/.match(@request.path_info).to_a
         return false unless project = Project.find_by_path(m.last)
       end
 
       # Git upload and receive
-      if @env['REQUEST_METHOD'] == 'GET'
+      if @request.get?
         true
-      elsif @env['REQUEST_METHOD'] == 'POST'
-        if @env['REQUEST_URI'].end_with?('git-upload-pack')
+      elsif @request.post?
+        if @request.path_info.end_with?('git-upload-pack')
           return project.dev_access_for?(user)
-        elsif @env['REQUEST_URI'].end_with?('git-receive-pack')
+        elsif @request.path_info.end_with?('git-receive-pack')
           if project.protected_branches.map(&:name).include?(current_ref)
             project.master_access_for?(user)
           else


### PR DESCRIPTION
Passenger didn't set `@env['REQUEST_PATH']` variable. use `@request.path` instead.
