### PR TITLE
Refactor tree views and improve consistency

### DIFF
--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -43,6 +43,10 @@
   }
 
   .tree-table {
+    th .btn {
+      margin: -2px -1px;
+      padding: 2px 10px;
+    }
     td {
       background:#fafafa;
     }

--- a/app/decorators/tree_decorator.rb
+++ b/app/decorators/tree_decorator.rb
@@ -28,17 +28,4 @@ class TreeDecorator < ApplicationDecorator
     file = File.join(path, "..")
     h.project_tree_path(project, h.tree_join(ref, file))
   end
-
-  def history_path
-    h.project_commits_path(project, h.tree_join(ref, path))
-  end
-
-  def mb_size
-    size = (tree.size / 1024)
-    if size < 1024
-      "#{size} KB"
-    else
-      "#{size/1024} MB"
-    end
-  end
 end

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -1,6 +1,6 @@
 = render "head"
 
-#tree-holder
+#tree-holder.tree-holder
   %ul.breadcrumb
     %li
       %span.arrow
@@ -15,12 +15,9 @@
     .file_title
       %i.icon-file
       %span.file_name
-        = @tree.name
-        %small blame
-      %span.options
-        = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
-        = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
-        = link_to "source", project_tree_path(@project, @id), class: "btn very_small"
+        = @tree.name.force_encoding('utf-8')
+        %small= number_to_human_size @tree.size
+      %span.options= render "tree/blob_actions"
     .file_content.blame
       %table
         - @blame.each do |commit, lines|

--- a/app/views/tree/_blob.html.haml
+++ b/app/views/tree/_blob.html.haml
@@ -2,34 +2,34 @@
   .file_title
     %i.icon-file
     %span.file_name
-      = tree_file.name.force_encoding('utf-8')
-      %small #{tree_file.mode}
+      = blob.name.force_encoding('utf-8')
+      %small #{blob.mode}
     %span.options
       .btn-group.tree-btn-group
         = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
         = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
         = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
         = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small"
-  - if tree_file.text?
-    - if gitlab_markdown?(tree_file.name)
+  - if blob.text?
+    - if gitlab_markdown?(blob.name)
       .file_content.wiki
         = preserve do
-          = markdown(tree_file.data)
-    - elsif markup?(tree_file.name)
+          = markdown(blob.data)
+    - elsif markup?(blob.name)
       .file_content.wiki
-        = raw GitHub::Markup.render(tree_file.name, tree_file.data)
+        = raw GitHub::Markup.render(blob.name, blob.data)
     - else
       .file_content.code
-        - unless tree_file.empty?
+        - unless blob.empty?
           %div{class: current_user.dark_scheme ? "black" : "white"}
             = preserve do
-              = raw tree_file.colorize(options: { linenos: 'True'})
+              = raw blob.colorize(options: { linenos: 'True'})
         - else
           %h4.nothing_here_message Empty file
 
-  - elsif tree_file.image?
+  - elsif blob.image?
     .file_content.image_file
-      %img{ src: "data:#{tree_file.mime_type};base64,#{Base64.encode64(tree_file.data)}"}
+      %img{ src: "data:#{blob.mime_type};base64,#{Base64.encode64(blob.data)}"}
 
   - else
     .file_content.blob_file
@@ -39,4 +39,4 @@
             %br
             = image_tag "download.png", width: 64
             %h3
-              Download (#{tree_file.mb_size})
+              Download (#{blob.mb_size})

--- a/app/views/tree/_blob.html.haml
+++ b/app/views/tree/_blob.html.haml
@@ -3,7 +3,7 @@
     %i.icon-file
     %span.file_name
       = blob.name.force_encoding('utf-8')
-      %small #{blob.mode}
+      %small= number_to_human_size blob.size
     %span.options= render "tree/blob_actions"
   - if blob.text?
     = render "tree/blob/text", blob: blob

--- a/app/views/tree/_blob.html.haml
+++ b/app/views/tree/_blob.html.haml
@@ -4,12 +4,7 @@
     %span.file_name
       = blob.name.force_encoding('utf-8')
       %small #{blob.mode}
-    %span.options
-      .btn-group.tree-btn-group
-        = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
-        = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
-        = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
-        = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small"
+    %span.options= render "tree/blob_actions"
   - if blob.text?
     - if gitlab_markdown?(blob.name)
       .file_content.wiki

--- a/app/views/tree/_blob.html.haml
+++ b/app/views/tree/_blob.html.haml
@@ -6,32 +6,8 @@
       %small #{blob.mode}
     %span.options= render "tree/blob_actions"
   - if blob.text?
-    - if gitlab_markdown?(blob.name)
-      .file_content.wiki
-        = preserve do
-          = markdown(blob.data)
-    - elsif markup?(blob.name)
-      .file_content.wiki
-        = raw GitHub::Markup.render(blob.name, blob.data)
-    - else
-      .file_content.code
-        - unless blob.empty?
-          %div{class: current_user.dark_scheme ? "black" : "white"}
-            = preserve do
-              = raw blob.colorize(options: { linenos: 'True'})
-        - else
-          %h4.nothing_here_message Empty file
-
+    = render "tree/blob/text", blob: blob
   - elsif blob.image?
-    .file_content.image_file
-      %img{ src: "data:#{blob.mime_type};base64,#{Base64.encode64(blob.data)}"}
-
+    = render "tree/blob/image", blob: blob
   - else
-    .file_content.blob_file
-      %center
-        = link_to project_blob_path(@project, @id) do
-          %div.padded
-            %br
-            = image_tag "download.png", width: 64
-            %h3
-              Download (#{blob.mb_size})
+    = render "tree/blob/download", blob: blob

--- a/app/views/tree/_blob_actions.html.haml
+++ b/app/views/tree/_blob_actions.html.haml
@@ -1,5 +1,12 @@
 .btn-group.tree-btn-group
+  -# only show edit link for text files
+  - if @tree.text?
+    = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small"
   = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
+  -# only show normal/blame view links for text files
+  - if @tree.text?
+    - if current_page? project_blame_path(@project, @id)
+      = link_to "normal view", project_tree_path(@project, @id), class: "btn very_small"
+    - else
+      = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
   = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
-  = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
-  = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small"

--- a/app/views/tree/_blob_actions.html.haml
+++ b/app/views/tree/_blob_actions.html.haml
@@ -1,0 +1,5 @@
+.btn-group.tree-btn-group
+  = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
+  = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
+  = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
+  = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small"

--- a/app/views/tree/_readme.html.haml
+++ b/app/views/tree/_readme.html.haml
@@ -1,0 +1,10 @@
+.file_holder#README
+  .file_title
+    %i.icon-file
+    = readme.name
+  .file_content.wiki
+    - if gitlab_markdown?(readme.name)
+      = preserve do
+        = markdown(readme.data)
+    - else
+      = raw GitHub::Markup.render(readme.name, readme.data)

--- a/app/views/tree/_submodule_item.html.haml
+++ b/app/views/tree/_submodule_item.html.haml
@@ -7,5 +7,5 @@
     %strong= truncate(name, length: 40)
   %td
     %code= submodule_item.id[0..10]
-  %td
+  %td{ colspan: 2 }
     = link_to truncate(url, length: 40), url

--- a/app/views/tree/_tree.html.haml
+++ b/app/views/tree/_tree.html.haml
@@ -12,7 +12,7 @@
 
 %div#tree-content-holder.tree-content-holder
   - if tree.is_blob?
-    = render partial: "tree/tree_file", object: tree
+    = render partial: "tree/blob", object: tree
   - else
     %table#tree-slider{class: "table_#{@hex_path} tree-table" }
       %thead

--- a/app/views/tree/_tree.html.haml
+++ b/app/views/tree/_tree.html.haml
@@ -12,7 +12,7 @@
 
 %div#tree-content-holder.tree-content-holder
   - if tree.is_blob?
-    = render partial: "tree/blob", object: tree
+    = render "tree/blob", blob: tree
   - else
     %table#tree-slider{class: "table_#{@hex_path} tree-table" }
       %thead
@@ -32,17 +32,8 @@
 
       = render_tree(tree.contents)
 
-    - if content = tree.contents.find { |c| c.is_a?(Grit::Blob) and c.name =~ /^readme/i }
-      .file_holder#README
-        .file_title
-          %i.icon-file
-          = content.name
-        .file_content.wiki
-          - if gitlab_markdown?(content.name)
-            = preserve do
-              = markdown(content.data)
-          - else
-            = raw GitHub::Markup.render(content.name, content.data)
+    - if readme = tree.contents.find { |c| c.is_a?(Grit::Blob) and c.name =~ /^readme/i }
+      = render "tree/readme", readme: readme
 
 - unless tree.is_blob?
   :javascript

--- a/app/views/tree/_tree.html.haml
+++ b/app/views/tree/_tree.html.haml
@@ -18,15 +18,15 @@
       %thead
         %th Name
         %th Last Update
-        %th
-          Last commit
-          = link_to "History", tree.history_path, class: "right"
+        %th Last Commit
+        %th= link_to "history", project_commits_path(@project, @id), class: "btn very_small right"
 
       - if tree.up_dir?
         %tr.tree-item
           %td.tree-item-file-name
             = image_tag "file_empty.png", size: '16x16'
             = link_to "..", tree.up_dir_path
+          %td
           %td
           %td
 

--- a/app/views/tree/_tree_item.html.haml
+++ b/app/views/tree/_tree_item.html.haml
@@ -6,4 +6,4 @@
     %span.log_loading.hide
       Loading commit data...
       = image_tag "ajax_loader_tree.gif", width: 14
-  %td.tree_commit
+  %td.tree_commit{ colspan: 2 }

--- a/app/views/tree/blob/_download.html.haml
+++ b/app/views/tree/blob/_download.html.haml
@@ -5,4 +5,4 @@
         %br
         = image_tag "download.png", width: 64
         %h3
-          Download (#{blob.mb_size})
+          Download (#{number_to_human_size blob.size})

--- a/app/views/tree/blob/_download.html.haml
+++ b/app/views/tree/blob/_download.html.haml
@@ -1,0 +1,8 @@
+.file_content.blob_file
+  %center
+    = link_to project_blob_path(@project, @id) do
+      %div.padded
+        %br
+        = image_tag "download.png", width: 64
+        %h3
+          Download (#{blob.mb_size})

--- a/app/views/tree/blob/_image.html.haml
+++ b/app/views/tree/blob/_image.html.haml
@@ -1,0 +1,2 @@
+.file_content.image_file
+  %img{ src: "data:#{blob.mime_type};base64,#{Base64.encode64(blob.data)}"}

--- a/app/views/tree/blob/_text.html.haml
+++ b/app/views/tree/blob/_text.html.haml
@@ -1,0 +1,15 @@
+- if gitlab_markdown?(blob.name)
+  .file_content.wiki
+    = preserve do
+      = markdown(blob.data)
+- elsif markup?(blob.name)
+  .file_content.wiki
+    = raw GitHub::Markup.render(blob.name, blob.data)
+- else
+  .file_content.code
+    - unless blob.empty?
+      %div{class: current_user.dark_scheme ? "black" : "white"}
+        = preserve do
+          = raw blob.colorize(options: { linenos: 'True'})
+    - else
+      %h4.nothing_here_message Empty file

--- a/features/steps/project/project_browse_files.rb
+++ b/features/steps/project/project_browse_files.rb
@@ -5,14 +5,14 @@ class ProjectBrowseFiles < Spinach::FeatureSteps
 
   Then 'I should see files from repository' do
     page.should have_content "app"
-    page.should have_content "History"
+    page.should have_content "history"
     page.should have_content "Gemfile"
   end
 
   Then 'I should see files from repository for "8470d70"' do
     current_path.should == project_tree_path(@project, "8470d70")
     page.should have_content "app"
-    page.should have_content "History"
+    page.should have_content "history"
     page.should have_content "Gemfile"
   end
 

--- a/lib/gitlab/file_editor.rb
+++ b/lib/gitlab/file_editor.rb
@@ -51,7 +51,7 @@ module Gitlab
     protected
 
     def can_edit?(path, last_commit)
-      current_last_commit = @project.commits(ref, path, 1).first.sha
+      current_last_commit = @project.last_commit_for(ref, path).sha
       last_commit == current_last_commit
     end
   end


### PR DESCRIPTION
- rename `_tree_file` to `_blob`
- extract `_blob_actions` from `_blob` and also use them in the blame view
- fix blob actions to only show appropriate actions
- extract partials for rendering different blob contents
- replace file mode with file size in file views
- clean up `TreeDecorator`
- make buttons in titles of tree and file views look alike
