### PR TITLE
Secure and httponly options on cookie.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-Gitlab::Application.config.session_store :cookie_store, key: '_gitlab_session'
+Gitlab::Application.config.session_store :cookie_store, key: '_gitlab_session',
+                                                      secure: Gitlab::Application.config.force_ssl,
+                                                      httponly: true
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
If administrators enable config.force_ssl this code automatically tells clients to only send cookies over SSL, improving security by complying with OWASP recommendations:
https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet#Rule_-_Use_.22Secure.22_Cookie_Flag

If config.force_ssl is not set there will be no effect.
