### PR TITLE
Add a link to each project on the Issues dashboard

### DIFF
--- a/app/views/dashboard/issues.html.haml
+++ b/app/views/dashboard/issues.html.haml
@@ -13,7 +13,7 @@
       - @issues.group_by(&:project).each do |group|
         %div.ui-box
           - @project = group[0]
-          %h5= @project.name
+          %h5= link_to(@project.name, project_path(@project))
           %ul.unstyled.issues_table
             - group[1].each do |issue|
               = render(partial: 'issues/show', locals: {issue: issue})

--- a/features/steps/dashboard/dashboard_issues.rb
+++ b/features/steps/dashboard/dashboard_issues.rb
@@ -7,6 +7,7 @@ class DashboardIssues < Spinach::FeatureSteps
     issues.each do |issue|
       page.should have_content(issue.title[0..10])
       page.should have_content(issue.project.name)
+      page.should have_link(issue.project.name)
     end
   end
 


### PR DESCRIPTION
Just a convenience thing I've wanted.

Update to #2018 for the new dashboard.
