### PR TITLE
Reduce complexity: replace case statement with method lookup.

### DIFF
--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -16,16 +16,11 @@ class NoteObserver < ActiveRecord::Observer
   protected
 
   def notify_team_of_new_note(note)
-    team_without_note_author(note).map do |u|
-      case note.noteable_type
-      when "Commit"; Notify.note_commit_email(u.id, note.id).deliver
-      when "Issue";  Notify.note_issue_email(u.id, note.id).deliver
-      when "Wiki";  Notify.note_wiki_email(u.id, note.id).deliver
-      when "MergeRequest"; Notify.note_merge_request_email(u.id, note.id).deliver
-      when "Wall"; Notify.note_wall_email(u.id, note.id).deliver
-      when "Snippet"; true # no notifications for snippets?
-      else
-        true
+    notify_method = 'note_' + note.noteable_type.underscore + '_email'
+
+    if Notify.respond_to? notify_method
+      team_without_note_author(note).map do |u|
+        Notify.send(notify_method.to_sym, u.id, note.id).deliver
       end
     end
   end

--- a/spec/observers/note_observer_spec.rb
+++ b/spec/observers/note_observer_spec.rb
@@ -90,7 +90,7 @@ describe NoteObserver do
     it 'does nothing for a new note on a snippet' do
         note.stub(:noteable_type).and_return('Snippet')
 
-        subject.send(:notify_team_of_new_note, note).should == [true, true]
+        subject.send(:notify_team_of_new_note, note).should be_nil
     end
   end
 


### PR DESCRIPTION
Code climate gave `NoteObserver` a "B" because of the complex `notify_team_of_new_note` method that used a case statement. According to straight code analysis, this change halves the complexity of the method. 

A concrete benefit of this change is that it reduces the number of code changes needed to add an email notification to a `Note` on a new model--or, say, `Snippet` with no email currently implemented. One would only have to make changes to `Notify` (add a `note_snippet_email` method and view) and update the tests for this method. No further change needed within the method itself.
