### PR TITLE
Option to allow unlimited repositories for users.

### DIFF
--- a/app/roles/account.rb
+++ b/app/roles/account.rb
@@ -22,6 +22,10 @@ module Account
     projects_limit > my_own_projects.count
   end
 
+  def show_project_limit?
+    projects_limit - my_own_projects.count < 100
+  end
+
   def can_create_group?
     is_admin?
   end

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -36,9 +36,10 @@
   %br
   %h4.nothing_here_message
     - if current_user.can_create_project?
-      You can create up to
-      = current_user.projects_limit
-      projects. Click on button below to add a new one
+      - if current_user.show_project_limit?
+        You can create up to
+        = current_user.projects_limit
+        projects. Click on button below to add a new one
       .link_holder
         = link_to new_project_path, class: "btn primary" do
           New Project »

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -65,11 +65,13 @@
           Personal projects:
           %small.right
             %span= current_user.my_own_projects.count
-            of
-            %span= current_user.projects_limit
+            - if current_user.show_project_limit?
+              of
+              %span= current_user.projects_limit
         .padded
-          .progress
-            .bar{style: "width: #{current_user.projects_limit_percent}%;"}
+          - if current_user.show_project_limit?
+            .progress
+              .bar{style: "width: #{current_user.projects_limit_percent}%;"}
 
       %fieldset
         %legend


### PR DESCRIPTION
Adds an option to remove the repositories limit for user projects. If enabled, user can create unlimited number of personal projects. By default this option is disabled.

This is a useful option for companies and universities where server resources are not a problem.
https://groups.google.com/d/msg/gitlabhq/ANAmyqP4m5U/ZqBGEWWVbhsJ
