### PR TITLE
Add Milestone details for Merge Requests

### DIFF
--- a/app/assets/javascripts/merge_requests.js
+++ b/app/assets/javascripts/merge_requests.js
@@ -115,4 +115,15 @@ var MergeRequest = {
         $(".merge_in_progress").hide();
         $(".automerge_widget.already_cannot_be_merged").show();
     }
+};
+
+/*
+ * Filter merge requests
+ */
+function merge_requestsPage() {
+  $("#assignee_id").chosen();
+  $("#milestone_id").chosen();
+  $("#milestone_id, #assignee_id").on("change", function(){
+    $(this).closest("form").submit();
+  });
 }

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -121,3 +121,20 @@ li.merge_request {
 .mr_direction_tip {
   margin-top:40px
 }
+
+.merge_requests_form_box {
+  @extend .main_box;
+  .merge_requests_middle_box {
+    @extend .middle_box_content;
+    height:30px;
+    .merge_requests_assignee {
+      @extend .span6;
+      float:left;
+    }
+    .merge_requests_milestone {
+      @extend .span4;
+      float:left;
+    }
+  }
+}
+

--- a/app/contexts/merge_requests_load_context.rb
+++ b/app/contexts/merge_requests_load_context.rb
@@ -2,7 +2,7 @@ class MergeRequestsLoadContext < BaseContext
   def execute
     type = params[:f]
 
-    merge_requests = project.merge_requests
+    merge_requests = @project.merge_requests
 
     merge_requests = case type
                      when 'all' then merge_requests
@@ -12,5 +12,18 @@ class MergeRequestsLoadContext < BaseContext
                      end.page(params[:page]).per(20)
 
     merge_requests.includes(:author, :project).order("closed, created_at desc")
+
+    @merge_requests = merge_requests
+
+    # Filter by specific assignee_id (or lack thereof)?
+    if params[:assignee_id].present?
+      @merge_requests = merge_requests.where(assignee_id: (params[:assignee_id] == '0' ? nil : params[:assignee_id]))
+    end
+
+    # Filter by specific milestone_id (or lack thereof)?
+    if params[:milestone_id].present?
+      @merge_requests = merge_requests.where(milestone_id: (params[:milestone_id] == '0' ? nil : params[:milestone_id]))
+    end
+	@merge_requests
   end
 end

--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -32,6 +32,7 @@ class MilestonesController < ProjectResourceController
   def show
     @issues = @milestone.issues
     @users = @milestone.participants
+    @merge_requests = @milestone.merge_requests
 
     respond_to do |format|
       format.html

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -4,10 +4,12 @@ class MergeRequest < ActiveRecord::Base
   include IssueCommonality
   include Votes
 
-  attr_accessible :title, :assignee_id, :closed, :target_branch, :source_branch,
+  attr_accessible :title, :assignee_id, :closed, :target_branch, :source_branch, :milestone_id,
                   :author_id_of_changes
 
   attr_accessor :should_remove_source_branch
+
+  belongs_to :milestone
 
   BROKEN_DIFF = "--broken-diff"
 
@@ -24,6 +26,10 @@ class MergeRequest < ActiveRecord::Base
 
   def self.find_all_by_branch(branch_name)
     where("source_branch LIKE :branch OR target_branch LIKE :branch", branch: branch_name)
+  end
+
+  def self.find_all_by_milestone(milestone)
+    where("milestone_id = :milestone_id", milestone_id: milestone)
   end
 
   def human_state
@@ -212,5 +218,6 @@ end
 #  st_diffs      :text(4294967295
 #  merged        :boolean         default(FALSE), not null
 #  state         :integer         default(1), not null
+#  milestone_id  :integer
 #
 

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -3,6 +3,7 @@ class Milestone < ActiveRecord::Base
 
   belongs_to :project
   has_many :issues
+  has_many :merge_requests
 
   validates :title, presence: true
   validates :project, presence: true

--- a/app/views/merge_requests/_form.html.haml
+++ b/app/views/merge_requests/_form.html.haml
@@ -28,16 +28,22 @@
   %h4.cdark 2. Fill info
 
   .clearfix
-    .main_box
+    .merge_requests_form_box
       .top_box_content
         = f.label :title do 
           %strong= "Title *"
         .input= f.text_field :title, class: "input-xxlarge pad gfm-input", maxlength: 255, rows: 5
-      .middle_box_content
-        = f.label :assignee_id do 
-          %i.icon-user 
-          Assign to
-        .input= f.select(:assignee_id, @project.users.all.collect {|p| [ p.name, p.id ] }, { include_blank: "Select user" }, {class: 'chosen span3'})
+      .merge_requests_middle_box
+        .merge_requests_assignee
+          = f.label :assignee_id do
+            %i.icon-user
+            Assign to
+          .input= f.select(:assignee_id, @project.users.all.collect {|p| [ p.name, p.id ] }, { include_blank: "Select user" }, {class: 'chosen span3'})
+        .merge_requests_milestone
+          = f.label :milestone_id do
+            %i.icon-time
+            Milestone
+          .input= f.select(:milestone_id, @project.milestones.active.all.collect {|p| [ p.title, p.id ] }, { include_blank: "Select milestone" }, {class: 'chosen'})
 
   .control-group
 

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -10,6 +10,10 @@
         %span.btn.small.disabled.grouped
           %i.icon-comment
           = merge_request.mr_and_commit_notes.count
+      - if merge_request.milestone_id?
+        %span.btn.small.disabled.grouped
+          %i.icon-time
+          = merge_request.project.milestones.find(merge_request.milestone_id).title
       %span.btn.small.disabled.grouped
         = merge_request.source_branch
         &rarr;

--- a/app/views/merge_requests/index.html.haml
+++ b/app/views/merge_requests/index.html.haml
@@ -9,19 +9,26 @@
 
 .ui-box
   .title
-    %ul.nav.nav-pills
-      %li{class: ("active" if (params[:f] == 'open' || !params[:f]))}
-        = link_to project_merge_requests_path(@project, f: 'open') do
-          Open
-      %li{class: ("active" if params[:f] == "closed")}
-        = link_to project_merge_requests_path(@project, f: "closed") do
-          Closed
-      %li{class: ("active" if params[:f] == 'assigned-to-me')}
-        = link_to project_merge_requests_path(@project, f: 'assigned-to-me') do
-          To Me
-      %li{class: ("active" if params[:f] == 'all')}
-        = link_to project_merge_requests_path(@project, f: 'all') do
-          All
+    .left
+      %ul.nav.nav-pills
+        %li{class: ("active" if (params[:f] == 'open' || !params[:f]))}
+          = link_to project_merge_requests_path(@project, f: 'open', milestone_id: params[:milestone_id]) do
+            Open
+        %li{class: ("active" if params[:f] == "closed")}
+          = link_to project_merge_requests_path(@project, f: "closed", milestone_id: params[:milestone_id]) do
+            Closed
+        %li{class: ("active" if params[:f] == 'assigned-to-me')}
+          = link_to project_merge_requests_path(@project, f: 'assigned-to-me', milestone_id: params[:milestone_id]) do
+            To Me
+        %li{class: ("active" if params[:f] == 'all')}
+          = link_to project_merge_requests_path(@project, f: 'all', milestone_id: params[:milestone_id]) do
+            All
+    .right
+      = form_tag project_merge_requests_path(@project), id: "merge_requests_search_form", method: :get, class: :right  do
+        = select_tag(:assignee_id, options_from_collection_for_select([unassigned_filter] + @project.users.all, "id", "name", params[:assignee_id]), prompt: "Assignee")
+        = select_tag(:milestone_id, options_from_collection_for_select([unassigned_filter] + @project.milestones.order("id desc").all, "id", "title", params[:milestone_id]), prompt: "Milestone")
+        = hidden_field_tag :f, params[:f]
+    .clearfix
 
   %ul.unstyled
     = render @merge_requests
@@ -35,3 +42,7 @@
           .span4.right
             %span.cgray.right #{@merge_requests.total_count} merge requests for this filter
 
+:javascript
+  $(function() {
+      merge_requestsPage();
+    })

--- a/app/views/merge_requests/show/_mr_box.html.haml
+++ b/app/views/merge_requests/show/_mr_box.html.haml
@@ -14,9 +14,13 @@
       %strong.author= link_to_merge_request_author(@merge_request)
 
       - if @merge_request.assignee
-        %cite.cgray and currently assigned to
+        %cite.cgray , currently assigned to
         = image_tag gravatar_icon(@merge_request.assignee_email), width: 16, class: "lil_av"
         %strong.author= link_to_merge_request_assignee(@merge_request)
+      - if @merge_request.milestone
+        - milestone = @merge_request.milestone
+        %cite.cgray and attached to milestone
+        %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
 
 
   - if @merge_request.closed

--- a/app/views/milestones/_milestone.html.haml
+++ b/app/views/milestones/_milestone.html.haml
@@ -4,6 +4,10 @@
       %span.btn.small.disabled.grouped= pluralize milestone.issues.count, 'issues'
     - if milestone.issues.count > 0
       = link_to 'Browse Issues', project_issues_path(milestone.project, milestone_id: milestone.id), class: "btn small grouped"
+    - if milestone.merge_requests.any?
+      %span.btn.small.disabled.grouped= pluralize milestone.issues.count, 'Merge Requests'
+    - if milestone.merge_requests.count > 0
+      = link_to 'Browse Merge Requests', project_merge_requests_path(milestone.project, milestone_id: milestone.id), class: "btn small grouped"
     - if can? current_user, :admin_milestone, milestone.project
       = link_to 'Edit', edit_project_milestone_path(milestone.project, milestone), class: "btn small edit-milestone-link grouped"
   %h4

--- a/app/views/milestones/show.html.haml
+++ b/app/views/milestones/show.html.haml
@@ -61,6 +61,22 @@
     %br
 
   .span6
+    %table.milestone-merge_requests-filter
+      %thead
+        %th
+          %ul.nav.nav-pills
+            %li.active= link_to('Open Merge Requests', '#')
+            %li=link_to('All Merge Requests', '#')
+      - @merge_requests.each do |merge_request|
+        %tr{data: {closed: merge_request.closed}}
+          %td
+            = link_to [@project, merge_request] do
+              %span.badge.badge-info ##{merge_request.id}
+            &ndash;
+            = link_to_gfm truncate(merge_request.title, length: 60), [@project, merge_request]
+    %br
+
+  .span6
     %table
       %thead
         %th Participants

--- a/db/migrate/20121026114600_add_milestone_id_to_merge_requests.rb
+++ b/db/migrate/20121026114600_add_milestone_id_to_merge_requests.rb
@@ -1,0 +1,5 @@
+class AddMilestoneIdToMergeRequests < ActiveRecord::Migration
+  def change
+    add_column :merge_requests, :milestone_id, :integer, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121009205010) do
+ActiveRecord::Schema.define(:version => 20121026114600) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(:version => 20121009205010) do
     t.text     "st_diffs",      :limit => 2147483647
     t.boolean  "merged",                              :default => false, :null => false
     t.integer  "state",                               :default => 1,     :null => false
