### PR TITLE
Provide an optional support button in the UI

### DIFF
--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -20,6 +20,10 @@
           = link_to new_project_path, class: "btn small", title: "Create New Project" do
             %i.icon-plus
             Project
+        - if Gitlab.config['support']  
+          %a{:class => "btn small", :href =>  Gitlab.config.support_url }
+            %i.icon-envelope
+            Support
       .account-box
         = link_to profile_path, class: "pic" do
           = image_tag gravatar_icon(current_user.email)

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -17,6 +17,10 @@ web:
 email:
   from: notify@localhost
 
+# URL used for support 
+#support:
+#  url: "http://helpdesk"
+
 # Application specific settings
 # Like default project limit for user etc
 app:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -14,6 +14,10 @@ class Settings < Settingslogic
       self.email['from'] ||= ("notify@" + web_host)
     end
 
+    def support_url
+      self.support['url'] ||= nil
+    end
+
     def url
       self['url'] ||= build_url
     end


### PR DESCRIPTION
Provide an optional support button in the interface which enable users to contact administrator.

By default, this setting is commented, so the button doesn't appear.

A preview is available here :
![](http://i.imgur.com/gFcHk.jpg)
