### PR TITLE
Have servers as a group in the bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,10 @@ gem "redcarpet",     "~> 2.1.1"
 gem "github-markup", "~> 0.7.4", require: 'github/markup'
 
 # Servers
-gem "thin"
-gem "unicorn"
+group :servers do
+  gem "thin"
+  gem "unicorn"
+end
 
 # Issue tags
 gem "acts-as-taggable-on", "2.3.1"


### PR DESCRIPTION
In case an installation relies on servers such as Passenger, there's no need to have additional servers in the bundle. This also allows for a clean installation on platforms such as Debian Testing, where eventmachine doesn't install due to a build problem.
