### PR TITLE
Fix content listing for non-ascii paths on files page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
-  helper_method :abilities, :can?
+  helper_method :abilities, :can?, :tree_join
 
   rescue_from Gitlab::Gitolite::AccessDenied do |exception|
     log_exception(exception)
@@ -21,6 +21,13 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound do |exception|
     log_exception(exception)
     render "errors/not_found", layout: "errors", status: 404
+  end
+
+  # Use this instead of File.join for paths presented in the UI
+  #
+  # Note: this will make sure the path is UTF-8-encoded
+  def tree_join(*args)
+    File.join(*args.map{|arg| arg.dup.force_encoding('UTF-8')})
   end
 
   protected

--- a/app/controllers/blob_controller.rb
+++ b/app/controllers/blob_controller.rb
@@ -11,7 +11,7 @@ class BlobController < ProjectResourceController
   before_filter :assign_ref_vars
 
   def show
-    if @tree.is_blob?
+    if @tree.blob?
       if @tree.text?
         encoding = detect_encoding(@tree.data)
         mime_type = encoding ? "text/plain; charset=#{encoding}" : "text/plain"

--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -29,13 +29,17 @@ class RefsController < ProjectResourceController
   end
 
   def logs_tree
-    contents = @tree.contents
-    @logs = contents.map do |content|
-      file = params[:path] ? File.join(params[:path], content.name) : content.name
+    @logs = @tree.contents.map do |content|
+      content_name = tree_join(content.name)
+      file = if params[:path].present?
+              tree_join(params[:path], content_name)
+            else
+              content_name
+            end
       last_commit = @project.commits(@commit.id, file, 1).last
       last_commit = CommitDecorator.decorate(last_commit)
       {
-        file_name: content.name,
+        file_name: content_name,
         commit: last_commit
       }
     end

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -44,7 +44,7 @@ class TreeController < ProjectResourceController
   private
 
   def edit_requirements
-    unless @tree.is_blob? && @tree.text?
+    unless @tree.blob? && @tree.text?
       redirect_to project_tree_path(@project, @id), notice: "You can only edit text files"
     end
 

--- a/app/decorators/tree_decorator.rb
+++ b/app/decorators/tree_decorator.rb
@@ -4,9 +4,7 @@ class TreeDecorator < ApplicationDecorator
   def breadcrumbs(max_links = 2)
     if path
       part_path = ""
-      parts = path.split("\/")
-
-      #parts = parts[0...-1] if is_blob?
+      parts = path.split('/')
 
       yield(h.link_to("..", "#")) if parts.count > max_links
 

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -55,11 +55,6 @@ module TreeHelper
     filename == 'README'
   end
 
-  # Simple shortcut to File.join
-  def tree_join(*args)
-    File.join(*args)
-  end
-
   def allowed_tree_edit?
     if @project.protected_branch? @ref
       can?(current_user, :push_code_to_protected_branches, @project)

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -14,7 +14,7 @@ class Tree
             end
   end
 
-  def is_blob?
+  def blob?
     tree.is_a?(Grit::Blob)
   end
 

--- a/app/views/tree/_tree.html.haml
+++ b/app/views/tree/_tree.html.haml
@@ -11,7 +11,7 @@
 %div.tree_progress
 
 %div#tree-content-holder.tree-content-holder
-  - if tree.is_blob?
+  - if tree.blob?
     = render "tree/blob", blob: tree
   - else
     %table#tree-slider{class: "table_#{@hex_path} tree-table" }
@@ -35,7 +35,7 @@
     - if tree.readme
       = render "tree/readme", readme: tree.readme
 
-- unless tree.is_blob?
+- unless tree.blob?
   :javascript
     // Load last commit log for each file in tree
     $(window).load(function(){


### PR DESCRIPTION
A new try for the incomplete fix in #1929.

As noted in https://github.com/gitlabhq/gitlabhq/pull/1929#issuecomment-10118329 the problem with history.js is still unresolved. So clicking the links directly will still fail, but opening them in a new tab will work now.
