### PR TITLE
Doc fix: Nginx init script requires sudo

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -284,7 +284,7 @@ a different host, you can configure its connection string in the
     sudo vim /etc/nginx/sites-enabled/gitlab
 
     # Restart nginx:
-    /etc/init.d/nginx restart
+    sudo /etc/init.d/nginx restart
 
 ## 3. Init script
 


### PR DESCRIPTION
The title says it all. General rule, when you run `/etc/init.d/nginx` without root privileges, you'll get some access denied errors.
