### PR TITLE
Allows to use markdown tables, automatic table of contents and HTML

### DIFF
--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -24,17 +24,6 @@ module GitlabMarkdownHelper
 
   def markdown(text)
     unless @markdown
-
-      # If the user wants TOC we run a Render::HTML_TOC
-      # See http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html
-      toc = nil
-      if text.lines.first.match("~toc~") != nil
-         html_toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC, space_after_headers: true)
-         toc = html_toc.render(text)
-
-         text["~toc~"]= ""
-      end
-
       gitlab_renderer = Redcarpet::Render::GitlabHTML.new(self,
                           # see https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch-
                           filter_html: false,
@@ -52,10 +41,7 @@ module GitlabMarkdownHelper
                       superscript: true)
     end
 
-    if toc == nil
-      @markdown.render(text).html_safe
-    else
-      (toc + @markdown.render(text)).html_safe
-    end
+    @markdown.render(text).html_safe
   end
 end
+

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -28,7 +28,7 @@ module GitlabMarkdownHelper
       # If the user wants TOC we run a Render::HTML_TOC
       # See http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html
       toc = nil
-      if text.match("~toc~") != nil
+      if text.lines.first.match("~toc~") != nil
          html_toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC, space_after_headers: true)
          toc = html_toc.render(text)
 
@@ -53,7 +53,7 @@ module GitlabMarkdownHelper
     end
 
     if toc == nil
-    @markdown.render(text).html_safe
+      @markdown.render(text).html_safe
     else
       (toc + @markdown.render(text)).html_safe
     end

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -24,9 +24,20 @@ module GitlabMarkdownHelper
 
   def markdown(text)
     unless @markdown
+
+      # If the user wants TOC we run a Render::HTML_TOC
+      # See http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html
+      toc = nil
+      if text.match("~toc~") != nil
+         html_toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC, space_after_headers: true)
+         toc = html_toc.render(text)
+
+         text["~toc~"]= ""
+      end
+
       gitlab_renderer = Redcarpet::Render::GitlabHTML.new(self,
                           # see https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch-
-                          filter_html: true,
+                          filter_html: false,
                           with_toc_data: true,
                           hard_wrap: true)
       @markdown = Redcarpet::Markdown.new(gitlab_renderer,
@@ -41,6 +52,10 @@ module GitlabMarkdownHelper
                       superscript: true)
     end
 
+    if toc == nil
     @markdown.render(text).html_safe
+    else
+      (toc + @markdown.render(text)).html_safe
+    end
   end
 end

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -60,6 +60,25 @@
       GFM will autolink standard URLs you copy and paste into your text.
       So if you want to link to a URL (instead of a textual link), you can simply put the URL in verbatim and it will be turned into a link to that URL.
 
+    %h4 Tables
+
+.row
+  .span8
+    %p
+      GFM will generate tables if you use PHP-Markdown Extra like syntax:
+    %pre= %Q{First Header   | Second Header\n---------------|---------------\nContent Cell 1 | Content Cell 2\nContent Cell 3 | Content Cell 4\nContent Cell 5 | Content Cell 6}
+    %p becomes
+    = markdown %Q{First Header   | Second Header\n---------------|---------------\nContent Cell 1 | Content Cell 2\nContent Cell 3 | Content Cell 4\nContent Cell 5 | Content Cell 6}
+
+  .span4
+    .alert.alert-info
+      %p
+        Consult the
+        %strong= link_to "PHP-Markdown Extra Tables", "http://michelf.ca/projects/php-markdown/extra/#table"
+        for more details.
+
+.row
+  .span8
     %h4 Fenced code blocks
 
     %p
@@ -70,6 +89,16 @@
     %pre= %Q{```ruby\nrequire 'redcarpet'\nmarkdown = Redcarpet.new("Hello World!")\nputs markdown.to_html\n```}
     %p becomes
     = markdown %Q{```ruby\nrequire 'redcarpet'\nmarkdown = Redcarpet.new("Hello World!")\nputs markdown.to_html\n```}
