### PR TITLE
Reversed order of progress indication so that the text matches the progress bar.

### DIFF
--- a/app/views/milestones/show.html.haml
+++ b/app/views/milestones/show.html.haml
@@ -28,9 +28,9 @@
     %h5
       Progress:
       %small
-        #{@milestone.issues.opened.count} open
-        &ndash;
         #{@milestone.issues.closed.count} closed
+        &ndash;
+        #{@milestone.issues.opened.count} open
     .progress.progress-success
       .bar{style: "width: #{@milestone.percent_complete}%;"}
 


### PR DESCRIPTION
On the milestone page http://demo.gitlabhq.com/rails/milestones/4

The text is: `Progress: 1 open – 18 closed`

While the progress bar first displays the closed issues and then the open ones.

This commit makes sure that both have the same order to improve consistency.
