### PR TITLE
Enable Oauth login for existing regular users

### DIFF
--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -48,8 +48,12 @@ module Gitlab
 
     def find_or_new_for_omniauth(auth)
       provider, uid = auth.provider, auth.uid
+      email = auth.info.email.downcase unless auth.info.email.nil?
 
       if @user = User.find_by_provider_and_extern_uid(provider, uid)
+        @user
+      elsif @user = User.find_by_email(email)
+        @user.update_attributes(:extern_uid => uid, :provider => provider)
         @user
       else
         if Gitlab.config.omniauth['allow_single_sign_on']


### PR DESCRIPTION
User were not searched by email on auth request as described in issue [#1620](https://github.com/gitlabhq/gitlabhq/issues/1620)

Code was borrowed from function **find_for_ldap_auth** a few lines above.
