### PR TITLE
Do not allow removal of a project owner user.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -98,6 +98,7 @@ class Admin::UsersController < AdminController
 
   def destroy
     @admin_user = User.find(params[:id])
+    redirect_to admin_users_url, notice: 'User is a project owner, cannot be removed.' and return if @admin_user.my_own_projects.count > 0
     @admin_user.destroy
 
     respond_to do |format|


### PR DESCRIPTION
If a user owns a project it should not be possible to delete the user. Doing so will cause the project to have no owner and lead to errors. The user should be blocked instead.

This fixes the following bug:
1. Make a user.
2. Make a project as this user (user is the owner of the project).
3. Delete the user.
4. Try to delete the project => `NoMethodError` because it the user is nil and it can't find its name.
