### PR TITLE
Detect encoding of note attachment url.

### DIFF
--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -36,5 +36,5 @@
     - if note.attachment.url
       .right
         %div.file
-          = link_to note.attachment_identifier, note.attachment.url, target: "_blank"
+          = link_to note.attachment_identifier, note.attachment.url.detect_encoding!, target: "_blank"
   .clear

--- a/app/views/projects/files.html.haml
+++ b/app/views/projects/files.html.haml
@@ -9,7 +9,7 @@
     - @notes.each do |note|
       %tr
         %td
-          %a{href: note.attachment.url}
+          %a{href: note.attachment.url.detect_encoding!}
             = image_tag gravatar_icon(note.author_email), class: "avatar s24"
             = note.attachment_identifier
         %td

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ProjectsController do
+  let(:project) { create(:project) }
+  let(:user)    { create(:user) }
+  let(:note) { create(:note, :project_id => project.code) }
+
+  before do
+    sign_in(user)
+    project.add_access(user, :read, :admin)
+  end
+  
+  describe "GET files" do
+    # Make sure any errors accessing the tree in our views bubble up to this spec
+    render_views
+
+    before { 
+      get :files, id: project.code
+    }
+
+    context "utf-8 filename attachment" do
+      it { should respond_with(:success) }
+    end
+  end
+end


### PR DESCRIPTION
If a user attaches a document that contains special characters in the filename( eg. çaão_riaá.doc) to a comment, comment is not displayed. 
PROJECT/files/ page will also give error 500. This PR solves that.

Unfortunately, the included test is passing even without the fix.

Travis build failed for postgresql but passed for mysql.
