### PR TITLE
Add initializer for customizing Resque's Redis connection

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,8 @@
+rails_root  = ENV['RAILS_ROOT'] || File.dirname(__FILE__) + '/../..'
+rails_env   = ENV['RAILS_ENV'] || 'development'
+config_file = File.join(rails_root, 'config', 'resque.yml')
+
+if File.exists?(config_file)
+  resque_config = YAML.load_file(config_file)
+  Resque.redis = resque_config[rails_env]
+end

--- a/config/resque.yml.example
+++ b/config/resque.yml.example
@@ -1,0 +1,3 @@
+development: localhost:6379
+test: localhost:6379
+production: redis.example.com:6379

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -251,6 +251,14 @@ You can login via web using admin generated with setup:
     # if you run this as root /home/gitlab/gitlab/tmp/pids/resque_worker.pid will be owned by root
     # causing the resque worker not to start via init script on next boot/service restart
 
+## Customizing Resque's Redis connection
+
+If you'd like Resque to connect to a Redis server on a non-standard port or on
+a different host, you can configure its connection string in the
+**config/resque.yml** file:
+
+    production: redis.example.com:6379
+
 **Ok - we have a working application now. **
 **But keep going - there are some things that should be done **
 
@@ -275,7 +283,6 @@ You can login via web using admin generated with setup:
     # to the IP address and fully-qualified domain name
     # of the host serving GitLab.
     sudo vim /etc/nginx/sites-enabled/gitlab
-
 
     # Restart nginx:
     /etc/init.d/nginx restart


### PR DESCRIPTION
Went with an optional `config/resque.yml` file. If it exists, it reads
the connection info from that based on environment. Also added a section
to the installation guide.

For reasoning behind not just using `Rails.root`, see https://github.com/defunkt/resque#configuration

Closes #1486
