### PR TITLE
allow redis database number to be specified in resque.yml

### DIFF
--- a/config/initializers/4_resque.rb
+++ b/config/initializers/4_resque.rb
@@ -5,7 +5,7 @@ config_file = File.join(rails_root, 'config', 'resque.yml')
 
 if File.exists?(config_file)
   resque_config = YAML.load_file(config_file)
-  Resque.redis = resque_config[rails_env]
+  Resque.redis = Redis.connect(:url => resque_config[rails_env])
 end
 
 # Queues

--- a/config/resque.yml.example
+++ b/config/resque.yml.example
@@ -1,3 +1,3 @@
-development: localhost:6379
-test: localhost:6379
-production: redis.example.com:6379
+development: redis://localhost:6379
+test: redis://localhost:6379/1
+production: redis://redis.example.com:6379

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -252,11 +252,11 @@ You can login via web using admin generated with setup:
 
 ## Customizing Resque's Redis connection
 
-If you'd like Resque to connect to a Redis server on a non-standard port or on
-a different host, you can configure its connection string in the
+If you'd like Resque to connect to a Redis server on a non-standard port, different host,
+or database other than the default, you can configure its connection string in the
 **config/resque.yml** file:
 
-    production: redis.example.com:6379
+    production: redis://redis.example.com:6379/0
 
 **Ok - we have a working application now. **
 **But keep going - there are some things that should be done **

--- a/lib/hooks/post-receive
+++ b/lib/hooks/post-receive
@@ -3,10 +3,14 @@
 # This file was placed here by GitLab. It makes sure that your pushed commits
 # will be processed properly.
 
+RHOST=localhost
+RPORT=6379
+RDB=0
+
 while read oldrev newrev ref
 do
   # For every branch or tag that was pushed, create a Resque job in redis.
   pwd=`pwd`
   reponame=`basename "$pwd" | sed s/\.git$//`
-  env -i redis-cli rpush "resque:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$reponame\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
+  env -i redis-cli -h $RHOST -p $RPORT -n $RDB rpush "resque:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$reponame\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
 done


### PR DESCRIPTION
I was attempting to run multiple gitlab instances on the same server, and figured the best way to keep them separated was to simply use different redis databases for them

the post-receive hook is not ideal, but it works
