### PR TITLE
Show numer of notes for commits and merge requests

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -203,6 +203,11 @@
     @extend .cgray;
   }
 
+  .notes_count {
+    float:right;
+    margin: -6px 8px 6px;
+  }
+
   code {
     background:#FCEEC1;
     color:$style_color;

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -186,6 +186,11 @@ class MergeRequest < ActiveRecord::Base
 
     patch_path
   end
+
+  def mr_and_commit_notes
+    commit_ids = commits.map(&:id)
+    Note.where("(noteable_type = 'MergeRequest' AND noteable_id = :mr_id) OR (noteable_type = 'Commit' AND noteable_id IN (:commit_ids))", mr_id: id, commit_ids: commit_ids)
+  end
 end
 
 # == Schema Information

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -13,3 +13,10 @@
       = time_ago_in_words(commit.committed_date)
       ago
       &nbsp;
+
+    %span.notes_count
+      - notes = @project.commit_notes(commit) + @project.commit_line_notes(commit)
+      - if notes.any?
+        %span.btn.small.disabled.grouped
+          %i.icon-comment
+          = notes.count

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -9,7 +9,7 @@
       - if merge_request.notes.any?
         %span.btn.small.disabled.grouped
           %i.icon-comment
-          = merge_request.notes.count
+          = merge_request.mr_and_commit_notes.count
       %span.btn.small.disabled.grouped
         = merge_request.source_branch
         &rarr;

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -35,4 +35,19 @@ describe MergeRequest do
     it { should include_module(IssueCommonality) }
     it { should include_module(Votes) }
   end
+
+  describe "#mr_and_commit_notes" do
+    let!(:merge_request) { Factory.create(:merge_request) }
+
+    before do
+      merge_request.stub(:commits) { [merge_request.project.commit] }
+      Factory.create(:note, noteable: merge_request.commits.first)
+      Factory.create(:note, noteable: merge_request)
+    end
+
+    it "should include notes for commits" do
+      merge_request.commits.should_not be_empty
+      merge_request.mr_and_commit_notes.count.should == 2
+    end
+  end
 end


### PR DESCRIPTION
- show number of comments for a commit in commits lists
- show number of comments for a merge request in MR list (includes commit notes)

screen shots: see below

One step towards fixing #1622
