### PR TITLE
Rewording for the account being blocked

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
   def reject_blocked!
     if current_user && current_user.blocked
       sign_out current_user
-      flash[:alert] = "Your account was blocked"
+      flash[:alert] = "Your account is blocked. Retry when an admin unblock it."
       redirect_to new_user_session_path
     end
   end
@@ -42,7 +42,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for resource
     if resource.is_a?(User) && resource.respond_to?(:blocked) && resource.blocked
       sign_out resource
-      flash[:alert] = "Your account was blocked"
+      flash[:alert] = "Your account is blocked. Retry when an admin unblock it."
       new_user_session_path
     else
       super


### PR DESCRIPTION
When signing in with SSO, if the default behaviour of gitlab is to block SSO user, the only message the people will get is 'Your account was blocked'

They should get the idea this might be only temporary and not because of a technical problem
