### PR TITLE
Rewrite build_url, use web_protocol for repo indicator.

### DIFF
--- a/app/views/blame/_head.html.haml
+++ b/app/views/blame/_head.html.haml
@@ -6,5 +6,5 @@
   %li.right
     .input-prepend.project_clone_holder
       %button{class: "btn small active", :"data-clone" => @project.ssh_url_to_repo} SSH
-      %button{class: "btn small", :"data-clone" => @project.http_url_to_repo} HTTP
+      %button{class: "btn small", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.web_protocol.upcase
       = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select span5"

--- a/app/views/projects/_clone_panel.html.haml
+++ b/app/views/projects/_clone_panel.html.haml
@@ -4,7 +4,7 @@
       .form-horizontal
         .input-prepend.project_clone_holder
           %button{class: "btn small active", :"data-clone" => @project.ssh_url_to_repo} SSH
-          %button{class: "btn small", :"data-clone" => @project.http_url_to_repo} HTTP
+          %button{class: "btn small", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.web_protocol.upcase
           = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select span5"
     .span4.right
       .right

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -31,15 +31,17 @@ class Settings < Settingslogic
     end
 
     def build_url
-      raw_url = self.web_protocol
-      raw_url << "://"
-      raw_url << web_host
-
       if web_custom_port?
-        raw_url << ":#{web_port}"
+        custom_port = ":#{web_port}"
+      else
+        custom_port = nil
       end
-
-      raw_url
+      [
+        web_protocol,
+        "://",
+        web_host,
+        custom_port
+      ].join('')
     end
 
     def ssh_port


### PR DESCRIPTION
Display `HTTPS` as the repo clone indicator when that is the protocol.

Had to rewrite the build_url function since it was modifying the web_protocol variable.
