### PR TITLE
add shared repository support

### DIFF
--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -151,6 +151,9 @@ module Gitlab
       repo.add_permission("RW+", "", name_writers) unless name_writers.blank?
       repo.add_permission("RW+", "", name_masters) unless name_masters.blank?
 
+      # Add sharedRepository config
+      repo.set_git_config("core.sharedRepository", "0660")
+
       repo
     end
 


### PR DESCRIPTION
### Problem

The original bug report comes from here: https://groups.google.com/forum/?fromgroups=#!topic/gitlabhq/l1wSZmULJSo
### Cause

This is a grack and gitolite cowork problem.

If u push over SSH, ur `.git/objects` 's permission look like this: 

```
drwxrwx---  git:git
```

when u push over HTTP, ur `.git/objects` 's permission looks like this:

```
drwxr-xr-x gitlab:gitlab
```

so, `git` user didn't have group write permission on that object, and `gitlab` user will always have push permission.
### Fix

To fix this problem, we need add a git config to each repo.

```
[core]
    sharedRepository = 0660
```

this will always give objects folder a `drwxrws---` permission. like gitolites umask variable.

Gitolite support `git config` varible.

Our `gitolite-client` also support config variable, its easy to use:

```
repo.set_git_config("core.sharedRepository", "0660")
```

also we need edit `.gitolite.rc` file

```
GIT_CONFIG_KEYS             =>  '.*'
```

when we done what we do.

our new repo will have this in the config:

```
[core]
    repositoryformatversion = 0
    filemode = true
    bare = true
    sharedRepository = 0660 
```

And all things will work again.
### TL;DR

merge this patch

edit `.gitolite.rc` file,  `GIT_CONFIG_KEYS             =>  '.*'` 

will fix this problem.
