### PR TITLE
Fix double icon on header button hover

### DIFF
--- a/app/assets/stylesheets/themes/ui_mars.scss
+++ b/app/assets/stylesheets/themes/ui_mars.scss
@@ -37,9 +37,6 @@
           background-image: -o-linear-gradient(#595D63 6.6%, #202227);
           background-position:0 0;
           color:#fff;
-          i { 
-            @extend .icon-white;
-          }
         }
 
         border: 1px solid #31363E;

--- a/app/assets/stylesheets/themes/ui_modern.scss
+++ b/app/assets/stylesheets/themes/ui_modern.scss
@@ -70,9 +70,6 @@
         color:#ccc;
         &:hover {
           color:#fff;
-          i { 
-            @extend .icon-white;
-          }
         }
         border: none;
         box-shadow:none;


### PR DESCRIPTION
Before this fix, the button icons in the header for non-default themes had a double icon.

![](http://f.cl.ly/items/300K3n1Q0Z100i0V103j/Screen%20Shot%202012-11-04%20at%204.30.39%20PM.png)

Closes #1910
