### PR TITLE
Update author info in tree listing

### DIFF
--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -52,14 +52,26 @@
     }
   }
 
-  .tree-commit-link {
-    color:#333;
+  .tree_author {
+    padding-right: 8px;
+
+    img.avatar {
+      border: 0 none;
+      float: none;
+      margin-right: 0;
+      padding: 0;
+      width: 16px;
+    }
   }
 
-  a.tree-commit-link {
-    color: #666;
-    &:hover {
-      text-decoration: underline;
+  .tree_commit {
+    color: gray;
+
+    .tree-commit-link {
+      color: #444;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -42,6 +42,28 @@ class CommitDecorator < ApplicationDecorator
     end
   end
 
+  # Returns a link to the commit author. If the author has a matching user and
+  # is a member of the current @project it will link to the team member page.
+  # Otherwise it will link to the author email as specified in the commit.
+  #
+  # options:
+  #  avatar: true   will prepend avatar image
+  def author_link(options)
+    text = if options[:avatar]
+            avatar = h.image_tag h.gravatar_icon(author_email), class: "avatar", width: 16
+            "#{avatar} #{author_name}"
+          else
+            author_name
+          end
+    team_member = @project.try(:team_member_by_name_or_email, author_name, author_email)
+
+    if team_member.nil?
+      h.mail_to author_email, text.html_safe, class: "commit-author-link"
+    else
+      h.link_to text, h.project_team_member_path(@project, team_member), class: "commit-author-link"
+    end
+  end
+
   protected
 
   def no_commit_message

--- a/app/roles/team.rb
+++ b/app/roles/team.rb
@@ -1,7 +1,7 @@
 module Team
-  def team_member_by_name_or_email(email = nil, name = nil)
-    user = users.where("email like ? or name like ?", email, name).first
-    users_projects.find_by_user_id(user.id) if user
+  def team_member_by_name_or_email(name = nil, email = nil)
+    user = users.where("name like ? or email like ?", name, email).first
+    users_projects.where(user: user) if user
   end
 
   # Get Team Member record by user id

--- a/app/views/refs/logs_tree.js.haml
+++ b/app/views/refs/logs_tree.js.haml
@@ -1,9 +1,8 @@
 - @logs.each do |content_data| 
   - file_name = content_data[:file_name]
-  - content_commit = content_data[:commit]
-  - tm = @project.team_member_by_name_or_email(content_commit.author_email, content_commit.author_name)
+  - commit = content_data[:commit]
 
   :plain
     var row = $("table.table_#{@hex_path} tr.file_#{hexdigest(file_name)}");
-    row.find("td.tree_time_ago").html('#{escape_javascript(time_ago_in_words(content_commit.committed_date))} ago');
-    row.find("td.tree_commit").html('#{escape_javascript(render("tree/tree_commit", tm: tm, content_commit: content_commit))}');
+    row.find("td.tree_time_ago").html('#{escape_javascript time_ago_in_words(commit.committed_date)} ago');
+    row.find("td.tree_commit").html('#{escape_javascript render("tree/tree_commit_column", commit: commit)}');

--- a/app/views/tree/_tree_commit.html.haml
+++ b/app/views/tree/_tree_commit.html.haml
@@ -1,3 +1,0 @@
-- if tm
-  = link_to "[#{tm.user_name}]", project_team_member_path(@project, tm)
-= link_to_gfm truncate(content_commit.title, length: tm ? 30 : 50), project_commit_path(@project, content_commit.id), class: "tree-commit-link"

--- a/app/views/tree/_tree_commit_column.html.haml
+++ b/app/views/tree/_tree_commit_column.html.haml
@@ -1,0 +1,2 @@
+%span.tree_author= commit.author_link avatar: true
+= link_to_gfm truncate(commit.title, length: 80), project_commit_path(@project, commit.id), class: "tree-commit-link"


### PR DESCRIPTION
Makes the commit information in the tree view more polished.
- adds the author's avatar
- shows more of the commit message
- fixes wrong argument order in `Team#team_member_by_name_or_email`
- adds `CommitDecorator#author_link` and pulls some code out of the views
- fixes a bug where the link was missing, when the author wasn't a project member (it will now fall back linking to the author's email)

new look:
![new look](http://i.imgur.com/nxRAZ.png)
