### PR TITLE
More verbose dashboard event feed

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -3,11 +3,11 @@ class EventDecorator < ApplicationDecorator
 
   def feed_title
     if self.issue?
-      "#{self.author_name} #{self.action_name} issue ##{self.target_id}:" + self.issue_title
+      "#{self.author_name} #{self.action_name} issue ##{self.target_id}: #{self.issue_title} at #{self.project.name}"
     elsif self.merge_request?
-      "#{self.author_name} #{self.action_name} MR ##{self.target_id}:" + self.merge_request_title
+      "#{self.author_name} #{self.action_name} MR ##{self.target_id}: #{self.merge_request_title} at #{self.project.name}"
     elsif self.push?
-      "#{self.author_name} #{self.push_action_name} #{self.ref_type} " + self.ref_name
+      "#{self.author_name} #{self.push_action_name} #{self.ref_type} #{self.ref_name} at #{self.project.name}"
     elsif self.membership_changed?
       "#{self.author_name} #{self.action_name} #{self.project.name}"
     else
@@ -20,8 +20,26 @@ class EventDecorator < ApplicationDecorator
       h.project_issue_url(self.project, self.issue)
     elsif self.merge_request?
       h.project_merge_request_url(self.project, self.merge_request)
+
     elsif self.push?
-      h.project_commits_url(self.project, ref: self.ref_name)
+      if self.push_with_commits?
+        if self.commits_count > 1
+          h.compare_project_commits_path(self.project, :from => self.parent_commit.id, :to => self.last_commit.id)
+        else
+          h.project_commit_path(self.project, :id => self.last_commit.id)
+        end
+      else
+        h.project_commits_url(self.project, ref: self.ref_name)
+      end
+    end
+
+  end
+
+  def feed_summary
+    if self.issue?
+      h.render "events/event_issue", issue: self.issue
+    elsif self.push?
+      h.render "events/event_push", event: self
     end
   end
 end

--- a/app/views/dashboard/index.atom.builder
+++ b/app/views/dashboard/index.atom.builder
@@ -12,6 +12,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://sear
       xml.entry do
         event_link = event.feed_url
         event_title = event.feed_title
+        event_summary = event.feed_summary
 
         xml.id      "tag:#{request.host},#{event.created_at.strftime("%Y-%m-%d")}:#{event.id}"
         xml.link    :href => event_link
@@ -22,7 +23,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://sear
           xml.name event.author_name
           xml.email event.author_email
         end
-        xml.summary event_title
+        xml.summary(:type => "xhtml") { |x| x << event_summary unless event_summary.nil? }
       end
     end
   end

--- a/app/views/events/_event_issue.atom.haml
+++ b/app/views/events/_event_issue.atom.haml
@@ -1,0 +1,2 @@
+%div{:xmlns => "http://www.w3.org/1999/xhtml"}
+  %p= simple_format issue.description

--- a/app/views/events/_event_push.atom.haml
+++ b/app/views/events/_event_push.atom.haml
@@ -1,0 +1,14 @@
+%div{:xmlns => "http://www.w3.org/1999/xhtml"}
+  - event.commits.first(15).each do |commit|
+    %p
+      %strong= commit.author_name
+      = link_to "(##{commit.short_id})", project_commit_path(event.project, :id => commit.id)
+      %i
+        at
+        = commit.committed_date.strftime("%Y-%m-%d %H:%M:%S")
+    %blockquote= simple_format commit.safe_message
+  - if event.commits_count > 15
+    %p
+      %i
+        \... and
+        = pluralize(event.commits_count - 15, "more commit")

--- a/app/views/events/_event_push.atom.haml
+++ b/app/views/events/_event_push.atom.haml
@@ -6,7 +6,7 @@
       %i
         at
         = commit.committed_date.strftime("%Y-%m-%d %H:%M:%S")
-    %blockquote= simple_format commit.safe_message
+    %blockquote= simple_format(escape_once(commit.safe_message))
   - if event.commits_count > 15
     %p
       %i


### PR DESCRIPTION
This is a follow up to #1050

As the commit message states I added following elements:
- Add project name to each event title
- Push: Entry links to single commit or commits overview depending on number of pushed commits
- Push: Display first 15 commits with commit message and author and link to single commit  (if there are more than 15 commits in a push you see a pluralized hint according to the html dashboard)
- Issues: Display issue description

I added two partials for rendering the content of the feed, I think this approach follows the app's MVC pattern best.

The resulting feed is valid according to W3 feed validation from http://validator.w3.org/appc/ 

Finally, a screenshot of a push feed entry:

![Screenshot](http://d.pr/i/WIWV+)

Feedback appreciated!
Alex
