### PR TITLE
Link directly to dashboard_path (instead of root_path)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -89,7 +89,7 @@ class ProjectsController < ApplicationController
     UsersProject.set_callback(:destroy, :after, :update_repository)
 
     respond_to do |format|
-      format.html { redirect_to root_path }
+      format.html { redirect_to dashboard_path }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
     default_nav = [
       { label: "Profile", url: profile_path },
       { label: "Keys", url: keys_path },
-      { label: "Dashboard", url: root_path },
+      { label: "Dashboard", url: dashboard_path },
       { label: "Admin", url: admin_root_path }
     ]
 

--- a/app/views/layouts/_app_menu.html.haml
+++ b/app/views/layouts/_app_menu.html.haml
@@ -1,6 +1,6 @@
 %ul.main_menu
   %li.home{class: tab_class(:root)}
-    = link_to "Home", root_path, title: "Home"
+    = link_to "Home", dashboard_path, title: "Home"
 
   %li{class: tab_class(:dash_issues)}
     = link_to dashboard_issues_path do

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -3,7 +3,7 @@
   .container
     .top_panel_content
       %div.app_logo
-        = link_to root_path, class: "home", title: "Home" do
+        = link_to dashboard_path, class: "home", title: "Home" do
           %h1
             GITLAB
         %span.separator


### PR DESCRIPTION
This change allows using a top-level /index.html file and also removes an internal redirect from root_path to dashboard_path. 
