### PR TITLE
Cannot remove user that owns a project.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -98,6 +98,9 @@ class Admin::UsersController < AdminController
 
   def destroy
     @admin_user = User.find(params[:id])
+    if @admin_user.my_own_projects.count > 0
+      redirect_to admin_users_path, alert: "User is a project owner and can't be removed." and return
+    end
     @admin_user.destroy
 
     respond_to do |format|


### PR DESCRIPTION
You get an error if you delete a user and then try to delete a project that user owns. To prevent this you should not be able to delete a user that owns project. This PR ensures that.

Also see https://github.com/dosire/gitlabhq/issues/55
