### PR TITLE
Removed float on emoji

### DIFF
--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -43,7 +43,9 @@
   padding: 8px 0;
   overflow: hidden;
   display: block;
+  position:relative;
   img {float: left; margin-right: 10px;}
+  img.emoji {float:none;margin:0;}
   .note-author cite{font-style: italic;}
   p { color:$style_color; }
   .note-author { color: $style_color;}
@@ -55,7 +57,9 @@
 
   .delete-note {
     display:none;
-    float:right;
+    position:absolute;
+    right:0;
+    top:0;
   }
 
   &:hover {


### PR DESCRIPTION
Images are floated to left in the `.note` element. That causes that emoji (which are... uhm.. images?) to jump to the left side of the.
Eg 

![emoji](http://img.iamntz.com/jing/2012-09-24_1008.png) 

the emoji should be at the end of the text

Also, hovering a comment, the `remove comment` button will not make the text jump anymore. 
[the previous behavior](http://img.iamntz.com/jing/2012-09-24_1011.swf)
