### PR TITLE
Link to commit authors everywhere

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -47,12 +47,15 @@
       padding-left: 32px;
     }
 
-    .author,
-    .committer {
+    .author a,
+    .committer a {
       font-size:14px;
       line-height:22px;
       text-shadow:0 1px 1px #fff;
       color:#777;
+      &:hover {
+        color: #999;
+      }
     }
 
     .avatar {
@@ -227,6 +230,9 @@
 
   .commit-author-name {
     color: #777;
+    &:hover {
+      color: #999;
+    }
   }
 }
 

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -72,6 +72,15 @@
       }
     }
   }
+
+  .blame {
+    img.avatar {
+      border: 0 none;
+      float: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
 }
 
 .tree-btn-group {

--- a/app/decorators/commit_decorator.rb
+++ b/app/decorators/commit_decorator.rb
@@ -47,26 +47,46 @@ class CommitDecorator < ApplicationDecorator
   # Otherwise it will link to the author email as specified in the commit.
   #
   # options:
-  #  avatar: true   will prepend avatar image
-  def author_link(options)
-    text = if options[:avatar]
-            avatar = h.image_tag h.gravatar_icon(author_email), class: "avatar s16", width: 16
-            "#{avatar} #{author_name}"
-          else
-            author_name
-          end
-    team_member = @project.try(:team_member_by_name_or_email, author_name, author_email)
+  #  avatar: true will prepend the avatar image
+  #  size:   size of the avatar image in px
+  def author_link(options = {})
+    person_link(options.merge source: :author)
+  end
 
-    if team_member.nil?
-      h.mail_to author_email, text.html_safe, class: "commit-author-link"
-    else
-      h.link_to text, h.project_team_member_path(@project, team_member), class: "commit-author-link"
-    end
+  # Just like #author_link but for the committer.
+  def committer_link(options = {})
+    person_link(options.merge source: :committer)
   end
 
   protected
 
   def no_commit_message
     "--no commit message"
+  end
+
+  # Private: Returns a link to a person. If the person has a matching user and
+  # is a member of the current @project it will link to the team member page.
+  # Otherwise it will link to the person email as specified in the commit.
+  #
+  # options:
+  #  source: one of :author or :committer
+  #  avatar: true will prepend the avatar image
+  #  size:   size of the avatar image in px
+  def person_link(options = {})
+    source_name = send "#{options[:source]}_name".to_sym
+    source_email = send "#{options[:source]}_email".to_sym
+    text = if options[:avatar]
+            avatar = h.image_tag h.gravatar_icon(source_email, options[:size]), class: "avatar #{"s#{options[:size]}" if options[:size]}", width: options[:size]
+            %Q{#{avatar} <span class="commit-#{options[:source]}-name">#{source_name}</span>}
+          else
+            source_name
+          end
+    team_member = @project.try(:team_member_by_name_or_email, source_name, source_email)
+
+    if team_member.nil?
+      h.mail_to source_email, text.html_safe, class: "commit-#{options[:source]}-link"
+    else
+      h.link_to text, h.project_team_member_path(@project, team_member), class: "commit-#{options[:source]}-link"
+    end
   end
 end

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -24,9 +24,7 @@
           - commit = Commit.new(commit)
           - commit = CommitDecorator.decorate(commit)
           %tr
-            %td.author
-              = image_tag gravatar_icon(commit.author_email, 16)
-              = commit.author_name
+            %td.author= commit.author_link avatar: true, size: 16
             %td.blame_commit
               &nbsp;
               %code= link_to commit.short_id, project_commit_path(@project, commit)

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -4,9 +4,8 @@
       %strong= link_to "Browse Code »", project_tree_path(@project, commit), class: "right"
   %p
     = link_to commit.short_id(8), project_commit_path(@project, commit), class: "commit_short_id"
-    %strong.commit-author-name= commit.author_name
+    %strong= commit.author_link avatar: true, size: 24
     %span.dash &ndash;
-    = image_tag gravatar_icon(commit.author_email), class: "avatar", width: 16
     = link_to_gfm truncate(commit.title, length: 50), project_commit_path(@project, commit.id), class: "row_title"
 
     %span.committed_ago

--- a/app/views/commits/_commit_box.html.haml
+++ b/app/views/commits/_commit_box.html.haml
@@ -18,16 +18,15 @@
   .commit-info
     .row
       .span5
-        = image_tag gravatar_icon(@commit.author_email, 40), class: "avatar"
         .author
-          %strong= @commit.author_name
+          %strong= @commit.author_link avatar: true, size: 40
           authored
           %time{title: @commit.authored_date.stamp("Aug 21, 2011 9:23pm")}
             #{time_ago_in_words(@commit.authored_date)} ago
         - if @commit.different_committer?
           .committer
             &rarr;
-            %strong= @commit.committer_name
+            %strong= @commit.committer_link
             committed
             %time{title: @commit.committed_date.stamp("Aug 21, 2011 9:23pm")}
               #{time_ago_in_words(@commit.committed_date)} ago


### PR DESCRIPTION
This fixes a few places where commit authors were only shown as text, but not linked to.
- add links to authors on commit list, commit details and blame pages
- Fix styles for avatar positioning and sizes
- Fix styles for hover color on links

Closes #1595
