### PR TITLE
Refer developers to the vagrant vm and remove out of date documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contribute to GitLab 
+## Contribute to GitLab
 
 If you want to contribute to GitLab, follow this process:
 
@@ -7,24 +7,20 @@ If you want to contribute to GitLab, follow this process:
 3. Code
 4. Create a pull request
 
-We will only accept pull requests if: 
+We will only accept pull requests if:
 
 * Your code has proper tests and all tests pass
-* Your code can be merged w/o problems 
+* Your code can be merged w/o problems
 * It won't break existing functionality
 * It's quality code
 * We like it :)
 
-## [You may need a developer VM](https://github.com/gitlabhq/developer-vm)
+For examples of feedback on pull requests please look at the [closed pull requests](https://github.com/gitlabhq/gitlabhq/pulls?direction=desc&page=1&sort=created&state=closed).
+
+## Installation
+
+Install the Gitlab development in a virtual machine with the [Gitlab Vagrant virtual machine](https://github.com/gitlabhq/gitlab-vagrant-vm). Installing it in a virtual machine makes it much easier to set up all the dependencies for integration testing.
 
 ## Running tests
 
-To run the specs for GitLab, you need to run seeds for test db.
-
-    cd gitlabhq
-    rake db:seed_fu RAILS_ENV=test
-
-Then you can run the test suite with rake:
-
-    rake gitlab:test
-
+For more information on running the tests please read the [development tips](https://github.com/gitlabhq/gitlabhq/blob/master/doc/development.md)

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,45 +1,36 @@
-## Development tips: 
+## Development tips:
+
+
+### Installation
+
+Install the Gitlab development in a virtual machine with the [Gitlab Vagrant virtual machine](https://github.com/gitlabhq/gitlab-vagrant-vm). Installing it in a virtual machine makes it much easier to set up all the dependencies for integration testing.
+
 
 ### Start application in development mode
 
-#### 1. Via foreman 
-
-    bundle exec foreman -p 3000
-
-#### 2. Via gitlab cli
+#### 1. Via gitlab cli
 
     ./gitlab start
 
-#### 3. Manually
+#### 2. Manually
 
-   bundle exec rails s
-   bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
+    bundle exec rails s
+    bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
 
 
-### Run tests: 
- 
-#### 1. Packages
-
-    # ubuntu
-    sudo apt-get install libqt4-dev libqtwebkit-dev
-    sudo apt-get install xvfb
-   
-    # Mac 
-    brew install qt
-    brew install xvfb
-
-#### 2. DB & seeds
+### Test DB seutup & seed
 
     bundle exec rake db:setup RAILS_ENV=test
     bundle exec rake db:seed_fu RAILS_ENV=test
 
-###  3. Run Tests
+
+###  Run the Tests
 
     # All in one
     bundle exec rake gitlab:test
-    
-    # Rspec 
+
+    # Rspec
     bundle exec rake spec
-    
+
     # Spinach
     bundle exec rake spinach


### PR DESCRIPTION
The best way to develop for Gitlab is to use the GItlab Vagrant virtual machine. This PR updates all the documentation to point to the vm. This will make it easier for new people to contribute.

Existing documentation that is out of date (the list of packages to install) or that doesn't work on the VM (using `foreman` to start gitlab) is removed.
