### PR TITLE
Auth: Net::BER::BerIdentifiedStrings to Strings

### DIFF
--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -20,8 +20,9 @@ module Gitlab
     def create_from_omniauth(auth, ldap = false)
       provider = auth.provider
       uid = auth.info.uid || auth.uid
-      name = auth.info.name.force_encoding("utf-8")
-      email = auth.info.email.downcase unless auth.info.email.nil?
+      uid = uid.to_s.force_encoding("utf-8")
+      name = auth.info.name.to_s.force_encoding("utf-8")
+      email = auth.info.email.to_s.downcase unless auth.info.email.nil?
 
       ldap_prefix = ldap ? '(LDAP) ' : ''
       raise OmniAuth::Error, "#{ldap_prefix}#{provider} does not provide an email"\


### PR DESCRIPTION
There is a bug with saving users in case of MS Active Directory and SQLite.
We need to cast BerIdentifiedStrings to Strings and force encode CN to UTF-8.
