### PR TITLE
Syntax error in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "seed-fu"
 
 # Markdown to HTML
 gem "redcarpet",     "~> 2.1.1"
-gem "github-markup", "~> 0.7.4", require: 'github/markup'
+gem "github-markup", "~> 0.7.4", :require => 'github/markup'
 
 # Servers
 gem "thin"


### PR DESCRIPTION
When following the install guide this error crops up.

``` bash
sriehl@seed:/home/gitlab/gitlab$ sudo -u gitlab -H bundle install --without development test --deployment
Gemfile syntax error:
/home/gitlab/gitlab/Gemfile:66: syntax error, unexpected ':', expecting $end
gem "github-markup", "~> 0.7.4", require: 'github/markup'
                                         ^
```

changing line 66 in Gemfile to read:

``` ruby
gem "github-markup", "~> 0.7.4", :require => 'github/markup'
```

fixes it.
