### PR TITLE
Minor bug fix to wiki note anchor and wiki note email template.

### DIFF
--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -1,4 +1,4 @@
-%li{id: dom_id(note), class: "note #{note_vote_class(note)}"}
+%li{id: dom_id(note), name: dom_id(note), class: "note #{note_vote_class(note)}"}
   = image_tag gravatar_icon(note.author.email), class: "avatar s32"
   %div.note-author
     %strong= note.author_name

--- a/app/views/notify/note_wiki_email.html.haml
+++ b/app/views/notify/note_wiki_email.html.haml
@@ -5,7 +5,7 @@
       %td{align: "left", style: "padding: 20px 0 0;"}
         %h2{style: "color:#646464 !important; font-weight: bold; margin: 0; padding: 0; line-height: 26px; font-size: 18px; font-family: Helvetica, Arial, sans-serif; "}
           New comment for Wiki page
-          = link_to_gfm @wiki.title, project_issue_url(@wiki.project, @wiki, anchor: "note_#{@note.id}")
+          = link_to_gfm @wiki.title, project_wiki_url(@wiki.project, @wiki, anchor: "note_#{@note.id}")
       %td{style: "font-size: 1px; line-height: 1px;", width: "21"}
     %tr
       %td{style: "font-size: 1px; line-height: 1px;", width: "21"}


### PR DESCRIPTION
- Fix in app/views/notify/note_wiki_email.html.haml broken link. Replaced project_issue_url for project_wiki_url.
- Added name attribute to li tag to the email link to work correctly.
