### PR TITLE
Session API polishing

### DIFF
--- a/app/views/help/api.html.haml
+++ b/app/views/help/api.html.haml
@@ -14,6 +14,8 @@
   %li
     %a{href: "#users"} Users
   %li
+    %a{href: "#session"} Session
+  %li
     %a{href: "#issues"} Issues
   %li
     %a{href: "#milestones"} Milestones
@@ -55,6 +57,16 @@
   .file_content.wiki
     = preserve do
       = markdown File.read(Rails.root.join("doc", "api", "users.md"))
+
+%br
+
+.file_holder#session
+  .file_title
+    %i.icon-file
+    Session
+  .file_content.wiki
+    = preserve do
+      = markdown File.read(Rails.root.join("doc", "api", "session.md"))
 
 %br
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -9,8 +9,8 @@ module Gitlab
       expose :id, :email, :name, :blocked, :created_at
     end
 
-    class UserLogin < Grape::Entity
-      expose :id, :email, :name, :private_token, :blocked, :created_at
+    class UserLogin < UserBasic
+      expose :private_token
     end
 
     class Hook < Grape::Entity
@@ -56,9 +56,7 @@ module Gitlab
     end
 
     class Key < Grape::Entity
-      expose  :id,
-              :title,
-              :key
+      expose  :id, :title, :key
     end
   end
 end

--- a/lib/api/session.rb
+++ b/lib/api/session.rb
@@ -8,14 +8,13 @@ module Gitlab
     post "/session" do
       resource = User.find_for_database_authentication(email: params[:email])
 
-      return forbidden! unless resource
+      return unauthorized! unless resource
 
       if resource.valid_password?(params[:password])
         present resource, with: Entities::UserLogin
       else
-        forbidden!
+        unauthorized!
       end
     end
   end
 end
-

--- a/spec/requests/api/session_spec.rb
+++ b/spec/requests/api/session_spec.rb
@@ -19,7 +19,7 @@ describe Gitlab::API do
     context "when invalid password" do
       it "should return authentication error" do
         post api("/session"), email: user.email, password: '123'
-        response.status.should == 403
+        response.status.should == 401
 
         json_response['email'].should be_nil
         json_response['private_token'].should be_nil
@@ -29,7 +29,7 @@ describe Gitlab::API do
     context "when empty password" do
       it "should return authentication error" do
         post api("/session"), email: user.email
-        response.status.should == 403
+        response.status.should == 401
 
         json_response['email'].should be_nil
         json_response['private_token'].should be_nil


### PR DESCRIPTION
> A 403 error response indicates that the client’s request is formed correctly, but the REST API refuses to honor it. 
