### PR TITLE
Make the rake import_projects task work again

### DIFF
--- a/lib/tasks/bulk_import.rake
+++ b/lib/tasks/bulk_import.rake
@@ -8,9 +8,7 @@ task :import_projects, [:directory,:email] => :environment  do |t, args|
   puts "Found #{repos_to_import.size} repos to import"
 
   repos_to_import.each do |repo_path|
-    repo_name = File.basename repo_path
-    clone_path = "#{git_base_path}#{repo_name}.git"
-
+    repo_name = File.basename(repo_path).sub(/\.git$/, '')
     puts "  Processing #{repo_name}"
 
     if Dir.exists? clone_path


### PR DESCRIPTION
Somewhere in the last month or so, this task has been completely broken, with the error: "ERROR: Failed to create project #Project:0xab74e18 because [:owner, "can't be blank"]"

This pull request makes it work again, and also makes it work properly if the bare repositories you're importing end in ".git".
