### PR TITLE
Use Font Awsome for icons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :assets do
   gem "modernizr",        "2.5.3"
   gem "raphael-rails",    "1.5.2"
   gem 'bootstrap-sass',   "2.0.4"
+  gem "font-awesome-sass-rails", "~> 2.0.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
       multipart-post (~> 1.1)
     ffaker (1.14.0)
     ffi (1.0.11)
+    font-awesome-sass-rails (2.0.0.0)
+      railties (>= 3.1.1)
+      sass-rails (>= 3.1.1)
     foreman (0.47.0)
       thor (>= 0.13.6)
     gherkin-ruby (0.2.1)
@@ -417,6 +420,7 @@ DEPENDENCIES
   email_spec
   factory_girl_rails
   ffaker
+  font-awesome-sass-rails (~> 2.0.0)
   foreman
   git
   github-linguist (~> 2.3.4)

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,5 +1,6 @@
 @import "bootstrap";
 @import "bootstrap-responsive";
+@import 'font-awesome';
 
 /** GitLab colors **/
 $link_color:#3A89A3;


### PR DESCRIPTION
Adds support for using [Font Awsome](http://fortawesome.github.com/Font-Awesome/) for icons.
Font Awsome is basically a _font_ containing icons instead of the characters of the alphabet.
It can be used for displaying icons the same way Bootstrap does it (in fact it is a drop in replacement).

Benefits:
- no spriting of icons necessary
- icons are resizable and still look good
- icons can be colored
- more icons than Bootstrap

GitHub has a nice blog post for how they are using this technique: https://github.com/blog/1106-say-hello-to-octicons
