### PR TITLE
Fix deletion of tmp/gitlabhq-gitolite* folders in a NFS environment.

### DIFF
--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -40,18 +40,22 @@ module Gitlab
 
             # Save changes in
             # gitolite-admin repo
-            # before pusht it
+            # before push it
             ga_repo.save
 
             # Push gitolite-admin repo
             # to apply all changes
             push(config_tmp_dir)
-
-            # Remove tmp dir
-            # wiith gitolite-admin
-            FileUtils.rm_rf(config_tmp_dir)
           ensure
-            # unlock so other task cann access
+            # Remove tmp dir
+            # removing the gitolite folder first is important to avoid
+            # NFS issues.
+            FileUtils.rm_rf(File.join(config_tmp_dir, 'gitolite'))
+
+            # Remove parent tmp dir
+            FileUtils.rm_rf(config_tmp_dir)
+
+            # Unlock so other task can access
             # gitolite configuration
             f.flock(File::LOCK_UN)
           end


### PR DESCRIPTION
When working inside of a Vagrant box with NFS enabled, the deletion of a
repository in tmp/ doesn't work every time.

It is related to NFS inability to delete a folder if it's still used by
a resource (e.g. `rm -rf ./folder` would leave the folder and a .nfs*
    file in it). In this case it's the temporary repository which can't
be deleted because `ga_repo` is still using it.

De-allocating ga_repo is not possible (thanks Ruby), but deleting the
folder it points to in the first place fixes the issue.

Reference:
http://stackoverflow.com/questions/11228079/python-remove-directory-error-file-exists
