### PR TITLE
fix: grouping commits by date desc doesn't sort the groups too

### DIFF
--- a/app/views/commits/_commits.html.haml
+++ b/app/views/commits/_commits.html.haml
@@ -1,4 +1,4 @@
-- @commits.group_by { |c| c.committed_date.to_date }.each do |day, commits|
+- @commits.group_by { |c| c.committed_date.to_date }.sort.reverse.each do |day, commits|
   %div.ui-box
     %h5.small
       %i.icon-calendar


### PR DESCRIPTION
When working on a repo with many commits in feature branches, the commit order is probably not the same as if sorted by date. In commits view, previously commits were only grouped by date, and with this fix those groups are also sorted by date, in descending order.
