### PR TITLE
Reject ssh keys that break gitolite

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -18,7 +18,7 @@ class Key < ActiveRecord::Base
   before_save :set_identifier
   before_validation :strip_white_space
   delegate :name, :email, to: :user, prefix: true
-  validate :unique_key
+  validate :unique_key, :fingerprintable_key
 
   def strip_white_space
     self.key = self.key.strip unless self.key.blank?
@@ -30,6 +30,21 @@ class Key < ActiveRecord::Base
     if (query.count > 0)
       errors.add :key, 'already exist.'
     end
+  end
+
+  def fingerprintable_key
+    return true unless key # Don't test if there is no key.
+    # `ssh-keygen -lf /dev/stdin <<< "#{key}"` errors with: redirection unexpected
+    file = Tempfile.new('key_file')
+    begin
+      file.puts key
+      file.rewind
+      fingerprint_output = `ssh-keygen -lf #{file.path} 2>&1` # Catch stderr.
+    ensure
+      file.close
+      file.unlink # deletes the temp file
+    end
+    errors.add(:key, "can't be fingerprinted") if fingerprint_output.match("failed")
   end
 
   def set_identifier

--- a/features/steps/profile/profile_ssh_keys.rb
+++ b/features/steps/profile/profile_ssh_keys.rb
@@ -13,7 +13,7 @@ class ProfileSshKeys < Spinach::FeatureSteps
 
   And 'I submit new ssh key "Laptop"' do
     fill_in "key_title", :with => "Laptop"
-    fill_in "key_key", :with => "ssh-rsa publickey234="
+    fill_in "key_key", :with => "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzrEJUIR6Y03TCE9rIJ+GqTBvgb8t1jI9h5UBzCLuK4VawOmkLornPqLDrGbm6tcwM/wBrrLvVOqi2HwmkKEIecVO0a64A4rIYScVsXIniHRS6w5twyn1MD3sIbN+socBDcaldECQa2u1dI3tnNVcs8wi77fiRe7RSxePsJceGoheRQgC8AZ510UdIlO+9rjIHUdVN7LLyz512auAfYsgx1OfablkQ/XJcdEwDNgi9imI6nAXhmoKUm1IPLT2yKajTIC64AjLOnE0YyCh6+7RFMpiMyu1qiOCpdjYwTgBRiciNRZCH8xIedyCoAmiUgkUT40XYHwLuwiPJICpkAzp7Q== user@laptop"
     click_button "Save"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -83,11 +83,7 @@ FactoryGirl.define do
   factory :key do
     title
     key do
-      """
-      ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
-      596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
-      soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=
-      """
+      "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="
     end
 
     factory :deploy_key do
@@ -96,6 +92,12 @@ FactoryGirl.define do
 
     factory :personal_key do
       user
+    end
+
+    factory :key_with_a_space_in_the_middle do
+      key do
+        "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa ++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="
+      end
     end
   end
 

--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 FactoryGirl.factories.map(&:name).each do |factory_name|
+  next if :key_with_a_space_in_the_middle == factory_name
   describe "#{factory_name} factory" do
     it 'should be valid' do
       build(factory_name).should be_valid

--- a/spec/models/key_spec.rb
+++ b/spec/models/key_spec.rb
@@ -46,4 +46,16 @@ describe Key do
       end
     end
   end
+
+  context "validate it is a fingerprintable key" do
+    let(:user) { Factory.create(:user) }
+
+    it "accepts the fingerprintable key" do
+      build(:key, user: user).should be_valid
+    end
+
+    it "rejects the unfingerprintable key" do
+      build(:key_with_a_space_in_the_middle).should_not be_valid
+    end
+  end
 end

--- a/spec/requests/projects_deploy_keys_spec.rb
+++ b/spec/requests/projects_deploy_keys_spec.rb
@@ -42,7 +42,7 @@ describe "Projects", "DeployKeys" do
     describe "fill in" do
       before do
         fill_in "key_title", with: "laptop"
-        fill_in "key_key", with: "ssh-rsa publickey234="
+        fill_in "key_key", with: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzrEJUIR6Y03TCE9rIJ+GqTBvgb8t1jI9h5UBzCLuK4VawOmkLornPqLDrGbm6tcwM/wBrrLvVOqi2HwmkKEIecVO0a64A4rIYScVsXIniHRS6w5twyn1MD3sIbN+socBDcaldECQa2u1dI3tnNVcs8wi77fiRe7RSxePsJceGoheRQgC8AZ510UdIlO+9rjIHUdVN7LLyz512auAfYsgx1OfablkQ/XJcdEwDNgi9imI6nAXhmoKUm1IPLT2yKajTIC64AjLOnE0YyCh6+7RFMpiMyu1qiOCpdjYwTgBRiciNRZCH8xIedyCoAmiUgkUT40XYHwLuwiPJICpkAzp7Q== user@laptop"
       end
 
       it { expect { click_button "Save" }.to change {Key.count}.by(1) }


### PR DESCRIPTION
Without this code an invalid ssh key could break Gitlab for everyone. For example an ssh key with a space in the middle would pass validation but would give errors in each Gitolite operation.

The errors would look like:

`remote: FATAL: fingerprinting failed for 'keydir/admin_local_host_1348232546.pub'`

This PR solves this by fingerprinting as part of the validation process.

These commits are not squashed because we already needed to merge them into the gitlab.com repository to prevent this problem.
