### PR TITLE
Checking app status fails if using custom repository path

### DIFF
--- a/lib/tasks/gitlab/status.rake
+++ b/lib/tasks/gitlab/status.rake
@@ -49,7 +49,7 @@ namespace :gitlab do
       end
 
       print "UMASK for .gitolite.rc is 0007? ............"
-      unless open("#{git_base_path}/../.gitolite.rc").grep(/UMASK([ \t]*)=([ \t>]*)0007/).empty?
+      unless open("#{Rails.root}/../../git/.gitolite.rc").grep(/UMASK([ \t]*)=([ \t>]*)0007/).empty?
         puts "YES".green 
       else
         puts "NO".red


### PR DESCRIPTION
Checking app status fails if repositories are not in the default path of gitolite:

bundle exec rake gitlab:app:status RAILS_ENV=production

....
Can clone gitolite-admin?............YES
UMASK for .gitolite.rc is 0007? ............rake aborted!
No such file or directory - /rpool/repositories/repositories//../.gitolite.rc

Happens in Gitlab 2.8, 2.9