+    t.integer  "milestone_id"
   end
 
   add_index "merge_requests", ["project_id"], :name => "index_merge_requests_on_project_id"


### PR DESCRIPTION
Hi,

In our organisation we follow a workflow for which it makes sense to assign Merge Requests to a Milestone, since we actually accept submissions over a certain time span, and than we have a merge window during which a person will merge in the next stable release all the MR marked as OK.

The idea is that:
- Someone will do the code review on the MR, and Set the Milestone field if the MR is accepted
- The person in charge for packing the next release will have to browse through all the MR marked for that Milestone and merge them all

Additionally, we plan on adding an automated tool (Jenkins? Travis? A custom script?) that does the same, checking that all the MR marked as OK for the next milestone apply and build correctly on the stable branch.

In this MR I've added
- Milestone detail when creating / editing a MR
- Ability to filter for Assignee / Milestone in the MR list view
- Show the amount of MR associated with a Milestone in the Milestone list view
- Show the amount of open MR in the Milestone details view

Let me know if you have any comments, additional requests, strong objections.
Please keep in mind that I'm not a Ruby developer and I really welcome suggestions on how to do it "better".

Here are a few screenshots

MR Listing
![MR Listing](http://i.imgur.com/ItFAd.png)

MR Detail
![MR Detail](http://i.imgur.com/AjY2u.png)

MR New / Edit
![MR New / Edit](http://i.imgur.com/CEuqn.png)

Milestones Listing
![Milestones Listing](http://i.imgur.com/8d1K6.png)

Milestones Detail
![Milestones Detail](http://i.imgur.com/yjHMH.png)
