### PR TITLE
Update requirements with processor architecture

### DIFF
--- a/doc/install/requirements.md
+++ b/doc/install/requirements.md
@@ -26,3 +26,4 @@ GitLab does **not** run on Windows and we have no plans of making GitLab compati
 ## Hardware: 
 
 We recommend to use server with at least 1GB RAM for gitlab instance.
+Processor architectures matter.  PowerPC doesn't run V8, so it's out.  ARM, even with Debian Unstable's libv8, doesn't seem to work either.  MIPS is less supported than ARM in V8.  Right now you should probably stick to normal architectures like x86 and x64.


### PR DESCRIPTION
Therubyracer doesn't compile on ARM or PowerPC, and probably not MIPS.  Probably should stick to x86 and x64.
