### PR TITLE
changed the post-receive hook in order to push the correct repository 

### DIFF
--- a/lib/hooks/post-receive
+++ b/lib/hooks/post-receive
@@ -7,6 +7,6 @@ while read oldrev newrev ref
 do
   # For every branch or tag that was pushed, create a Resque job in redis.
   pwd=`pwd`
-  reponame=`basename "$pwd" | cut -d. -f1`
+  reponame=`basename "$pwd" | sed s/\.git$//`
   env -i redis-cli rpush "resque:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$reponame\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
 done


### PR DESCRIPTION
changed the post-receive hook in order to push the correct repository  name when the name contain special characters like repository names that contain dots.
