### PR TITLE
can't open a chinese file name doc

### DIFF
--- a/app/assets/javascripts/tree.js.coffee
+++ b/app/assets/javascripts/tree.js.coffee
@@ -28,7 +28,7 @@ $ ->
         return false
 
       $('#tree-slider .tree-item-file-name a, .breadcrumb li > a').live 'click', (e) ->
-        History.pushState(null, null, $(@).attr('href'))
+        History.pushState(null, null, decodeURIComponent($(@).attr('href')))
         return false
 
       History.Adapter.bind window, 'statechange', ->


### PR DESCRIPTION
if link to a chinese file name, it will jump to error page;
for example, the chinese file name called "消息文档.md", when after urlencode, it will be "%E6%B6%88%E6%81%AF%E6%96%87%E6%A1%A3.md", but after use History.pushState, will jump to a bad decode link.
