### PR TITLE
Protect users projects_limit from mass assignment.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < AdminController
 
 
   def new
-    @admin_user = User.new(projects_limit: Gitlab.config.default_projects_limit)
+    @admin_user = User.new({ projects_limit: Gitlab.config.default_projects_limit }, as: :admin)
   end
 
   def edit
@@ -60,7 +60,7 @@ class Admin::UsersController < AdminController
   def create
     admin = params[:user].delete("admin")
 
-    @admin_user = User.new(params[:user])
+    @admin_user = User.new(params[:user], as: :admin)
     @admin_user.admin = (admin && admin.to_i > 0)
 
     respond_to do |format|
@@ -86,7 +86,7 @@ class Admin::UsersController < AdminController
     @admin_user.admin = (admin && admin.to_i > 0)
 
     respond_to do |format|
-      if @admin_user.update_attributes(params[:user])
+      if @admin_user.update_attributes(params[:user], as: :admin)
         format.html { redirect_to [:admin, @admin_user], notice: 'User was successfully updated.' }
         format.json { head :ok }
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,9 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   attr_accessible :email, :password, :password_confirmation, :remember_me, :bio,
-                  :name, :projects_limit, :skype, :linkedin, :twitter, :dark_scheme,
-                  :theme_id, :force_random_password, :extern_uid, :provider
+                  :name, :skype, :linkedin, :twitter, :dark_scheme,
+                  :theme_id, :force_random_password, :extern_uid, :provider, :as => [:default, :admin]
+  attr_accessible :projects_limit, :as => :admin
 
   attr_accessor :force_random_password
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,4 +73,30 @@ describe User do
       user.authentication_token.should_not be_blank
     end
   end
+
+  describe "attributes can be changed by a regular user" do
+    before do
+      @user = Factory :user
+      @user.update_attributes(skype: "testskype", linkedin: "testlinkedin")
+    end
+    it { @user.skype.should == 'testskype' }
+    it { @user.linkedin.should == 'testlinkedin' }
+  end
+
+  describe "attributes that shouldn't be changed by a regular user" do
+    before do
+      @user = Factory :user
+      @user.update_attributes(projects_limit: 50)
+    end
+    it { @user.projects_limit.should_not == 50 }
+  end
+
+  describe "attributes can be changed by an admin user" do
+    before do
+      @admin_user = Factory :admin
+      @admin_user.update_attributes({ skype: "testskype", projects_limit: 50 }, as: :admin)
+    end
+    it { @admin_user.skype.should == 'testskype' }
+    it { @admin_user.projects_limit.should == 50 }
+  end
 end


### PR DESCRIPTION
Users should not be able to set their own projects_limit. Before this change they where able to do so by submitting an extra parameter to the profile controller.
