### PR TITLE
Fix hash key settings["gitlab_version"] to settings[:gitlab_version]

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -85,11 +85,11 @@ namespace :gitlab do
       ENV["VERSION"] = "#{settings["db_version"]}" if settings["db_version"].to_i > 0
 
       # restoring mismatching backups can lead to unexpected problems
-      if settings["gitlab_version"] != %x{git rev-parse HEAD}.gsub(/\n/,"")
+      if settings[:gitlab_version] != %x{git rev-parse HEAD}.gsub(/\n/,"")
         puts "gitlab_version mismatch:".red
         puts "  Your current HEAD differs from the HEAD in the backup!".red
         puts "  Please switch to the following revision and try again:".red
-        puts "  revision: #{settings["gitlab_version"]}".red
+        puts "  revision: #{settings[:gitlab_version]}".red
         exit 1
       end
 


### PR DESCRIPTION
In backup_create, backup information hash is using symbol as its key.
But in backup_restore, string key is used and it returns empty value.
