### PR TITLE
Improve completion of emoji and team members 

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -14,4 +14,10 @@ module NotesHelper
       "vote downvote"
     end
   end
+
+  def emoji_for_completion
+    # should be an array of strings
+    # so to_s can be called, because it is sufficient and to_json is too slow
+    Emoji::NAMES
+  end
 end

--- a/app/views/notes/_common_form.html.haml
+++ b/app/views/notes/_common_form.html.haml
@@ -39,12 +39,46 @@
 
 :javascript
   $(function(){
-    var names = #{@project.users.pluck(:name)}, emoji = ['+1', '-1'];
-    var emoji = $.map(emoji, function(value, i) {return {key:value + ':', name:value}});
-    $('#note_note, .per_line_form .line-note-text').
-      atWho('@', { data: names }).
-      atWho(':', {
-        data: emoji,
-        tpl: "<li data-value='${key}'>${name} #{escape_javascript image_tag('emoji/${name}.png', :size => '20x20')}</li>"
-      });
+    // init auto-completion of team members
+    var membersUrl = "#{root_url}/api/v2/projects/#{@project.code}/members";
+    var membersParams = {
+      private_token: "#{current_user.authentication_token}",
+      page: 1,
+    };
+    var membersData = [];
+    $('.gfm-input').atWho('@', function(query, callback) {
+      (function getMoreMembers() {
+        $.getJSON(membersUrl, membersParams).
+          success(function(members) {
+            // pick the data we need
+            var newMembersData = $.map(members, function(member) { return member.name });
+
+            // add the new page of data to the rest
+            $.merge(membersData, newMembersData);
+
+            // show the pop-up with a copy of the current data
+            callback(membersData.slice(0));
+
+            // are we past the last page?
+            if (newMembersData.length == 0) {
+              // set static data and stop callbacks
+              $('.gfm-input').atWho('@', { data: membersData, callback: null });
+            } else {
+              // get next page
+              getMoreMembers();
+            }
+          });
+        // next request will get the next page
+        membersParams.page += 1;
+      })();
+    });
+
+    // init auto-completion of emoji
+    var emoji = #{emoji_for_completion};
+    // convert the list so that the items have the right format for completion
+    emoji = $.map(emoji, function(value) {return { key: value+':', name: value }});
+    $('.gfm-input').atWho(':', {
+      data: emoji,
+      tpl: "<li data-value='${key}'>${name} #{escape_javascript image_tag('emoji/${name}.png', :size => '20x20')}</li>"
+    });
   });

--- a/app/views/notes/_common_form.html.haml
+++ b/app/views/notes/_common_form.html.haml
@@ -8,7 +8,7 @@
 
     = f.hidden_field :noteable_id
     = f.hidden_field :noteable_type
-    = f.text_area :note, size: 255, class: 'note-text'
+    = f.text_area :note, size: 255, class: 'note-text gfm-input'
     #preview-note.preview_note.hide
     .hint
       .right Comments are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.

--- a/app/views/notes/_per_line_form.html.haml
+++ b/app/views/notes/_per_line_form.html.haml
@@ -13,7 +13,7 @@
             = f.hidden_field :noteable_id
             = f.hidden_field :noteable_type
             = f.hidden_field :line_code
-            = f.text_area :note,  size: 255, class: 'line-note-text'
+            = f.text_area :note,  size: 255, class: 'line-note-text gfm-input'
             .note_actions
               .buttons
                 = f.submit 'Add note', class: "btn save-btn submit_note submit_inline_note", id: "submit_note"

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe NotesHelper do
+  describe "#emoji_for_completion" do
+    it "should be an Array of Strings" do
+      emoji_for_completion.should be_a(Array)
+      emoji_for_completion.each { |emoji| emoji.should be_a(String) }
+    end
+  end
+end


### PR DESCRIPTION
Improves on #1539 and #1551
- Adds completion for all emoji
- Only load auto-completion data if it's actually used (e.g. someone types `@`) This also improves loading times for pages with notes.
- Use API for auto-completion of team members
- Introduce the `.gfm-input` class for fields that accept GFM (works only with notes at the moment) and use them for setting up auto-completion.

Preparing the emoji data (when rendering) still slows the request down (try commenting out the call to the helper ;) ). But impact has been minimized by using to_s instead of to_json and doing the format mapping in JS (client-side) instead in Ruby (server-side).
