### PR TITLE
Fix broken Note scopes with lambdas, 4.0 compat

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -23,13 +23,13 @@ class Note < ActiveRecord::Base
   mount_uploader  :attachment, AttachmentUploader
 
   # Scopes
-  scope :common, where(noteable_id: nil)
-  scope :today, where("created_at >= :date", date: Date.today)
-  scope :last_week, where("created_at  >= :date", date: (Date.today - 7.days))
+  scope :common, ->{ where(noteable_id: nil) }
+  scope :today, ->{ where("created_at >= :date", date: Date.today) }
+  scope :last_week, ->{ where("created_at  >= :date", date: (Date.today - 7.days)) }
   scope :since, ->(day) { where("created_at  >= :date", date: (day)) }
-  scope :fresh, order("created_at ASC, id ASC")
-  scope :inc_author_project, includes(:project, :author)
-  scope :inc_author, includes(:author)
+  scope :fresh, ->{ order("created_at ASC, id ASC") }
+  scope :inc_author_project, ->{ includes(:project, :author) }
+  scope :inc_author, ->{ includes(:author) }
 
   def self.create_status_change_note(noteable, author, status)
     create({


### PR DESCRIPTION
Without lambdas, Date.today will be evaluated in the class body.
For it to have a running scope of last week etc, it will need to
be evaluated each time the scope is called.
In Rails 4.0, lambdas will be required for all scopes, so not a bad
idea to go ahead and change them all now.
