### PR TITLE
Fix query for wiki pages listing to work on all databases (ie. incl. PostgreSQL)

### DIFF
--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -7,7 +7,7 @@ class WikisController < ApplicationController
   layout "project"
   
   def pages
-    @wikis = @project.wikis.group(:slug).order("created_at")
+    @wikis = @project.wikis.last_revisions.order("created_at")
   end
 
   def show

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -28,6 +28,21 @@ class Wiki < ActiveRecord::Base
       end
       new_wiki
     end
+
+    # Scope with last revisions of pages (i.e. newest page per project_id
+    # and slug).
+    #
+    # This is instead of Wiki.group(:slug).order(:created_at) which in this
+    # case generates query violating SQL standard (thus doesn't work on PgSQL).
+    #
+    # return:
+    #   ActiveRecord::Relation
+    #
+    def last_revisions
+      t1 = arel_table.alias(table_name + '1')
+      where(created_at: from(t1).select(t1[:created_at].maximum)
+                                .where(project_id: t1[:project_id], slug: t1[:slug]))
+    end
   end
 end
 # == Schema Information


### PR DESCRIPTION
ActiveRecord query `Wiki.group("slug").order("created_at")` in this case generates ambiguous _group by_ query violating SQL standard: _“The columns in a select list must be in the group by expression or they must be arguments of aggregate functions.”_ Therefore it doesn’t work on truly SQL compliant databases such as PostgreSQL (and almost all except MySQL and SQLite3).

``` sql
SELECT wikis.* 
FROM wikis 
GROUP BY slug 
ORDER BY updated_at;
```

PostgreSQL has clause `DISTINCT ON` for these situations, sadly MySQL doesn’t. Well, I rewrote this query to another form that should work on every SQL database including MySQL.

``` sql
SELECT wikis.* 
FROM wikis 
WHERE wikis.project_id = ?
    AND wikis.created_at IN (
        SELECT MAX(wikis1.created_at) AS max_id 
        FROM wikis wikis1 
        WHERE wikis.project_id = wikis1.project_id
            AND wikis.slug = wikis1.slug)
ORDER BY created_at;
```

I used _ActiveRecord::Relation_ and _ARel_ for this query so the code doesn’t look very nice, but it’s the best way how I was able to write it and it works well. Moreover, it’s actually _scope!_

Related to #554.
