### PR TITLE
Update timeout comment in unicorn example config.

### DIFF
--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -6,7 +6,7 @@ working_directory app_dir
 # worker spawn times
 preload_app true
 
-# nuke workers after 60 seconds (the default)
+# nuke workers after 30 seconds (60 is the default)
 timeout 30
 
 # listen on a Unix domain socket and/or a TCP port,


### PR DESCRIPTION
The timeout was changed to 30 and the comment wasn't updated. 

Also I've seen several reports of this timeout not being long enough for quite a few people. It resulted in me getting a 502 bad gateway from nginx until I upped it. Perhaps going back to the default 60 would be better? I changed mine to 300, running on an AWS micro instance.
