### PR TITLE
Improve performance of Commits#show

### DIFF
--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -16,13 +16,15 @@ class CommitDecorator < ApplicationDecorator
   # In case this first line is longer than 80 characters, it is cut off
   # after 70 characters and ellipses (`&hellp;`) are appended.
   def title
-    return no_commit_message if safe_message.blank?
+    title = safe_message
 
-    title_end = safe_message.index(/\n/)
-    if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
-      safe_message[0..69] << "&hellip;".html_safe
+    return no_commit_message if title.blank?
+
+    title_end = title.index(/\n/)
+    if (!title_end && title.length > 80) || (title_end && title_end > 80)
+      title[0..69] << "&hellip;".html_safe
     else
-      safe_message.split(/\n/, 2).first
+      title.split(/\n/, 2).first
     end
   end
 
@@ -30,11 +32,13 @@ class CommitDecorator < ApplicationDecorator
   #
   # cut off, ellipses (`&hellp;`) are prepended to the commit message.
   def description
-    title_end = safe_message.index(/\n/)
-    if (!title_end && safe_message.length > 80) || (title_end && title_end > 80)
-      "&hellip;".html_safe << safe_message[70..-1]
+    description = safe_message
+
+    title_end = description.index(/\n/)
+    if (!title_end && description.length > 80) || (title_end && title_end > 80)
+      "&hellip;".html_safe << description[70..-1]
     else
-      safe_message.split(/\n/, 2)[1].try(:chomp)
+      description.split(/\n/, 2)[1].try(:chomp)
     end
   end
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -107,7 +107,7 @@ class Commit
   end
 
   def safe_message
-    utf8 message
+    @safe_message ||= utf8 message
   end
 
   def created_at

--- a/app/views/commits/_head.html.haml
+++ b/app/views/commits/_head.html.haml
@@ -9,12 +9,12 @@
   = nav_link(html_options: {class: branches_tab_class}) do
     = link_to project_repository_path(@project) do
       Branches
-      %span.badge= @project.repo.branch_count
+      %span.badge= @project.branches.length
 
   = nav_link(controller: :repositories, action: :tags) do
     = link_to tags_project_repository_path(@project) do
       Tags
-      %span.badge= @project.repo.tag_count
+      %span.badge= @project.tags.length
 
   - if current_controller?(:commits) && current_user.private_token
     %li.right

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Commit do
+  let(:commit) { create(:project).commit }
+
+  describe CommitDecorator do
+    let(:decorator) { CommitDecorator.new(commit) }
+
+    describe '#title' do
+      it "returns no_commit_message when safe_message is blank" do
+        decorator.stub(:safe_message).and_return('')
+        decorator.title.should == "--no commit message"
+      end
+
+      it "truncates a message without a newline at 70 characters" do
+        message = commit.safe_message * 10
+
+        decorator.stub(:safe_message).and_return(message)
+        decorator.title.should == "#{message[0..69]}&hellip;"
+      end
+
+      it "truncates a message with a newline before 80 characters at the newline" do
+        message = commit.safe_message.split(" ").first
+
+        decorator.stub(:safe_message).and_return(message + "\n" + message)
+        decorator.title.should == message
+      end
+
+      it "truncates a message with a newline after 80 characters at 70 characters" do
+        message = (commit.safe_message * 10) + "\n"
+
+        decorator.stub(:safe_message).and_return(message)
+        decorator.title.should == "#{message[0..69]}&hellip;"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commit#safe_message was getting called several times for every commit
message, which slowed down the "Commit History" page quite a bit because
it was constantly converting the same message to utf8.

Benchmarks:

```
Calling `commit.title` on the same commit, 500 times each run:

                         user     system      total        real
performance branch:  0.600000  17.450000  18.050000 ( 18.058806)
master branch:       2.520000 280.670000 283.190000 (283.191723)
```

In terms of actual performance, on the master branch it takes my system
about 3.5 to 4 seconds to load the first page of the commit history for
GitLab itself in the development environment, and after this change it
takes about 800 ms. That number should still be lower, but this is a
start.
