### PR TITLE
Fix notification for notes on a wall. (regression)

### DIFF
--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -16,7 +16,8 @@ class NoteObserver < ActiveRecord::Observer
   protected
 
   def notify_team_of_new_note(note)
-    notify_method = 'note_' + note.noteable_type.underscore + '_email'
+    note_is_on = note.noteable_type || 'Wall'
+    notify_method = 'note_' + note_is_on.underscore + '_email'
 
     if Notify.respond_to? notify_method
       team_without_note_author(note).map do |u|

--- a/spec/observers/note_observer_spec.rb
+++ b/spec/observers/note_observer_spec.rb
@@ -80,7 +80,7 @@ describe NoteObserver do
         subject.send(:notify_team_of_new_note, note)
       end
       it 'a wall' do
-        note.stub(:noteable_type).and_return('Wall')
+        note.stub(:noteable_type).and_return(nil)
         Notify.should_receive(:note_wall_email).twice.and_return(double(deliver: true))
 
         subject.send(:notify_team_of_new_note, note)


### PR DESCRIPTION
The fact that Notes on Walls have a noteable_type value of "nil" got
lost in the refactoring of the observer.

Fixes [regression issue](https://github.com/gitlabhq/gitlabhq/commit/16ceae895e32c2474de04c42307d914bf9a4c304#commitcomment-1991187) identified by @riyad that I introduced (#1675) with the MailerObserver -> NoteObserver refactoring.
