### PR TITLE
fixes :notice after project is created in projects_controller

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,9 +21,10 @@ class ProjectsController < ProjectResourceController
     @project = Project.create_by_user(params[:project], current_user)
 
     respond_to do |format|
+      flash[:notice] = 'Project was successfully created.' if @project.saved?
       format.html do
         if @project.saved?
-          redirect_to(@project, notice: 'Project was successfully created.')
+          redirect_to @project
         else
           render action: "new"
         end

--- a/app/views/projects/create.js.haml
+++ b/app/views/projects/create.js.haml
@@ -1,6 +1,6 @@
 - if @project.saved?
   :plain
-    location.href = "#{project_path(@project, notice: 'Project was successfully created.')}";
+    location.href = "#{project_path(@project)}";
 - else
   - if @project.git_error?
     location.href = "#{errors_githost_path}";


### PR DESCRIPTION
When projects were created in projects_controller, code in create.js.haml passed :notice as url parameter and therefore notice was not displayed after redirect
