### PR TITLE
Added autofocus for issue title

### DIFF
--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -12,7 +12,7 @@
           = f.label :title do
             %strong= "Subject *"
           .input
-            = f.text_field :title, maxlength: 255, class: "xxlarge gfm-input"
+            = f.text_field :title, maxlength: 255, class: "xxlarge gfm-input", autofocus: true
       .issue_middle_block
         .issue_assignee
           = f.label :assignee_id do


### PR DESCRIPTION
When editing or adding a new issue, the title field will be autofocus.

Works only on modern browsers ( http://diveintohtml5.info/forms.html#autofocus ), but I guess that's ok :)
