### PR TITLE
grack auth bugfix: allow dots in reponame

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Gitlab::Application.routes.draw do
     project_root: Gitlab.config.git_base_path,
     upload_pack:  Gitlab.config.git_upload_pack,
     receive_pack: Gitlab.config.git_receive_pack
-  }), at: '/:path', constraints: { path: /[\w-]+\.git/ }
+  }), at: '/:path', constraints: { path: /[\w\.-]+\.git/ }
 
   #
   # Help

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -18,7 +18,7 @@ module Grack
       @env['SCRIPT_NAME'] = ""
 
       # Find project by PATH_INFO from env
-      if m = /^\/([\w-]+).git/.match(@request.path_info).to_a
+      if m = /^\/([\w\.-]+)\.git/.match(@request.path_info).to_a
         self.project = Project.find_by_path(m.last)
         return false unless project
       end
@@ -65,7 +65,7 @@ module Grack
       end
       # Need to reset seek point
       @request.body.rewind
-      /refs\/heads\/([\w-]+)/.match(input).to_a.first
+      /refs\/heads\/([\w\.-]+)/.match(input).to_a.first
     end
 
     protected


### PR DESCRIPTION
Its not possible to work with a repo over HTTP when there are dots in its name. E.g. having a repo "serverconfig.my-example-host.com" will fail while cloning/pushing.

I modified some regexp in routes.rb & grack_auth.rb to make this work.
