### PR TITLE
Add a public mode ( to be used with gitdaemon )

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ActiveRecord::Base
   include Team
 
   attr_accessible :name, :path, :description, :code, :default_branch, :issues_enabled,
-                  :wall_enabled, :merge_requests_enabled, :wiki_enabled
+                  :wall_enabled, :merge_requests_enabled, :wiki_enabled, :public_enabled
   attr_accessor :error_code
 
   # Relations
@@ -62,7 +62,7 @@ class Project < ActiveRecord::Base
             format: { with: /\A[a-zA-Z][a-zA-Z0-9_\-\.]*\z/,
                       message: "only letters, digits & '_' '-' '.' allowed. Letter should be first" }
   validates :issues_enabled, :wall_enabled, :merge_requests_enabled,
-            :wiki_enabled, inclusion: { in: [true, false] }
+            :wiki_enabled, :public_enabled, inclusion: { in: [true, false] }
   validate :check_limit, :repo_name
 
   # Scopes

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -60,6 +60,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix
+        = f.label :public_enabled, "Public"
+        .input= f.check_box :public_enabled
+
   - unless project.new_record?
     .actions
       = f.submit 'Save Project', class: "btn save-btn"

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -52,6 +52,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix
+        = f.label :public_enabled, "Public"
+        .input= f.check_box :public_enabled
+
   %br
 
   .actions

--- a/db/migrate/20121122134605_add_public_enabled_to_project.rb
+++ b/db/migrate/20121122134605_add_public_enabled_to_project.rb
@@ -1,0 +1,5 @@
+class AddPublicEnabledToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :public_enabled, :boolean, :default => false, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121120113838) do
+ActiveRecord::Schema.define(:version => 20121122134605) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -107,17 +107,18 @@ ActiveRecord::Schema.define(:version => 20121120113838) do
     t.string   "name"
     t.string   "path"
     t.text     "description"
-    t.datetime "created_at",                               :null => false
-    t.datetime "updated_at",                               :null => false
-    t.boolean  "private_flag",           :default => true, :null => false
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
+    t.boolean  "private_flag",           :default => true,  :null => false
     t.string   "code"
     t.integer  "owner_id"
     t.string   "default_branch"
-    t.boolean  "issues_enabled",         :default => true, :null => false
-    t.boolean  "wall_enabled",           :default => true, :null => false
-    t.boolean  "merge_requests_enabled", :default => true, :null => false
-    t.boolean  "wiki_enabled",           :default => true, :null => false
+    t.boolean  "issues_enabled",         :default => true,  :null => false
+    t.boolean  "wall_enabled",           :default => true,  :null => false
+    t.boolean  "merge_requests_enabled", :default => true,  :null => false
+    t.boolean  "wiki_enabled",           :default => true,  :null => false
     t.integer  "group_id"
+    t.boolean  "public_enabled",         :default => false, :null => false
   end
 
   create_table "protected_branches", :force => true do |t|

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -27,6 +27,7 @@ GET /projects
     "merge_requests_enabled": false,
     "wall_enabled": true,
     "wiki_enabled": true,
+    "public_enabled": false,
     "created_at": "2012-05-23T08:05:02Z"
   },
   {
@@ -48,6 +49,7 @@ GET /projects
     "merge_requests_enabled": true,
     "wall_enabled": true,
     "wiki_enabled": true,
+    "public_enabled": false,
     "created_at": "2012-05-30T12:49:20Z"
   }
 ]
@@ -85,6 +87,7 @@ Parameters:
   "merge_requests_enabled": true,
   "wall_enabled": true,
   "wiki_enabled": true,
+  "public_enabled": false,
   "created_at": "2012-05-30T12:49:20Z"
 }
 ```

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -21,7 +21,7 @@ module Gitlab
       expose :id, :code, :name, :description, :path, :default_branch
       expose :owner, using: Entities::UserBasic
       expose :private_flag, as: :private
-      expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :created_at
+      expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :public_enabled, :created_at
     end
 
     class ProjectMember < UserBasic

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -35,6 +35,7 @@ module Gitlab
       #   wall_enabled (optional) - enabled by default
       #   merge_requests_enabled (optional) - enabled by default
       #   wiki_enabled (optional) - enabled by default
+      #   public_enabled (optional) - disabled by default
       # Example Request
       #   POST /projects
       post do
@@ -48,7 +49,8 @@ module Gitlab
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled]
+                                    :wiki_enabled,
+                                    :public_enabled]
         @project = Project.create_by_user(attrs, current_user)
         if @project.saved?
           present @project, with: Entities::Project

--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -154,6 +154,8 @@ module Gitlab
       repo.add_permission("RW+", "", name_writers) unless name_writers.blank?
       repo.add_permission("RW+", "", name_masters) unless name_masters.blank?
 
+      repo.add_permission("R", "", "daemon") if project.public_enabled
+
       # Add sharedRepository config
       repo.set_git_config("core.sharedRepository", "0660")
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -12,10 +12,11 @@
 #  code                   :string(255)
 #  owner_id               :integer
 #  default_branch         :string(255)
-#  issues_enabled         :boolean          default(TRUE), not null
-#  wall_enabled           :boolean          default(TRUE), not null
-#  merge_requests_enabled :boolean          default(TRUE), not null
-#  wiki_enabled           :boolean          default(TRUE), not null
+#  issues_enabled         :boolean         default(TRUE), not null
+#  wall_enabled           :boolean         default(TRUE), not null
+#  merge_requests_enabled :boolean         default(TRUE), not null
+#  wiki_enabled           :boolean         default(TRUE), not null
+#  public_enabled         :boolean         default(FALSE), not null
 #  group_id               :integer
 #
 
@@ -68,6 +69,7 @@ describe Project do
     it { should ensure_inclusion_of(:wall_enabled).in_array([true, false]) }
     it { should ensure_inclusion_of(:merge_requests_enabled).in_array([true, false]) }
     it { should ensure_inclusion_of(:wiki_enabled).in_array([true, false]) }
+    it { should ensure_inclusion_of(:public_enabled).in_array([true, false]) }
 
     it "should not allow new projects beyond user limits" do
       project.stub(:owner).and_return(double(can_create_project?: false, projects_limit: 1))

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -60,7 +60,8 @@ describe Gitlab::API do
         issues_enabled: false,
         wall_enabled: false,
         merge_requests_enabled: false,
-        wiki_enabled: false
+        wiki_enabled: false,
+        public_enabled: false
       })
 
       post api("/projects", user), project


### PR DESCRIPTION
This request contains code to select individual project to be accessed publicly

It should be used with git-daemon. The code simply puts a R = daemon in gitolite configuration file

This creates a  git-daemon-export-ok file in each selected project
