### PR TITLE
fix RESTful design of URLs for merge requests API

### DIFF
--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -4,9 +4,9 @@ module Gitlab
     before { authenticate! }
 
     resource :projects do
-      
+
       # List merge requests
-      # 
+      #
       # Parameters:
       #   id (required) - The ID or code name of a project
       #
@@ -15,24 +15,24 @@ module Gitlab
       #
       get ":id/merge_requests" do
         authorize! :read_merge_request, user_project
-        
+
         present paginate(user_project.merge_requests), with: Entities::MergeRequest
       end
-      
+
       # Show MR
-      # 
+      #
       # Parameters:
       #   id (required)               - The ID or code name of a project
       #   merge_request_id (required) - The ID of MR
-      # 
+      #
       # Example:
       #   GET /projects/:id/merge_request/:merge_request_id
       #
-      get ":id/merge_request/:merge_request_id" do
+      get ":id/merge_requests/:merge_request_id" do
         merge_request = user_project.merge_requests.find(params[:merge_request_id])
-        
+
         authorize! :read_merge_request, merge_request
-        
+
         present merge_request, with: Entities::MergeRequest
       end
 
@@ -45,17 +45,17 @@ module Gitlab
       #   target_branch (required) - The target branch
       #   assignee_id              - Assignee user ID
       #   title (required)         - Title of MR
-      # 
+      #
       # Example:
       #   POST /projects/:id/merge_requests
       #
       post ":id/merge_requests" do
         authorize! :write_merge_request, user_project
-        
+
         attrs = attributes_for_keys [:source_branch, :target_branch, :assignee_id, :title]
         merge_request = user_project.merge_requests.new(attrs)
         merge_request.author = current_user
-        
+
         if merge_request.save
           merge_request.reload_code
           present merge_request, with: Entities::MergeRequest
@@ -77,12 +77,12 @@ module Gitlab
       # Example:
       #   PUT /projects/:id/merge_request/:merge_request_id
       #
-      put ":id/merge_request/:merge_request_id" do
+      put ":id/merge_requests/:merge_request_id" do
         attrs = attributes_for_keys [:source_branch, :target_branch, :assignee_id, :title, :closed]
         merge_request = user_project.merge_requests.find(params[:merge_request_id])
-        
+
         authorize! :modify_merge_request, merge_request
-        
+
         if merge_request.update_attributes attrs
           merge_request.reload_code
           merge_request.mark_as_unchecked
@@ -98,10 +98,10 @@ module Gitlab
       #   id (required) - The ID or code name of a project
       #   merge_request_id (required) - ID of MR
       #   note (required) - Text of comment
-      # Examples: 
+      # Examples:
       #   POST /projects/:id/merge_request/:merge_request_id/comments
       #
-      post ":id/merge_request/:merge_request_id/comments" do
+      post ":id/merge_requests/:merge_request_id/comments" do
         merge_request = user_project.merge_requests.find(params[:merge_request_id])
         note = merge_request.notes.new(note: params[:note], project_id: user_project.id)
         note.author = current_user

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -26,9 +26,9 @@ describe Gitlab::API do
     end
   end
 
-  describe "GET /projects/:id/merge_request/:merge_request_id" do
+  describe "GET /projects/:id/merge_requests/:merge_request_id" do
     it "should return merge_request" do
-      get api("/projects/#{project.path}/merge_request/#{merge_request.id}", user)
+      get api("/projects/#{project.path}/merge_requests/#{merge_request.id}", user)
       response.status.should == 200
       json_response['title'].should == merge_request.title
     end
@@ -43,17 +43,17 @@ describe Gitlab::API do
     end
   end
 
-  describe "PUT /projects/:id/merge_request/:merge_request_id" do
+  describe "PUT /projects/:id/merge_requests/:merge_request_id" do
     it "should return merge_request" do
-      put api("/projects/#{project.path}/merge_request/#{merge_request.id}", user), title: "New title"
+      put api("/projects/#{project.path}/merge_requests/#{merge_request.id}", user), title: "New title"
       response.status.should == 200
       json_response['title'].should == 'New title'
     end
   end
 
-  describe "POST /projects/:id/merge_request/:merge_request_id/comments" do
+  describe "POST /projects/:id/merge_requests/:merge_request_id/comments" do
     it "should return comment" do
-      post api("/projects/#{project.path}/merge_request/#{merge_request.id}/comments", user), note: "My comment"
+      post api("/projects/#{project.path}/merge_requests/#{merge_request.id}/comments", user), note: "My comment"
       response.status.should == 201
       json_response['note'].should == 'My comment'
     end


### PR DESCRIPTION
Keep API URLs RESTful: use plural routes for plural resources.
