### PR TITLE
When the post-receive hook file fails the exists? test, suggest checking its permissions.

### DIFF
--- a/lib/tasks/gitlab/status.rake
+++ b/lib/tasks/gitlab/status.rake
@@ -65,6 +65,7 @@ namespace :gitlab do
           puts "YES".green
         else
           puts "NO".red
+          puts "Check read and execute permissions on file #{dest} and directory #{gitolite_hooks_path}"
           return
         end
       end


### PR DESCRIPTION
This seems to be a FAQ on the mailing list, try adding a short suggestion of what the user should do when their post-receive hooks are reported missing, yet the file exists. It's typically a permissions problem.