+
+    %h4 Automatic table of contents (TOC)
+
+    %p
+      GFM can create a table of contents (TOC) from all headers.
+      To use this feature you must add <code>~toc~</code> anywhere. Note that the TOC will always appear in the top above enything else.
+
+    %pre= %Q{~toc~\n# Header 1\n## Header 2\n# Header 1}
+    %p becomes
+    = markdown %Q{* [Header 1](#toc_0)\n  * [Header 2](#toc_1)\n* [Header 1](#toc_2)\n\n# Header 1\n## Header 2\n# Header 1}
 
     %h4 Emoji
 
@@ -94,6 +123,15 @@
 
 .row
   .span8
+    %h4 Custom HTML
+
+    %p
+      If you still want to, you can use custom HTML for specific tasks.
+
+    %pre= %Q{<em>\n  <p>This line is in HTML</p>\n</em>}
+    %p becomes
+    = markdown %Q{<em>\n  <p>This line is in HTML</p>\n</em>}
+
     %h4 Special GitLab references
 
     %p

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -90,11 +90,11 @@
     %p becomes
     = markdown %Q{```ruby\nrequire 'redcarpet'\nmarkdown = Redcarpet.new("Hello World!")\nputs markdown.to_html\n```}
 
-    %h4 Automatic table of contents (TOC)
+    %h4 Table of contents (TOC) generation
 
     %p
-      GFM can create a table of contents (TOC) from all headers.
-      To use this feature you must add <code>~toc~</code> <strong>anywhere <em>at the first line</em> of your content</strong>. Note that the TOC will always appear in the top above enything else.
+      GFM can automatically generate a TOC from the headers in the text.
+      To have the TOC generated just place <code>~toc~</code> on the first line.
 
     %pre= %Q{~toc~\n# Header 1\n## Header 2\n# Header 1}
     %p becomes

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -94,7 +94,7 @@
 
     %p
       GFM can create a table of contents (TOC) from all headers.
-      To use this feature you must add <code>~toc~</code> anywhere. Note that the TOC will always appear in the top above enything else.
+      To use this feature you must add <code>~toc~</code> <strong>anywhere <em>at the first line</em> of your content</strong>. Note that the TOC will always appear in the top above enything else.
 
     %pre= %Q{~toc~\n# Header 1\n## Header 2\n# Header 1}
     %p becomes

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -88,6 +88,7 @@ module Gitlab
     def parse(text)
       parse_references(text) if @project
       parse_emoji(text)
+      text = parse_toc(text)
 
       text
     end
@@ -119,6 +120,35 @@ module Gitlab
         else
           match
         end
+      end
+    end
+
+    # If the user wants TOC we run a Render::HTML_TOC
+    # See http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html
+    # TODO: Allow TOC to be placed in the middle of the document, not only at top
+    def parse_toc(text)
+      if text.lines.first.match("~toc~") != nil
+        html_text = text.dup.to_str
+
+        # First we must convert HTML headers back to Markdown headers
+        html_text.gsub!(/<h1[^>]*>/, "# ")
+        html_text.gsub!(/<h2[^>]*>/, "## ")
+        html_text.gsub!(/<h3[^>]*>/, "### ")
+        html_text.gsub!(/<h4[^>]*>/, "#### ")
+        html_text.gsub!(/<h5[^>]*>/, "##### ")
+        html_text.gsub!(/<h6[^>]*>/, "###### ")
+
+        html_text.gsub!(/<\/?h\d[^>]*>/, "")
+
+
+        html_toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC, space_after_headers: true)
+        toc = html_toc.render(html_text)
+
+        text["~toc~"]= ""
+
+        toc + text
+      else
+        text
       end
     end
 

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -73,7 +73,7 @@ module Gitlab
         extractions[$1]
       end
 
-      sanitize text.html_safe, attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class)
+      sanitize text.html_safe, attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class), tags: ActionView::Base.sanitized_allowed_tags + %w(table tr td th)
     end
 
     private


### PR DESCRIPTION
This patch will allow to embed tables, generate automatic table of contents and add custom HTML within Markdown. Documentation is also updated accordingly.

I tested the code with Travis: https://travis-ci.org/#!/Anthony-Gaudino/gitlabhq/builds/2614387
Merged the feature branch with Master before testing, so test was made with the change.

Here is an example image:
http://www.freeimagehosting.net/p7dyx

And here is the source:
http://pastebin.com/vHKpyvza

---

Commit 32657a5b7a4075a5a0505ebd36e41bb1459f47f5 will make ~toc~ only work if placed on first line of content, so if for whatever reason there's a ~toc~ in the content it will not trigger the TOC feature.
