### PR TITLE
SCSS/CSS refactor

### DIFF
--- a/app/assets/javascripts/issues.js
+++ b/app/assets/javascripts/issues.js
@@ -1,20 +1,20 @@
 function switchToNewIssue(){
-  $(".issues_content").hide("fade", { direction: "left" }, 150, function(){
+  $(".issues-content").hide("fade", { direction: "left" }, 150, function(){
     $('select#issue_assignee_id').chosen();
     $('select#issue_milestone_id').chosen();
     $("#new_issue_dialog").show("fade", { direction: "right" }, 150);
-    $('.top-tabs .add_new').hide();
+    $('.top-tabs .add-new').hide();
     disableButtonIfEmptyField("#issue_title", ".save-btn");
     GitLab.GfmAutoComplete.setup();
   });
 }
 
 function switchToEditIssue(){
-  $(".issues_content").hide("fade", { direction: "left" }, 150, function(){
+  $(".issues-content").hide("fade", { direction: "left" }, 150, function(){
     $('select#issue_assignee_id').chosen();
     $('select#issue_milestone_id').chosen();
     $("#edit_issue_dialog").show("fade", { direction: "right" }, 150);
-    $('.add_new').hide();
+    $('.add-new').hide();
     disableButtonIfEmptyField("#issue_title", ".save-btn");
     GitLab.GfmAutoComplete.setup();
   });
@@ -30,10 +30,10 @@ function switchFromEditIssue(){
 
 function backToIssues(){
   $("#edit_issue_dialog, #new_issue_dialog").hide("fade", { direction: "right" }, 150, function(){
-    $(".issues_content").show("fade", { direction: "left" }, 150, function() { 
+    $(".issues-content").show("fade", { direction: "left" }, 150, function() { 
       $("#edit_issue_dialog").html("");
       $("#new_issue_dialog").html("");
-      $('.add_new').show();
+      $('.add-new').show();
     });
   });
 }
@@ -80,7 +80,7 @@ function issuesPage(){
     updateNewIssueURL();
   });
 
-  $('body').on('ajax:success', '.close_issue, .reopen_issue, #new_issue', function(){
+  $('body').on('ajax:success', '.close-issue, .reopen-issue, #new_issue', function(){
     var t = $(this),
         totalIssues,
         reopen = t.hasClass('reopen_issue'),
@@ -88,11 +88,11 @@ function issuesPage(){
     if( this.id == 'new_issue' ){
       newIssue = true;
     }
-    $('.issue_counter, #new_issue').each(function(){
+    $('.issue-counter, #new_issue').each(function(){
       var issue = $(this);
       totalIssues = parseInt( $(this).html(), 10 );
 
-      if( newIssue || ( reopen && issue.closest('.main_menu').length ) ){
+      if( newIssue || ( reopen && issue.closest('.main-menu').length ) ){
         $(this).html( totalIssues+1 );
       }else {
         $(this).html( totalIssues-1 );
@@ -101,16 +101,16 @@ function issuesPage(){
 
   });
 
-  $(".check_all_issues").click(function () {
-    $('.selected_issue').attr('checked', this.checked);
+  $(".check-all-issues").click(function () {
+    $('.selected-issue').attr('checked', this.checked);
     issuesCheckChanged();
   });
 
-  $('.selected_issue').bind('change', issuesCheckChanged);
+  $('.selected-issue').bind('change', issuesCheckChanged);
 }
 
 function issuesCheckChanged() { 
-  var checked_issues = $('.selected_issue:checked');
+  var checked_issues = $('.selected-issue:checked');
 
   if(checked_issues.length > 0) { 
     var ids = []
@@ -118,12 +118,12 @@ function issuesCheckChanged() {
       ids.push($(value).attr("data-id"));
     })
     $('#update_issues_ids').val(ids);
-    $('.issues_filters').hide();
-    $('.issues_bulk_update').show();
+    $('.issues-filters').hide();
+    $('.issues-bulk-update').show();
   } else { 
     $('#update_issues_ids').val([]);
-    $('.issues_bulk_update').hide();
-    $('.issues_filters').show();
+    $('.issues-bulk-update').hide();
+    $('.issues-filters').show();
   }
 }
 

--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -21,17 +21,17 @@ window.disableButtonIfEmptyField = (field_selector, button_selector) ->
       closest_submit.enable()
 
 $ ->
-  # Click a .one_click_select field, select the contents
-  $(".one_click_select").on 'click', -> $(@).select()
+  # Click a .one-click-select field, select the contents
+  $(".one-click-select").on 'click', -> $(@).select()
 
   # Initialize chosen selects
   $('select.chosen').chosen()
 
   # Initialize tooltips
-  $('.has_tooltip').tooltip()
+  $('.has-tooltip').tooltip()
 
   # Bottom tooltip
-  $('.has_bottom_tooltip').tooltip(placement: 'bottom')
+  $('.has-bottom_tooltip').tooltip(placement: 'bottom')
 
 
   # Disable form buttons while a form is submitting
@@ -58,7 +58,7 @@ $ ->
         e.preventDefault()
 
   # Commit show suppressed diff
-  $(".supp_diff_link").bind "click", ->
+  $(".supp-diff-link").bind "click", ->
     $(@).next('table').show()
     $(@).remove()
 

--- a/app/assets/javascripts/merge_requests.js
+++ b/app/assets/javascripts/merge_requests.js
@@ -11,12 +11,12 @@ var MergeRequest = {
       self.initTabs();
       self.initMergeWidget();
 
-      $(".mr_show_all_commits").bind("click", function() { 
+      $(".mr-show-all-commits").bind("click", function() { 
         self.showAllCommits();
       });
 
-      $(".line_note_link, .line_note_reply_link").live("click", function(e) {
-        var form = $(".per_line_form");
+      $(".line-note-link, .line-note-reply-link").live("click", function(e) {
+        var form = $(".per-line-form");
         $(this).parent().parent().after(form);
         form.find("#note_line_code").val($(this).attr("line_code"));
         form.show();
@@ -29,7 +29,7 @@ var MergeRequest = {
       var self = this;
       self.showState(self.opts.current_state);
 
-      if($(".automerge_widget").length && self.opts.check_enable){
+      if($(".automerge-widget").length && self.opts.check_enable){
         $.get(self.opts.url_to_automerge_check, function(data){
           self.showState(data.state);
         }, "json");
@@ -38,16 +38,16 @@ var MergeRequest = {
 
   initTabs:
     function() { 
-      $(".mr_nav_tabs a").live("click", function() { 
-        $(".mr_nav_tabs a").parent().removeClass("active");
+      $(".mr-nav-tabs a").live("click", function() { 
+        $(".mr-nav-tabs a").parent().removeClass("active");
         $(this).parent().addClass("active");
       });
 
       var current_tab;
       if(this.opts.action == "diffs") { 
-        current_tab = $(".mr_nav_tabs .merge-diffs-tab");
+        current_tab = $(".mr-nav-tabs .merge-diffs-tab");
       } else {
-        current_tab = $(".mr_nav_tabs .merge-notes-tab");
+        current_tab = $(".mr-nav-tabs .merge-notes-tab");
       }
       current_tab.parent().addClass("active");
 
@@ -57,9 +57,9 @@ var MergeRequest = {
 
   initNotesTab: 
     function() { 
-      $(".mr_nav_tabs a.merge-notes-tab").live("click", function(e) { 
+      $(".mr-nav-tabs a.merge-notes-tab").live("click", function(e) { 
         $(".merge-request-diffs").hide();
-        $(".merge_request_notes").show();
+        $(".merge-request-notes").show();
         var mr_path = $(".merge-notes-tab").attr("data-url");
         history.pushState({ path: mr_path }, '', mr_path);
         e.preventDefault();
@@ -68,11 +68,11 @@ var MergeRequest = {
 
   initDiffTab: 
     function() { 
-      $(".mr_nav_tabs a.merge-diffs-tab").live("click", function(e) { 
+      $(".mr-nav-tabs a.merge-diffs-tab").live("click", function(e) { 
         if(!MergeRequest.diffs_loaded) { 
           MergeRequest.loadDiff(); 
         }
-        $(".merge_request_notes").hide();
+        $(".merge-request-notes").hide();
         $(".merge-request-diffs").show();
         var mr_diff_path = $(".merge-diffs-tab").attr("data-url");
         history.pushState({ path: mr_diff_path }, '', mr_diff_path);
@@ -83,8 +83,8 @@ var MergeRequest = {
 
   showState:
     function(state){
-      $(".automerge_widget").hide();
-      $(".automerge_widget." + state).show();
+      $(".automerge-widget").hide();
+      $(".automerge-widget." + state).show();
     },
 
 
@@ -97,7 +97,7 @@ var MergeRequest = {
         beforeSend: function(){ $('.status').addClass("loading")},
         complete: function(){ 
           MergeRequest.diffs_loaded = true;
-          $(".merge_request_notes").hide();
+          $(".merge-request-notes").hide();
           $('.status').removeClass("loading");
         },
         dataType: "script"});
@@ -105,15 +105,15 @@ var MergeRequest = {
 
   showAllCommits: 
     function() { 
-      $(".first_mr_commits").remove();
-      $(".all_mr_commits").removeClass("hide");
+      $(".first-mr-commits").remove();
+      $(".all-mr-commits").removeClass("hide");
     },
 
   already_cannot_be_merged:
     function(){
-        $(".automerge_widget").hide();
-        $(".merge_in_progress").hide();
-        $(".automerge_widget.already_cannot_be_merged").show();
+        $(".automerge-widget").hide();
+        $(".merge-in-progress").hide();
+        $(".automerge-widget.already-cannot-be-merged").show();
     }
 };
 

--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -28,30 +28,30 @@ var NoteList = {
       });
 
       $(".note-form-holder").on("ajax:before", function(){
-        $(".submit_note").disable();
+        $(".submit-note").disable();
       })
 
       $(".note-form-holder").on("ajax:complete", function(){
-        $(".submit_note").enable();
+        $(".submit-note").enable();
         $('#preview-note').hide();
-        $('#note_note').show();
+        $('#note-note').show();
       })
 
-      disableButtonIfEmptyField(".note-text", ".submit_note");
+      disableButtonIfEmptyField(".note-text", ".submit-note");
 
       $("#note_attachment").change(function(e){
         var val = $('.input-file').val();
         var filename = val.replace(/^.*[\\\/]/, '');
-        $(".file_name").text(filename);
+        $(".file-name").text(filename);
       });
 
       if(this.reversed) {
         var textarea = $(".note-text");
-        $('.note_advanced_opts').hide();
+        $('.note-advanced-opts').hide();
         textarea.css("height", "40px");
         textarea.on("focus", function(){
           $(this).css("height", "80px");
-          $('.note_advanced_opts').show();
+          $('.note-advanced-opts').show();
         });
       }
 
@@ -281,15 +281,15 @@ var PerLineNotes = {
        * Shows the note form below the line.
        * Sets some hidden fields in the form.
        */
-      $(".diff_file_content").on("click", ".line_note_link, .line_note_reply_link", function(e) {
-        var form = $(".per_line_form");
+      $(".diff-file-content").on("click", ".line-note-link, .line-note-reply-link", function(e) {
+        var form = $(".per-line-form");
         $(this).closest("tr").after(form);
         form.find("#note_line_code").val($(this).data("lineCode"));
         form.show();
         e.preventDefault();
       });
 
-      disableButtonIfEmptyField(".line-note-text", ".submit_inline_note");
+      disableButtonIfEmptyField(".line-note-text", ".submit-inline-note");
 
       /**
        * Called in response to successfully deleting a note on a diff line.
@@ -297,7 +297,7 @@ var PerLineNotes = {
        * Removes the actual note from view.
        * Removes the reply button if the last note for that line has been removed.
        */
-      $(".diff_file_content").on("ajax:success", ".delete-note", function() {
+      $(".diff-file-content").on("ajax:success", ".delete-note", function() {
         var trNote = $(this).closest("tr");
         trNote.fadeOut(function() {
           $(this).remove();
@@ -307,7 +307,7 @@ var PerLineNotes = {
         // elements must really be removed for this to work reliably
         var trLine = trNote.prev();
         var trRpl  = trNote.next();
-        if (trLine.is(".line_holder") && trRpl.is(".reply")) {
+        if (trLine.is(".line-holder") && trRpl.is(".reply")) {
           trRpl.fadeOut(function() { $(this).remove(); });
         }
       });

--- a/app/assets/javascripts/pager.js
+++ b/app/assets/javascripts/pager.js
@@ -23,7 +23,7 @@ var Pager = {
 
   append:
     function(count, html) {
-      $(".content_list").append(html);
+      $(".content-list").append(html);
       if(count > 0) {
         this.offset += count;
       } else { 

--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -1,10 +1,10 @@
 $ ->
-  $('.edit_user .application-theme input, .edit_user .code-preview-theme input').click ->
+  $('.edit-user .application-theme input, .edit-user .code-preview-theme input').click ->
     # Hide any previous submission feedback
-    $('.edit_user .update-feedback').hide()
+    $('.edit-user .update-feedback').hide()
 
     # Submit the form
-    $('.edit_user').submit()
+    $('.edit-user').submit()
 
     # Go up the hierarchy and show the corresponding submission feedback element
     $(@).closest('fieldset').find('.update-feedback').show('highlight', {color: '#DFF0D8'}, 500)

--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -3,8 +3,8 @@ window.Projects = ->
     slug = slugify $(@).val()
     $('#project_code, #project_path').val slug
 
-  $('.new_project, .edit_project').on 'ajax:before', ->
-    $('.project_new_holder, .project_edit_holder').hide()
+  $('.new-project, .edit-project').on 'ajax:before', ->
+    $('.project-new-holder, .project-edit-holder').hide()
     $('.save-project-loader').show()
 
   $('form #project_default_branch').chosen()
@@ -12,7 +12,7 @@ window.Projects = ->
 
 $ ->
   # Git clone panel switcher
-  scope = $ '.project_clone_holder'
+  scope = $ '.project-clone-holder'
   if scope.length > 0
     $('a, button', scope).click ->
       $('a, button', scope).removeClass 'active'

--- a/app/assets/javascripts/tree.js.coffee
+++ b/app/assets/javascripts/tree.js.coffee
@@ -3,7 +3,7 @@
 $ ->
   if $('#tree-slider').length > 0
     # Show the "Loading commit data" for only the first element
-    $('span.log_loading:first').removeClass('hide')
+    $('span.log-loading:first').removeClass('hide')
 
     $('#tree-slider .tree-item-file-name a, .breadcrumb li > a').live "click", ->
       $("#tree-content-holder").hide("slide", { direction: "left" }, 150)
@@ -14,8 +14,8 @@ $ ->
 
     # Show/Hide the loading spinner
     $('#tree-slider .tree-item-file-name a, .breadcrumb a, .project-refs-form').live
-      "ajax:beforeSend": -> $('.tree_progress').addClass("loading")
-      "ajax:complete":   -> $('.tree_progress').removeClass("loading")
+      "ajax:beforeSend": -> $('.tree-progress').addClass("loading")
+      "ajax:complete":   -> $('.tree-progress').removeClass("loading")
 
     # Maintain forward/back history while browsing the file tree
     ((window) ->

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -21,14 +21,14 @@ body {
 }
 
 
-.visible_link,
-.author_link {
+.visible-link,
+.author-link {
   color: $link_color;
 }
 
 .help li { color:#111 }
 
-.back_link {
+.back-link {
   text-decoration: underline;
   font-size: 14px;
   font-weight: bold;
@@ -36,16 +36,7 @@ body {
   padding-bottom: 0;
 }
 
-.info_link {
-  margin-right: 5px;
-  float: left;
-
-  img {
-    width: 20px;
-  }
-}
-
-.download_repo_link {
+.download-repo-link {
   background: url("images.png") no-repeat 0 -48px;
   padding-left: 20px;
 }
@@ -68,7 +59,7 @@ table a code {
 }
 
 /** FLASH message **/
-#flash_container {
+#flash-container {
   height: 50px;
   position: fixed;
   z-index: 10001;
@@ -90,7 +81,7 @@ table a code {
   }
 }
 
-.git_url_wrapper {
+.git-url-wrapper {
   margin-right:50px
 }
 
@@ -200,7 +191,7 @@ form {
 }
 
 
-.field_with_errors {
+.field-with-errors {
   display: inline;
 }
 
@@ -231,13 +222,13 @@ ul.breadcrumb {
 }
 
 input[type=text] {
-  &.large_text {
+  &.large-text {
     padding: 6px;
     font-size: 16px;
   }
 }
 
-input.git_clone_url {
+input.git-clone-url {
   width: 325px;
 }
 
@@ -248,15 +239,15 @@ input.git_clone_url {
 }
 
 /** Issues **/
-#issue_assignee_id {
+#issue-assignee-id {
   width: 300px;
 }
 
-#new_issue_dialog textarea{
+#new-issue-dialog textarea{
     height: 100px;
 }
 
-.project_list_url {
+.project-list-url {
   width: 250px;
   background:#fff !important;
 }
@@ -277,7 +268,7 @@ ul.bordered-list {
 
 ul.bordered-list li:last-child { border:none }
 
-.line_holder {
+.line-holder {
   &:hover {
     td {
       background: #FFFFCF !important;
@@ -309,7 +300,7 @@ p.time {
 }
 
 
-.styled_image {
+.styled-image {
   border: 2px solid #ddd;
 }
 
@@ -419,11 +410,11 @@ p.time {
 }
 
 
-.highlight_word {
+.highlight-word {
   background: #EEDC94;
 }
 
-.status_info {
+.status-info {
   font-size: 14px;
   padding: 5px 15px;
   line-height: 24px;
@@ -457,11 +448,11 @@ p.time {
   font-weight: bold;
 }
 
-.thin_area{
+.thin-area{
   height: 150px;
 }
 
-.gitlab_pagination {
+.gitlab-pagination {
   span a { color: $link_color; }
   .prev, .next, .current, .page a {
     padding: 10px;
@@ -472,7 +463,7 @@ p.time {
 }
 
 // Fixes alignment on notes.
-.new_note {
+.new-note {
   label {
     text-align: left;
   }
@@ -498,17 +489,17 @@ li.note {
   }
 }
 
-.wiki_content code, .readme code{
+.wiki-content code, .readme code{
   background-color: inherit;
 }
 
-.team_member_show {
+.team-member-show {
   td:first-child {
     color: #aaa;
   }
 }
 
-.remember_me {
+.remember-me {
   text-align: left;
 
   input {
@@ -526,7 +517,7 @@ li.note {
  * Admin area
  *
  */
-.admin_dash {
+.admin-dash {
   .data {
     a {
       h1 {
@@ -563,12 +554,12 @@ li.note {
 }
 
 
-.supp_diff_link,
-.mr_show_all_commits {
+.supp-diff-link,
+.mr-show-all-commits {
   cursor: pointer;
 }
 
-.merge_request,
+.merge-request,
 .issue {
   &.today{
     background: #EFE;
@@ -584,7 +575,7 @@ li.note {
   }
 }
 
-.git_error_tips {
+.git-error-tips {
   @extend .span6;
   text-align: left;
   margin-top: 40px;
@@ -595,7 +586,7 @@ li.note {
   }
 }
 
-.error_message {
+.error-message {
   @extend .cred;
   border-left: 4px solid #E99;
   padding: 10px;
@@ -604,7 +595,7 @@ li.note {
   padding-left: 20px;
 }
 
-.oauth_select_holder {
+.oauth-select-holder {
   padding: 20px;
   img {
     padding: 5px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -374,12 +374,12 @@ p.time {
       height: 100%;
     }
     .bar-success {
+      @include linear-gradient(#62C462, #51A351);
       background-color: #468847;
-      @include bg-gradient(#62C462, #51A351);
     }
     .bar-danger {
+      @include linear-gradient(#EE5F5B, #BD362F);
       background-color: #B94A48;
-      @include bg-gradient(#EE5F5B, #BD362F);
     }
   }
   .upvotes {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,12 +1,12 @@
 /** LAYOUT **/
 
 body {
-  margin-bottom:20px;
+  margin-bottom: 20px;
 }
 
 .container {
-  padding-top:0;
-  z-index:5;
+  padding-top: 0;
+  z-index: 5;
 }
 
 .container .content {
@@ -15,9 +15,9 @@ body {
 
 .container  .sidebar {
   width: 200px;
-  height:100%;
-  min-height:450px;
-  float:right;
+  height: 100%;
+  min-height: 450px;
+  float: right;
 }
 
 
@@ -29,25 +29,25 @@ body {
 .help li { color:#111 }
 
 .back_link {
-  text-decoration:underline;
-  font-size:14px;
-  font-weight:bold;
+  text-decoration: underline;
+  font-size: 14px;
+  font-weight: bold;
   padding:10px 0;
-  padding-bottom:0;
+  padding-bottom: 0;
 }
 
 .info_link {
-  margin-right:5px;
-  float:left;
+  margin-right: 5px;
+  float: left;
 
   img {
-    width:20px;
+    width: 20px;
   }
 }
 
 .download_repo_link {
   background: url("images.png") no-repeat 0 -48px;
-  padding-left:20px;
+  padding-left: 20px;
 }
 
 table a code {
@@ -63,30 +63,30 @@ table a code {
 .loading {
   margin:20px auto;
   background: url(ajax_loader.gif) no-repeat center center;
-  width:40px;
-  height:40px;
+  width: 40px;
+  height: 40px;
 }
 
 /** FLASH message **/
 #flash_container {
-  height:50px;
-  position:fixed;
-  z-index:10001;
-  top:0px;
-  width:100%;
-  margin-bottom:15px;
-  overflow:hidden;
-  background:white;
-  cursor:pointer;
+  height: 50px;
+  position: fixed;
+  z-index: 10001;
+  top: 0px;
+  width: 100%;
+  margin-bottom: 15px;
+  overflow: hidden;
+  background: white;
+  cursor: pointer;
   border-bottom:1px solid #ccc;
 
   h4 {
     color:#666;
-    font-size:18px;
-    line-height:38px;
-    padding-top:5px;
-    margin:2px;
-    font-weight:normal;
+    font-size: 18px;
+    line-height: 38px;
+    padding-top: 5px;
+    margin: 2px;
+    font-weight: normal;
   }
 }
 
@@ -95,39 +95,39 @@ table a code {
 }
 
 .handle:hover {
-  cursor:move;
+  cursor: move;
 }
 
 span.update-author {
-  display:block;
+  display: block;
 }
 span.update-author {
   color:#999;
-  font-weight:normal;
-  font-style:italic;
+  font-weight: normal;
+  font-style: italic;
 }
 span.update-author strong {
-  font-weight:bold;
+  font-weight: bold;
   font-style: normal;
 }
 
 /** UPDATE ITEM **/
 span.update-author {
-  display:block;
+  display: block;
 }
 /** END UPDATE ITEM **/
 .dashboard-loader {
-  float:left;
-  margin:10px;
-  display:none;
+  float: left;
+  margin: 10px;
+  display: none;
 }
 .user-mention {
   color:#2FA0BB;
-  font-weight:bold;
+  font-weight: bold;
 }
 
 .neib {
-  margin-right:10px;
+  margin-right: 10px;
 }
 
 .label {
@@ -201,12 +201,12 @@ form {
 
 
 .field_with_errors {
-  display:inline;
+  display: inline;
 }
 
 ul.breadcrumb {
-  background:white;
-  border:none;
+  background: white;
+  border: none;
   li {
     display: inline;
     text-shadow: 0 1px 0 white
@@ -214,8 +214,8 @@ ul.breadcrumb {
 
   a {
     color:#474D57;
-    font-weight:bold;
-    font-size:14px;
+    font-weight: bold;
+    font-size: 14px;
   }
 
   .arrow {
@@ -225,31 +225,31 @@ ul.breadcrumb {
     float: left;
     position: relative;
     left: -10px;
-    padding:0;
-    margin:0;
+    padding: 0;
+    margin: 0;
   }
 }
 
 input[type=text] {
   &.large_text {
-    padding:6px;
-    font-size:16px;
+    padding: 6px;
+    font-size: 16px;
   }
 }
 
 input.git_clone_url {
-  width:325px;
+  width: 325px;
 }
 
 .merge-request-form-holder {
   select {
-    width:300px;
+    width: 300px;
   }
 }
 
 /** Issues **/
 #issue_assignee_id {
-  width:300px;
+  width: 300px;
 }
 
 #new_issue_dialog textarea{
@@ -257,7 +257,7 @@ input.git_clone_url {
 }
 
 .project_list_url {
-  width:250px;
+  width: 250px;
   background:#fff !important;
 }
 
@@ -265,13 +265,13 @@ input.git_clone_url {
 /** bordered list **/
 ul.bordered-list {
   margin:5px 0px;
-  padding:0px;
+  padding: 0px;
   li {
     padding: 5px 0;
     border-bottom: 1px solid #EEE;
     overflow: hidden;
     display: block;
-    margin:0px;
+    margin: 0px;
   }
 }
 
@@ -287,10 +287,10 @@ ul.bordered-list li:last-child { border:none }
 
 li.commit {
   .avatar {
-    width:24px;
+    width: 24px;
     top:-5px;
-    margin-right:10px;
-    margin-left:10px;
+    margin-right: 10px;
+    margin-left: 10px;
   }
 
   code {
@@ -341,17 +341,17 @@ p.time {
   }
 
   h4 {
-    font-size:14px;
+    font-size: 14px;
     padding:2px 10px;
     color:#666;
     border-bottom:1px solid #f1f1f1;
   }
-  a:last-child h4 { border:none; }
+  a:last-child h4 { border: none; }
 
   a:hover {
     h4 {
       color:#111;
-      background:$hover;
+      background: $hover;
       border-color:#CCC;
       .ico.project {
         background-position:-209px -21px;
@@ -359,7 +359,7 @@ p.time {
     }
   }
   .bottom {
-    padding:10px;
+    padding: 10px;
   }
 }
 
@@ -424,13 +424,13 @@ p.time {
 }
 
 .status_info {
-  font-size:14px;
+  font-size: 14px;
   padding:5px 15px;
-  line-height:24px;
-  width:60px;
-  text-align:center;
-  float:left;
-  margin-right:20px;
+  line-height: 24px;
+  width: 60px;
+  text-align: center;
+  float: left;
+  margin-right: 20px;
 
   &.success {
     background: #5BB75B;
@@ -449,12 +449,12 @@ p.time {
 .arrow{
   background: #E3E5EA;
   padding: 5px;
-  margin-top:5px;
+  margin-top: 5px;
   border-radius: 5px;
   text-shadow: none;
   color: #999;
   line-height: 16px;
-  font-weight:bold;
+  font-weight: bold;
 }
 
 .thin_area{
@@ -462,9 +462,9 @@ p.time {
 }
 
 .gitlab_pagination {
-  span a { color:$link_color; }
+  span a { color: $link_color; }
   .prev, .next, .current, .page a {
-    padding:10px;
+    padding: 10px;
   }
   .current {
     border-bottom:2px solid $style_color;
@@ -474,7 +474,7 @@ p.time {
 // Fixes alignment on notes.
 .new_note {
   label {
-    text-align:left;
+    text-align: left;
   }
 }
 
@@ -486,7 +486,7 @@ li.note {
       border-bottom:none !important;
     }
     .file {
-      padding-left:20px;
+      padding-left: 20px;
       background:url("icon-attachment.png") no-repeat left center;
     }
   }
@@ -494,7 +494,7 @@ li.note {
 
 .markdown {
   img {
-    max-width:100%;
+    max-width: 100%;
   }
 }
 
@@ -509,14 +509,14 @@ li.note {
 }
 
 .remember_me {
-  text-align:left;
+  text-align: left;
 
   input {
-    margin:0;
+    margin: 0;
   }
 
   span {
-    padding-left:5px;
+    padding-left: 5px;
   }
 }
 
@@ -530,10 +530,10 @@ li.note {
   .data {
     a {
       h1 {
-        line-height:48px;
-        font-size:48px;
-        padding:20px;
-        text-align:center;
+        line-height: 48px;
+        font-size: 48px;
+        padding: 20px;
+        text-align: center;
       }
     }
   }
@@ -541,12 +541,12 @@ li.note {
 
 .rss-icon {
   img {
-    width:24px;
-    vertical-align:top;
+    width: 24px;
+    vertical-align: top;
   }
 
   strong {
-    line-height:24px;
+    line-height: 24px;
   }
 }
 
@@ -556,7 +556,7 @@ li.note {
 .chzn-container-single .chzn-single {
   background:#FFF;
   border: 1px solid #bbb;
-  box-shadow:none;
+  box-shadow: none;
 }
 .chzn-container-active .chzn-single {
   background:#fff;
@@ -565,7 +565,7 @@ li.note {
 
 .supp_diff_link,
 .mr_show_all_commits {
-  cursor:pointer;
+  cursor: pointer;
 }
 
 .merge_request,
@@ -586,11 +586,11 @@ li.note {
 
 .git_error_tips {
   @extend .span6;
-  text-align:left;
-  margin-top:40px;
+  text-align: left;
+  margin-top: 40px;
   pre {
-    background:white;
-    border:none;
+    background: white;
+    border: none;
     font-size: 12px;
   }
 }
@@ -605,15 +605,15 @@ li.note {
 }
 
 .oauth_select_holder {
-  padding:20px;
+  padding: 20px;
   img {
-    padding:5px;
-    margin-right:10px;
+    padding: 5px;
+    margin-right: 10px;
   }
   .active {
     img {
       border:1px solid #ccc;
-      background:$hover;
+      background: $hover;
       @include border-radius(5px);
     }
   }
@@ -634,23 +634,23 @@ li.note {
 
 pre {
   &.clean {
-    background:none;
-    border:none;
-    margin:0;
-    padding:0;
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
   }
 }
 
 .milestone .progress {
   margin-bottom: 0;
-  margin-top:4px;
+  margin-top: 4px;
 }
 
 .float-link {
-  float:left;
-  margin-right:15px;
+  float: left;
+  margin-right: 15px;
   .s16 {
-    margin-right:5px;
+    margin-right: 5px;
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -10,7 +10,7 @@ body {
 }
 
 .container .content {
-  margin:0 0;
+  margin: 0 0;
 }
 
 .container  .sidebar {
@@ -32,7 +32,7 @@ body {
   text-decoration: underline;
   font-size: 14px;
   font-weight: bold;
-  padding:10px 0;
+  padding: 10px 0;
   padding-bottom: 0;
 }
 
@@ -61,7 +61,7 @@ table a code {
 }
 
 .loading {
-  margin:20px auto;
+  margin: 20px auto;
   background: url(ajax_loader.gif) no-repeat center center;
   width: 40px;
   height: 40px;
@@ -78,10 +78,10 @@ table a code {
   overflow: hidden;
   background: white;
   cursor: pointer;
-  border-bottom:1px solid #ccc;
+  border-bottom: 1px solid #ccc;
 
   h4 {
-    color:#666;
+    color: #666;
     font-size: 18px;
     line-height: 38px;
     padding-top: 5px;
@@ -102,7 +102,7 @@ span.update-author {
   display: block;
 }
 span.update-author {
-  color:#999;
+  color: #999;
   font-weight: normal;
   font-style: italic;
 }
@@ -122,7 +122,7 @@ span.update-author {
   display: none;
 }
 .user-mention {
-  color:#2FA0BB;
+  color: #2FA0BB;
   font-weight: bold;
 }
 
@@ -136,9 +136,9 @@ span.update-author {
   &.label-tag {
     background: none;
     border: none;
-    padding:4px 6px;
-    color:#444;
-    text-shadow:0 0 1px #fff;
+    padding: 4px 6px;
+    color: #444;
+    text-shadow: 0 0 1px #fff;
 
     &.grouped {
       float: left;
@@ -149,9 +149,9 @@ span.update-author {
   &.label-issue {
     background-color: #eee;
     border: 1px solid #ccc;
-    padding:4px 6px;
-    color:#444;
-    text-shadow:0 0 1px #fff;
+    padding: 4px 6px;
+    color: #444;
+    text-shadow: 0 0 1px #fff;
 
     &.grouped {
       float: left;
@@ -213,7 +213,7 @@ ul.breadcrumb {
   }
 
   a {
-    color:#474D57;
+    color: #474D57;
     font-weight: bold;
     font-size: 14px;
   }
@@ -264,7 +264,7 @@ input.git_clone_url {
 
 /** bordered list **/
 ul.bordered-list {
-  margin:5px 0px;
+  margin: 5px 0px;
   padding: 0px;
   li {
     padding: 5px 0;
@@ -310,7 +310,7 @@ p.time {
 
 
 .styled_image {
-  border:2px solid #ddd;
+  border: 2px solid #ddd;
 }
 
 
@@ -337,22 +337,22 @@ p.time {
 
 .leftbar {
   h5, .title {
-    padding:5px 10px;
+    padding: 5px 10px;
   }
 
   h4 {
     font-size: 14px;
-    padding:2px 10px;
-    color:#666;
-    border-bottom:1px solid #f1f1f1;
+    padding: 2px 10px;
+    color: #666;
+    border-bottom: 1px solid #f1f1f1;
   }
   a:last-child h4 { border: none; }
 
   a:hover {
     h4 {
-      color:#111;
+      color: #111;
       background: $hover;
-      border-color:#CCC;
+      border-color: #CCC;
       .ico.project {
         background-position:-209px -21px;
       }
@@ -420,12 +420,12 @@ p.time {
 
 
 .highlight_word {
-  background:#EEDC94;
+  background: #EEDC94;
 }
 
 .status_info {
   font-size: 14px;
-  padding:5px 15px;
+  padding: 5px 15px;
   line-height: 24px;
   width: 60px;
   text-align: center;
@@ -450,7 +450,7 @@ p.time {
   background: #E3E5EA;
   padding: 5px;
   margin-top: 5px;
-  border-radius: 5px;
+  @include border-radius(5px);
   text-shadow: none;
   color: #999;
   line-height: 16px;
@@ -504,7 +504,7 @@ li.note {
 
 .team_member_show {
   td:first-child {
-    color:#aaa;
+    color: #aaa;
   }
 }
 
@@ -554,12 +554,12 @@ li.note {
 
 /* CHZN reset few styles */
 .chzn-container-single .chzn-single {
-  background:#FFF;
+  background: #FFF;
   border: 1px solid #bbb;
   box-shadow: none;
 }
 .chzn-container-active .chzn-single {
-  background:#fff;
+  background: #fff;
 }
 
 
@@ -572,15 +572,15 @@ li.note {
 .issue {
   &.today{
     background: #EFE;
-    border-color:#CEC;
+    border-color: #CEC;
   }
   &.closed {
     background: #F5f5f5;
-    border-color:#E5E5E5;
+    border-color: #E5E5E5;
   }
   &.merged {
     background: #F5f5f5;
-    border-color:#E5E5E5;
+    border-color: #E5E5E5;
   }
 }
 
@@ -612,7 +612,7 @@ li.note {
   }
   .active {
     img {
-      border:1px solid #ccc;
+      border: 1px solid #ccc;
       background: $hover;
       @include border-radius(5px);
     }
@@ -627,7 +627,7 @@ li.note {
 
 .gitlab-promo {
   a {
-    color:#aaa;
+    color: #aaa;
     margin-right: 30px;
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -467,7 +467,7 @@ p.time {
     padding: 10px;
   }
   .current {
-    border-bottom:2px solid $style_color;
+    border-bottom: 2px solid $style_color;
   }
 }
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,0 +1,7 @@
+@font-face{ 
+  font-family: Korolev; 
+  src: font-url('korolev-medium-compressed.otf');
+}
+
+/** Typo **/
+$monospace: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono', 'lucida console', monospace;

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -15,7 +15,7 @@
   @extend .borders;
   @extend .prepend-top-20;
   @extend .append-bottom-20;
-  border-width:1px;
+  border-width: 1px;
   @include solid_shade;
 
 
@@ -30,22 +30,22 @@
   .top_box_content,
   .middle_box_content,
   .bottom_box_content {
-    padding:15px;
+    padding: 15px;
 
     pre {
       background: none !important;
-      margin:0;
-      border:none;
-      padding:0;
+      margin: 0;
+      border: none;
+      padding: 0;
     }
   }
 
   .middle_box_content {
-    border-radius:0;
-    border:none;
-    font-size:12px;
+    border-radius: 0;
+    border: none;
+    font-size: 12px;
     background-color:#f5f5f5;
-    border:none;
+    border: none;
     border-top:1px solid #eee;
   }
 
@@ -70,7 +70,7 @@
   }
 
   ul {
-    margin:0;
+    margin: 0;
   }
 
   h5, .title {
@@ -82,21 +82,21 @@
     &.small {
       line-height: 28px;
       font-size: 14px;
-      line-height:28px;
+      line-height: 28px;
       text-shadow: 0 1px 1px white;
     }
 
     form {
       padding:9px 0;
-      margin:0px;
+      margin: 0px;
     }
 
     .nav-pills {
       li {
         padding:3px 0;
-        &.active a { background-color:$style_color; }
+        &.active a { background-color: $style_color; }
         a {
-          border-radius:7px;
+          border-radius: 7px;
         }
       }
     }
@@ -105,7 +105,7 @@
   .bottom {
     @include bg-gray-gradient;
     @include round-borders-bottom(4px);
-    border-bottom:none;
+    border-bottom: none;
     border-top: 1px solid #bbb;
   }
 
@@ -121,33 +121,33 @@
       padding: 0 20px;
       border-top:1px solid #eee;
       border-bottom:1px solid #eee;
-      font-size:14px;
+      font-size: 14px;
       color:#777;
     }
   }
   .row_title {
-    font-weight:bold;
+    font-weight: bold;
     color:#444;
     &:hover {
       color:#444;
-      text-decoration:underline;
+      text-decoration: underline;
     }
   }
 
   li, .wll {
-    padding:10px;
+    padding: 10px;
     &:first-child {
       @include round-borders-top(4px);
-      border-top:none;
+      border-top: none;
     }
 
     &:last-child {
       @include round-borders-bottom(4px);
-      border:none;
+      border: none;
     }
   }
 
   .ui-box-body {
-    padding:10px;
+    padding: 10px;
   }
 }

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -1,7 +1,7 @@
 /**
  * ===================================
  * Contain 3 main UI block elements:
- *   .main_box - for show pages
+ *   .main-box - for show pages
  *   .ui-box   - for simple block & widgets
  * ===================================
  */
@@ -11,7 +11,7 @@
  *  contains top, middle, bottom blocks
  *
  */
-.main_box {
+.main-box {
   @extend .borders;
   @extend .prepend-top-20;
   @extend .append-bottom-20;
@@ -27,9 +27,9 @@
     }
   }
 
-  .top_box_content,
-  .middle_box_content,
-  .bottom_box_content {
+  .top-box-content,
+  .middle-box-content,
+  .bottom-box-content {
     padding: 15px;
 
     pre {
@@ -40,7 +40,7 @@
     }
   }
 
-  .middle_box_content {
+  .middle-box-content {
     @include border-radius(0);
     border: none;
     font-size: 12px;
@@ -49,7 +49,7 @@
     border-top: 1px solid #eee;
   }
 
-  .bottom_box_content {
+  .bottom-box-content {
     border-top: 1px solid #eee;
   }
 }
@@ -119,7 +119,7 @@
       margin-bottom: 0;
       padding: 5px 20px;
     }
-    .middle_title {
+    .middle-title {
       background: #f5f5f5;
       margin:20px -20px;
       padding: 0 20px;
@@ -129,7 +129,7 @@
       color: #777;
     }
   }
-  .row_title {
+  .row-title {
     font-weight: bold;
     color: #444;
     &:hover {

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -41,16 +41,16 @@
   }
 
   .middle_box_content {
-    border-radius: 0;
+    @include border-radius(0);
     border: none;
     font-size: 12px;
-    background-color:#f5f5f5;
+    background-color: #f5f5f5;
     border: none;
-    border-top:1px solid #eee;
+    border-top: 1px solid #eee;
   }
 
   .bottom_box_content {
-    border-top:1px solid #eee;
+    border-top: 1px solid #eee;
   }
 }
 
@@ -59,14 +59,14 @@
  *
  */
 .ui-box {
-  background:#F9F9F9;
+  background: #F9F9F9;
   margin-bottom: 25px;
   @include round-borders-all(4px);
   border-color: #CCC;
   @include solid_shade;
 
   &.white {
-    background:#fff;
+    background: #fff;
   }
 
   ul {
@@ -87,16 +87,16 @@
     }
 
     form {
-      padding:9px 0;
+      padding: 9px 0;
       margin: 0px;
     }
 
     .nav-pills {
       li {
-        padding:3px 0;
+        padding: 3px 0;
         &.active a { background-color: $style_color; }
         a {
-          border-radius: 7px;
+          @include border-radius(7px);
         }
       }
     }
@@ -116,20 +116,20 @@
       padding: 5px 20px;
     }
     .middle_title {
-      background:#f5f5f5;
+      background: #f5f5f5;
       margin:20px -20px;
       padding: 0 20px;
-      border-top:1px solid #eee;
-      border-bottom:1px solid #eee;
+      border-top: 1px solid #eee;
+      border-bottom: 1px solid #eee;
       font-size: 14px;
-      color:#777;
+      color: #777;
     }
   }
   .row_title {
     font-weight: bold;
-    color:#444;
+    color: #444;
     &:hover {
-      color:#444;
+      color: #444;
       text-decoration: underline;
     }
   }

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -61,7 +61,10 @@
 .ui-box {
   background: #F9F9F9;
   margin-bottom: 25px;
-  @include round-borders-all(4px);
+
+  border: 1px solid #eaeaea;
+  @include border-radius(4px);
+  
   border-color: #CCC;
   @include solid_shade;
 
@@ -75,8 +78,9 @@
 
   h5, .title {
     padding: 0 10px;
-    @include round-borders-top(4px);
+    @include border-radius(4px 4px 0 0);
     @include bg-gray-gradient;
+    border-top: 1px solid #eaeaea;
     border-bottom: 1px solid #bbb;
 
     &.small {
@@ -104,7 +108,7 @@
 
   .bottom {
     @include bg-gray-gradient;
-    @include round-borders-bottom(4px);
+    @include border-radius(0 0 4px 4px);
     border-bottom: none;
     border-top: 1px solid #bbb;
   }
@@ -137,12 +141,12 @@
   li, .wll {
     padding: 10px;
     &:first-child {
-      @include round-borders-top(4px);
+      @include border-radius(4px 4px 0 0);
       border-top: none;
     }
 
     &:last-child {
-      @include round-borders-bottom(4px);
+      @include border-radius(0 0 4px 4px);
       border: none;
     }
   }

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -16,7 +16,7 @@
   @extend .prepend-top-20;
   @extend .append-bottom-20;
   border-width: 1px;
-  @include solid_shade;
+  @include solid-shade;
 
 
   img { max-width: 100%; }
@@ -66,7 +66,7 @@
   @include border-radius(4px);
   
   border-color: #CCC;
-  @include solid_shade;
+  @include solid-shade;
 
   &.white {
     background: #fff;

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -14,7 +14,7 @@
     color:#fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
-      background:$blue_link;
+      background: $blue_link;
       color:#fff;
     }
 
@@ -30,7 +30,7 @@
     color:#fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
-      background:$blue_link;
+      background: $blue_link;
       color:#fff;
     }
 
@@ -60,12 +60,12 @@
   }
 
   &.cancel-btn {
-    float:right;
+    float: right;
   }
 
   &.wide {
-    padding-left:30px;
-    padding-right:30px;
+    padding-left: 30px;
+    padding-right: 30px;
   }
 
   &.danger {
@@ -92,19 +92,19 @@
   }
 
   &.very_small {
-    font-size:11px;
+    font-size: 11px;
     padding:2px 6px;
     line-height: 16px;
-    margin:2px;
+    margin: 2px;
   }
 
   &.grouped {
-    margin-right:7px;
-    float:left;
+    margin-right: 7px;
+    float: left;
   }
 
   &.padded {
-    margin-right:3px;
+    margin-right: 3px;
     padding:4px 10px 4px;
   }
 }

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -14,7 +14,7 @@
     color: #fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
-      background: $blue_link;
+      background: $primary_color;
       color: #fff;
     }
 
@@ -26,11 +26,11 @@
 
   &.btn-info {
     background: #5aB9C3;
-    border-color: $blue_link;
+    border-color: $primary_color;
     color: #fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
-      background: $blue_link;
+      background: $primary_color;
       color: #fff;
     }
 

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -91,7 +91,7 @@
     background-color: #ccc;
   }
 
-  &.very_small {
+  &.tiny {
     font-size: 11px;
     padding: 2px 6px;
     line-height: 16px;

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -1,5 +1,5 @@
 .btn {
-  @include bg-gradient(#f7f7f7, #d5d5d5);
+  @include linear-gradient(#f7f7f7, #d5d5d5);
   border-color: #aaa;
   &:hover {
     @include bg-gray-gradient;
@@ -9,7 +9,7 @@
 
   &.primary {
     background: #2a79A3;
-    @include bg-gradient(#47A7b7, #2585b5);
+    @include linear-gradient(#47A7b7, #2585b5);
     border-color: #2A79A3;
     color: #fff;
     text-shadow: 0 1px 1px #268;

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -1,42 +1,42 @@
 .btn {
   @include bg-gradient(#f7f7f7, #d5d5d5);
-  border-color:#aaa;
+  border-color: #aaa;
   &:hover {
     @include bg-gray-gradient;
-    border-color:#bbb;
-    color:#333;
+    border-color: #bbb;
+    color: #333;
   }
 
   &.primary {
-    background:#2a79A3;
+    background: #2a79A3;
     @include bg-gradient(#47A7b7, #2585b5);
     border-color: #2A79A3;
-    color:#fff;
+    color: #fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
       background: $blue_link;
-      color:#fff;
+      color: #fff;
     }
 
     &.disabled {
-      color:#fff;
-      background:#29B;
+      color: #fff;
+      background: #29B;
     }
   }
 
   &.btn-info {
-    background:#5aB9C3;
+    background: #5aB9C3;
     border-color: $blue_link;
-    color:#fff;
+    color: #fff;
     text-shadow: 0 1px 1px #268;
     &:hover {
       background: $blue_link;
-      color:#fff;
+      color: #fff;
     }
 
     &.disabled {
-      color:#fff;
-      background:#29B;
+      color: #fff;
+      background: #29B;
     }
   }
 
@@ -49,8 +49,8 @@
     }
 
     &.disabled {
-      color:#fff;
-      background:#2b2;
+      color: #fff;
+      background: #2b2;
     }
   }
 
@@ -73,7 +73,7 @@
     border-color: #BD362F;
 
     &:hover {
-      color:#fff;
+      color: #fff;
       background: #EE4E49;
     }
   }
@@ -87,13 +87,13 @@
   }
 
   &.active {
-    border-color:#aaa;
-    background-color:#ccc;
+    border-color: #aaa;
+    background-color: #ccc;
   }
 
   &.very_small {
     font-size: 11px;
-    padding:2px 6px;
+    padding: 2px 6px;
     line-height: 16px;
     margin: 2px;
   }
@@ -105,6 +105,6 @@
 
   &.padded {
     margin-right: 3px;
-    padding:4px 10px 4px;
+    padding: 4px 10px 4px;
   }
 }

--- a/app/assets/stylesheets/gitlab_bootstrap/common.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/common.scss
@@ -32,22 +32,22 @@
 .light { color: #888 }
 
 /** PILLS & TABS**/
-.nav-pills a:hover { background-color:#888; }
+.nav-pills a:hover { background-color: #888; }
 .nav-pills .active a { background-color: $style_color; }
 .nav-tabs > li > a, .nav-pills > li > a { color: $style_color; }
 .nav.nav-tabs {
   li {
     > a {
-      padding:8px 20px;
+      padding: 8px 20px;
       margin-right: 7px;
       line-height: 19px;
       border-color: #EEE;
-      color:#888;
+      color: #888;
       border-bottom: 1px solid #ddd;
       .badge {
         background-color: #eee;
-        color:#888;
-        text-shadow:0 1px 1px #fff;
+        color: #888;
+        text-shadow: 0 1px 1px #fff;
       }
       i[class^="icon-"] {
         line-height: 14px;
@@ -57,7 +57,7 @@
       > a {
         border-color: #CCC;
         border-bottom: 1px solid #fff;
-        color:#333;
+        color: #333;
       }
     }
   }
@@ -69,7 +69,7 @@
 .alert-message.error { @extend .alert-error; }
 
 /** AVATARS **/
-img.avatar { float: left; margin-right: 12px; width: 40px; border:1px solid #ddd; padding: 1px; }
+img.avatar { float: left; margin-right: 12px; width: 40px; border: 1px solid #ddd; padding: 1px; }
 img.avatar.s16 { width: 16px; height: 16px; margin-right: 6px; }
 img.avatar.s24 { width: 24px; height: 24px; margin-right: 8px; }
 img.avatar.s32 { width: 32px; height: 32px; margin-right: 10px; }
@@ -77,8 +77,8 @@ img.lil_av { padding-left: 4px; padding-right: 3px; }
 img.small { width: 80px; }
 
 /** HELPERS **/
-.nothing_here_message { text-align: center; padding: 20px; color:#777; }
-p.slead { color:#456; font-size: 16px; margin-bottom: 12px; font-weight: 200; line-height: 24px; }
+.nothing_here_message { text-align: center; padding: 20px; color: #777; }
+p.slead { color: #456; font-size: 16px; margin-bottom: 12px; font-weight: 200; line-height: 24px; }
 
 /** FORMS **/
 input[type='search'].search-text-input {
@@ -87,7 +87,7 @@ input[type='search'].search-text-input {
   background-position: 10px;
   padding-left: 25px;
   @include border-radius(4px);
-  border:1px solid #ccc;
+  border: 1px solid #ccc;
 }
 
 fieldset legend { font-size: 17px; }

--- a/app/assets/stylesheets/gitlab_bootstrap/common.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/common.scss
@@ -24,7 +24,7 @@
 .lborder { border-left:1px solid #eee }
 .no-padding { padding:0 !important; }
 .underlined { border-bottom: 1px solid #CCC; }
-.no-borders { border:none; }
+.no-borders { border: none; }
 .vlink { color: $link_color !important; }
 .underlined_link { text-decoration: underline; }
 .borders { border: 1px solid #ccc; @include shade; }
@@ -34,7 +34,7 @@
 /** PILLS & TABS**/
 .nav-pills a:hover { background-color:#888; }
 .nav-pills .active a { background-color: $style_color; }
-.nav-tabs > li > a, .nav-pills > li > a { color:$style_color; }
+.nav-tabs > li > a, .nav-pills > li > a { color: $style_color; }
 .nav.nav-tabs {
   li {
     > a {
@@ -50,7 +50,7 @@
         text-shadow:0 1px 1px #fff;
       }
       i[class^="icon-"] {
-        line-height:14px;
+        line-height: 14px;
       }
     }
     &.active {
@@ -69,23 +69,23 @@
 .alert-message.error { @extend .alert-error; }
 
 /** AVATARS **/
-img.avatar { float:left; margin-right:12px; width:40px; border:1px solid #ddd; padding:1px; }
-img.avatar.s16 { width:16px; height:16px; margin-right:6px; }
-img.avatar.s24 { width:24px; height:24px; margin-right:8px; }
-img.avatar.s32 { width:32px; height:32px; margin-right:10px; }
-img.lil_av { padding-left: 4px; padding-right:3px; }
+img.avatar { float: left; margin-right: 12px; width: 40px; border:1px solid #ddd; padding: 1px; }
+img.avatar.s16 { width: 16px; height: 16px; margin-right: 6px; }
+img.avatar.s24 { width: 24px; height: 24px; margin-right: 8px; }
+img.avatar.s32 { width: 32px; height: 32px; margin-right: 10px; }
+img.lil_av { padding-left: 4px; padding-right: 3px; }
 img.small { width: 80px; }
 
 /** HELPERS **/
-.nothing_here_message { text-align:center; padding:20px; color:#777; }
-p.slead { color:#456; font-size:16px; margin-bottom: 12px; font-weight: 200; line-height: 24px; }
+.nothing_here_message { text-align: center; padding: 20px; color:#777; }
+p.slead { color:#456; font-size: 16px; margin-bottom: 12px; font-weight: 200; line-height: 24px; }
 
 /** FORMS **/
 input[type='search'].search-text-input {
   background-image: url("icon-search.png");
   background-repeat: no-repeat;
   background-position: 10px;
-  padding-left:25px;
+  padding-left: 25px;
   @include border-radius(4px);
   border:1px solid #ccc;
 }

--- a/app/assets/stylesheets/gitlab_bootstrap/common.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/common.scss
@@ -26,7 +26,7 @@
 .underlined { border-bottom: 1px solid #CCC; }
 .no-borders { border: none; }
 .vlink { color: $link_color !important; }
-.underlined_link { text-decoration: underline; }
+.underlined-link { text-decoration: underline; }
 .borders { border: 1px solid #ccc; @include shade; }
 .hint { font-style: italic; color: #999; }
 .light { color: #888 }
@@ -73,11 +73,11 @@ img.avatar { float: left; margin-right: 12px; width: 40px; border: 1px solid #dd
 img.avatar.s16 { width: 16px; height: 16px; margin-right: 6px; }
 img.avatar.s24 { width: 24px; height: 24px; margin-right: 8px; }
 img.avatar.s32 { width: 32px; height: 32px; margin-right: 10px; }
-img.lil_av { padding-left: 4px; padding-right: 3px; }
+img.lil-av { padding-left: 4px; padding-right: 3px; }
 img.small { width: 80px; }
 
 /** HELPERS **/
-.nothing_here_message { text-align: center; padding: 20px; color: #777; }
+.nothing-here-message { text-align: center; padding: 20px; color: #777; }
 p.slead { color: #456; font-size: 16px; margin-bottom: 12px; font-weight: 200; line-height: 24px; }
 
 /** FORMS **/

--- a/app/assets/stylesheets/gitlab_bootstrap/files.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/files.scss
@@ -5,7 +5,7 @@
 .file_holder {
   border: 1px solid #BBB;
   margin-bottom: 1em;
-  @include solid_shade;
+  @include solid-shade;
 
   .file_title {
     border-bottom: 1px solid #bbb;

--- a/app/assets/stylesheets/gitlab_bootstrap/files.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/files.scss
@@ -2,12 +2,12 @@
  * File content holder
  *
  */
-.file_holder {
+.file-holder {
   border: 1px solid #BBB;
   margin-bottom: 1em;
   @include solid-shade;
 
-  .file_title {
+  .file-title {
     border-bottom: 1px solid #bbb;
     @include bg-dark-gray-gradient;
     margin: 0;
@@ -23,7 +23,7 @@
       margin-top: -5px;
     }
 
-    .file_name {
+    .file-name {
       color: $style_color;
       font-size: 14px;
       text-shadow: 0 1px 1px #fff;
@@ -33,7 +33,7 @@
       }
     }
   }
-  .file_content {
+  .file-content {
     background: #fff;
     font-size: 11px;
 
@@ -51,7 +51,7 @@
       }
     }
 
-    &.image_file {
+    &.image-file {
       background: #eee;
       text-align: center;
       img {
@@ -60,7 +60,7 @@
       }
     }
 
-    &.blob_file {
+    &.blob-file {
 
     }
 
@@ -87,7 +87,7 @@
         padding: 5px;
       }
       .author,
-      .blame_commit {
+      .blame-commit {
         background: #f5f5f5;
         vertical-align: top;
       }
@@ -167,7 +167,7 @@
           background: none;
         }
 
-        pre.line_numbers {
+        pre.line-numbers {
           color: #666;
           padding: 10px 6px 10px 0;
           text-align: right;

--- a/app/assets/stylesheets/gitlab_bootstrap/files.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/files.scss
@@ -4,7 +4,7 @@
  */
 .file_holder {
   border:1px solid #BBB;
-  margin-bottom:1em;
+  margin-bottom: 1em;
   @include solid_shade;
 
   .file_title {
@@ -16,20 +16,20 @@
     text-align: left;
     color: #666;
     padding: 9px 10px;
-    height:18px;
+    height: 18px;
 
     .options {
-      float:right;
+      float: right;
       margin-top: -5px;
     }
 
     .file_name {
-      color:$style_color;
-      font-size:14px;
+      color: $style_color;
+      font-size: 14px;
       text-shadow: 0 1px 1px #fff;
       small {
         color:#999;
-        font-size:13px;
+        font-size: 13px;
       }
     }
   }
@@ -42,7 +42,7 @@
       code {
         padding:0 4px;
       }
-      padding:20px;
+      padding: 20px;
       h1, h2 {
         line-height: 46px;
       }
@@ -53,10 +53,10 @@
 
     &.image_file {
       background:#eee;
-      text-align:center;
+      text-align: center;
       img {
-        padding:100px;
-        max-width:300px;
+        padding: 100px;
+        max-width: 300px;
       }
     }
 
@@ -69,34 +69,34 @@
      */
     &.blame {
       table {
-        border:none;
-        box-shadow:none;
-        margin:0;
+        border: none;
+        box-shadow: none;
+        margin: 0;
       }
       tr {
         border-bottom: 1px solid #eee;
       }
       td {
         &:first-child {
-          border-left:none;
+          border-left: none;
         }
         &:last-child {
-          border-right:none;
+          border-right: none;
         }
         background:#fff;
-        padding:5px;
+        padding: 5px;
       }
       .author,
       .blame_commit {
         background:#f5f5f5;
-        vertical-align:top;
+        vertical-align: top;
       }
       .lines {
         pre {
-          padding:0;
-          margin:0;
-          border:none;
-          border-radius: 0;
+          padding: 0;
+          margin: 0;
+          background: none;
+          border: none;
         }
       }
     }
@@ -107,22 +107,22 @@
       overflow-y: auto;
 
       ol {
-        margin-left:40px;
+        margin-left: 40px;
         padding: 10px 0;
         border-left: 1px solid #CCC;
-        margin-bottom:0;
+        margin-bottom: 0;
         background: white;
         li {
           color:#888;
           p {
-            margin:0;
+            margin: 0;
             color:#333;
-            line-height:24px;
+            line-height: 24px;
             padding-left: 10px;
           }
 
           &:hover {
-            background:$hover;
+            background: $hover;
           }
         }
       }

--- a/app/assets/stylesheets/gitlab_bootstrap/files.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/files.scss
@@ -3,7 +3,7 @@
  *
  */
 .file_holder {
-  border:1px solid #BBB;
+  border: 1px solid #BBB;
   margin-bottom: 1em;
   @include solid_shade;
 
@@ -28,19 +28,19 @@
       font-size: 14px;
       text-shadow: 0 1px 1px #fff;
       small {
-        color:#999;
+        color: #999;
         font-size: 13px;
       }
     }
   }
   .file_content {
-    background:#fff;
+    background: #fff;
     font-size: 11px;
 
     &.wiki {
       font-size: 13px;
       code {
-        padding:0 4px;
+        padding: 0 4px;
       }
       padding: 20px;
       h1, h2 {
@@ -52,7 +52,7 @@
     }
 
     &.image_file {
-      background:#eee;
+      background: #eee;
       text-align: center;
       img {
         padding: 100px;
@@ -83,12 +83,12 @@
         &:last-child {
           border-right: none;
         }
-        background:#fff;
+        background: #fff;
         padding: 5px;
       }
       .author,
       .blame_commit {
-        background:#f5f5f5;
+        background: #f5f5f5;
         vertical-align: top;
       }
       .lines {
@@ -102,7 +102,7 @@
     }
 
     &.logs {
-      background:#eee;
+      background: #eee;
       max-height: 700px;
       overflow-y: auto;
 
@@ -113,10 +113,10 @@
         margin-bottom: 0;
         background: white;
         li {
-          color:#888;
+          color: #888;
           p {
             margin: 0;
-            color:#333;
+            color: #333;
             line-height: 24px;
             padding-left: 10px;
           }

--- a/app/assets/stylesheets/gitlab_bootstrap/lists.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/lists.scss
@@ -14,7 +14,7 @@ ul {
 
     &.smoke { background-color:#f5f5f5; }
     &:hover {
-      background:$hover;
+      background: $hover;
       border-bottom:1px solid #ADF;
     }
     &:last-child { border:none }
@@ -22,11 +22,11 @@ ul {
 
     p {
       padding-top: 1px;
-      margin:0;
+      margin: 0;
       color:#222;
       img {
-        position:relative;
-        top:3px;
+        position: relative;
+        top: 3px;
       }
     }
   }
@@ -35,7 +35,7 @@ ul {
 ol, ul {
   &.styled {
     li {
-      padding:2px;
+      padding: 2px;
     }
   }
 }

--- a/app/assets/stylesheets/gitlab_bootstrap/lists.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/lists.scss
@@ -12,10 +12,10 @@ ul {
     border-bottom: 1px solid #eee;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 
-    &.smoke { background-color:#f5f5f5; }
+    &.smoke { background-color: #f5f5f5; }
     &:hover {
       background: $hover;
-      border-bottom:1px solid #ADF;
+      border-bottom: 1px solid #ADF;
     }
     &:last-child { border:none }
     .author { color: #999; }
@@ -23,7 +23,7 @@ ul {
     p {
       padding-top: 1px;
       margin: 0;
-      color:#222;
+      color: #222;
       img {
         position: relative;
         top: 3px;

--- a/app/assets/stylesheets/gitlab_bootstrap/tables.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/tables.scss
@@ -3,11 +3,11 @@ table {
   @extend .table-striped;
   @include solid_shade;
   border:1px solid #bbb;
-  width:100%;
+  width: 100%;
 
   &.low {
     td {
-      line-height:18px;
+      line-height: 18px;
     }
   }
 
@@ -32,7 +32,7 @@ table {
 
   td {
     border-color:#f1f1f1;
-    line-height:28px;
+    line-height: 28px;
 
     .s16 {
       margin-top: 5px;
@@ -53,10 +53,10 @@ table {
   }
 
   &.lite {
-    border:none;
-    box-shadow:none;
+    border: none;
+    box-shadow: none;
     tr, td {
-      border:none;
+      border: none;
       background:none !important;
     }
   }

--- a/app/assets/stylesheets/gitlab_bootstrap/tables.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/tables.scss
@@ -1,7 +1,7 @@
 table {
   @extend .table;
   @extend .table-striped;
-  @include solid_shade;
+  @include solid-shade;
   border: 1px solid #bbb;
   width: 100%;
 

--- a/app/assets/stylesheets/gitlab_bootstrap/tables.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/tables.scss
@@ -2,7 +2,7 @@ table {
   @extend .table;
   @extend .table-striped;
   @include solid_shade;
-  border:1px solid #bbb;
+  border: 1px solid #bbb;
   width: 100%;
 
   &.low {
@@ -31,7 +31,7 @@ table {
   }
 
   td {
-    border-color:#f1f1f1;
+    border-color: #f1f1f1;
     line-height: 28px;
 
     .s16 {
@@ -40,11 +40,11 @@ table {
     }
 
     &:first-child {
-      border-left:1px solid #bbb;
+      border-left: 1px solid #bbb;
     }
 
     &:last-child {
-      border-right:1px solid #bbb;
+      border-right: 1px solid #bbb;
     }
   }
 

--- a/app/assets/stylesheets/gitlab_bootstrap/typography.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/typography.scss
@@ -7,7 +7,7 @@ h1, h2, h3, h4, h5, h6 { margin: 0; }
 h3, h4, h5, h6 { line-height: 36px; }
 h5 { font-size: 14px; }
 
-h3.page_title {
+h3.page-title {
   color: #456;
   font-size: 20px;
   font-weight: normal;
@@ -61,7 +61,7 @@ a {
     color: gray;
   }
 
-  &.supp_diff_link {
+  &.supp-diff-link {
     text-align: center;
     padding: 20px 0;
     background: #f1f1f1;

--- a/app/assets/stylesheets/gitlab_bootstrap/typography.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/typography.scss
@@ -5,11 +5,11 @@
 
 h1, h2, h3, h4, h5, h6 { margin: 0; }
 h3, h4, h5, h6 { line-height: 36px; }
-h5 { font-size:14px; }
+h5 { font-size: 14px; }
 
 h3.page_title {
   color:#456;
-  font-size:20px;
+  font-size: 20px;
   font-weight: normal;
   line-height: 28px;
 }
@@ -37,7 +37,7 @@ a {
   outline: none;
   color: $link_color;
   &:hover {
-    text-decoration:none;
+    text-decoration: none;
     color: $blue_link;
   }
 
@@ -53,24 +53,24 @@ a {
   }
 
   &.lined {
-    text-decoration:underline;
-    &:hover { text-decoration:underline; }
+    text-decoration: underline;
+    &:hover { text-decoration: underline; }
   }
 
   &.gray {
-    color:gray;
+    color: gray;
   }
 
   &.supp_diff_link {
-    text-align:center;
+    text-align: center;
     padding:20px 0;
     background:#f1f1f1;
-    width:100%;
-    float:left;
+    width: 100%;
+    float: left;
   }
 
   &.neib  {
-    margin-right:15px;
+    margin-right: 15px;
   }
 }
 

--- a/app/assets/stylesheets/gitlab_bootstrap/typography.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/typography.scss
@@ -8,7 +8,7 @@ h3, h4, h5, h6 { line-height: 36px; }
 h5 { font-size: 14px; }
 
 h3.page_title {
-  color:#456;
+  color: #456;
   font-size: 20px;
   font-weight: normal;
   line-height: 28px;
@@ -25,7 +25,7 @@ pre {
 
   &.dark {
     background: #333;
-    color:#f5f5f5;
+    color: #f5f5f5;
   }
 }
 
@@ -63,8 +63,8 @@ a {
 
   &.supp_diff_link {
     text-align: center;
-    padding:20px 0;
-    background:#f1f1f1;
+    padding: 20px 0;
+    background: #f1f1f1;
     width: 100%;
     float: left;
   }

--- a/app/assets/stylesheets/gitlab_bootstrap/typography.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/typography.scss
@@ -38,7 +38,7 @@ a {
   color: $link_color;
   &:hover {
     text-decoration: none;
-    color: $blue_link;
+    color: $primary_color;
   }
 
   &.btn {

--- a/app/assets/stylesheets/highlight/dark.scss
+++ b/app/assets/stylesheets/highlight/dark.scss
@@ -28,29 +28,29 @@
   .kn{font-weight: bold;} /* Keyword.Namespace */
   .kp{font-weight: bold;} /* Keyword.Pseudo */
   .kr{font-weight: bold;} /* Keyword.Reserved */
-  .kt{color:#458;font-weight: bold;} /* Keyword.Type */
+  .kt{color: #458;font-weight: bold;} /* Keyword.Type */
   .m { color: #0000DD; font-weight: bold } /* Literal.Number */
   .p { color: #eee;  }
   .s { color: #0AD; background-color: transparent } /* Literal.String */
-  .na{color:#008080;} /* Name.Attribute */
-  .nb{color:#0086B3;} /* Name.Builtin */
-  .nc{color:#ccc;font-weight: bold;} /* Name.Class */
+  .na{color: #008080;} /* Name.Attribute */
+  .nb{color: #0086B3;} /* Name.Builtin */
+  .nc{color: #ccc;font-weight: bold;} /* Name.Class */
   .no{color: turquoise;} /* Name.Constant */
-  .ni{color:#800080;}
-  .ne{color:#900;font-weight: bold;} /* Name.Exception */
-  .nf{color:#ccc;font-weight: bold;} /* Name.Function */
-  .nn{color:#79C3E0;font-weight: bold;} /* Name.Namespace */
-  .nt{color:#fc5;} /* Name.Tag */
-  .nv{color:#FA4;} /* Name.Variable */
+  .ni{color: #800080;}
+  .ne{color: #900;font-weight: bold;} /* Name.Exception */
+  .nf{color: #ccc;font-weight: bold;} /* Name.Function */
+  .nn{color: #79C3E0;font-weight: bold;} /* Name.Namespace */
+  .nt{color: #fc5;} /* Name.Tag */
+  .nv{color: #FA4;} /* Name.Variable */
   .py { color: #336699; font-weight: bold } /* Name.Property */
   .ow { color: #008800 } /* Operator.Word */
   .w { color: #bbbbbb } /* Text.Whitespace */
   .mf { color: #7AC; font-weight: bold } /* Literal.Number.Float */
   .mh { color: #7AC; font-weight: bold } /* Literal.Number.Hex */
-  .mi {color:#099;} /* Literal.Number.Integer */
+  .mi {color: #099;} /* Literal.Number.Integer */
   .mo { color: #0000DD; font-weight: bold } /* Literal.Number.Oct */
   .sb { color: #dd2200; background-color: transparent; } /* Literal.String.Backtick */
-  .sc{color:#d14;} /* Literal.String.Char */
+  .sc{color: #d14;} /* Literal.String.Char */
   .sd { color: #dd2200; background-color: transparent; } /* Literal.String.Doc */
   .s2{color: orange;} /* Literal.String.Double */
   .se{color: orange;} /* Literal.String.Escape */

--- a/app/assets/stylesheets/highlight/dark.scss
+++ b/app/assets/stylesheets/highlight/dark.scss
@@ -23,23 +23,23 @@
   .gs { font-weight: bold } /* Generic.Strong */
   .gu { color: #606060 } /* Generic.Subheading */
   .gt { color: #aa0000 } /* Generic.Traceback */
-  .kc{font-weight:bold;} /* Keyword.Constant */
-  .kd{font-weight:bold;} /* Keyword.Declaration */
-  .kn{font-weight:bold;} /* Keyword.Namespace */
-  .kp{font-weight:bold;} /* Keyword.Pseudo */
-  .kr{font-weight:bold;} /* Keyword.Reserved */
-  .kt{color:#458;font-weight:bold;} /* Keyword.Type */
+  .kc{font-weight: bold;} /* Keyword.Constant */
+  .kd{font-weight: bold;} /* Keyword.Declaration */
+  .kn{font-weight: bold;} /* Keyword.Namespace */
+  .kp{font-weight: bold;} /* Keyword.Pseudo */
+  .kr{font-weight: bold;} /* Keyword.Reserved */
+  .kt{color:#458;font-weight: bold;} /* Keyword.Type */
   .m { color: #0000DD; font-weight: bold } /* Literal.Number */
   .p { color: #eee;  }
   .s { color: #0AD; background-color: transparent } /* Literal.String */
   .na{color:#008080;} /* Name.Attribute */
   .nb{color:#0086B3;} /* Name.Builtin */
-  .nc{color:#ccc;font-weight:bold;} /* Name.Class */
-  .no{color:turquoise;} /* Name.Constant */
+  .nc{color:#ccc;font-weight: bold;} /* Name.Class */
+  .no{color: turquoise;} /* Name.Constant */
   .ni{color:#800080;}
-  .ne{color:#900;font-weight:bold;} /* Name.Exception */
-  .nf{color:#ccc;font-weight:bold;} /* Name.Function */
-  .nn{color:#79C3E0;font-weight:bold;} /* Name.Namespace */
+  .ne{color:#900;font-weight: bold;} /* Name.Exception */
+  .nf{color:#ccc;font-weight: bold;} /* Name.Function */
+  .nn{color:#79C3E0;font-weight: bold;} /* Name.Namespace */
   .nt{color:#fc5;} /* Name.Tag */
   .nv{color:#FA4;} /* Name.Variable */
   .py { color: #336699; font-weight: bold } /* Name.Property */
@@ -52,14 +52,14 @@
   .sb { color: #dd2200; background-color: transparent; } /* Literal.String.Backtick */
   .sc{color:#d14;} /* Literal.String.Char */
   .sd { color: #dd2200; background-color: transparent; } /* Literal.String.Doc */
-  .s2{color:orange;} /* Literal.String.Double */
-  .se{color:orange;} /* Literal.String.Escape */
-  .sh{color:orange;} /* Literal.String.Heredoc */
-  .si{color:orange;} /* Literal.String.Interpol */
-  .sx{color:orange;} /* Literal.String.Other */
-  .sr{color:orange;} /* Literal.String.Regex */
-  .s1{color:orange;} /* Literal.String.Single */
-  .ss{color:orange;} /* Literal.String.Symbol */
+  .s2{color: orange;} /* Literal.String.Double */
+  .se{color: orange;} /* Literal.String.Escape */
+  .sh{color: orange;} /* Literal.String.Heredoc */
+  .si{color: orange;} /* Literal.String.Interpol */
+  .sx{color: orange;} /* Literal.String.Other */
+  .sr{color: orange;} /* Literal.String.Regex */
+  .s1{color: orange;} /* Literal.String.Single */
+  .ss{color: orange;} /* Literal.String.Symbol */
   .bp { color: #D58 } /* Name.Builtin.Pseudo */
   .vc { color: #336699 } /* Name.Variable.Class */
   .vg { color: #dd7700 } /* Name.Variable.Global */

--- a/app/assets/stylesheets/highlight/white.scss
+++ b/app/assets/stylesheets/highlight/white.scss
@@ -27,37 +27,37 @@
   .kn{font-weight: bold;} /* Keyword.Namespace */
   .kp{font-weight: bold;} /* Keyword.Pseudo */
   .kr{font-weight: bold;} /* Keyword.Reserved */
-  .kt{color:#458;font-weight: bold;} /* Keyword.Type */
+  .kt{color: #458;font-weight: bold;} /* Keyword.Type */
   .m { color: #0000DD; font-weight: bold } /* Literal.Number */
   .s { color: #dd2200; background-color: #fff0f0 } /* Literal.String */
-  .na{color:#008080;} /* Name.Attribute */
-  .nb{color:#0086B3;} /* Name.Builtin */
-  .nc{color:#458;font-weight: bold;} /* Name.Class */
-  .no{color:#008080;} /* Name.Constant */
-  .ni{color:#800080;}
-  .ne{color:#900;font-weight: bold;} /* Name.Exception */
-  .nf{color:#900;font-weight: bold;} /* Name.Function */
-  .nn{color:#005;font-weight: bold;} /* Name.Namespace */
-  .nt{color:#000080;} /* Name.Tag */
-  .nv{color:#008080;} /* Name.Variable */
+  .na{color: #008080;} /* Name.Attribute */
+  .nb{color: #0086B3;} /* Name.Builtin */
+  .nc{color: #458;font-weight: bold;} /* Name.Class */
+  .no{color: #008080;} /* Name.Constant */
+  .ni{color: #800080;}
+  .ne{color: #900;font-weight: bold;} /* Name.Exception */
+  .nf{color: #900;font-weight: bold;} /* Name.Function */
+  .nn{color: #005;font-weight: bold;} /* Name.Namespace */
+  .nt{color: #000080;} /* Name.Tag */
+  .nv{color: #008080;} /* Name.Variable */
   .py { color: #336699; font-weight: bold } /* Name.Property */
   .ow { color: #008800 } /* Operator.Word */
   .w { color: #bbbbbb } /* Text.Whitespace */
   .mf { color: #0000DD; font-weight: bold } /* Literal.Number.Float */
   .mh { color: #0000DD; font-weight: bold } /* Literal.Number.Hex */
-  .mi {color:#099;} /* Literal.Number.Integer */
+  .mi {color: #099;} /* Literal.Number.Integer */
   .mo { color: #0000DD; font-weight: bold } /* Literal.Number.Oct */
   .sb { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Backtick */
-  .sc{color:#d14;} /* Literal.String.Char */
+  .sc{color: #d14;} /* Literal.String.Char */
   .sd { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Doc */
-  .s2{color:#d14;} /* Literal.String.Double */
-  .se{color:#d14;} /* Literal.String.Escape */
-  .sh{color:#d14;} /* Literal.String.Heredoc */
-  .si{color:#d14;} /* Literal.String.Interpol */
-  .sx{color:#d14;} /* Literal.String.Other */
-  .sr{color:#d14;} /* Literal.String.Regex */
-  .s1{color:#d14;} /* Literal.String.Single */
-  .ss{color:#d14;} /* Literal.String.Symbol */
+  .s2{color: #d14;} /* Literal.String.Double */
+  .se{color: #d14;} /* Literal.String.Escape */
+  .sh{color: #d14;} /* Literal.String.Heredoc */
+  .si{color: #d14;} /* Literal.String.Interpol */
+  .sx{color: #d14;} /* Literal.String.Other */
+  .sr{color: #d14;} /* Literal.String.Regex */
+  .s1{color: #d14;} /* Literal.String.Single */
+  .ss{color: #d14;} /* Literal.String.Symbol */
   .bp { color: #003388 } /* Name.Builtin.Pseudo */
   .vc { color: #336699 } /* Name.Variable.Class */
   .vg { color: #dd7700 } /* Name.Variable.Global */
@@ -65,7 +65,5 @@
 }
 
 .shadow {
-  -webkit-box-shadow:0 5px 15px #000;
-  -moz-box-shadow:0 5px 15px #000;
-  box-shadow:0 5px 15px #000;
+  @include box-shadow(0 5px 15px #000);
 }

--- a/app/assets/stylesheets/highlight/white.scss
+++ b/app/assets/stylesheets/highlight/white.scss
@@ -22,22 +22,22 @@
   .gs { font-weight: bold } /* Generic.Strong */
   .gu { color: #606060 } /* Generic.Subheading */
   .gt { color: #aa0000 } /* Generic.Traceback */
-  .kc{font-weight:bold;} /* Keyword.Constant */
-  .kd{font-weight:bold;} /* Keyword.Declaration */
-  .kn{font-weight:bold;} /* Keyword.Namespace */
-  .kp{font-weight:bold;} /* Keyword.Pseudo */
-  .kr{font-weight:bold;} /* Keyword.Reserved */
-  .kt{color:#458;font-weight:bold;} /* Keyword.Type */
+  .kc{font-weight: bold;} /* Keyword.Constant */
+  .kd{font-weight: bold;} /* Keyword.Declaration */
+  .kn{font-weight: bold;} /* Keyword.Namespace */
+  .kp{font-weight: bold;} /* Keyword.Pseudo */
+  .kr{font-weight: bold;} /* Keyword.Reserved */
+  .kt{color:#458;font-weight: bold;} /* Keyword.Type */
   .m { color: #0000DD; font-weight: bold } /* Literal.Number */
   .s { color: #dd2200; background-color: #fff0f0 } /* Literal.String */
   .na{color:#008080;} /* Name.Attribute */
   .nb{color:#0086B3;} /* Name.Builtin */
-  .nc{color:#458;font-weight:bold;} /* Name.Class */
+  .nc{color:#458;font-weight: bold;} /* Name.Class */
   .no{color:#008080;} /* Name.Constant */
   .ni{color:#800080;}
-  .ne{color:#900;font-weight:bold;} /* Name.Exception */
-  .nf{color:#900;font-weight:bold;} /* Name.Function */
-  .nn{color:#005;font-weight:bold;} /* Name.Namespace */
+  .ne{color:#900;font-weight: bold;} /* Name.Exception */
+  .nf{color:#900;font-weight: bold;} /* Name.Function */
+  .nn{color:#005;font-weight: bold;} /* Name.Namespace */
   .nt{color:#000080;} /* Name.Tag */
   .nv{color:#008080;} /* Name.Variable */
   .py { color: #336699; font-weight: bold } /* Name.Property */

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -5,101 +5,26 @@ $baseLineHeight: 18px !default;
 // BOOTSTRAP
 // ------------------
 @import "bootstrap";
+@import "bootstrap-responsive";
+@import "font-awesome";
 
-// BOOTSTRAP RESPONSIVE
-// ------------------
-@import "bootstrap/responsive-utilities";
-@import "bootstrap/responsive-1200px-min";
+/**
+ * Variables
+ * Contains colors
+ */
+@import "variables.scss";
 
-// FONT AWESOME
-@import 'font-awesome';
+/**
+ * Custom fonts
+ * Contains @font-face font Korolev and default $monotype
+ */
+@import "fonts.scss";
 
-/** GitLab colors **/
-$link_color: #3A89A3;
-$blue_link: #2FA0BB;
-$style_color: #474D57;
-$hover: #D9EDF7;
-$hover_border: #ADF;
-
-/** GitLab Fonts **/
-@font-face { font-family: Korolev; src: font-url('korolev-medium-compressed.otf'); }
-$monospace: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono', 'lucida console', monospace;
-
-/** MIXINS **/
-@mixin shade {
-  -moz-box-shadow: 0 0 3px #ddd;
-  -webkit-box-shadow: 0 0 3px #ddd;
-  box-shadow: 0 0 3px #ddd;
-}
-
-@mixin solid_shade {
-  -moz-box-shadow: 0 0 0 3px #f1f1f1;
-  -webkit-box-shadow: 0 0 0 3px #f1f1f1;
-  box-shadow: 0 0 0 3px #f1f1f1;
-}
-
-@mixin border-radius($radius) {
-  -moz-border-radius: $radius;
-  -webkit-border-radius: $radius;
-  border-radius: $radius;
-}
-
-@mixin round-borders-bottom($radius) {
-  border-top: 1px solid #eaeaea;
-  -moz-border-radius-bottomright: $radius;
-  -moz-border-radius-bottomleft: $radius;
-  border-bottom-right-radius: $radius;
-  border-bottom-left-radius: $radius;
-  -webkit-border-bottom-left-radius: $radius;
-  -webkit-border-bottom-right-radius: $radius;
-}
-
-@mixin round-borders-top($radius) {
-  border-top: 1px solid #eaeaea;
-  -moz-border-radius-topright: $radius;
-  -moz-border-radius-topleft: $radius;
-  border-top-right-radius: $radius;
-  border-top-left-radius: $radius;
-  -webkit-border-top-left-radius: $radius;
-  -webkit-border-top-right-radius: $radius;
-}
-
-@mixin round-borders-all($radius) {
-  border: 1px solid #eaeaea;
-  -moz-border-radius: $radius;
-  -webkit-border-radius: $radius;
-  border-radius: $radius;
-}
-
-@mixin bg-gradient($from, $to) {
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from($from), to($to));
-  background-image: -webkit-linear-gradient($from, $to);
-  background-image: -moz-linear-gradient($from, $to);
-  background-image: -o-linear-gradient($from, $to);
-}
-
-@mixin bg-light-gray-gradient {
-  background:#f1f1f1;
-  background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #f5f5f5), to(#e1e1e1));
-  background-image: -webkit-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
-  background-image: -moz-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
-  background-image: -o-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
-}
-
-@mixin bg-gray-gradient {
-  background:#eee;
-  background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #eee), to(#dfdfdf));
-  background-image: -webkit-linear-gradient(#eee 6.6%, #dfdfdf);
-  background-image: -moz-linear-gradient(#eee 6.6%, #dfdfdf);
-  background-image: -o-linear-gradient(#eee 6.6%, #dfdfdf);
-}
-
-@mixin bg-dark-gray-gradient {
-  background:#eee;
-  background-image: -webkit-linear-gradient(#e9e9e9, #d7d7d7);
-  background-image: -moz-linear-gradient(#e9e9e9, #d7d7d7);
-  background-image: -o-linear-gradient(#e9e9e9, #d7d7d7);
-}
+/**
+ * General mixins.
+ * Contains rounded borders, gradients and shades
+ */
+@import "mixins.scss";
 
 /**
  * Header of application.

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -1,17 +1,7 @@
-@mixin shade {
-  -moz-box-shadow: 0 0 3px #ddd;
-  -webkit-box-shadow: 0 0 3px #ddd;
-  box-shadow: 0 0 3px #ddd;
-}
-
-@mixin solid_shade {
-  -moz-box-shadow: 0 0 0 3px #f1f1f1;
-  -webkit-box-shadow: 0 0 0 3px #f1f1f1;
-  box-shadow: 0 0 0 3px #f1f1f1;
-}
-
-
-@mixin box-shadow($shadow) {
+/**
+ * Generic mixins
+ */
+ @mixin box-shadow($shadow) {
   -webkit-box-shadow: $shadow;
   -moz-box-shadow: $shadow;
   -ms-box-shadow: $shadow;
@@ -34,6 +24,10 @@
   background-image: -o-linear-gradient($from, $to);
 }
 
+/**
+ * Prefilled mixins
+ * Mixins with fixed values
+ */
 @mixin bg-light-gray-gradient {
   background: #f1f1f1;
   background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #f5f5f5), to(#e1e1e1));
@@ -55,4 +49,12 @@
   background-image: -webkit-linear-gradient(#e9e9e9, #d7d7d7);
   background-image: -moz-linear-gradient(#e9e9e9, #d7d7d7);
   background-image: -o-linear-gradient(#e9e9e9, #d7d7d7);
+}
+
+@mixin shade {
+  @include box-shadow(0 0 3px #ddd);
+}
+
+@mixin solid-shade {
+  @include box-shadow(0 0 0 3px #f1f1f1);
 }

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -34,21 +34,6 @@
   background-image: -o-linear-gradient($from, $to);
 }
 
-@mixin round-borders-bottom($radius) {
-  border-top: 1px solid #eaeaea;
-  @include border-radius(0 0 $radius $radius);
-}
-
-@mixin round-borders-top($radius) {
-  border-top: 1px solid #eaeaea;
-  @include border-radius($radius $radius 0 0);
-}
-
-@mixin round-borders-all($radius) {
-  border: 1px solid #eaeaea;
-  @include border-radius($radius);
-}
-
 @mixin bg-gradient($from, $to) {
   @include linear-gradient($from, $to);
 }

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -18,10 +18,20 @@
 }
 
 @mixin linear-gradient($from, $to) {
+  background-color: mix($from, $to, 80%);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from($from), to($to));
   background-image: -webkit-linear-gradient($from, $to);
   background-image: -moz-linear-gradient($from, $to);
   background-image: -o-linear-gradient($from, $to);
+}
+
+// User select
+// For selecting text on the page
+@mixin user-select($select) {
+  -webkit-user-select: $select;
+  -moz-user-select: $select;
+  -o-user-select: $select;
+  user-select: $select;
 }
 
 /**

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -10,37 +10,36 @@
   box-shadow: 0 0 0 3px #f1f1f1;
 }
 
+
+@mixin box-shadow($shadow) {
+  -webkit-box-shadow: $radius;
+  -moz-box-shadow: $radius;
+  -ms-box-shadow: $radius;
+  -o-box-shadow: $radius;
+  box-shadow: $radius;
+}
+
 @mixin border-radius($radius) {
-  -moz-border-radius: $radius;
   -webkit-border-radius: $radius;
+  -moz-border-radius: $radius;
+  -ms-border-radius: $radius;
+  -o-border-radius: $radius;
   border-radius: $radius;
 }
 
 @mixin round-borders-bottom($radius) {
   border-top: 1px solid #eaeaea;
-  -webkit-border-bottom-left-radius: $radius;
-  -webkit-border-bottom-right-radius: $radius;
-  -moz-border-radius-bottomright: $radius;
-  -moz-border-radius-bottomleft: $radius;
-  border-bottom-right-radius: $radius;
-  border-bottom-left-radius: $radius;
+  @include border-radius(0 0 $radius $radius);
 }
 
 @mixin round-borders-top($radius) {
   border-top: 1px solid #eaeaea;
-  -moz-border-radius-topright: $radius;
-  -moz-border-radius-topleft: $radius;
-  border-top-right-radius: $radius;
-  border-top-left-radius: $radius;
-  -webkit-border-top-left-radius: $radius;
-  -webkit-border-top-right-radius: $radius;
+  @include border-radius($radius $radius 0 0);
 }
 
 @mixin round-borders-all($radius) {
   border: 1px solid #eaeaea;
-  -moz-border-radius: $radius;
-  -webkit-border-radius: $radius;
-  border-radius: $radius;
+  @include border-radius($radius);
 }
 
 @mixin bg-gradient($from, $to) {
@@ -51,7 +50,7 @@
 }
 
 @mixin bg-light-gray-gradient {
-  background:#f1f1f1;
+  background: #f1f1f1;
   background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #f5f5f5), to(#e1e1e1));
   background-image: -webkit-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
   background-image: -moz-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
@@ -59,7 +58,7 @@
 }
 
 @mixin bg-gray-gradient {
-  background:#eee;
+  background: #eee;
   background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #eee), to(#dfdfdf));
   background-image: -webkit-linear-gradient(#eee 6.6%, #dfdfdf);
   background-image: -moz-linear-gradient(#eee 6.6%, #dfdfdf);
@@ -67,7 +66,7 @@
 }
 
 @mixin bg-dark-gray-gradient {
-  background:#eee;
+  background: #eee;
   background-image: -webkit-linear-gradient(#e9e9e9, #d7d7d7);
   background-image: -moz-linear-gradient(#e9e9e9, #d7d7d7);
   background-image: -o-linear-gradient(#e9e9e9, #d7d7d7);

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -34,10 +34,6 @@
   background-image: -o-linear-gradient($from, $to);
 }
 
-@mixin bg-gradient($from, $to) {
-  @include linear-gradient($from, $to);
-}
-
 @mixin bg-light-gray-gradient {
   background: #f1f1f1;
   background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #f5f5f5), to(#e1e1e1));

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -1,0 +1,74 @@
+@mixin shade {
+  -moz-box-shadow: 0 0 3px #ddd;
+  -webkit-box-shadow: 0 0 3px #ddd;
+  box-shadow: 0 0 3px #ddd;
+}
+
+@mixin solid_shade {
+  -moz-box-shadow: 0 0 0 3px #f1f1f1;
+  -webkit-box-shadow: 0 0 0 3px #f1f1f1;
+  box-shadow: 0 0 0 3px #f1f1f1;
+}
+
+@mixin border-radius($radius) {
+  -moz-border-radius: $radius;
+  -webkit-border-radius: $radius;
+  border-radius: $radius;
+}
+
+@mixin round-borders-bottom($radius) {
+  border-top: 1px solid #eaeaea;
+  -webkit-border-bottom-left-radius: $radius;
+  -webkit-border-bottom-right-radius: $radius;
+  -moz-border-radius-bottomright: $radius;
+  -moz-border-radius-bottomleft: $radius;
+  border-bottom-right-radius: $radius;
+  border-bottom-left-radius: $radius;
+}
+
+@mixin round-borders-top($radius) {
+  border-top: 1px solid #eaeaea;
+  -moz-border-radius-topright: $radius;
+  -moz-border-radius-topleft: $radius;
+  border-top-right-radius: $radius;
+  border-top-left-radius: $radius;
+  -webkit-border-top-left-radius: $radius;
+  -webkit-border-top-right-radius: $radius;
+}
+
+@mixin round-borders-all($radius) {
+  border: 1px solid #eaeaea;
+  -moz-border-radius: $radius;
+  -webkit-border-radius: $radius;
+  border-radius: $radius;
+}
+
+@mixin bg-gradient($from, $to) {
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from($from), to($to));
+  background-image: -webkit-linear-gradient($from, $to);
+  background-image: -moz-linear-gradient($from, $to);
+  background-image: -o-linear-gradient($from, $to);
+}
+
+@mixin bg-light-gray-gradient {
+  background:#f1f1f1;
+  background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #f5f5f5), to(#e1e1e1));
+  background-image: -webkit-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
+  background-image: -moz-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
+  background-image: -o-linear-gradient(#f5f5f5 6.6%, #e1e1e1);
+}
+
+@mixin bg-gray-gradient {
+  background:#eee;
+  background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #eee), to(#dfdfdf));
+  background-image: -webkit-linear-gradient(#eee 6.6%, #dfdfdf);
+  background-image: -moz-linear-gradient(#eee 6.6%, #dfdfdf);
+  background-image: -o-linear-gradient(#eee 6.6%, #dfdfdf);
+}
+
+@mixin bg-dark-gray-gradient {
+  background:#eee;
+  background-image: -webkit-linear-gradient(#e9e9e9, #d7d7d7);
+  background-image: -moz-linear-gradient(#e9e9e9, #d7d7d7);
+  background-image: -o-linear-gradient(#e9e9e9, #d7d7d7);
+}

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -12,11 +12,11 @@
 
 
 @mixin box-shadow($shadow) {
-  -webkit-box-shadow: $radius;
-  -moz-box-shadow: $radius;
-  -ms-box-shadow: $radius;
-  -o-box-shadow: $radius;
-  box-shadow: $radius;
+  -webkit-box-shadow: $shadow;
+  -moz-box-shadow: $shadow;
+  -ms-box-shadow: $shadow;
+  -o-box-shadow: $shadow;
+  box-shadow: $shadow;
 }
 
 @mixin border-radius($radius) {
@@ -25,6 +25,13 @@
   -ms-border-radius: $radius;
   -o-border-radius: $radius;
   border-radius: $radius;
+}
+
+@mixin linear-gradient($from, $to) {
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from($from), to($to));
+  background-image: -webkit-linear-gradient($from, $to);
+  background-image: -moz-linear-gradient($from, $to);
+  background-image: -o-linear-gradient($from, $to);
 }
 
 @mixin round-borders-bottom($radius) {
@@ -43,10 +50,7 @@
 }
 
 @mixin bg-gradient($from, $to) {
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from($from), to($to));
-  background-image: -webkit-linear-gradient($from, $to);
-  background-image: -moz-linear-gradient($from, $to);
-  background-image: -o-linear-gradient($from, $to);
+  @include linear-gradient($from, $to);
 }
 
 @mixin bg-light-gray-gradient {

--- a/app/assets/stylesheets/ref_select.scss
+++ b/app/assets/stylesheets/ref_select.scss
@@ -1,6 +1,6 @@
 /** Branch/tag selector **/
 .project-refs-form {
-  margin:0;
+  margin: 0;
   span {
     background:none !important;
     position:static !important;
@@ -9,7 +9,7 @@
   }
 }
 .project-refs-select {
-  width:120px;
+  width: 120px;
 }
 
 .project-refs-form .chzn-container {
@@ -21,10 +21,10 @@
   .chzn-drop {
     min-width: 400px;
     .chzn-results {
-      max-height:300px;
+      max-height: 300px;
     }
     .chzn-search input {
-      min-width:365px;
+      min-width: 365px;
     }
   }
 }
@@ -43,11 +43,11 @@
     margin:7px 0;
     min-width: 200px;
     border: 1px solid #bbb;
-    border-radius:0;
+    border-radius: 0;
 
     .chzn-results {
       margin-top: 5px;
-      max-height:300px;
+      max-height: 300px;
 
       .group-result {
         color: $style_color;
@@ -71,7 +71,7 @@
     .chzn-search {
       @include bg-gray-gradient;
       input {
-        min-width:165px;
+        min-width: 165px;
         border-color: #CCC;
       }
     }
@@ -81,8 +81,8 @@
     @include bg-light-gray-gradient;
 
     div {
-      background:transparent;
-      border-left:none;
+      background: transparent;
+      border-left: none;
     }
 
     span {

--- a/app/assets/stylesheets/ref_select.scss
+++ b/app/assets/stylesheets/ref_select.scss
@@ -33,17 +33,15 @@
 .chzn-container {
   .chzn-search {
     input:focus {
-      -webkit-box-shadow: none;
-      -moz-box-shadow: none;
-      box-shadow: none;
+      @include box-shadow(none);
     }
   }
 
   .chzn-drop {
-    margin:7px 0;
+    margin: 7px 0;
     min-width: 200px;
     border: 1px solid #bbb;
-    border-radius: 0;
+    @include border-radius(0);
 
     .chzn-results {
       margin-top: 5px;
@@ -55,7 +53,7 @@
         padding: 8px;
       }
       .active-result {
-        border-radius: 0;
+        @include border-radius(0);
 
         &.highlighted {
           background: $hover;

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -6,14 +6,14 @@
 
     .commit-title {
       line-height: 26px;
-      margin:0;
+      margin: 0;
     }
 
     .commit-description {
       font-size: 14px;
       border: none;
       background-color: white;
-      padding-top:10px;
+      padding-top: 10px;
     }
 
     .browse-button {
@@ -28,9 +28,9 @@
     @extend .clearfix;
 
     .sha-block {
-      text-align:right;
+      text-align: right;
       &:first-child {
-        padding-bottom:6px;
+        padding-bottom: 6px;
       }
 
       a {
@@ -49,8 +49,8 @@
 
     .author a,
     .committer a {
-      font-size:14px;
-      line-height:22px;
+      font-size: 14px;
+      line-height: 22px;
       text-shadow:0 1px 1px #fff;
       color:#777;
       &:hover {
@@ -71,7 +71,7 @@
  */
 .diff_file {
   border:1px solid #CCC;
-  margin-bottom:1em;
+  margin-bottom: 1em;
 
   .diff_file_header {
     @extend .clearfix;
@@ -86,7 +86,7 @@
 
     > span {
       font-family: $monospace;
-      font-size:14px;
+      font-size: 14px;
       line-height: 30px;
     }
 
@@ -104,8 +104,8 @@
     }
   }
   .diff_file_content {
-    overflow:auto;
-    overflow-y:hidden;
+    overflow: auto;
+    overflow-y: hidden;
     background:#fff;
     color:#333;
     font-size: 12px;
@@ -123,17 +123,17 @@
 
     table {
       td {
-        line-height:18px;
+        line-height: 18px;
       }
     }
   }
   .diff_file_content_image {
     background:#eee;
-    text-align:center;
+    text-align: center;
     .image {
       display: inline-block;
-      margin:50px;
-      max-width:400px;
+      margin: 50px;
+      max-width: 400px;
 
       img{
         background: url('trans_bg.gif');
@@ -158,7 +158,7 @@
 
     &.img_compared {
       .image {
-        max-width:300px;
+        max-width: 300px;
       }
     }
   }
@@ -166,46 +166,46 @@
 
 .diff_file_content{
   table {
-    border:none;
-    margin:0px;
-    padding:0px;
+    border: none;
+    margin: 0px;
+    padding: 0px;
     tr {
       td {
-        font-size:12px;
+        font-size: 12px;
       }
     }
   }
   .old_line, .new_line {
-    margin:0px;
-    padding:0px;
-    border:none;
+    margin: 0px;
+    padding: 0px;
+    border: none;
     background:#EEE;
     color:#666;
     padding: 0px 5px;
     border-right: 1px solid #ccc;
-    text-align:right;
-    min-width:35px;
-    max-width:35px;
-    width:35px;
+    text-align: right;
+    min-width: 35px;
+    max-width: 35px;
+    width: 35px;
     moz-user-select: none;
     -khtml-user-select: none;
     user-select: none;
     a {
-      float:left;
-      width:35px;
-      font-weight:normal;
+      float: left;
+      width: 35px;
+      font-weight: normal;
       color:#666;
       &:hover {
-        text-decoration:underline;
+        text-decoration: underline;
       }
     }
   }
   .line_content {
-    white-space:pre;
-    height:14px;
-    margin:0px;
-    padding:0px;
-    border:none;
+    white-space: pre;
+    height: 14px;
+    margin: 0px;
+    padding: 0px;
+    border: none;
     &.new {
       background: #CFD;
     }
@@ -232,28 +232,28 @@
 
   .browse_code_link_holder {
     @extend .span2;
-    float:right;
+    float: right;
   }
 
   .committed_ago {
-    float:right;
+    float: right;
     @extend .cgray;
   }
 
   .notes_count {
-    float:right;
+    float: right;
     margin: -6px 8px 6px;
   }
 
   code {
     background:#FCEEC1;
-    color:$style_color;
+    color: $style_color;
   }
 
   .commit_short_id {
-    float:left;
+    float: left;
     @extend .lined;
-    min-width:65px;
+    min-width: 65px;
     font-family: $monospace;
   }
 
@@ -296,8 +296,8 @@
 .label_commit {
   @include round-borders-all(4px);
   padding:2px 4px;
-  border:none;
-  font-size:13px;
+  border: none;
+  font-size: 13px;
   background: #474D57;
   color:#fff;
   font-family: $monospace;

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -295,9 +295,8 @@
 }
 
 .label_commit {
-  @include round-borders-all(4px);
+  @include border-radius(4px);
   padding: 2px 4px;
-  border: none;
   font-size: 13px;
   background: #474D57;
   color: #fff;

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -51,8 +51,8 @@
     .committer a {
       font-size: 14px;
       line-height: 22px;
-      text-shadow:0 1px 1px #fff;
-      color:#777;
+      text-shadow: 0 1px 1px #fff;
+      color: #777;
       &:hover {
         color: #999;
       }
@@ -70,15 +70,16 @@
  *
  */
 .diff_file {
-  border:1px solid #CCC;
+  border: 1px solid #CCC;
   margin-bottom: 1em;
 
   .diff_file_header {
     @extend .clearfix;
     padding: 5px 5px 5px 10px;
     color: #555;
-    border-bottom:1px solid #CCC;
+    border-bottom: 1px solid #CCC;
     background: #eee;
+    // TODO Replace with linear-gradient mixin
     background-image: -webkit-gradient(linear, 0 0, 0 30, color-stop(0.066, #eee), to(#dfdfdf));
     background-image: -webkit-linear-gradient(#eee 6.6%, #dfdfdf);
     background-image: -moz-linear-gradient(#eee 6.6%, #dfdfdf);
@@ -106,18 +107,18 @@
   .diff_file_content {
     overflow: auto;
     overflow-y: hidden;
-    background:#fff;
-    color:#333;
+    background: #fff;
+    color: #333;
     font-size: 12px;
     font-family: $monospace;
     .old{
       span.idiff{
-        background-color:#FAA;
+        background-color: #FAA;
       }
     }
     .new{
       span.idiff{
-        background-color:#AFA;
+        background-color: #AFA;
       }
     }
 
@@ -128,7 +129,7 @@
     }
   }
   .diff_file_content_image {
-    background:#eee;
+    background: #eee;
     text-align: center;
     .image {
       display: inline-block;
@@ -179,8 +180,8 @@
     margin: 0px;
     padding: 0px;
     border: none;
-    background:#EEE;
-    color:#666;
+    background: #EEE;
+    color: #666;
     padding: 0px 5px;
     border-right: 1px solid #ccc;
     text-align: right;
@@ -194,7 +195,7 @@
       float: left;
       width: 35px;
       font-weight: normal;
-      color:#666;
+      color: #666;
       &:hover {
         text-decoration: underline;
       }
@@ -213,8 +214,8 @@
       background: #FDD;
     }
     &.matched {
-      color:#ccc;
-      background:#fafafa;
+      color: #ccc;
+      background: #fafafa;
     }
   }
 }
@@ -246,7 +247,7 @@
   }
 
   code {
-    background:#FCEEC1;
+    background: #FCEEC1;
     color: $style_color;
   }
 
@@ -295,10 +296,10 @@
 
 .label_commit {
   @include round-borders-all(4px);
-  padding:2px 4px;
+  padding: 2px 4px;
   border: none;
   font-size: 13px;
   background: #474D57;
-  color:#fff;
+  color: #fff;
   font-family: $monospace;
 }

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -1,8 +1,8 @@
 .commit-box {
-  @extend .main_box;
+  @extend .main-box;
 
   .commit-head {
-    @extend .top_box_content;
+    @extend .top-box-content;
 
     .commit-title {
       line-height: 26px;
@@ -24,7 +24,7 @@
   }
 
   .commit-info {
-    @extend .middle_box_content;
+    @extend .middle-box-content;
     @extend .clearfix;
 
     .sha-block {
@@ -69,11 +69,11 @@
  * COMMIT SHOw
  *
  */
-.diff_file {
+.diff-file {
   border: 1px solid #CCC;
   margin-bottom: 1em;
 
-  .diff_file_header {
+  .diff-file-header {
     @extend .clearfix;
     padding: 5px 5px 5px 10px;
     color: #555;
@@ -104,7 +104,7 @@
       font-family: $monospace;
     }
   }
-  .diff_file_content {
+  .diff-file-content {
     overflow: auto;
     overflow-y: hidden;
     background: #fff;
@@ -128,7 +128,7 @@
       }
     }
   }
-  .diff_file_content_image {
+  .diff-file-content-image {
     background: #eee;
     text-align: center;
     .image {
@@ -140,13 +140,13 @@
         background: url('trans_bg.gif');
       }
 
-      &.diff_removed {
+      &.diff-removed {
         img{
           border: 1px solid #C00;
         }
       }
 
-      &.diff_added {
+      &.diff-added {
         img{
           border: 1px solid #0C0;
         }
@@ -157,7 +157,7 @@
       }
     }
 
-    &.img_compared {
+    &.img-compared {
       .image {
         max-width: 300px;
       }
@@ -165,7 +165,7 @@
   }
 }
 
-.diff_file_content{
+.diff-file-content{
   table {
     border: none;
     margin: 0px;
@@ -176,7 +176,7 @@
       }
     }
   }
-  .old_line, .new_line {
+  .old-line, .new-line {
     margin: 0px;
     padding: 0px;
     border: none;
@@ -188,9 +188,7 @@
     min-width: 35px;
     max-width: 35px;
     width: 35px;
-    moz-user-select: none;
-    -khtml-user-select: none;
-    user-select: none;
+    @include user-select(none);
     a {
       float: left;
       width: 35px;
@@ -201,7 +199,7 @@
       }
     }
   }
-  .line_content {
+  .line-content {
     white-space: pre;
     height: 14px;
     margin: 0px;
@@ -231,17 +229,17 @@
 .commit {
   @extend .wll;
 
-  .browse_code_link_holder {
+  .browse-code-link-holder {
     @extend .span2;
     float: right;
   }
 
-  .committed_ago {
+  .committed-ago {
     float: right;
     @extend .cgray;
   }
 
-  .notes_count {
+  .notes-count {
     float: right;
     margin: -6px 8px 6px;
   }
@@ -251,7 +249,7 @@
     color: $style_color;
   }
 
-  .commit_short_id {
+  .commit-short-id {
     float: left;
     @extend .lined;
     min-width: 65px;
@@ -266,7 +264,7 @@
   }
 }
 
-.diff_file_header a,
+.diff-file_header a,
 .file-stats a {
   color: $style_color;
 }
@@ -294,7 +292,7 @@
   }
 }
 
-.label_commit {
+.label-commit {
   @include border-radius(4px);
   padding: 2px 4px;
   font-size: 13px;

--- a/app/assets/stylesheets/sections/editor.scss
+++ b/app/assets/stylesheets/sections/editor.scss
@@ -1,7 +1,7 @@
 .file-editor {
   #editor{
     border: none;
-    border-radius: 0;
+    @include border-radius(0);
     height: 500px;
     margin: 0;
     padding: 0;

--- a/app/assets/stylesheets/sections/editor.scss
+++ b/app/assets/stylesheets/sections/editor.scss
@@ -34,7 +34,7 @@
       margin: 5px 8px 0 8px;
     }
   }
-  .commit_message-group {
+  .commit-message-group {
     margin-top: 20px;
 
     label {

--- a/app/assets/stylesheets/sections/events.scss
+++ b/app/assets/stylesheets/sections/events.scss
@@ -22,7 +22,7 @@
   &.left,
   &.joined {
     padding:0 2px;
-    float:none;
+    float: none;
   }
 }
 
@@ -31,7 +31,7 @@
  *
  */
 .event-item {
-  min-height:40px;
+  min-height: 40px;
   border-bottom:1px solid #eee;
   .event-title {
     color:#333;
@@ -50,7 +50,7 @@
     }
   }
   .avatar {
-    width:32px;
+    width: 32px;
   }
   .event_icon {
     float: right;
@@ -59,15 +59,15 @@
     @include border-radius(5px);
     background: #F9F9F9;
     img {
-      width:20px;
+      width: 20px;
     }
   }
   ul {
-    margin-left:50px;
-    margin-bottom:5px;
+    margin-left: 50px;
+    margin-bottom: 5px;
     .avatar {
-      width:18px;
-      margin-top:3px;
+      width: 18px;
+      margin-top: 3px;
     }
   }
 
@@ -81,9 +81,9 @@
     li {
       &.commit {
         background: transparent;
-        padding:3px;
-        border:none;
-        font-size:12px;
+        padding: 3px;
+        border: none;
+        font-size: 12px;
       }
       &.commits-stat {
         display: block;
@@ -99,14 +99,14 @@
  */
 .event_lp {
   color:#777;
-  padding:10px;
-  min-height:22px;
+  padding: 10px;
+  min-height: 22px;
   border-left: 5px solid #5AB9C3;
-  margin-bottom:20px;
+  margin-bottom: 20px;
   background:#f9f9f9;
 
   .avatar {
-    width:24px;
+    width: 24px;
   }
 
   .btn-new-mr {
@@ -133,7 +133,7 @@
     background: #f9f9f9;
     margin-bottom: 10px;
     img {
-      width:20px;
+      width: 20px;
     }
 
     &.inactive {

--- a/app/assets/stylesheets/sections/events.scss
+++ b/app/assets/stylesheets/sections/events.scss
@@ -4,24 +4,24 @@
  */
 .event_label {
   &.pushed {
-    padding:0 2px;
+    padding: 0 2px;
   }
 
   &.opened {
-    padding:0 2px;
+    padding: 0 2px;
   }
 
   &.closed {
-    padding:0 2px;
+    padding: 0 2px;
   }
 
   &.merged {
-    padding:0 2px;
+    padding: 0 2px;
   }
 
   &.left,
   &.joined {
-    padding:0 2px;
+    padding: 0 2px;
     float: none;
   }
 }
@@ -32,21 +32,21 @@
  */
 .event-item {
   min-height: 40px;
-  border-bottom:1px solid #eee;
+  border-bottom: 1px solid #eee;
   .event-title {
-    color:#333;
+    color: #333;
     font-weight: bold;
     .author_name {
-      color:#333;
+      color: #333;
     }
   }
   .event-body {
     p {
-      color:#555;
+      color: #555;
       padding-top: 5px;
     }
     .event-info {
-      color:#666;
+      color: #666;
     }
   }
   .avatar {
@@ -98,12 +98,12 @@
  *
  */
 .event_lp {
-  color:#777;
+  color: #777;
   padding: 10px;
   min-height: 22px;
   border-left: 5px solid #5AB9C3;
   margin-bottom: 20px;
-  background:#f9f9f9;
+  background: #f9f9f9;
 
   .avatar {
     width: 24px;

--- a/app/assets/stylesheets/sections/events.scss
+++ b/app/assets/stylesheets/sections/events.scss
@@ -2,7 +2,7 @@
  * Events labels
  *
  */
-.event_label {
+.event-label {
   &.pushed {
     padding: 0 2px;
   }
@@ -36,7 +36,7 @@
   .event-title {
     color: #333;
     font-weight: bold;
-    .author_name {
+    .author-name {
       color: #333;
     }
   }
@@ -52,7 +52,7 @@
   .avatar {
     width: 32px;
   }
-  .event_icon {
+  .event-icon {
     float: right;
     border: 1px solid #EEE;
     padding: 5px;
@@ -75,7 +75,7 @@
   &:last-child { border:none }
   .wll:hover { background:none }
 
-  .event_commits {
+  .event-commits {
     margin-top: 5px;
 
     li {
@@ -97,7 +97,7 @@
  * Push event widget
  *
  */
-.event_lp {
+.event-lp {
   color: #777;
   padding: 10px;
   min-height: 22px;
@@ -121,12 +121,12 @@
  * Event filter
  *
  */
-.event_filter {
+.event-filter {
   position: absolute;
   width: 40px;
   margin-left: -50px;
 
-  .filter_icon {
+  .filter-icon {
     float: left;
     border-left: 3px solid #4bc;
     padding: 7px;

--- a/app/assets/stylesheets/sections/graph.scss
+++ b/app/assets/stylesheets/sections/graph.scss
@@ -4,7 +4,7 @@
 
 
   h4 { 
-    padding:0 10px;
+    padding: 0 10px;
     border-bottom: 1px solid #bbb;
     @include bg-gray-gradient;
   }

--- a/app/assets/stylesheets/sections/graph.scss
+++ b/app/assets/stylesheets/sections/graph.scss
@@ -1,6 +1,6 @@
 .graph_holder { 
   border: 1px solid #aaa;
-  padding:1px;
+  padding: 1px;
 
 
   h4 { 

--- a/app/assets/stylesheets/sections/graph.scss
+++ b/app/assets/stylesheets/sections/graph.scss
@@ -1,4 +1,4 @@
-.graph_holder { 
+.graph-holder { 
   border: 1px solid #aaa;
   padding: 1px;
 

--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -5,7 +5,7 @@
 header {
   &.navbar-gitlab {
     .navbar-inner {
-      height:45px;
+      height: 45px;
       padding: 5px;
       background: #F1F1F1;
 
@@ -24,8 +24,8 @@ header {
     }
   }
 
-  z-index:10;
-  /*height:60px;*/
+  z-index: 10;
+  /*height: 60px;*/
 
   /**
    *
@@ -33,24 +33,24 @@ header {
    *
    */
   .app_logo {
-    width:170px;
-    float:left;
+    width: 170px;
+    float: left;
     a {
-      float:left;
+      float: left;
       padding: 0px;
 
       h1 {
-        width:90px;
+        width: 90px;
         background: url('logo_dark.png') no-repeat 0px 2px;
-        float:left;
-        margin-left:2px;
-        font-size:30px;
-        line-height:48px;
-        font-weight:normal;
-        color:$style_color;
+        float: left;
+        margin-left: 2px;
+        font-size: 30px;
+        line-height: 48px;
+        font-weight: normal;
+        color: $style_color;
         text-shadow: 0 1px 1px #FFF;
-        padding-left:45px;
-        height:40px;
+        padding-left: 45px;
+        height: 40px;
         font-family: 'Korolev', sans-serif;
       }
     }
@@ -62,14 +62,14 @@ header {
    *
    */
   .project_name {
-    position:relative;
-    float:left;
-    margin:0;
-    margin-right:30px;
-    font-size:30px;
-    line-height:48px;
-    font-weight:normal;
-    color:$style_color;
+    position: relative;
+    float: left;
+    margin: 0;
+    margin-right: 30px;
+    font-size: 30px;
+    line-height: 48px;
+    font-weight: normal;
+    color: $style_color;
     text-shadow: 0 1px 1px #FFF;
     font-family: 'Korolev', sans-serif;
   }
@@ -81,7 +81,7 @@ header {
    */
   .search {
     margin-right: 45px;
-    margin-left:10px;
+    margin-left: 10px;
     margin-top: 2px;
 
     .search-input {
@@ -89,11 +89,11 @@ header {
       background-image: url("icon-search.png");
       background-repeat: no-repeat;
       background-position: 10px;
-      padding-left:25px;
+      padding-left: 25px;
       font-size: 13px;
       @include border-radius(3px);
       border:1px solid #c6c6c6;
-      box-shadow:none;
+      box-shadow: none;
       &:focus {
         @extend .span3;
       }
@@ -122,7 +122,7 @@ header {
       width: 28px;
       height: 28px;
       display: block;
-      top:1px;
+      top: 1px;
       &:after {
         content: " ";
         display: block;

--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -135,9 +135,12 @@ header {
         @include border-radius(5px);
         border: 1px solid rgba(255, 255, 255, 0.1);
         border-bottom: 0;
-        background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(rgba(255, 255, 255, 0.15)), to(rgba(0, 0, 0, 0.25))), -webkit-gradient(linear, left top, right bottom, color-stop(0, rgba(255, 255, 255, 0)), color-stop(0.5, rgba(255, 255, 255, 0.1)), color-stop(0.501, rgba(255, 255, 255, 0)), color-stop(1, rgba(255, 255, 255, 0)));
-        background: -moz-linear-gradient(top, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.25)), -moz-linear-gradient(left top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0));
-        background: linear-gradient(top, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.25)), linear-gradient(left top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0));
+        background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(rgba(255, 255, 255, 0.15)), to(rgba(0, 0, 0, 0.25))),
+                    -webkit-gradient(linear, left top, right bottom, color-stop(0, rgba(255, 255, 255, 0)), color-stop(0.5, rgba(255, 255, 255, 0.1)), color-stop(0.501, rgba(255, 255, 255, 0)), color-stop(1, rgba(255, 255, 255, 0)));
+        background: -moz-linear-gradient(top, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.25)),
+                    -moz-linear-gradient(left top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0));
+        background: linear-gradient(top, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.25)),
+                    linear-gradient(left top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0));
         -webkit-background-origin: border-box;
         -moz-background-origin: border;
   background-origin: border-box; } } }

--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -32,7 +32,7 @@ header {
    * Logo holder
    *
    */
-  .app_logo {
+  .app-logo {
     width: 170px;
     float: left;
     a {
@@ -61,7 +61,7 @@ header {
    * Project / Area name
    *
    */
-  .project_name {
+  .project-name {
     position: relative;
     float: left;
     margin: 0;
@@ -240,7 +240,7 @@ header {
     .search-input::-webkit-input-placeholder {
       color: #666;
     }
-    .app_logo {
+    .app-logo {
       a {
         h1 {
           background: url('logo_white.png') no-repeat 0px 2px;
@@ -249,7 +249,7 @@ header {
         }
       }
     }
-    .project_name {
+    .project-name {
       color: #fff;
       text-shadow: 0 1px 1px #111;
     }

--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -92,7 +92,7 @@ header {
       padding-left: 25px;
       font-size: 13px;
       @include border-radius(3px);
-      border:1px solid #c6c6c6;
+      border: 1px solid #c6c6c6;
       box-shadow: none;
       &:focus {
         @extend .span3;
@@ -132,7 +132,7 @@ header {
         left: 0;
         bottom: 0;
         float: right;
-        border-radius: 5px;
+        @include border-radius(5px);
         border: 1px solid rgba(255, 255, 255, 0.1);
         border-bottom: 0;
         background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(rgba(255, 255, 255, 0.15)), to(rgba(0, 0, 0, 0.25))), -webkit-gradient(linear, left top, right bottom, color-stop(0, rgba(255, 255, 255, 0)), color-stop(0.5, rgba(255, 255, 255, 0.1)), color-stop(0.501, rgba(255, 255, 255, 0)), color-stop(1, rgba(255, 255, 255, 0)));
@@ -149,7 +149,7 @@ header {
   display: block; } }
 
   .account-links {
-    border-radius: 5px;
+    @include border-radius(5px);
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
     position: relative;
     &:before {
@@ -184,7 +184,7 @@ header {
       border-bottom: 1px solid #666;
       font-size: 12px;
       &:hover {
-        color:#fff;
+        color: #fff;
         background: #333;
       }
     }
@@ -197,20 +197,13 @@ header {
 
   .account-links a {
     &:first-child {
-      -webkit-border-top-left-radius: 5px;
-      -webkit-border-top-right-radius: 5px;
-      -moz-border-radius-topleft: 5px;
-      -moz-border-radius-topright: 5px;
-      border-top-left-radius: 5px;
-    border-top-right-radius: 5px; }
+      @include border-radius(5px 5px 0 0);
+    }
     &:last-child {
-      -webkit-border-bottom-right-radius: 5px;
-      -webkit-border-bottom-left-radius: 5px;
-      -moz-border-radius-bottomright: 5px;
-      -moz-border-radius-bottomleft: 5px;
-      border-bottom-right-radius: 5px;
-      border-bottom-left-radius: 5px;
-  border-bottom: 0; } }
+      @include border-radius(0 0 5px 5px);
+      border-bottom: 0; 
+    } 
+  }
 
 
 
@@ -248,13 +241,13 @@ header {
       a {
         h1 {
           background: url('logo_white.png') no-repeat 0px 2px;
-          color:#fff;
+          color: #fff;
           text-shadow: 0 1px 1px #111;
         }
       }
     }
     .project_name {
-      color:#fff;
+      color: #fff;
       text-shadow: 0 1px 1px #111;
     }
   }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -139,7 +139,7 @@ input.check_all_issues {
   border: none;
   box-shadow: none;
   .ui-datepicker-header {
-    @include solid_shade;
+    @include solid-shade;
     margin-bottom: 10px;
     border: 1px solid #bbb;
   }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -3,7 +3,7 @@
   .issue_title {
     @extend .top_box_content;
     .clearfix {
-      margin-bottom:0px;
+      margin-bottom: 0px;
       input {
         @extend .span8;
       }
@@ -11,14 +11,14 @@
   }
   .issue_middle_block {
     @extend .middle_box_content;
-    height:30px;
+    height: 30px;
     .issue_assignee {
       @extend .span6;
-      float:left;
+      float: left;
     }
     .issue_milestone {
       @extend .span4;
-      float:left;
+      float: left;
     }
   }
   .issue_description {
@@ -31,28 +31,28 @@
     padding:7px 10px;
 
     .issue_check {
-      float:left;
+      float: left;
       padding: 8px 0;
       padding-right: 8px;
       min-width: 15px;
     }
 
     p {
-      padding-top:0;
-      padding-bottom:2px;
+      padding-top: 0;
+      padding-bottom: 2px;
     }
 
     img.avatar {
-      width:32px;
-      margin-top:1px;
+      width: 32px;
+      margin-top: 1px;
     }
   }
 }
 
 input.check_all_issues {
-  float:left;
+  float: left;
   padding: 0;
-  margin:0;
+  margin: 0;
   margin-right: 10px;
   position: relative;
   top: 8px;
@@ -82,16 +82,16 @@ input.check_all_issues {
   }
 }
 
-@media (min-width: 800px) { .issues_filters select { width:160px; }  }
-@media (min-width: 1000px) { .issues_filters select { width:200px; }  }
-@media (min-width: 1200px) { .issues_filters select { width:220px; }  }
+@media (min-width: 800px) { .issues_filters select { width: 160px; }  }
+@media (min-width: 1000px) { .issues_filters select { width: 200px; }  }
+@media (min-width: 1200px) { .issues_filters select { width: 220px; }  }
 
 
 #issues-table-holder {
   .issues_filters {
     form {
-      padding:0;
-      margin:0;
+      padding: 0;
+      margin: 0;
       margin-top:7px
     }
   }
@@ -99,27 +99,27 @@ input.check_all_issues {
   .issues_bulk_update {
     margin: 0;
     form {
-      padding:0;
-      margin:0;
+      padding: 0;
+      margin: 0;
       margin-top:7px
     }
     .update_selected_issues {
-      position:relative;
+      position: relative;
       top:-2px;
-      margin-left:4px;
-      float:left;
+      margin-left: 4px;
+      float: left;
     }
 
     .update_issues_text {
-      padding:3px;
+      padding: 3px;
       line-height: 18px;
-      float:left;
+      float: left;
     }
   }
 }
 
 #update_status {
-  width:100px;
+  width: 100px;
 }
 
 
@@ -136,11 +136,11 @@ input.check_all_issues {
  */
 
 .ui-datepicker {
-  border:none;
-  box-shadow:none;
+  border: none;
+  box-shadow: none;
   .ui-datepicker-header {
     @include solid_shade;
-    margin-bottom:10px;
+    margin-bottom: 10px;
     border:1px solid #bbb;
   }
 }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -28,7 +28,7 @@
 
 .issues_table {
   .issue {
-    padding:7px 10px;
+    padding: 7px 10px;
 
     .issue_check {
       float: left;
@@ -141,6 +141,6 @@ input.check_all_issues {
   .ui-datepicker-header {
     @include solid_shade;
     margin-bottom: 10px;
-    border:1px solid #bbb;
+    border: 1px solid #bbb;
   }
 }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -1,7 +1,7 @@
-.issue_form_box {
-  @extend .main_box;
-  .issue_title {
-    @extend .top_box_content;
+.issue-form-box {
+  @extend .main-box;
+  .issue-title {
+    @extend .top-box-content;
     .clearfix {
       margin-bottom: 0px;
       input {
@@ -9,28 +9,28 @@
       }
     }
   }
-  .issue_middle_block {
-    @extend .middle_box_content;
+  .issue-middle-block {
+    @extend .middle-box-content;
     height: 30px;
-    .issue_assignee {
+    .issue-assignee {
       @extend .span6;
       float: left;
     }
-    .issue_milestone {
+    .issue-milestone {
       @extend .span4;
       float: left;
     }
   }
-  .issue_description {
-    @extend .bottom_box_content;
+  .issue-description {
+    @extend .bottom-box-content;
   }
 }
 
-.issues_table {
+.issues-table {
   .issue {
     padding: 7px 10px;
 
-    .issue_check {
+    .issue-check {
       float: left;
       padding: 8px 0;
       padding-right: 8px;
@@ -49,7 +49,7 @@
   }
 }
 
-input.check_all_issues {
+input.check-all-issues {
   float: left;
   padding: 0;
   margin: 0;
@@ -59,13 +59,13 @@ input.check_all_issues {
   height: 22px;
 }
 
-.issues_content {
+.issues-content {
   .title {
     height: 40px;
   }
 }
 
-.btn.close_issue {
+.btn.close-issue {
   color: #B94A48;
   font-weight: bold;
   @include shade;
@@ -73,7 +73,7 @@ input.check_all_issues {
     color: #B94A48;
   }
 }
-.btn.reopen_issue {
+.btn.reopen-issue {
   color: #468847;
   font-weight: bold;
   @include shade;
@@ -82,13 +82,13 @@ input.check_all_issues {
   }
 }
 
-@media (min-width: 800px) { .issues_filters select { width: 160px; }  }
-@media (min-width: 1000px) { .issues_filters select { width: 200px; }  }
-@media (min-width: 1200px) { .issues_filters select { width: 220px; }  }
+@media (min-width: 800px) { .issues-filters select { width: 160px; }  }
+@media (min-width: 1000px) { .issues-filters select { width: 200px; }  }
+@media (min-width: 1200px) { .issues-filters select { width: 220px; }  }
 
 
 #issues-table-holder {
-  .issues_filters {
+  .issues-filters {
     form {
       padding: 0;
       margin: 0;
@@ -96,21 +96,21 @@ input.check_all_issues {
     }
   }
 
-  .issues_bulk_update {
+  .issues-bulk-update {
     margin: 0;
     form {
       padding: 0;
       margin: 0;
       margin-top:7px
     }
-    .update_selected_issues {
+    .update-selected-issues {
       position: relative;
       top:-2px;
       margin-left: 4px;
       float: left;
     }
 
-    .update_issues_text {
+    .update-issues-text {
       padding: 3px;
       line-height: 18px;
       float: left;
@@ -118,7 +118,7 @@ input.check_all_issues {
   }
 }
 
-#update_status {
+#update-status {
   width: 100px;
 }
 

--- a/app/assets/stylesheets/sections/login.scss
+++ b/app/assets/stylesheets/sections/login.scss
@@ -1,13 +1,13 @@
 /* Login Page */
 body.login-page{ 
   padding-top: 10%;
-  background:#f1f1f1;
+  background: #f1f1f1;
 }
 
 .login-box{
   width: 304px;
   position: relative;
-  border-radius: 5px;
+  @include border-radius(5px);
   margin: auto;
   padding: 20px;
   background: white;
@@ -18,25 +18,15 @@ body.login-page{
   display: block;
 }
 
-.login-box input.text{background-color: #f1f1f1; font-size: 16px; border-radius: 0; padding: 14px 10px; width: 280px}
+.login-box input.text{background-color: #f1f1f1; font-size: 16px; @include border-radius(0); padding: 14px 10px; width: 280px}
 
 .login-box input.text.top{
-  -webkit-border-top-left-radius: 5px;
-  -webkit-border-top-right-radius: 5px;
-  -moz-border-radius-topleft: 5px;
-  -moz-border-radius-topright: 5px;
-  border-top-left-radius: 5px;
-  border-top-right-radius: 5px;
+  @include border-radius(5px 5px 0 0);
   margin-bottom: 0px;
 }
 
 .login-box input.text.bottom{
-  -webkit-border-bottom-right-radius: 5px;
-  -webkit-border-bottom-left-radius: 5px;
-  -moz-border-radius-bottomright: 5px;
-  -moz-border-radius-bottomleft: 5px;
-  border-bottom-right-radius: 5px;
-  border-bottom-left-radius: 5px;
+  @include border-radius(0 0 5px 5px);
   border-top: 0;
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/sections/login.scss
+++ b/app/assets/stylesheets/sections/login.scss
@@ -27,7 +27,7 @@ body.login-page{
   -moz-border-radius-topright: 5px;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
-  margin-bottom:0px;
+  margin-bottom: 0px;
 }
 
 .login-box input.text.bottom{

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -5,7 +5,7 @@
 
 .mr_branch_box {
   @extend .ui-box;
-  margin-bottom:20px;
+  margin-bottom: 20px;
 
   .body {
     background:#f1f1f1;
@@ -23,14 +23,14 @@
   }
 
   form {
-    margin-bottom:0;
+    margin-bottom: 0;
     .clearfix {
-      margin-bottom:0;
+      margin-bottom: 0;
     }
   }
 
   .accept_group {
-    float:left;
+    float: left;
     border: 1px solid #ADA;
     padding: 2px;
     @include border-radius(5px);
@@ -38,13 +38,13 @@
     background: #CEB;
 
     .accept_merge_request {
-      font-size:13px;
-      float:left;
+      font-size: 13px;
+      float: left;
     }
     .remove_branch_holder {
-      margin-left:20px;
-      margin-right:10px;
-      float:left;
+      margin-left: 20px;
+      margin-right: 10px;
+      float: left;
     }
     label {
       color:#444;
@@ -60,9 +60,9 @@
 .mr_nav_tabs {
   li {
     a {
-      font-weight:bold;
+      font-weight: bold;
       padding:8px 20px;
-      text-align:center;
+      text-align: center;
     }
   }
 }
@@ -87,8 +87,8 @@ li.merge_request {
 .label_branch {
   @include round-borders-all(4px);
   padding:2px 4px;
-  border:none;
-  font-size:14px;
+  border: none;
+  font-size: 14px;
   background: #474D57;
   color:#fff;
   font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
@@ -97,8 +97,8 @@ li.merge_request {
 .mr_source_commit,
 .mr_target_commit {
   .commit {
-    margin:0;
-    padding:0;
+    margin: 0;
+    padding: 0;
     padding: 5px;
     margin-bottom: 5px;
     .avatar { position:relative }
@@ -109,11 +109,11 @@ li.merge_request {
     .dash,
     .committed_ago,
     .browse_code_link_holder {
-      display:none;
+      display: none;
     }
-    list-style:none;
+    list-style: none;
     &:hover {
-      background:none;
+      background: none;
     }
   }
 }
@@ -126,14 +126,14 @@ li.merge_request {
   @extend .main_box;
   .merge_requests_middle_box {
     @extend .middle_box_content;
-    height:30px;
+    height: 30px;
     .merge_requests_assignee {
       @extend .span6;
-      float:left;
+      float: left;
     }
     .merge_requests_milestone {
       @extend .span4;
-      float:left;
+      float: left;
     }
   }
 }

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -84,7 +84,7 @@ li.merge_request {
 }
 
 .label_branch {
-  @include round-borders-all(4px);
+  @include border-radius(4px);
   padding: 2px 4px;
   border: none;
   font-size: 14px;

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -8,7 +8,7 @@
   margin-bottom: 20px;
 
   .body {
-    background:#f1f1f1;
+    background: #f1f1f1;
   }
 
 }
@@ -34,7 +34,6 @@
     border: 1px solid #ADA;
     padding: 2px;
     @include border-radius(5px);
-    border-radius: 5px;
     background: #CEB;
 
     .accept_merge_request {
@@ -47,7 +46,7 @@
       float: left;
     }
     label {
-      color:#444;
+      color: #444;
     }
   }
 
@@ -61,14 +60,14 @@
   li {
     a {
       font-weight: bold;
-      padding:8px 20px;
+      padding: 8px 20px;
       text-align: center;
     }
   }
 }
 
 li.merge_request {
-  padding:7px 10px;
+  padding: 7px 10px;
   img.avatar {
     width: 32px;
     margin-top: 1px;
@@ -86,11 +85,11 @@ li.merge_request {
 
 .label_branch {
   @include round-borders-all(4px);
-  padding:2px 4px;
+  padding: 2px 4px;
   border: none;
   font-size: 14px;
   background: #474D57;
-  color:#fff;
+  color: #fff;
   font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
 }
 
@@ -103,7 +102,7 @@ li.merge_request {
     margin-bottom: 5px;
     .avatar { position:relative }
     .row_title {
-      color:#444;
+      color: #444;
     }
     .commit-author-name,
     .dash,

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -3,7 +3,7 @@
  *
  */
 
-.mr_branch_box {
+.mr-branch-box {
   @extend .ui-box;
   margin-bottom: 20px;
 
@@ -17,8 +17,8 @@
  * MR -> show: Automerge widget
  *
  */
-.automerge_widget {
-  &.can_be_merged {
+.automerge-widget {
+  &.can-be-merged {
     background: #DFF0D8;
   }
 
@@ -29,18 +29,18 @@
     }
   }
 
-  .accept_group {
+  .accept-group {
     float: left;
     border: 1px solid #ADA;
     padding: 2px;
     @include border-radius(5px);
     background: #CEB;
 
-    .accept_merge_request {
+    .accept-merge-request {
       font-size: 13px;
       float: left;
     }
-    .remove_branch_holder {
+    .remove-branch-holder {
       margin-left: 20px;
       margin-right: 10px;
       float: left;
@@ -51,12 +51,12 @@
   }
 
 
-  .how_to_merge_link {
+  .how-to-merge-link {
     @extend .primary;
   }
 }
 
-.mr_nav_tabs {
+.mr-nav-tabs {
   li {
     a {
       font-weight: bold;
@@ -66,7 +66,7 @@
   }
 }
 
-li.merge_request {
+li.merge-request {
   padding: 7px 10px;
   img.avatar {
     width: 32px;
@@ -78,12 +78,12 @@ li.merge_request {
   }
 }
 
-.merge_in_progress {
+.merge-in-progress {
   @extend .padded;
   @extend .append-bottom-10;
 }
 
-.label_branch {
+.label-branch {
   @include border-radius(4px);
   padding: 2px 4px;
   border: none;
@@ -93,21 +93,21 @@ li.merge_request {
   font-family: 'Menlo', 'Liberation Mono', 'Consolas', 'Courier New', 'andale mono','lucida console',monospace;
 }
 
-.mr_source_commit,
-.mr_target_commit {
+.mr-source-commit,
+.mr-target-commit {
   .commit {
     margin: 0;
     padding: 0;
     padding: 5px;
     margin-bottom: 5px;
     .avatar { position:relative }
-    .row_title {
+    .row-title {
       color: #444;
     }
     .commit-author-name,
     .dash,
-    .committed_ago,
-    .browse_code_link_holder {
+    .committed-ago,
+    .browse-code-link-holder {
       display: none;
     }
     list-style: none;
@@ -117,20 +117,20 @@ li.merge_request {
   }
 }
 
-.mr_direction_tip {
+.mr-direction-tip {
   margin-top:40px
 }
 
-.merge_requests_form_box {
-  @extend .main_box;
-  .merge_requests_middle_box {
-    @extend .middle_box_content;
+.merge-requests-form-box {
+  @extend .main-box;
+  .merge-requests-middle-box {
+    @extend .middle-box_content;
     height: 30px;
-    .merge_requests_assignee {
+    .merge-requests-assignee {
       @extend .span6;
       float: left;
     }
-    .merge_requests_milestone {
+    .merge-requests-milestone {
       @extend .span4;
       float: left;
     }

--- a/app/assets/stylesheets/sections/nav.scss
+++ b/app/assets/stylesheets/sections/nav.scss
@@ -2,7 +2,7 @@
  *  Main Menu of Application
  *
  */
-ul.main_menu {
+ul.main-menu {
   @include border-radius(4px);
   margin: auto;
   margin: 30px 0;

--- a/app/assets/stylesheets/sections/nav.scss
+++ b/app/assets/stylesheets/sections/nav.scss
@@ -3,7 +3,7 @@
  *
  */
 ul.main_menu {
-  border-radius: 4px;
+  @include border-radius(4px);
   margin: auto;
   margin: 30px 0;
   border: 1px solid #BBB;
@@ -26,8 +26,7 @@ ul.main_menu {
     color: #777;
     background: #f2f2f2;
     border-top: 1px solid #CCC;
-    border-radius: 8px;
-    -moz-border-radius: 8px;
+    @include border-radius(8px);
   }
   .label {
     background: $hover;
@@ -41,23 +40,18 @@ ul.main_menu {
     width: 1%;
     border-right: 1px solid #DDD;
     border-left: 1px solid #EEE;
-    border-bottom:2px solid #CFCFCF;
+    border-bottom: 2px solid #CFCFCF;
 
     &:first-child{
-      -webkit-border-top-left-radius: 4px;
-      -webkit-border-bottom-left-radius: 4px;
-      -moz-border-radius-topleft: 4px;
-      -moz-border-radius-bottomleft: 4px;
-      border-top-left-radius: 4px;
-      border-bottom-left-radius: 4px;
+      @include border-radius(5px 0 0 5px);
       border-left: 0;
     }
 
     &.active {
-      background-color:#D5D5D5;
+      background-color: #D5D5D5;
       border-right: 1px solid #BBB;
       border-left: 1px solid #BBB;
-      border-radius: 0 0 1px 1px;
+      @include border-radius(0 0 1px 1px);
       &:first-child{
         border-bottom: none;
         border-left: none;
@@ -83,8 +77,8 @@ ul.main_menu {
     height: 35px;
     line-height: 36px;
     color: $style_color;
-    text-shadow:0 1px 1px white;
-    padding:0 10px;
+    text-shadow: 0 1px 1px white;
+    padding: 0 10px;
   }
 }
 /*

--- a/app/assets/stylesheets/sections/nav.scss
+++ b/app/assets/stylesheets/sections/nav.scss
@@ -5,34 +5,34 @@
 ul.main_menu {
   border-radius: 4px;
   margin: auto;
-  margin:30px 0;
-  border:1px solid #BBB;
-  height:37px;
+  margin: 30px 0;
+  border: 1px solid #BBB;
+  height: 37px;
   @include bg-gray-gradient;
-  position:relative;
-  overflow:hidden;
+  position: relative;
+  overflow: hidden;
   @include shade;
   .count {
     position: relative;
-	  top: -1px;
-	  display: inline-block;
-	  height: 15px;
-	  margin: 0 0 0 5px;
-	  padding: 0 8px 1px 8px;
-	  height: auto;
-	  font-size: 0.82em;
-	  line-height: 14px;
-	  text-align: center;
-	  color: #777;
-	  background: #f2f2f2;
-	  border-top: 1px solid #CCC;
-	  border-radius: 8px;
-	 -moz-border-radius: 8px;
+    top: -1px;
+    display: inline-block;
+    height: 15px;
+    margin: 0 0 0 5px;
+    padding: 0 8px 1px 8px;
+    height: auto;
+    font-size: 0.82em;
+    line-height: 14px;
+    text-align: center;
+    color: #777;
+    background: #f2f2f2;
+    border-top: 1px solid #CCC;
+    border-radius: 8px;
+    -moz-border-radius: 8px;
   }
   .label {
-    background:$hover;
-    text-shadow:none;
-    color:$style_color;
+    background: $hover;
+    text-shadow: none;
+    color: $style_color;
   }
   li {
     list-style-type: none;
@@ -59,8 +59,8 @@ ul.main_menu {
       border-left: 1px solid #BBB;
       border-radius: 0 0 1px 1px;
       &:first-child{
-        border-bottom:none;
-        border-left:none;
+        border-bottom: none;
+        border-left: none;
       }
     }
 
@@ -68,10 +68,10 @@ ul.main_menu {
       a {
         background: url(home_icon.PNG) no-repeat center center;
         text-indent:-9999px;
-        min-width:20px;
+        min-width: 20px;
         img {
-          position:relative;
-          top:4px;
+          position: relative;
+          top: 4px;
         }
       }
     }
@@ -79,9 +79,9 @@ ul.main_menu {
   a {
     display: block;
     text-align: center;
-    font-weight:bold;
-    height:35px;
-    line-height:36px;
+    font-weight: bold;
+    height: 35px;
+    line-height: 36px;
     color: $style_color;
     text-shadow:0 1px 1px white;
     padding:0 10px;

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -4,30 +4,30 @@
  */
 #notes-list,
 #new-notes-list {
-  display:block;
-  list-style:none;
-  margin:0px;
-  padding:0px;
+  display: block;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
 }
 
 .issue_notes,
 .wiki_notes {
   .note_content {
-    float:left;
-    width:400px;
+    float: left;
+    width: 400px;
   }
 }
 
 /* Note textare */
 #note_note {
-  height:80px;
-  width:99%;
-  font-size:14px;
+  height: 80px;
+  width: 99%;
+  font-size: 14px;
 }
 
 #new_note {
   .attach_holder {
-    display:none;
+    display: none;
   }
 }
 
@@ -43,27 +43,27 @@
   padding: 8px 0;
   overflow: hidden;
   display: block;
-  position:relative;
+  position: relative;
   img {float: left; margin-right: 10px;}
-  img.emoji {float:none;margin:0;}
+  img.emoji {float: none;margin: 0;}
   .note-author cite{font-style: italic;}
-  p { color:$style_color; }
+  p { color: $style_color; }
   .note-author { color: $style_color;}
 
-  .note-title { margin-left:45px; padding-top: 5px;}
+  .note-title { margin-left: 45px; padding-top: 5px;}
   .avatar {
-    margin-top:3px;
+    margin-top: 3px;
   }
 
   .delete-note {
-    display:none;
-    position:absolute;
-    right:0;
-    top:0;
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 0;
   }
 
   &:hover {
-    .delete-note { display:block; }
+    .delete-note { display: block; }
   }
 }
 #notes-list:not(.reversed) .note,
@@ -107,17 +107,17 @@ tr.line_notes_row {
     a.line_note_reply_link {
       @include round-borders-all(4px);
       padding: 3px 10px;
-      margin-left:5px;
+      margin-left: 5px;
       color: white;
       background: #2A79A3;
       border-color: #2A79A3;
     }
   }
   ul {
-    margin:0;
+    margin: 0;
     li {
-      padding:0;
-      border:none;
+      padding: 0;
+      border: none;
     }
   }
 }
@@ -132,21 +132,21 @@ tr.line_notes_row {
     border-bottom:1px solid #ddd;
   }
   .note_actions {
-    margin:0;
+    margin: 0;
     padding-top: 10px;
 
     .buttons {
-      float:left;
-      width:300px;
+      float: left;
+      width: 300px;
     }
     .options {
       .labels {
-        float:left;
-        padding-left:10px;
+        float: left;
+        padding-left: 10px;
         label {
           padding: 6px 0;
           margin: 0;
-          width:120px;
+          width: 120px;
         }
       }
     }
@@ -154,13 +154,13 @@ tr.line_notes_row {
 }
 
 td .line_note_link {
-  position:absolute;
+  position: absolute;
   margin-left:-70px;
   margin-top:-10px;
-  z-index:10;
+  z-index: 10;
   background: url("comment_add.png") no-repeat left 0;
-  width:32px;
-  height:32px;
+  width: 32px;
+  height: 32px;
 
   opacity: 0.0;
   filter: alpha(opacity=0);
@@ -180,13 +180,13 @@ td .line_note_link {
 .new_note {
   .input-file {
     font: 500px monospace;
-    opacity:0;
+    opacity: 0;
     filter: alpha(opacity=0);
     position: absolute;
     z-index: 1;
-    top:0;
-    right:0;
-    padding:0;
+    top: 0;
+    right: 0;
+    padding: 0;
     margin: 0;
   }
 
@@ -198,24 +198,24 @@ td .line_note_link {
   }
 
   .attachments {
-    position:relative;
+    position: relative;
     width: 350px;
     height: 50px;
-    overflow:hidden;
+    overflow: hidden;
     margin:0 0 5px !important;
 
     .input_file {
       .file_upload {
         position: absolute;
-        right:14px;
-        top:7px;
+        right: 14px;
+        top: 7px;
       }
 
       .file_name {
-        line-height:30px;
-        width:240px;
-        height:28px;
-        overflow:hidden;
+        line-height: 30px;
+        width: 240px;
+        height: 28px;
+        overflow: hidden;
       }
       .input-file {
         width: 260px;
@@ -228,5 +228,5 @@ td .line_note_link {
 
 .note-text {
   border: 1px solid #aaa;
-  box-shadow:none;
+  box-shadow: none;
 }

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -105,7 +105,8 @@ tr.line_notes_row {
       padding: 7px 10px;
     }
     a.line_note_reply_link {
-      @include round-borders-all(4px);
+      border: 1px solid #eaeaea;
+      @include border-radius(4px);
       padding: 3px 10px;
       margin-left: 5px;
       color: white;

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -36,7 +36,7 @@
   border: 1px solid #ddd;
   padding: 10px;
   min-height: 60px;
-  background:#f5f5f5;
+  background: #f5f5f5;
 }
 
 .note {
@@ -94,15 +94,15 @@ p.notify_controls span{
 }
 
 tr.line_notes_row {
-  border-bottom:1px solid #DDD;
+  border-bottom: 1px solid #DDD;
   border-left: 7px solid #2A79A3;
 
   &.reply {
-    background:#eee;
+    background: #eee;
     border-left: 7px solid #2A79A3;
-    border-top:1px solid #ddd;
+    border-top: 1px solid #ddd;
     td {
-      padding:7px 10px;
+      padding: 7px 10px;
     }
     a.line_note_reply_link {
       @include round-borders-all(4px);
@@ -125,11 +125,11 @@ tr.line_notes_row {
 .line_notes_row,  .per_line_form { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
 .per_line_form {
-  background:#f5f5f5;
-  border-top:1px solid #eee;
+  background: #f5f5f5;
+  border-top: 1px solid #eee;
   form {  margin: 0; }
   td {
-    border-bottom:1px solid #ddd;
+    border-bottom: 1px solid #ddd;
   }
   .note_actions {
     margin: 0;

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -10,28 +10,28 @@
   padding: 0px;
 }
 
-.issue_notes,
-.wiki_notes {
-  .note_content {
+.issue-notes,
+.wiki-notes {
+  .note-content {
     float: left;
     width: 400px;
   }
 }
 
 /* Note textare */
-#note_note {
+#note-note {
   height: 80px;
   width: 99%;
   font-size: 14px;
 }
 
-#new_note {
-  .attach_holder {
+#new-note {
+  .attach-holder {
     display: none;
   }
 }
 
-.preview_note {
+.preview-note {
   margin: 2px;
   border: 1px solid #ddd;
   padding: 10px;
@@ -76,7 +76,7 @@
 }
 
 /* mark vote notes */
-.voting_notes .note {
+.voting-notes .note {
   padding: 8px 0;
 }
 
@@ -85,15 +85,15 @@
 }
 
 
-p.notify_controls input{
+p.notify-controls input{
   margin: 5px;
 }
 
-p.notify_controls span{
+p.notify-controls span{
   font-weight: 700;
 }
 
-tr.line_notes_row {
+tr.line-notes-row {
   border-bottom: 1px solid #DDD;
   border-left: 7px solid #2A79A3;
 
@@ -104,7 +104,7 @@ tr.line_notes_row {
     td {
       padding: 7px 10px;
     }
-    a.line_note_reply_link {
+    a.line-note-reply-link {
       border: 1px solid #eaeaea;
       @include border-radius(4px);
       padding: 3px 10px;
@@ -123,16 +123,19 @@ tr.line_notes_row {
   }
 }
 
-.line_notes_row,  .per_line_form { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
+.line-notes-row,
+.per-line-form { 
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; 
+}
 
-.per_line_form {
+.per-line-form {
   background: #f5f5f5;
   border-top: 1px solid #eee;
   form {  margin: 0; }
   td {
     border-bottom: 1px solid #ddd;
   }
-  .note_actions {
+  .note-actions {
     margin: 0;
     padding-top: 10px;
 
@@ -154,7 +157,7 @@ tr.line_notes_row {
   }
 }
 
-td .line_note_link {
+td .line-note-link {
   position: absolute;
   margin-left:-70px;
   margin-top:-10px;
@@ -172,13 +175,15 @@ td .line_note_link {
   }
 }
 
-.diff_file_content tr.line_holder:hover > td { background: $hover !important; }
-.diff_file_content tr.line_holder:hover > td .line_note_link {
+.diff-file-content tr.line-holder:hover > td { 
+  background: $hover !important; 
+}
+.diff-file-content tr.line-holder:hover > td .line-note-link {
   opacity: 1.0;
   filter: alpha(opacity=100);
 }
 
-.new_note {
+.new-note {
   .input-file {
     font: 500px monospace;
     opacity: 0;
@@ -191,7 +196,7 @@ td .line_note_link {
     margin: 0;
   }
 
-  .note_advanced_opts {
+  .note-advanced-opts {
     h6 {
       line-height: 32px;
       padding-right: 15px;
@@ -205,14 +210,14 @@ td .line_note_link {
     overflow: hidden;
     margin:0 0 5px !important;
 
-    .input_file {
-      .file_upload {
+    .input-file {
+      .file-upload {
         position: absolute;
         right: 14px;
         top: 7px;
       }
 
-      .file_name {
+      .file-name {
         line-height: 30px;
         width: 240px;
         height: 28px;

--- a/app/assets/stylesheets/sections/profile.scss
+++ b/app/assets/stylesheets/sections/profile.scss
@@ -1,20 +1,20 @@
 .profile_history {
   .event_feed {
-    min-height:20px;
+    min-height: 20px;
     .avatar {
-      width:20px;
+      width: 20px;
     }
   }
 }
 
 .profile_avatar_holder {
-  float:left;
-  width:60px;
-  height:60px;
-  margin-right:20px;
+  float: left;
+  width: 60px;
+  height: 60px;
+  margin-right: 20px;
   img {
-    width:60px;
-    height:60px;
+    width: 60px;
+    height: 60px;
     background:#fff;
     padding: 1px;
     border: 1px solid #ddd;

--- a/app/assets/stylesheets/sections/profile.scss
+++ b/app/assets/stylesheets/sections/profile.scss
@@ -15,7 +15,7 @@
   img {
     width: 60px;
     height: 60px;
-    background:#fff;
+    background: #fff;
     padding: 1px;
     border: 1px solid #ddd;
   }

--- a/app/assets/stylesheets/sections/profile.scss
+++ b/app/assets/stylesheets/sections/profile.scss
@@ -1,5 +1,5 @@
-.profile_history {
-  .event_feed {
+.profile-history {
+  .event-feed {
     min-height: 20px;
     .avatar {
       width: 20px;
@@ -7,7 +7,7 @@
   }
 }
 
-.profile_avatar_holder {
+.profile-avatar-holder {
   float: left;
   width: 60px;
   height: 60px;

--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -10,37 +10,37 @@
     .groups_box,
     .projects_box {
       h5 {
-        color:$style_color;
-        font-size:16px;
+        color: $style_color;
+        font-size: 16px;
         text-shadow: 0 1px 1px #fff;
         padding: 2px 10px;
-        line-height:32px;
-        font-size:14px;
+        line-height: 32px;
+        font-size: 14px;
       }
       ul {
         li {
-          padding:0;
+          padding: 0;
           a {
-            display:block;
+            display: block;
             .group_name {
-              font-size:14px;
-              line-height:18px;
+              font-size: 14px;
+              line-height: 18px;
             }
             .project_name {
               color:#4fa2bd;
-              font-size:14px;
-              line-height:18px;
+              font-size: 14px;
+              line-height: 18px;
             }
             .arrow {
-              float:right;
-              padding:10px;
-              margin:0;
+              float: right;
+              padding: 10px;
+              margin: 0;
             }
             .last_activity {
-              padding-top:5px;
-              display:block;
+              padding-top: 5px;
+              display: block;
               span, strong {
-                font-size:12px;
+                font-size: 12px;
                 color:#666;
               }
             }
@@ -58,21 +58,21 @@
   .project_name_holder {
     input,
     label {
-      font-size:16px;
-      line-height:20px;
-      padding:8px;
+      font-size: 16px;
+      line-height: 20px;
+      padding: 8px;
     }
     label {
       color:#888;
     }
     .btn {
       padding:6px 10px;
-      margin-left:10px;
-      margin-bottom:8px;
+      margin-left: 10px;
+      margin-bottom: 8px;
     }
   }
   .adv_settings {
-    h6 { margin-left:40px; }
+    h6 { margin-left: 40px; }
   }
 }
 
@@ -81,13 +81,13 @@
   @include bg-gray-gradient;
   padding: 4px 7px;
   border: 1px solid #CCC;
-  margin-bottom:20px;
+  margin-bottom: 20px;
 }
 
 .project_clone_holder {
   input[type="text"],
   .btn {
-    font-size:12px;
+    font-size: 12px;
     line-height: 18px;
     margin: 0;
     padding: 3px 10px;
@@ -102,8 +102,8 @@
 
 .save-project-loader {
   img {
-    margin-top:50px;
-    margin-bottom:50px;
+    margin-top: 50px;
+    margin-bottom: 50px;
   }
   h3 {
     @extend .page_title;

--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -27,7 +27,7 @@
               line-height: 18px;
             }
             .project_name {
-              color:#4fa2bd;
+              color: #4fa2bd;
               font-size: 14px;
               line-height: 18px;
             }
@@ -41,7 +41,7 @@
               display: block;
               span, strong {
                 font-size: 12px;
-                color:#666;
+                color: #666;
               }
             }
           }
@@ -63,10 +63,10 @@
       padding: 8px;
     }
     label {
-      color:#888;
+      color: #888;
     }
     .btn {
-      padding:6px 10px;
+      padding: 6px 10px;
       margin-left: 10px;
       margin-bottom: 8px;
     }

--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -7,8 +7,8 @@
     @extend .span4;
     @extend .right;
 
-    .groups_box,
-    .projects_box {
+    .groups-box,
+    .projects-box {
       h5 {
         color: $style_color;
         font-size: 16px;
@@ -22,11 +22,11 @@
           padding: 0;
           a {
             display: block;
-            .group_name {
+            .group-name {
               font-size: 14px;
               line-height: 18px;
             }
-            .project_name {
+            .project-name {
               color: #4fa2bd;
               font-size: 14px;
               line-height: 18px;
@@ -36,7 +36,7 @@
               padding: 10px;
               margin: 0;
             }
-            .last_activity {
+            .last-activity {
               padding-top: 5px;
               display: block;
               span, strong {
@@ -53,9 +53,9 @@
   }
 }
 
-.new_project,
-.edit_project {
-  .project_name_holder {
+.new-project,
+.edit-project {
+  .project-name-holder {
     input,
     label {
       font-size: 16px;
@@ -71,12 +71,12 @@
       margin-bottom: 8px;
     }
   }
-  .adv_settings {
+  .adv-settings {
     h6 { margin-left: 40px; }
   }
 }
 
-.project_clone_panel {
+.project-clone-panel {
   @include border-radius(4px);
   @include bg-gray-gradient;
   padding: 4px 7px;
@@ -84,7 +84,7 @@
   margin-bottom: 20px;
 }
 
-.project_clone_holder {
+.project-clone-holder {
   input[type="text"],
   .btn {
     font-size: 12px;
@@ -106,7 +106,7 @@
     margin-bottom: 50px;
   }
   h3 {
-    @extend .page_title;
+    @extend .page-title;
   }
 
 }

--- a/app/assets/stylesheets/sections/themes.scss
+++ b/app/assets/stylesheets/sections/themes.scss
@@ -6,17 +6,17 @@
 }
 
 .themes_opts {
-  padding-left:20px;
+  padding-left: 20px;
 
   label {
-    width:175px;
-    margin-right:40px;
+    width: 175px;
+    margin-right: 40px;
 
     .prev {
       @extend .thumbnail;
-      height:30px;
-      width:175px;
-      margin-bottom:10px;
+      height: 30px;
+      width: 175px;
+      margin-bottom: 10px;
 
       &.classic {
         background: #31363e;
@@ -42,17 +42,17 @@
 }
 
 .code_highlight_opts {
-  padding-left:20px;
+  padding-left: 20px;
 
   label {
-    width:220px;
-    margin-right:40px;
+    width: 220px;
+    margin-right: 40px;
 
     .prev {
       @extend .thumbnail;
-      height:151px;
-      width:220px;
-      margin-bottom:10px;
+      height: 151px;
+      width: 220px;
+      margin-bottom: 10px;
     }
   }
 }

--- a/app/assets/stylesheets/sections/themes.scss
+++ b/app/assets/stylesheets/sections/themes.scss
@@ -5,7 +5,7 @@
   }
 }
 
-.themes_opts {
+.themes-opts {
   padding-left: 20px;
 
   label {
@@ -41,7 +41,7 @@
   }
 }
 
-.code_highlight_opts {
+.code-highlight-opts {
   padding-left: 20px;
 
   label {

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -31,7 +31,7 @@
       vertical-align: middle;
       a {
         &:hover {
-          color: $blue_link;
+          color: $primary_color;
         }
       }
 

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -1,14 +1,14 @@
 .tree-holder {
   .tree-content-holder {
-    float:left;
-    width:100%;
+    float: left;
+    width: 100%;
   }
 
   .tree_progress {
-    display:none;
-    margin:20px;
+    display: none;
+    margin: 20px;
     &.loading {
-      display:block;
+      display: block;
     }
   }
 
@@ -21,17 +21,17 @@
           border-top:1px solid #ADF;
           border-bottom:1px solid #ADF;
         }
-        cursor:pointer;
+        cursor: pointer;
       }
     }
   }
 
   .tree-item {
     .tree-item-file-name {
-      vertical-align:middle;
+      vertical-align: middle;
       a {
         &:hover {
-          color:$blue_link;
+          color: $blue_link;
         }
       }
 
@@ -48,7 +48,7 @@
       padding: 2px 10px;
     }
     td {
-      line-height:20px;
+      line-height: 20px;
       background:#fafafa;
     }
   }

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -4,7 +4,7 @@
     width: 100%;
   }
 
-  .tree_progress {
+  .tree-progress {
     display: none;
     margin: 20px;
     &.loading {
@@ -53,7 +53,7 @@
     }
   }
 
-  .tree_author {
+  .tree-author {
     padding-right: 8px;
 
     img.avatar {
@@ -62,7 +62,7 @@
     }
   }
 
-  .tree_commit {
+  .tree-commit {
     color: gray;
 
     .tree-commit-link {

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -18,8 +18,8 @@
       &:hover {
         td {
           background: $hover;
-          border-top:1px solid #ADF;
-          border-bottom:1px solid #ADF;
+          border-top: 1px solid #ADF;
+          border-bottom: 1px solid #ADF;
         }
         cursor: pointer;
       }
@@ -49,7 +49,7 @@
     }
     td {
       line-height: 20px;
-      background:#fafafa;
+      background: #fafafa;
     }
   }
 
@@ -86,7 +86,7 @@
 .tree-btn-group {
   .btn {
     margin-right:-3px;
-    padding:2px 10px;
+    padding: 2px 10px;
   }
 }
 

--- a/app/assets/stylesheets/themes/ui_basic.scss
+++ b/app/assets/stylesheets/themes/ui_basic.scss
@@ -3,7 +3,7 @@
  * during web app restyle or theme select.
  *
  */
-.ui_basic {
+.ui-basic {
   /*
    * Common styles
    *
@@ -16,7 +16,7 @@
     }
   }
 
-  .app_logo {
+  .app-logo {
     .separator {
       margin-left: 0;
       margin-right: 0;

--- a/app/assets/stylesheets/themes/ui_basic.scss
+++ b/app/assets/stylesheets/themes/ui_basic.scss
@@ -12,7 +12,7 @@
     color: $link_color;
     &:hover {
       text-decoration: none;
-      color: $blue_link;
+      color: $primary_color;
     }
   }
 

--- a/app/assets/stylesheets/themes/ui_basic.scss
+++ b/app/assets/stylesheets/themes/ui_basic.scss
@@ -11,7 +11,7 @@
   a {
     color: $link_color;
     &:hover {
-      text-decoration:none;
+      text-decoration: none;
       color: $blue_link;
     }
   }

--- a/app/assets/stylesheets/themes/ui_color.scss
+++ b/app/assets/stylesheets/themes/ui_color.scss
@@ -7,7 +7,7 @@
  * - header restyles
  *
  */
-.ui_color {
+.ui-color {
   /*
    *  Application Header
    *

--- a/app/assets/stylesheets/themes/ui_gray.scss
+++ b/app/assets/stylesheets/themes/ui_gray.scss
@@ -7,7 +7,7 @@
  * - header restyles
  *
  */
-.ui_gray {
+.ui-gray {
   /*
    *  Application Header
    *

--- a/app/assets/stylesheets/themes/ui_mars.scss
+++ b/app/assets/stylesheets/themes/ui_mars.scss
@@ -7,7 +7,7 @@
  * - header restyles
  *
  */
-.ui_mars {
+.ui-mars {
 
   /*
    *  Application Header
@@ -43,7 +43,7 @@
     .search-input::-webkit-input-placeholder {
       color: #666;
     }
-    .app_logo {
+    .app-logo {
       a {
         h1 {
           background: url('logo_white.png') no-repeat 0px 2px;
@@ -56,7 +56,7 @@
       }
 
     }
-    .project_name {
+    .project-name {
       color: #eee;
       text-shadow: 0 1px 1px #111;
     }

--- a/app/assets/stylesheets/themes/ui_mars.scss
+++ b/app/assets/stylesheets/themes/ui_mars.scss
@@ -47,7 +47,7 @@
       a {
         h1 {
           background: url('logo_white.png') no-repeat 0px 2px;
-          color:#eee;
+          color: #eee;
           text-shadow: 0 1px 1px #111;
         }
       }
@@ -57,7 +57,7 @@
 
     }
     .project_name {
-      color:#eee;
+      color: #eee;
       text-shadow: 0 1px 1px #111;
     }
   }

--- a/app/assets/stylesheets/themes/ui_mars.scss
+++ b/app/assets/stylesheets/themes/ui_mars.scss
@@ -52,7 +52,7 @@
         }
       }
       .separator {
-        display:none;
+        display: none;
       }
 
     }

--- a/app/assets/stylesheets/themes/ui_modern.scss
+++ b/app/assets/stylesheets/themes/ui_modern.scss
@@ -7,7 +7,7 @@
  * - header restyles
  *
  */
-.ui_modern {
+.ui-modern {
   /*
    *  Application Header
    *

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,0 +1,6 @@
+/** Colors **/
+$link_color: #3A89A3;
+$blue_link: #2FA0BB;
+$style_color: #474D57;
+$hover: #D9EDF7;
+$hover_border: #ADF;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,6 +1,5 @@
 /** Colors **/
+$primary_color: #2FA0BB;
 $link_color: #3A89A3;
-$blue_link: #2FA0BB;
 $style_color: #474D57;
 $hover: #D9EDF7;
-$hover_border: #ADF;

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -29,7 +29,7 @@ module EventsHelper
 
     return nil unless event_image_path
 
-    content_tag :div, class: 'event_icon' do
+    content_tag :div, class: 'event-icon' do
       image_tag event_image_path
     end
   end
@@ -45,8 +45,8 @@ module EventsHelper
                  'inactive'
                end
 
-    content_tag :div, class: "filter_icon #{inactive}" do
-      link_to dashboard_path(event_filter: filter), class: 'has_tooltip', 'data-original-title' => tooltip do
+    content_tag :div, class: "filter-icon #{inactive}" do
+      link_to dashboard_path(event_filter: filter), class: 'has-tooltip', 'data-original-title' => tooltip do
         image_tag "event_filter_#{key}.png"
       end
     end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -9,7 +9,7 @@ module IssuesHelper
 
     tm = project.team_member_by_id(issue.assignee_id)
     if tm
-      link_to issue.assignee_name, project_team_member_path(project, tm), class: "author_link"
+      link_to issue.assignee_name, project_team_member_path(project, tm), class: "author-link"
     else
       issue.assignee_name
     end
@@ -20,7 +20,7 @@ module IssuesHelper
 
     tm = project.team_member_by_id(issue.author_id)
     if tm
-      link_to issue.author_name, project_team_member_path(project, tm), class: "author_link"
+      link_to issue.author_name, project_team_member_path(project, tm), class: "author-link"
     else
       issue.author_name
     end

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -4,7 +4,7 @@ module MergeRequestsHelper
 
     tm = project.team_member_by_id(merge_request.assignee_id)
     if tm
-      link_to merge_request.assignee_name, project_team_member_path(project, tm), class: "author_link"
+      link_to merge_request.assignee_name, project_team_member_path(project, tm), class: "author-link"
     else
       merge_request.assignee_name
     end
@@ -15,7 +15,7 @@ module MergeRequestsHelper
 
     tm = project.team_member_by_id(merge_request.author_id)
     if tm
-      link_to merge_request.author_name, project_team_member_path(project, tm), class: "author_link"
+      link_to merge_request.author_name, project_team_member_path(project, tm), class: "author-link"
     else
       merge_request.author_name
     end
@@ -33,7 +33,7 @@ module MergeRequestsHelper
   end
 
   def mr_css_classes mr
-    classes = "merge_request"
+    classes = "merge-request"
     classes << " closed" if mr.closed
     classes << " merged" if mr.merged?
     classes

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -34,7 +34,7 @@ module TreeHelper
   end
 
   def tree_hex_class(content)
-    "file_#{hexdigest(content.name)}"
+    "file-#{hexdigest(content.name)}"
   end
 
   # Public: Determines if a given filename is compatible with GitHub::Markup.

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-.admin_dash.row
+.admin-dash.row
   .span4
     .ui-box
       %h5

--- a/app/views/admin/groups/_form.html.haml
+++ b/app/views/admin/groups/_form.html.haml
@@ -2,7 +2,7 @@
   - if @group.errors.any?
     .alert-message.block-message.error
       %span= @group.errors.full_messages.first
-  .clearfix.group_name_holder
+  .group-name-holder.clearfix
     = f.label :name do
       Group name is
     .input

--- a/app/views/admin/groups/edit.html.haml
+++ b/app/views/admin/groups/edit.html.haml
@@ -1,3 +1,3 @@
-%h3.page_title Edit Group
+%h3.page-title Edit Group
 %br
 = render 'form'

--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -1,5 +1,5 @@
 = render 'admin/shared/projects_head'
-%h3.page_title
+%h3.page-title
   Groups
   %small
     allows you to keep projects organized.

--- a/app/views/admin/groups/new.html.haml
+++ b/app/views/admin/groups/new.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title New Group
+%h3.page-title New Group
 %hr
 = form_for [:admin, @group] do |f|
   - if @group.errors.any?

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -1,5 +1,5 @@
 = render 'admin/shared/projects_head'
-%h3.page_title
+%h3.page-title
   Group: #{@group.name}
   = link_to edit_admin_group_path(@group), class: "btn right" do
     %i.icon-edit
@@ -44,7 +44,7 @@
         .clearfix
 
 
-= form_tag project_update_admin_group_path(@group), class: "bulk_import", method: :put  do
+= form_tag project_update_admin_group_path(@group), class: "bulk-import", method: :put  do
   %fieldset
     %legend Move projects to group
     .clearfix

--- a/app/views/admin/hooks/index.html.haml
+++ b/app/views/admin/hooks/index.html.haml
@@ -13,7 +13,7 @@
   .clearfix
     = f.label :url, "URL:"
     .input
-      = f.text_field :url, class: "text_field xxlarge"
+      = f.text_field :url, class: "text-field xxlarge"
       &nbsp;
       = f.submit "Add System Hook", class: "btn primary"
 %hr

--- a/app/views/admin/logs/show.html.haml
+++ b/app/views/admin/logs/show.html.haml
@@ -5,21 +5,21 @@
     = link_to "application.log", "#application", 'data-toggle' => 'tab'
 .tab-content
   .tab-pane.active#githost
-    .file_holder#README
-      .file_title
+    .file-holder#README
+      .file-title
         %i.icon-file
         githost.log
-      .file_content.logs
+      .file-content.logs
         %ol
           - Gitlab::GitLogger.read_latest.each do |line|
             %li
               %p= line
   .tab-pane#application
-    .file_holder#README
-      .file_title
+    .file-holder#README
+      .file-title
         %i.icon-file
         application.log
-      .file_content.logs
+      .file-content.logs
         %ol
           - Gitlab::AppLogger.read_latest.each do |line|
             %li

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -5,13 +5,13 @@
         - project.errors.full_messages.each do |msg|
           %li= msg
 
-  .clearfix.project_name_holder
+  .clearfix.project-name-holder
     = f.label :name do
       Project name is
     .input
       = f.text_field :name, placeholder: "Example Project", class: "xxlarge"
 
-  %fieldset.adv_settings
+  %fieldset.adv-settings
     %legend Advanced settings:
     .clearfix
       = f.label :path do
@@ -34,7 +34,7 @@
           .input= f.select(:default_branch, project.heads.map(&:name), {}, style: "width:210px;")
 
   - unless project.new_record?
-    %fieldset.adv_settings
+    %fieldset.adv-settings
       %legend Features:
 
       .clearfix

--- a/app/views/admin/projects/edit.html.haml
+++ b/app/views/admin/projects/edit.html.haml
@@ -1,3 +1,3 @@
-%h3.page_title #{@project.name} &rarr; Edit project
+%h3.page-title #{@project.name} &rarr; Edit project
 %hr
 = render 'form', project: @project

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -1,5 +1,5 @@
 = render 'admin/shared/projects_head'
-%h3.page_title
+%h3.page-title
   Projects
   = link_to 'New Project', new_project_path, class: "btn small right"
 %br

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -1,5 +1,5 @@
 = render 'admin/shared/projects_head'
-%h3.page_title
+%h3.page-title
   Project: #{@project.name_with_namespace}
   = link_to edit_admin_project_path(@project), class: "btn right" do
     %i.icon-edit
@@ -69,7 +69,7 @@
 %br
 %h3 Add new team member
 %br
-= form_tag team_update_admin_project_path(@project), class: "bulk_import", method: :put  do
+= form_tag team_update_admin_project_path(@project), class: "bulk-import", method: :put  do
   %table.zebra-striped
     %thead
       %tr

--- a/app/views/admin/resque/show.html.haml
+++ b/app/views/admin/resque/show.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title Resque
+%h3.page-title Resque
 %br
 .ui-box
   %iframe{src: resque_path, width: '100%', height: 600, style: "border: none"}

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -1,4 +1,4 @@
-.user_new
+.user-new
   = form_for [:admin, @admin_user] do |f|
     -if @admin_user.errors.any?
       #error_explanation

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   #{@admin_user.name} &rarr;
   %i.icon-edit
   Edit user

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Users
   = link_to 'New User', new_admin_user_path, class: "btn small right"
 %br

--- a/app/views/admin/users/new.html.haml
+++ b/app/views/admin/users/new.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   %i.icon-plus
   New user
 %hr

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   User: #{@admin_user.name}
   - if @admin_user.blocked
     %small Blocked
@@ -68,7 +68,7 @@
 %br
 %h3 Add User to Projects
 %br
-= form_tag team_update_admin_user_path(@admin_user), class: "bulk_import", method: :put  do
+= form_tag team_update_admin_user_path(@admin_user), class: "bulk-import", method: :put  do
   %table
     %thead
       %tr

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -11,24 +11,24 @@
       %li= link
   .clear
 
-  .file_holder
-    .file_title
+  .file-holder
+    .file-title
       %i.icon-file
-      %span.file_name
+      %span.file-name
         = @tree.name
         %small= number_to_human_size @tree.size
       %span.options= render "tree/blob_actions"
-    .file_content.blame
+    .file-content.blame
       %table
         - @blame.each do |commit, lines|
           - commit = Commit.new(commit)
           - commit = CommitDecorator.decorate(commit)
           %tr
             %td.author= commit.author_link avatar: true, size: 16
-            %td.blame_commit
+            %td.blame-commit
               &nbsp;
               %code= link_to commit.short_id, project_commit_path(@project, commit)
-              = link_to_gfm truncate(commit.title, length: 30), project_commit_path(@project, commit), class: "row_title" rescue "--broken encoding"
+              = link_to_gfm truncate(commit.title, length: 30), project_commit_path(@project, commit), class: "row-title" rescue "--broken encoding"
             %td.lines
               = preserve do
                 %pre

--- a/app/views/commit/show.html.haml
+++ b/app/views/commit/show.html.haml
@@ -8,16 +8,16 @@
   $(function(){
     PerLineNotes.init();
     var w, h;
-    $('.diff_file').each(function(){
-      $('.image.diff_removed img', this).on('load', $.proxy(function(event){
+    $('.diff-file').each(function(){
+      $('.image.diff-removed img', this).on('load', $.proxy(function(event){
         var w = event.currentTarget.naturalWidth
           , h = event.currentTarget.naturalHeight;
-        $('.image.diff_removed .image-info', this).append(' | <b>W:</b> ' + w + 'px | <b>H:</b> ' + h + 'px');
+        $('.image.diff-removed .image-info', this).append(' | <b>W:</b> ' + w + 'px | <b>H:</b> ' + h + 'px');
       }, this));
-      $('.image.diff_added img', this).on('load', $.proxy(function(event){
+      $('.image.diff-added img', this).on('load', $.proxy(function(event){
         var w = event.currentTarget.naturalWidth
           , h = event.currentTarget.naturalHeight;
-        $('.image.diff_added .image-info', this).append(' | <b>W:</b> ' + w + 'px | <b>H:</b> ' + h + 'px');
+        $('.image.diff-added .image-info', this).append(' | <b>W:</b> ' + w + 'px | <b>H:</b> ' + h + 'px');
       }, this));
       
     });

--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -1,19 +1,19 @@
 %li.commit
-  .browse_code_link_holder
+  .browse-code-link-holder
     %p
       %strong= link_to "Browse Code »", project_tree_path(@project, commit), class: "right"
   %p
-    = link_to commit.short_id(8), project_commit_path(@project, commit), class: "commit_short_id"
+    = link_to commit.short_id(8), project_commit_path(@project, commit), class: "commit-short-id"
     = commit.author_link avatar: true, size: 24
     &nbsp;
-    = link_to_gfm truncate(commit.title, length: 50), project_commit_path(@project, commit.id), class: "row_title"
+    = link_to_gfm truncate(commit.title, length: 50), project_commit_path(@project, commit.id), class: "row-title"
 
-    %span.committed_ago
+    %span.committed-ago
       = time_ago_in_words(commit.committed_date)
       ago
       &nbsp;
 
-    %span.notes_count
+    %span.notes-count
       - notes = @project.commit_notes(commit) + @project.commit_line_notes(commit)
       - if notes.any?
         %span.btn.small.disabled.grouped

--- a/app/views/commits/_commit_box.html.haml
+++ b/app/views/commits/_commit_box.html.haml
@@ -15,7 +15,7 @@
           %li= link_to "Plain Diff",    project_commit_path(@project, @commit, format: :diff)
       = link_to project_tree_path(@project, @commit), class: "browse-button primary grouped" do
         %strong Browse Code »
-    %h3.commit-title.page_title
+    %h3.commit-title.page-title
       = gfm escape_once(@commit.title)
     - if @commit.description.present?
       %pre.commit-description
@@ -38,7 +38,7 @@
       .span6.right
         .sha-block
           %span.cgray commit
-          %code.label_commit= @commit.id
+          %code.label-commit= @commit.id
         .sha-block
           %span.cgray= pluralize(@commit.parents.count, "parent")
           - @commit.parents.each do |parent|

--- a/app/views/commits/_diffs.html.haml
+++ b/app/views/commits/_diffs.html.haml
@@ -5,7 +5,7 @@
     %p To prevent performance issue we rejected diff information.
     %p
       But if you still want to see diff
-      = link_to "click this link", project_commit_path(@project, @commit, force_show_diff: true), class: "underlined_link"
+      = link_to "click this link", project_commit_path(@project, @commit, force_show_diff: true), class: "underlined-link"
 
 %p.cgray
   Showing #{pluralize(diffs.count, "changed file")}
@@ -18,8 +18,8 @@
     - file = (@commit.tree / diff.new_path)
     - file = (@commit.prev_commit.tree / diff.old_path) unless file
     - next unless file
-    .diff_file{id: "diff-#{i}"}
-      .diff_file_header
+    .diff-file{id: "diff-#{i}"}
+      .diff-file-header
         - if diff.deleted_file
           %span= diff.old_path
 
@@ -32,12 +32,12 @@
           - if diff.a_mode && diff.b_mode && diff.a_mode != diff.b_mode
             %span.file-mode= "#{diff.a_mode} → #{diff.b_mode}"
 
-          = link_to project_tree_path(@project, tree_join(@commit.id, diff.new_path)), {:class => 'btn very_small right view-commit'} do
+          = link_to project_tree_path(@project, tree_join(@commit.id, diff.new_path)), {:class => 'btn tiny right view-commit'} do
             View file @
             %span.commit-short-id= @commit.short_id(6)
 
         %br/
-      .diff_file_content
+      .diff-file-content
         -# Skipp all non non-supported blobs
         - next unless file.respond_to?('text?')
         - if file.text?
@@ -45,17 +45,17 @@
         - elsif file.image?
           - old_file = (@commit.prev_commit.tree / diff.old_path)
           - if diff.renamed_file || diff.new_file || diff.deleted_file
-            .diff_file_content_image
+            .diff-file-content-image
               .image{class: image_diff_class(diff)}
                 %img{src: "data:#{file.mime_type};base64,#{Base64.encode64(file.data)}"}
                 %div.image-info= "#{number_to_human_size file.size}"
           - else
-            .diff_file_content_image.img_compared
-              .image.diff_removed
+            .diff-file-content-image.img-compared
+              .image.diff-removed
                 %img{src: "data:#{file.mime_type};base64,#{Base64.encode64(old_file.data)}"}
                 %div.image-info= "#{number_to_human_size file.size}"
-              .image.diff_added
+              .image.diff-added
                 %img{src: "data:#{file.mime_type};base64,#{Base64.encode64(file.data)}"}
                 %div.image-info= "#{number_to_human_size file.size}"
         - else
-          %p.nothing_here_message No preview for this file type
+          %p.nothing-here-message No preview for this file type

--- a/app/views/commits/_text_file.html.haml
+++ b/app/views/commits/_text_file.html.haml
@@ -1,21 +1,21 @@
 - too_big = diff.diff.lines.count > 1000
 - if too_big
-  %a.supp_diff_link Diff suppressed. Click to show
+  %a.supp-diff-link Diff suppressed. Click to show
 
 %table{class: "#{'hide' if too_big}"}
   - each_diff_line(diff.diff.lines.to_a, index) do |line, type, line_code, line_new, line_old|
-    %tr.line_holder{ id: line_code }
+    %tr.line-holder{ id: line_code }
       - if type == "match"
-        %td.old_line= "..."
-        %td.new_line= "..."
-        %td.line_content.matched= line
+        %td.old-line= "..."
+        %td.new-line= "..."
+        %td.line-content.matched= line
       - else
-        %td.old_line
+        %td.old-line
           = link_to raw(type == "new" ? "&nbsp;" : line_old), "##{line_code}", id: line_code
           - if @comments_allowed
             = render "notes/per_line_note_link", line_code: line_code
-        %td.new_line= link_to raw(type == "old" ? "&nbsp;" : line_new) , "##{line_code}", id: line_code
-        %td.line_content{class: "noteable_line #{type} #{line_code}", "line_code" => line_code}= raw "#{line} &nbsp;"
+        %td.new-line= link_to raw(type == "old" ? "&nbsp;" : line_new) , "##{line_code}", id: line_code
+        %td.line-content{class: "noteable-line #{type} #{line_code}", "line_code" => line_code}= raw "#{line} &nbsp;"
 
         - if @comments_allowed
           - comments = @line_notes.select { |n| n.line_code == line_code }.sort_by(&:created_at)

--- a/app/views/compare/_form.html.haml
+++ b/app/views/compare/_form.html.haml
@@ -1,9 +1,9 @@
 %div
   %p.slead
     Fill input field with commit id like
-    %code.label_branch 4eedf23
+    %code.label-branch 4eedf23
     or branch/tag name like
-    %code.label_branch master
+    %code.label-branch master
     and press compare button for commits list, code diff.
 
   %br

--- a/app/views/compare/index.html.haml
+++ b/app/views/compare/index.html.haml
@@ -1,6 +1,6 @@
 = render "commits/head"
 
-%h3.page_title
+%h3.page-title
   Compare View
 %hr
 

--- a/app/views/compare/show.html.haml
+++ b/app/views/compare/show.html.haml
@@ -1,6 +1,6 @@
 = render "commits/head"
 
-%h3.page_title
+%h3.page-title
   Compare View
 %hr
 

--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -1,20 +1,20 @@
-.groups_box
+.groups-box
   %h5
     Groups
     %small
       (#{groups.count})
     - if current_user.can_create_group?
       %span.right
-        = link_to new_admin_group_path, class: "btn very_small info" do
+        = link_to new_admin_group_path, class: "btn tiny info" do
           %i.icon-plus
           New Group
   %ul.unstyled
     - groups.each do |group|
       %li.wll
         = link_to group_path(id: group.path), class: dom_class(group) do
-          %strong.group_name= truncate(group.name, length: 25)
+          %strong.group-name= truncate(group.name, length: 25)
           %span.arrow
             &rarr;
-          %span.last_activity
+          %span.last-activity
             %strong Projects:
             %span= group.projects.authorized_for(current_user).count

--- a/app/views/dashboard/_projects.html.haml
+++ b/app/views/dashboard/_projects.html.haml
@@ -1,11 +1,11 @@
-.projects_box
+.projects-box
   %h5
     Projects
     %small
       (#{projects.total_count})
     - if current_user.can_create_project?
       %span.right
-        = link_to new_project_path, class: "btn very_small info" do
+        = link_to new_project_path, class: "btn tiny info" do
           %i.icon-plus
           New Project
   %ul.unstyled
@@ -15,11 +15,11 @@
           - if project.namespace
             = project.namespace.human_name
             \/
-          %strong.project_name
+          %strong.project-name
             = truncate(project.name, length: 25)
           %span.arrow
             &rarr;
-          %span.last_activity
+          %span.last-activity
             %strong Last activity:
             %span= project_last_activity(project)
   .bottom= paginate projects, theme: "gitlab"

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -4,16 +4,16 @@
       = render "events/event_last_push", event: @last_push
       = render 'shared/no_ssh'
 
-      .event_filter
+      .event-filter
         = event_filter_link EventFilter.push, 'Push events'
         = event_filter_link EventFilter.merged, 'Merge events'
         = event_filter_link EventFilter.comments, 'Comments'
         = event_filter_link EventFilter.team, 'Team'
 
       - if @events.any?
-        .content_list= render @events
+        .content-list= render @events
       - else
-        %p.nothing_here_message Projects activity will be displayed here
+        %p.nothing-here-message Projects activity will be displayed here
       .loading.hide
     .side
       - if @groups.present?
@@ -33,14 +33,14 @@
 
 
 - else
-  %h3.nothing_here_message There are no projects you have access to.
+  %h3.nothing-here-message There are no projects you have access to.
   %br
-  %h4.nothing_here_message
+  %h4.nothing-here-message
     - if current_user.can_create_project?
       You can create up to
       = current_user.projects_limit
       projects. Click on button below to add a new one
-      .link_holder
+      .link-holder
         = link_to new_project_path, class: "btn primary" do
           New Project »
     - else

--- a/app/views/dashboard/issues.html.haml
+++ b/app/views/dashboard/issues.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Issues
   %small (assigned to you)
   %small.right #{@issues.total_count} issues
@@ -14,10 +14,10 @@
         %div.ui-box
           - @project = group[0]
           %h5= link_to(@project.name, project_path(@project))
-          %ul.unstyled.issues_table
+          %ul.unstyled.issues-table
             - group[1].each do |issue|
               = render(partial: 'issues/show', locals: {issue: issue})
       %hr
       = paginate @issues, theme: "gitlab"
     - else
-      %p.nothing_here_message Nothing to show here
+      %p.nothing-here-message Nothing to show here

--- a/app/views/dashboard/merge_requests.html.haml
+++ b/app/views/dashboard/merge_requests.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Merge Requests
   %small (authored by or assigned to you)
   %small.right #{@merge_requests.total_count} merge requests
@@ -19,4 +19,4 @@
       = paginate @merge_requests, theme: "gitlab"
 
     - else
-      %h3.nothing_here_message Nothing to show here
+      %h3.nothing-here-message Nothing to show here

--- a/app/views/deploy_keys/new.html.haml
+++ b/app/views/deploy_keys/new.html.haml
@@ -1,6 +1,6 @@
 = render "repositories/head"
 
-%h3.page_title New Deploy key
+%h3.page-title New Deploy key
 %hr
 
 = render 'form'

--- a/app/views/deploy_keys/show.html.haml
+++ b/app/views/deploy_keys/show.html.haml
@@ -1,11 +1,11 @@
 = render "repositories/head"
-%h3.page_title
+%h3.page-title
   Deploy key:
   = @key.title
   %small
     created at
     = @key.created_at.stamp("Aug 21, 2011")
-.back_link
+.back-link
   = link_to project_deploy_keys_path(@project) do
     &larr; To keys list
 %hr

--- a/app/views/devise/sessions/_new_ldap.html.haml
+++ b/app/views/devise/sessions/_new_ldap.html.haml
@@ -20,7 +20,7 @@
   = f.password_field :password, :class => "text bottom", :placeholder => "Password"
   - if devise_mapping.rememberable?
     .clearfix.inputs-list
-      %label.checkbox.remember_me{:for => "user_remember_me"}
+      %label.checkbox.remember-me{:for => "user_remember_me"}
         = f.check_box :remember_me
         %span Remember me
   %br/

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,7 +7,7 @@
     = f.password_field :password, :class => "text bottom", :placeholder => "Password"
     - if devise_mapping.rememberable?
       .clearfix.inputs-list
-        %label.checkbox.remember_me{:for => "user_remember_me"}
+        %label.checkbox.remember-me{:for => "user_remember_me"}
           = f.check_box :remember_me
           %span Remember me
     %br/

--- a/app/views/errors/gitolite.html.haml
+++ b/app/views/errors/gitolite.html.haml
@@ -2,7 +2,7 @@
 %h3.page_title GitLab was unable to access your Gitolite system.
 %hr
 
-.git_error_tips
+.git-error-tips
   %h4 Tips for Administrator:
   %ol
     %li

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -1,7 +1,7 @@
 - commit = CommitDecorator.decorate(commit)
 %li.commit
   %p
-    = link_to commit.short_id(8), project_commit_path(project, commit), class: "commit_short_id"
+    = link_to commit.short_id(8), project_commit_path(project, commit), class: "commit-short-id"
     %span= commit.author_name
     &ndash;
     = image_tag gravatar_icon(commit.author_email), class: "avatar", width: 16

--- a/app/views/events/_event_last_push.html.haml
+++ b/app/views/events/_event_last_push.html.haml
@@ -1,5 +1,5 @@
 - if show_last_push_widget?(event)
-  .event_lp
+  .event-lp
     = image_tag "event_push.png"
     &nbsp;
     %span You pushed to

--- a/app/views/events/event/_common.html.haml
+++ b/app/views/events/event/_common.html.haml
@@ -1,6 +1,6 @@
 .event-title
-  %span.author_name= link_to_author event
-  %span.event_label{class: event.action_name}= event_action_name(event)
+  %span.author-name= link_to_author event
+  %span.event-label{class: event.action_name}= event_action_name(event)
   - if event.target
     = link_to [event.project, event.target] do
       %strong= truncate event.target_title

--- a/app/views/events/event/_push.html.haml
+++ b/app/views/events/event/_push.html.haml
@@ -1,6 +1,6 @@
 .event-title
-  %span.author_name= link_to_author event
-  %span.event_label.pushed #{event.push_action_name} #{event.ref_type}
+  %span.author-name= link_to_author event
+  %span.event-label.pushed #{event.push_action_name} #{event.ref_type}
   - if event.rm_ref?
     %strong= event.ref_name
   - else
@@ -12,7 +12,7 @@
 - if event.push_with_commits?
   - project = event.project
   .event-body
-    %ul.unstyled.event_commits
+    %ul.unstyled.event-commits
       - few_commits = event.commits[0...2]
       - few_commits.each do |commit|
         = render "events/commit", commit: commit, project: project

--- a/app/views/groups/_projects.html.haml
+++ b/app/views/groups/_projects.html.haml
@@ -1,20 +1,20 @@
-.projects_box
+.projects-box
   %h5
     Projects
     %small
       (#{projects.count})
     - if can? current_user, :manage_group, @group
       %span.right
-        = link_to new_project_path(namespace_id: @group.id), class: "btn very_small info" do
+        = link_to new_project_path(namespace_id: @group.id), class: "btn tiny info" do
           %i.icon-plus
           New Project
   %ul.unstyled
     - projects.each do |project|
       %li.wll
         = link_to project_path(project), class: dom_class(project) do
-          %strong.project_name= truncate(project.name, length: 25)
+          %strong.project-name= truncate(project.name, length: 25)
           %span.arrow
             &rarr;
-          %span.last_activity
+          %span.last-activity
             %strong Last activity:
             %span= project_last_activity(project)

--- a/app/views/groups/issues.html.haml
+++ b/app/views/groups/issues.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Issues
   %small (assigned to you)
   %small.right #{@issues.total_count} issues
@@ -10,10 +10,10 @@
     %div.ui-box
       - @project = group[0]
       %h5= @project.name
-      %ul.unstyled.issues_table
+      %ul.unstyled.issues-table
         - group[1].each do |issue|
           = render(partial: 'issues/show', locals: {issue: issue})
   %hr
   = paginate @issues, theme: "gitlab"
 - else
-  %h3.nothing_here_message Nothing to show here
+  %h3.nothing-here-message Nothing to show here

--- a/app/views/groups/merge_requests.html.haml
+++ b/app/views/groups/merge_requests.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Merge Requests
   %small (authored by or assigned to you)
   %small.right #{@merge_requests.total_count} merge requests
@@ -15,4 +15,4 @@
   = paginate @merge_requests, theme: "gitlab"
 
 - else
-  %h3.nothing_here_message Nothing to show here
+  %h3.nothing-here-message Nothing to show here

--- a/app/views/groups/search.html.haml
+++ b/app/views/groups/search.html.haml
@@ -11,7 +11,7 @@
     Search results
     %small (#{@projects.count + @merge_requests.count + @issues.count})
   %hr
-  .search_results
+  .search-results
     .row
       .span6
         %table
@@ -30,7 +30,7 @@
             - if @projects.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Projects
+                  %h4.nothing-here-message No Projects
         %br
         %table
           %thead
@@ -49,7 +49,7 @@
             - if @merge_requests.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Merge Requests
+                  %h4.nothing-here-message No Merge Requests
       .span6
         %table
           %thead
@@ -68,8 +68,8 @@
             - if @issues.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Issues
+                  %h4.nothing-here-message No Issues
   :javascript
     $(function() {
-      $(".search_results .term").highlight("#{params[:search]}");
+      $(".search-results .term").highlight("#{params[:search]}");
     })

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,16 +1,16 @@
 .projects
   .activities.span8
     = render "events/event_last_push", event: @last_push
-    = link_to dashboard_path, class: 'btn very_small' do
+    = link_to dashboard_path, class: 'btn tiny' do
       &larr; To dashboard
     &nbsp;
     %span.cgray Events and projects are filtered in scope of group
     %hr
     = render 'shared/no_ssh'
     - if @events.any?
-      .content_list= render @events
+      .content-list= render @events
     - else
-      %h4.nothing_here_message Projects activity will be displayed here
+      %h4.nothing-here-message Projects activity will be displayed here
     .loading.hide
   .side
     = render "projects", projects: @projects

--- a/app/views/help/api.html.haml
+++ b/app/views/help/api.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title API
-.back_link
+%h3.page-title API
+.back-link
   = link_to help_path do
     &larr; to index
 %br
@@ -24,73 +24,73 @@
 
 .tab-content
   .tab-pane.active#README
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         README
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "README.md"))
 
   .tab-pane#projects
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Projects
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "projects.md"))
 
   .tab-pane#snippets
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Projects Snippets
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "snippets.md"))
 
   .tab-pane#repositories
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Projects
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "repositories.md"))
 
   .tab-pane#users
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Users
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "users.md"))
 
   .tab-pane#session
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Session
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "session.md"))
 
   .tab-pane#issues
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Issues
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "issues.md"))
 
   .tab-pane#milestones
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
         Milestones
-      .file_content.wiki
+      .file-content.wiki
         = preserve do
           = markdown File.read(Rails.root.join("doc", "api", "milestones.md"))

--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   GITLAB
   .right
     %span= Gitlab::Version

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title GitLab Flavored Markdown
-.back_link
+%h3.page-title GitLab Flavored Markdown
+.back-link
   = link_to help_path do 
     &larr; to index
 %hr

--- a/app/views/help/permissions.html.haml
+++ b/app/views/help/permissions.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title Permissions
-.back_link
+%h3.page-title Permissions
+.back-link
   = link_to help_path do
     &larr; to index
 %hr

--- a/app/views/help/ssh.html.haml
+++ b/app/views/help/ssh.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title SSH Keys
-.back_link
+%h3.page-title SSH Keys
+.back-link
   = link_to help_path do
     &larr; to index
 %hr

--- a/app/views/help/system_hooks.html.haml
+++ b/app/views/help/system_hooks.html.haml
@@ -1,5 +1,5 @@
 %h3 System hooks
-.back_link
+.back-link
   = link_to :back do
     &larr; back
 %hr

--- a/app/views/help/web_hooks.html.haml
+++ b/app/views/help/web_hooks.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title Web hooks
-.back_link
+%h3.page-title Web hooks
+.back-link
   = link_to help_path do
     &larr; to index
 %hr

--- a/app/views/help/workflow.html.haml
+++ b/app/views/help/workflow.html.haml
@@ -1,5 +1,5 @@
-%h3.page_title Workflow
-.back_link
+%h3.page-title Workflow
+.back-link
   = link_to help_path do
     &larr; to index
 %hr

--- a/app/views/hooks/index.html.haml
+++ b/app/views/hooks/index.html.haml
@@ -16,7 +16,7 @@
   .clearfix
     = f.label :url, "URL:"
     .input
-      = f.text_field :url, class: "text_field xxlarge"
+      = f.text_field :url, class: "text-field xxlarge"
       &nbsp;
       = f.submit "Add Web Hook", class: "btn primary"
 %hr

--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -1,31 +1,31 @@
 %div.issue-form-holder
-  %h3.page_title= @issue.new_record? ? "New Issue" : "Edit Issue ##{@issue.id}"
+  %h3.page-title= @issue.new_record? ? "New Issue" : "Edit Issue ##{@issue.id}"
   = form_for [@project, @issue], remote: request.xhr? do |f|
     -if @issue.errors.any?
       .alert-message.block-message.error
         %ul
           - @issue.errors.full_messages.each do |msg|
             %li= msg
-    .issue_form_box
-      .issue_title
+    .issue-form-box
+      .issue-title
         .clearfix
           = f.label :title do
             %strong= "Subject *"
           .input
             = f.text_field :title, maxlength: 255, class: "xxlarge js-gfm-input", autofocus: true
-      .issue_middle_block
-        .issue_assignee
+      .issue-middle-block
+        .issue-assignee
           = f.label :assignee_id do
             %i.icon-user
             Assign to
           .input= f.select(:assignee_id, @project.users.all.collect {|p| [ p.name, p.id ] }, { include_blank: "Select a user" }, {class: 'chosen'})
-        .issue_milestone
+        .issue-milestone
           = f.label :milestone_id do
             %i.icon-time
             Milestone
           .input= f.select(:milestone_id, @project.milestones.active.all.collect {|p| [ p.title, p.id ] }, { include_blank: "Select milestone" }, {class: 'chosen'})
 
-      .issue_description
+      .issue-description
         .clearfix
           = f.label :label_list do
             %i.icon-tag

--- a/app/views/issues/_issues.html.haml
+++ b/app/views/issues/_issues.html.haml
@@ -7,9 +7,9 @@
       .span7= paginate @issues, remote: true, theme: "gitlab"
       .span3.right
         %span.cgray.right 
-          %span.issue_counter #{@issues.total_count}
+          %span.issue-counter #{@issues.total_count}
           issues for this filter
 - else
   %li
-    %h4.nothing_here_message Nothing to show here
+    %h4.nothing-here-message Nothing to show here
 

--- a/app/views/issues/_show.html.haml
+++ b/app/views/issues/_show.html.haml
@@ -1,7 +1,7 @@
 %li.wll{ id: dom_id(issue), class: issue_css_classes(issue), url: project_issue_path(issue.project, issue) }
   - if controller.controller_name == 'issues'
-    .issue_check
-      = check_box_tag dom_id(issue,"selected"), nil, false, 'data-id' => issue.id, class: "selected_issue", disabled: !can?(current_user, :modify_issue, issue)
+    .issue-check
+      = check_box_tag dom_id(issue,"selected"), nil, false, 'data-id' => issue.id, class: "selected-issue", disabled: !can?(current_user, :modify_issue, issue)
   .right
     - issue.labels.each do |label|
       %span.label.label-tag.grouped
@@ -13,9 +13,9 @@
         = issue.notes.count
     - if can? current_user, :modify_issue, issue
       - if issue.closed
-        = link_to 'Reopen', project_issue_path(issue.project, issue, issue: {closed: false }, status_only: true), method: :put,  class: "btn small grouped reopen_issue", remote: true
+      = link_to 'Reopen', project_issue_path(issue.project, issue, issue: {closed: false }, status_only: true), method: :put,  class: "btn small grouped reopen-issue", remote: true
       - else
-        = link_to 'Close', project_issue_path(issue.project, issue, issue: {closed: true }, status_only: true), method: :put, class: "btn small grouped close_issue", remote: true
+        = link_to 'Close', project_issue_path(issue.project, issue, issue: {closed: true }, status_only: true), method: :put, class: "btn small grouped close-issue", remote: true
       = link_to edit_project_issue_path(issue.project, issue), class: "btn small edit-issue-link grouped", remote: true do
         %i.icon-edit
         Edit
@@ -25,7 +25,7 @@
   - else
     = image_tag "no_avatar.png", class: "avatar"
 
-  %p= link_to_gfm truncate(issue.title, length: 100), project_issue_path(issue.project, issue), class: "row_title"
+  %p= link_to_gfm truncate(issue.title, length: 100), project_issue_path(issue.project, issue), class: "row-title"
 
   %span.update-author
     %small.cdark= "##{issue.id}"

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -1,37 +1,37 @@
 = render "issues/head"
 .issues_content
-  %h3.page_title
+  %h3.page-title
     Issues
     %small (<span class=issue_counter>#{@issues.total_count}</span>)
     .right
       .span5
         - if can? current_user, :write_issue, @project
-          = link_to new_project_issue_path(@project), class: "right btn", title: "New Issue", remote: true, id: "new_issue_link" do
+          = link_to new_project_issue_path(@project), class: "right btn", title: "New Issue", remote: true, id: "new-issue-link" do
             %i.icon-plus
             New Issue
         = form_tag search_project_issues_path(@project), method: :get, remote: true, id: "issue_search_form", class: :right  do
           = hidden_field_tag :project_id, @project.id, { id: 'project_id' }
           = hidden_field_tag :status, params[:f]
-          = search_field_tag :issue_search, nil, { placeholder: 'Search', class: 'issue_search span3 right neib search-text-input' }
+          = search_field_tag :issue_search, nil, { placeholder: 'Search', class: 'issue-search span3 right neib search-text-input' }
 
   .clearfix
 
   %div#issues-table-holder.ui-box
     .title
-      = check_box_tag "check_all_issues", nil, false, class: "check_all_issues left"
+      = check_box_tag "check_all_issues", nil, false, class: "check-all-issues left"
 
 
-      .issues_bulk_update.hide
+      .issues-bulk-update.hide
         = form_tag bulk_update_project_issues_path(@project), method: :post  do
-          %span.update_issues_text Update selected issues with &nbsp;
+          %span.update-issues-text Update selected issues with &nbsp;
           .left
             = select_tag('update[status]', options_for_select(['open', 'closed']), prompt: "Status")
             = select_tag('update[assignee_id]', options_from_collection_for_select(@project.users.all, "id", "name", params[:assignee_id]), prompt: "Assignee")
             = select_tag('update[milestone_id]', options_from_collection_for_select(@project.milestones.order("id desc").all, "id", "title", params[:milestone_id]), prompt: "Milestone")
             = hidden_field_tag 'update[issues_ids]', []
             = hidden_field_tag :f, params[:f]
-          = button_tag "Save", class: "btn update_selected_issues"
-      .issues_filters
+          = button_tag "Save", class: "btn update-selected-issues"
+      .issues-filters
         .left
           %ul.nav.nav-pills.left
             %li{class: ("active" if (params[:f] == issues_filter[:open] || !params[:f]))}

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Issue ##{@issue.id}
 
   %small
@@ -8,9 +8,9 @@
   %span.right
     - if can?(current_user, :admin_project, @project) || @issue.author == current_user
       - if @issue.closed
-        = link_to 'Reopen', project_issue_path(@project, @issue, issue: {closed: false }, status_only: true), method: :put,  class: "btn grouped reopen_issue"
+        = link_to 'Reopen', project_issue_path(@project, @issue, issue: {closed: false }, status_only: true), method: :put,  class: "btn grouped reopen-issue"
       - else
-        = link_to 'Close', project_issue_path(@project, @issue, issue: {closed: true }, status_only: true), method: :put, class: "btn grouped close_issue", title: "Close Issue"
+        = link_to 'Close', project_issue_path(@project, @issue, issue: {closed: true }, status_only: true), method: :put, class: "btn grouped close-issue", title: "Close Issue"
     - if can?(current_user, :admin_project, @project) || @issue.author == current_user
       = link_to edit_project_issue_path(@project, @issue), class: "btn grouped" do
         %i.icon-edit
@@ -19,28 +19,28 @@
 .right
   .span3#votes= render 'votes/votes_block', votable: @issue
 
-.back_link
+.back-link
   = link_to project_issues_path(@project) do
     &larr; To issues list
 
 
-.main_box
-  .top_box_content
+.main-box
+  .top-box-content
     %h4
       - if @issue.closed
-        .alert-message.error.status_info Closed
+        .alert-message.error.status-info Closed
       - else
-        .alert-message.success.status_info Open
+        .alert-message.success.status-info Open
       = gfm escape_once(@issue.title)
 
-  .middle_box_content
+  .middle-box-content
     %cite.cgray Created by
-    = image_tag gravatar_icon(@issue.author_email), width: 16, class: "lil_av"
+    = image_tag gravatar_icon(@issue.author_email), width: 16, class: "lil-av"
     %strong.author= link_to_issue_author(@issue)
 
     - if @issue.assignee
       %cite.cgray and currently assigned to
-      = image_tag gravatar_icon(@issue.assignee_email), width: 16, class: "lil_av"
+      = image_tag gravatar_icon(@issue.assignee_email), width: 16, class: "lil-av"
       %strong.author= link_to_issue_assignee(@issue)
 
     - if @issue.milestone
@@ -56,9 +56,9 @@
         &nbsp;
 
   - if @issue.description.present?
-    .bottom_box_content
+    .bottom-box-content
       = preserve do
         = markdown @issue.description
 
 
-.issue_notes.voting_notes#notes= render "notes/notes_with_form", tid: @issue.id, tt: "issue"
+.issue-notes.voting-notes#notes= render "notes/notes_with_form", tid: @issue.id, tt: "issue"

--- a/app/views/kaminari/gitlab/_paginator.html.haml
+++ b/app/views/kaminari/gitlab/_paginator.html.haml
@@ -6,7 +6,7 @@
 -#    remote:        data-remote
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
-  %nav.gitlab_pagination
+  %nav.gitlab-pagination
     = prev_page_tag
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?

--- a/app/views/keys/index.html.haml
+++ b/app/views/keys/index.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   SSH Keys
   = link_to "Add new", new_key_path, class: "btn right"
 
@@ -18,5 +18,5 @@
   - if @keys.blank?
     %tr
       %td{colspan: 3}
-        %p.nothing_here_message There are no SSH keys with access to your account.
+        %p.nothing-here-message There are no SSH keys with access to your account.
 

--- a/app/views/keys/new.html.haml
+++ b/app/views/keys/new.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title Add an SSH Key
+%h3.page-title Add an SSH Key
 %hr
 = render 'form'
 

--- a/app/views/keys/show.html.haml
+++ b/app/views/keys/show.html.haml
@@ -1,10 +1,10 @@
-%h3.page_title
+%h3.page-title
   Public key:
   = @key.title
   %small
     created at
     = @key.created_at.stamp("Aug 21, 2011")
-.back_link
+.back-link
   = link_to keys_path do
     &larr; To keys list
 %hr

--- a/app/views/labels/index.html.haml
+++ b/app/views/labels/index.html.haml
@@ -1,6 +1,6 @@
 = render "issues/head"
 
-%h3.page_title
+%h3.page-title
   Labels
 %br
 %div.ui-box
@@ -10,5 +10,5 @@
 
     - unless @labels.present?
       %li
-        %h3.nothing_here_message Nothing to show here
+        %h3.nothing-here-message Nothing to show here
 

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -1,22 +1,22 @@
 %header.navbar.navbar-static-top.navbar-gitlab
   .navbar-inner
     .container
-      %div.app_logo
+      %div.app-logo
         = link_to root_path, class: "home", title: "Home" do
           %h1 GITLAB
         %span.separator
-      %h1.project_name= title
+      %h1.project-name= title
       %ul.nav
         - if current_user.is_admin?
           %li
-            = link_to admin_root_path, title: "Admin area", class: 'has_bottom_tooltip', 'data-original-title' => 'Admin area' do
+            = link_to admin_root_path, title: "Admin area", class: 'has-bottom-tooltip', 'data-original-title' => 'Admin area' do
               %i.icon-cogs
         - if current_user.can_create_project?
           %li
-            = link_to new_project_path, title: "Create New Project", class: 'has_bottom_tooltip', 'data-original-title' => 'New project'  do
+            = link_to new_project_path, title: "Create New Project", class: 'has-bottom-tooltip', 'data-original-title' => 'New project'  do
               %i.icon-plus
         %li
-          = link_to profile_path, title: "Your Profile", class: 'has_bottom_tooltip', 'data-original-title' => 'Your profile'  do
+          = link_to profile_path, title: "Your Profile", class: 'has-bottom-tooltip', 'data-original-title' => 'Your profile'  do
             %i.icon-user
         %span.separator
         %li

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     = render "layouts/head_panel", title: "Admin area"
     .container
-      %ul.main_menu
+      %ul.main-menu
         = nav_link(controller: :dashboard, html_options: {class: 'home'}) do
           = link_to "Stats", admin_root_path
         = nav_link(controller: [:projects, :groups]) do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     = render "layouts/head_panel", title: "Dashboard"
     .container
-      %ul.main_menu
+      %ul.main-menu
         = nav_link(path: 'dashboard#index', html_options: {class: 'home'}) do
           = link_to "Home", root_path, title: "Home"
         = nav_link(path: 'dashboard#issues') do

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -1,6 +1,6 @@
 !!! 5
 %html{ lang: "en"}
   = render "layouts/head"
-  %body.ui_basic.login-page
+  %body.ui-basic.login-page
     = render partial: "layouts/flash"
     .container= yield

--- a/app/views/layouts/group.html.haml
+++ b/app/views/layouts/group.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     = render "layouts/head_panel", title: "#{@group.name}"
     .container
-      %ul.main_menu
+      %ul.main-menu
         = nav_link(path: 'groups#show', html_options: {class: 'home'}) do
           = link_to "Home", group_path(@group), title: "Home"
         = nav_link(path: 'groups#issues') do

--- a/app/views/layouts/profile.html.haml
+++ b/app/views/layouts/profile.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     = render "layouts/head_panel", title: "Profile"
     .container
-      %ul.main_menu
+      %ul.main-menu
         = nav_link(path: 'profile#show', html_options: {class: 'home'}) do
           = link_to "Profile", profile_path
         = nav_link(path: 'profile#account') do

--- a/app/views/layouts/project_resource.html.haml
+++ b/app/views/layouts/project_resource.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     = render "layouts/head_panel", title: @project.name
     .container
-      %ul.main_menu
+      %ul.main-menu
         = nav_link(html_options: {class: "home #{project_tab_class}"}) do
           = link_to @project.path, project_path(@project), title: "Project"
 

--- a/app/views/merge_requests/_form.html.haml
+++ b/app/views/merge_requests/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for [@project, @merge_request], html: { class: "new_merge_request form-horizontal" } do |f|
+= form_for [@project, @merge_request], html: { class: "new-merge-request form-horizontal" } do |f|
   -if @merge_request.errors.any?
     .alert-message.block-message.error
       %ul
@@ -10,36 +10,36 @@
 
   .row
     .span5
-      .mr_branch_box
+      .mr-branch-box
         %h5 From (Head Branch)
         .body
           .padded= f.select(:source_branch, @project.heads.map(&:name), { include_blank: "Select branch" }, {class: 'chosen span4'})
-      .mr_source_commit
+      .mr-source-commit
 
     .span2
-      %center= image_tag "merge.png", class: 'mr_direction_tip'
+      %center= image_tag "merge.png", class: 'mr-direction-tip'
     .span5
-      .mr_branch_box
+      .mr-branch-box
         %h5 To (Base Branch)
         .body
           .padded= f.select(:target_branch, @project.heads.map(&:name), { include_blank: "Select branch" }, {class: 'chosen span4'})
-      .mr_target_commit
+      .mr-target-commit
 
   %h4.cdark 2. Fill info
 
   .clearfix
-    .merge_requests_form_box
-      .top_box_content
+    .merge-requests-form-box
+      .top-box-content
         = f.label :title do
           %strong= "Title *"
         .input= f.text_field :title, class: "input-xxlarge pad js-gfm-input", maxlength: 255, rows: 5
-      .merge_requests_middle_box
-        .merge_requests_assignee
+      .merge-requests-middle-box
+        .merge-requests-assignee
           = f.label :assignee_id do
             %i.icon-user
             Assign to
           .input= f.select(:assignee_id, @project.users.all.collect {|p| [ p.name, p.id ] }, { include_blank: "Select user" }, {class: 'chosen span3'})
-        .merge_requests_milestone
+        .merge-requests-milestone
           = f.label :milestone_id do
             %i.icon-time
             Milestone

--- a/app/views/merge_requests/_merge_request.html.haml
+++ b/app/views/merge_requests/_merge_request.html.haml
@@ -20,7 +20,7 @@
         = merge_request.target_branch
   = image_tag gravatar_icon(merge_request.author_email), class: "avatar"
 
-  %p= link_to_gfm truncate(merge_request.title, length: 80), project_merge_request_path(merge_request.project, merge_request), class: "row_title"
+  %p= link_to_gfm truncate(merge_request.title, length: 80), project_merge_request_path(merge_request.project, merge_request), class: "row-title"
 
   %span.update-author
     %small.cdark= "##{merge_request.id}"

--- a/app/views/merge_requests/_show.html.haml
+++ b/app/views/merge_requests/_show.html.haml
@@ -5,7 +5,7 @@
 = render "merge_requests/show/commits"
 
 - if @commits.present?
-  %ul.nav.nav-tabs.mr_nav_tabs
+  %ul.nav.nav-tabs.mr-nav-tabs
     %li
       = link_to "#notes", "data-url" => project_merge_request_path(@project, @merge_request), class: "merge-notes-tab tab" do
         %i.icon-comment
@@ -15,7 +15,7 @@
         %i.icon-list-alt
         Diff
 
-.merge_request_notes.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
+.merge-request-notes.voting-notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
   = render("notes/notes_with_form", tid: @merge_request.id, tt: "merge_request")
 .merge-request-diffs
   = render "merge_requests/show/diffs" if @diffs
@@ -32,9 +32,9 @@
       action: "#{controller.action_name}"
     });
 
-    $(".edit_merge_request").live("ajax:beforeSend", function() {
-      $('.can_be_merged').hide();
-      $('.merge_in_progress').show();
+    $(".edit-merge-request").live("ajax:beforeSend", function() {
+      $('.can-be-merged').hide();
+      $('.merge-in-progress').show();
     })
   })
 

--- a/app/views/merge_requests/edit.html.haml
+++ b/app/views/merge_requests/edit.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   = "Edit merge request #{@merge_request.id}"
 %hr
 = render 'form'

--- a/app/views/merge_requests/index.html.haml
+++ b/app/views/merge_requests/index.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Merge Requests
   - if can? current_user, :write_issue, @project
     = link_to new_project_merge_request_path(@project), class: "right btn", title: "New Merge Request" do
@@ -34,7 +34,7 @@
     = render @merge_requests
     - if @merge_requests.blank?
       %li
-        %h4.nothing_here_message Nothing to show here
+        %h4.nothing-here-message Nothing to show here
     - if @merge_requests.present?
       %li.bottom
         .row

--- a/app/views/merge_requests/new.html.haml
+++ b/app/views/merge_requests/new.html.haml
@@ -1,3 +1,3 @@
-%h3.page_title New Merge Request
+%h3.page-title New Merge Request
 %hr
 = render 'form'

--- a/app/views/merge_requests/show/_commits.html.haml
+++ b/app/views/merge_requests/show/_commits.html.haml
@@ -5,14 +5,14 @@
       Commits (#{@commits.count})
     .merge-request-commits
       - if @commits.count > 8
-        %ul.first_mr_commits.unstyled
+        %ul.first-mr-commits.unstyled
           - @commits.first(8).each do |commit|
             = render "commits/commit", commit: commit
           %li.bottom
             8 of #{@commits.count} commits displayed.
             %strong
-              %a.mr_show_all_commits Click here to show all
-        %ul.all_mr_commits.hide.unstyled
+              %a.mr-show-all-commits Click here to show all
+        %ul.all-mr-commits.hide.unstyled
           - @commits.each do |commit|
             = render "commits/commit", commit: commit
 

--- a/app/views/merge_requests/show/_diffs.html.haml
+++ b/app/views/merge_requests/show/_diffs.html.haml
@@ -1,10 +1,10 @@
 - if @merge_request.valid_diffs?
   = render "commits/diffs", diffs: @diffs
 - elsif @merge_request.broken_diffs?
-  %h4.nothing_here_message
+  %h4.nothing-here-message
     Can't load diff.
     You can
     = link_to "download it", project_merge_request_path(@project, @merge_request), format: :diff, class: "vlink"
     instead.
 - else
-  %h4.nothing_here_message Nothing to merge
+  %h4.nothing-here-message Nothing to merge

--- a/app/views/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/merge_requests/show/_mr_accept.html.haml
@@ -4,42 +4,42 @@
 
 
 - if @merge_request.open? && @commits.any? && can?(current_user, :accept_mr, @project)
-  .automerge_widget.can_be_merged{style: "display:none"}
+  .automerge-widget.can-be-merged{style: "display:none"}
     .alert.alert-success
       %span
         = form_for [:automerge, @project, @merge_request], remote: true, method: :get do |f|
           %p
             You can accept this request automatically. 
             If you still want to do it manually - 
-            %strong= link_to "click here", "#", class: "how_to_merge_link vlink", title: "How To Merge"
+            %strong= link_to "click here", "#", class: "how-to-merge-link vlink", title: "How To Merge"
             for instructions
-          .accept_group
-            = f.submit "Accept Merge Request", class: "btn small success accept_merge_request"
+          .accept-group
+            = f.submit "Accept Merge Request", class: "btn small success accept-merge-request"
             - unless @project.root_ref? @merge_request.source_branch 
-              .remove_branch_holder
+              .remove-branch-holder
                 = label_tag :should_remove_source_branch, class: "checkbox" do 
                   = check_box_tag :should_remove_source_branch
                   Remove source-branch
           .clearfix
              
 
-  .automerge_widget.cannot_be_merged{style: "display:none"}
+  .automerge-widget.cannot-be-merged{style: "display:none"}
     .alert.alert-info
       %span
-        = link_to "Show how to merge", "#", class: "how_to_merge_link btn small padded", title: "How To Merge"
+        = link_to "Show how to merge", "#", class: "how-to-merge-link btn small padded", title: "How To Merge"
         &nbsp;
         %strong This request can't be merged with GitLab. You should do it manually
 
-  .automerge_widget.unchecked
+  .automerge-widget.unchecked
     .alert-message
       %strong
         %i.icon-refresh
         Checking for ability to automatically merge…
 
-  .automerge_widget.already_cannot_be_merged{style: "display:none"}
+  .automerge-widget.already-cannot-be-merged{style: "display:none"}
     .alert.alert-info
       %strong This merge request already can not be merged. Try to reload page.
 
-  .merge_in_progress.hide
+  .merge-in-progress.hide
     %span.cgray Merge is in progress. Please wait. Page will be automatically reloaded. &nbsp;
     = image_tag "ajax_loader.gif"

--- a/app/views/merge_requests/show/_mr_box.html.haml
+++ b/app/views/merge_requests/show/_mr_box.html.haml
@@ -1,24 +1,24 @@
-.main_box
-  .top_box_content
+.main-box
+  .top-box-content
     %h4
       - if @merge_request.closed
-        .alert-message.error.status_info Closed
+        .alert-message.error.status-info Closed
       - else
-        .alert-message.success.status_info Open
+        .alert-message.success.status-info Open
       = gfm escape_once(@merge_request.title)
       - if @project.gitlab_ci?
         .right
           = image_tag ci_status_path, class: 'status-badge'
 
-  .middle_box_content
+  .middle-box-content
     %div
       %cite.cgray Created at #{@merge_request.created_at.stamp("Aug 21, 2011")} by
-      = image_tag gravatar_icon(@merge_request.author_email), width: 16, class: "lil_av"
+      = image_tag gravatar_icon(@merge_request.author_email), width: 16, class: "lil-av"
       %strong.author= link_to_merge_request_author(@merge_request)
 
       - if @merge_request.assignee
         %cite.cgray , currently assigned to
-        = image_tag gravatar_icon(@merge_request.assignee_email), width: 16, class: "lil_av"
+        = image_tag gravatar_icon(@merge_request.assignee_email), width: 16, class: "lil-av"
         %strong.author= link_to_merge_request_assignee(@merge_request)
       - if @merge_request.milestone
         - milestone = @merge_request.milestone
@@ -27,7 +27,7 @@
 
 
   - if @merge_request.closed
-    .bottom_box_content
+    .bottom-box-content
       - if @merge_request.merged?
         %span
           Merged by #{@merge_request.merge_event.author_name}

--- a/app/views/merge_requests/show/_mr_title.html.haml
+++ b/app/views/merge_requests/show/_mr_title.html.haml
@@ -1,9 +1,9 @@
-%h3.page_title
+%h3.page-title
   = "Merge Request ##{@merge_request.id}:"
   &nbsp;
-  %span.label_branch= @merge_request.source_branch
+  %span.label-branch= @merge_request.source_branch
   &rarr;
-  %span.label_branch= @merge_request.target_branch
+  %span.label-branch= @merge_request.target_branch
 
   %span.right
     - if @merge_request.merged?
@@ -31,6 +31,6 @@
 .right
   .span3#votes= render 'votes/votes_block', votable: @merge_request
 
-.back_link
+.back-link
   = link_to project_merge_requests_path(@project) do
     &larr; To merge requests

--- a/app/views/milestones/_form.html.haml
+++ b/app/views/milestones/_form.html.haml
@@ -1,11 +1,11 @@
-%h3.page_title= @milestone.new_record? ? "New Milestone" : "Edit Milestone ##{@milestone.id}"
-.back_link
+%h3.page-title= @milestone.new_record? ? "New Milestone" : "Edit Milestone ##{@milestone.id}"
+.back-link
   = link_to project_milestones_path(@project) do
     &larr; To milestones
 
 %hr
 
-= form_for [@project, @milestone], html: {class: "new_milestone form-horizontal"}  do |f|
+= form_for [@project, @milestone], html: {class: "new-milestone form-horizontal"}  do |f|
   -if @milestone.errors.any?
     .alert-message.block-message.error
       %ul

--- a/app/views/milestones/index.html.haml
+++ b/app/views/milestones/index.html.haml
@@ -1,6 +1,6 @@
 = render "issues/head"
 .milestones_content
-  %h3.page_title
+  %h3.page-title
     Milestones
     - if can? current_user, :admin_milestone, @project
       = link_to "New Milestone", new_project_milestone_path(@project), class: "right btn small", title: "New Milestone"
@@ -22,4 +22,4 @@
         %li.bottom= paginate @milestones, remote: true, theme: "gitlab"
       - else
         %li
-          %h3.nothing_here_message Nothing to show here
+          %h3.nothing-here-message Nothing to show here

--- a/app/views/milestones/show.html.haml
+++ b/app/views/milestones/show.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Milestone ##{@milestone.id}
   %small
     = @milestone.expires_at
@@ -13,21 +13,21 @@
         %i.icon-edit
         Edit
 
-.back_link
+.back-link
   = link_to project_milestones_path(@project) do
     &larr; To milestones list
 
-.main_box
-  .top_box_content
+.main-box
+  .top-box-content
     %h5
       - if @milestone.closed
-        .alert-message.error.status_info Closed
+        .alert-message.error.status-info Closed
       - else
-        .alert-message.success.status_info Open
+        .alert-message.success.status-info Open
       = gfm escape_once(@milestone.title)
       %small.right= @milestone.expires_at
 
-  .middle_box_content
+  .middle-box-content
     %h5
       Progress:
       %small
@@ -39,7 +39,7 @@
 
 
   - if @milestone.description.present?
-    .bottom_box_content
+    .bottom-box-content
       = preserve do
         = markdown @milestone.description
 

--- a/app/views/notes/_common_form.html.haml
+++ b/app/views/notes/_common_form.html.haml
@@ -1,6 +1,6 @@
 .note-form-holder
   = form_for [@project, @note], remote: "true", multipart: true do |f|
-    %h3.page_title Leave a comment
+    %h3.page-title Leave a comment
     -if @note.errors.any?
       .alert-message.block-message.error
         - @note.errors.full_messages.each do |msg|
@@ -9,14 +9,14 @@
     = f.hidden_field :noteable_id
     = f.hidden_field :noteable_type
     = f.text_area :note, size: 255, class: 'note-text js-gfm-input'
-    #preview-note.preview_note.hide
+    #preview-note.preview-note.hide
     .hint
       .right Comments are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
       .clearfix
 
     .row.note_advanced_opts
       .span3
-        = f.submit 'Add Comment', class: "btn success submit_note grouped", id: "submit_note"
+        = f.submit 'Add Comment', class: "btn success submit-note grouped", id: "submit_note"
         = link_to 'Preview', preview_project_notes_path(@project), class: 'btn grouped', id: 'preview-link'
       .span4.notify_opts
         %h6.left Notify via email:
@@ -30,9 +30,9 @@
             %span Commit author
       .span5.attachments
         %h6.left Attachment:
-        %span.file_name File name...
+        %span.file-name File name...
 
         .input.input_file
-          %a.file_upload.btn.small Upload File
+          %a.file-upload.btn.small Upload File
           = f.file_field :attachment, class: "input-file"
         %span.hint Any file less than 10 MB

--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -26,7 +26,7 @@
 
     -# remove button
     - if(note.author_id == current_user.id) || can?(current_user, :admin_note, @project)
-      = link_to [@project, note], confirm: 'Are you sure?', method: :delete, remote: true, class: "cred delete-note btn very_small" do
+      = link_to [@project, note], confirm: 'Are you sure?', method: :delete, remote: true, class: "cred delete-note btn tiny" do
         %i.icon-trash
         Remove
 

--- a/app/views/notes/_per_line_form.html.haml
+++ b/app/views/notes/_per_line_form.html.haml
@@ -1,9 +1,9 @@
 %table{style: "display:none;"}
-  %tr.per_line_form
+  %tr.per-line-form
     %td{colspan: 3 }
       .line-note-form-holder
         = form_for [@project, @note], remote: "true", multipart: true do |f|
-          %h3.page_title Leave a note
+          %h3.page-title Leave a note
           %div.span10
             -if @note.errors.any?
               .alert-message.block-message.error
@@ -14,9 +14,9 @@
             = f.hidden_field :noteable_type
             = f.hidden_field :line_code
             = f.text_area :note,  size: 255, class: 'line-note-text js-gfm-input'
-            .note_actions
+            .note-actions
               .buttons
-                = f.submit 'Add note', class: "btn save-btn submit_note submit_inline_note", id: "submit_note"
+                = f.submit 'Add note', class: "btn save-btn submit-note submit-inline-note", id: "submit_note"
                 = link_to "Cancel", "#", class: "btn hide-button"
               .options
                 %h6.left Notify via email:

--- a/app/views/notes/_per_line_note.html.haml
+++ b/app/views/notes/_per_line_note.html.haml
@@ -1,4 +1,4 @@
-%tr.line_notes_row
+%tr.line-notes-row
   %td{colspan: 3}
     %ul
       = render "notes/note", note: note

--- a/app/views/notes/_per_line_note_link.html.haml
+++ b/app/views/notes/_per_line_note_link.html.haml
@@ -1,1 +1,1 @@
-= link_to "", "#", class: "line_note_link", data: { line_code: line_code }, title: "Add note for this line"
+= link_to "", "#", class: "line-note-link", data: { line_code: line_code }, title: "Add note for this line"

--- a/app/views/notes/_per_line_reply_button.html.haml
+++ b/app/views/notes/_per_line_reply_button.html.haml
@@ -1,4 +1,4 @@
-%tr.line_notes_row.reply
+%tr.line-notes-row.reply
   %td{colspan: 3}
     %i.icon-comment
-    = link_to "Reply", "#", class: "line_note_reply_link", data: { line_code: line_code }, title: "Add note for this line"
+    = link_to "Reply", "#", class: "line-note-reply-link", data: { line_code: line_code }, title: "Add note for this line"

--- a/app/views/profile/account.html.haml
+++ b/app/views/profile/account.html.haml
@@ -1,7 +1,7 @@
 - if Gitlab.config.omniauth_enabled?
   %fieldset
     %legend Social Accounts
-    .oauth_select_holder
+    .oauth-select-holder
       %p.hint Tip: Click on icon to activate sigin with one of the following services
       - User.omniauth_providers.each do |provider|
         %span{class: oauth_active_class(provider) }
@@ -23,7 +23,7 @@
           It can be used for atom feed or API
         %p.cgray
           - if current_user.private_token
-            = text_field_tag "token", current_user.private_token, class: "xxlarge large_text"
+            = text_field_tag "token", current_user.private_token, class: "xxlarge large-text"
             = f.submit 'Reset', confirm: "Are you sure?", class: "btn primary btn-build-token"
           - else
             %span You don`t have one yet. Click generate to fix it.

--- a/app/views/profile/design.html.haml
+++ b/app/views/profile/design.html.haml
@@ -5,7 +5,7 @@
       .update-feedback.hide
         %i.icon-ok
         Saved
-    .themes_opts
+    .themes-opts
       = label_tag do
         .prev.default
         = f.radio_button :theme_id, 1
@@ -39,7 +39,7 @@
       .update-feedback.hide
         %i.icon-ok
         Saved
-    .code_highlight_opts
+    .code-highlight-opts
       = label_tag do
         .prev
           = image_tag "white.png"

--- a/app/views/profile/show.html.haml
+++ b/app/views/profile/show.html.haml
@@ -1,6 +1,6 @@
 .profile_avatar_holder
   = image_tag gravatar_icon(@user.email, 90)
-%h3.page_title
+%h3.page-title
   = @user.name
   %br
   %small
@@ -8,7 +8,7 @@
 
 %hr
 
-= form_for @user, url: profile_update_path, method: :put, html: { class: "edit_user form-horizontal" }  do |f|
+= form_for @user, url: profile_update_path, method: :put, html: { class: "edit-user form-horizontal" }  do |f|
   -if @user.errors.any?
     %div.alert-message.block-message.error
       %ul

--- a/app/views/profile/update.js.erb
+++ b/app/views/profile/update.js.erb
@@ -1,9 +1,9 @@
 // Remove body class for any previous theme, re-add current one
-$('body').removeClass('ui_basic ui_mars ui_modern ui_gray ui_color')
+$('body').removeClass('ui-basic ui-mars ui-modern ui-gray ui-color')
 $('body').addClass('<%= app_theme %>')
 
 // Re-render the header to reflect the new theme
 $('header').html('<%= escape_javascript(render("layouts/head_panel", title: "Profile")) %>')
 
 // Re-initialize header tooltips
-$('.has_bottom_tooltip').tooltip({placement: 'bottom'})
+$('.has-bottom-tooltip').tooltip({placement: 'bottom'})

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -1,6 +1,6 @@
 = render "project_head"
 .project_edit_holder
-  %h3.page_title Edit Project
+  %h3.page-title Edit Project
   %hr
   = render "projects/form"
 %div.save-project-loader.hide

--- a/app/views/projects/graph.html.haml
+++ b/app/views/projects/graph.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title Project Network Graph
+%h3.page-title Project Network Graph
 %br
 .graph_holder
   %h4

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -1,5 +1,5 @@
 .project_new_holder
-  %h3.page_title
+  %h3.page-title
     New Project
   %hr
   = render 'new_form'

--- a/app/views/projects/wall.html.haml
+++ b/app/views/projects/wall.html.haml
@@ -1,2 +1,2 @@
-%div.wall_page
+%div.wall-page
   = render "notes/reversed_notes_with_form", tid: nil, tt: "wall"

--- a/app/views/refs/logs_tree.js.haml
+++ b/app/views/refs/logs_tree.js.haml
@@ -3,6 +3,6 @@
   - commit = content_data[:commit]
 
   :plain
-    var row = $("table.table_#{@hex_path} tr.file_#{hexdigest(file_name)}");
-    row.find("td.tree_time_ago").html('#{escape_javascript time_ago_in_words(commit.committed_date)} ago');
-    row.find("td.tree_commit").html('#{escape_javascript render("tree/tree_commit_column", commit: commit)}');
+    var row = $("table.table-#{@hex_path} tr.file-#{hexdigest(file_name)}");
+    row.find("td.tree-time-ago").html('#{escape_javascript time_ago_in_words(commit.committed_date)} ago');
+    row.find("td.tree-commit").html('#{escape_javascript render("tree/tree_commit_column", commit: commit)}');

--- a/app/views/repositories/_branch.html.haml
+++ b/app/views/repositories/_branch.html.haml
@@ -11,7 +11,7 @@
       - if branch.name == @project.root_ref
         %span.label default
   %td
-    = link_to project_commit_path(@project, commit.id), class: 'commit_short_id' do
+    = link_to project_commit_path(@project, commit.id), class: 'commit-short-id' do
       = commit.short_id
     = image_tag gravatar_icon(commit.author_email), class: "avatar s16"
     %span.light

--- a/app/views/repositories/tags.html.haml
+++ b/app/views/repositories/tags.html.haml
@@ -18,7 +18,7 @@
           %small.light= truncate(tag.message || '', length: 70)
         %td
           = image_tag gravatar_icon(commit.author_email), class: "avatar s16"
-          = link_to project_commit_path(@project, commit.id), class: 'commit_short_id' do
+          = link_to project_commit_path(@project, commit.id), class: 'commit-short-id' do
             = commit.short_id
           %span.light
             = time_ago_in_words(commit.committed_date)

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -11,7 +11,7 @@
     Search results
     %small (#{@projects.count + @merge_requests.count + @issues.count + @wiki_pages.count})
   %hr
-  .search_results
+  .search-results
     .row
       .span6
         %table
@@ -30,7 +30,7 @@
             - if @projects.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Projects
+                  %h4.nothing-here-message No Projects
         %br
         %table
           %thead
@@ -49,7 +49,7 @@
             - if @merge_requests.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Merge Requests
+                  %h4.nothing-here-message No Merge Requests
       .span6
         %table
           %thead
@@ -68,7 +68,7 @@
             - if @issues.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No Issues
+                  %h4.nothing-here-message No Issues
       .span6
         %table
           %thead
@@ -85,7 +85,7 @@
             - if @wiki_pages.blank?
               %tr
                 %td
-                  %h4.nothing_here_message No wiki pages
+                  %h4.nothing-here-message No wiki pages
   :javascript
     $(function() {
       $(".search_results .term").highlight("#{params[:search]}");

--- a/app/views/services/_gitlab_ci.html.haml
+++ b/app/views/services/_gitlab_ci.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   Services &rarr; GitLab CI Integration
 
   .right

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -1,5 +1,5 @@
 = render "projects/project_head"
-%h3.page_title Services
+%h3.page-title Services
 %hr
 
 .row

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,4 +1,4 @@
 .input-prepend.project_clone_holder
   %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
   %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.web_protocol.upcase
-  = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select span5"
+  = text_field_tag :project_clone, @project.url_to_repo, class: "one-click-select span5"

--- a/app/views/shared/_no_ssh.html.haml
+++ b/app/views/shared/_no_ssh.html.haml
@@ -1,3 +1,3 @@
 - if current_user.require_ssh_key?
-  %p.error_message
+  %p.error-message
     You won't be able to pull or push project code via SSH until you #{link_to 'add an SSH key', new_key_path} to your profile

--- a/app/views/snippets/_blob.html.haml
+++ b/app/views/snippets/_blob.html.haml
@@ -1,12 +1,12 @@
-.file_holder
-  .file_title
+.file-holder
+  .file-title
     %i.icon-file
     %strong= @snippet.file_name
     %span.options
-      = link_to "raw", raw_project_snippet_path(@project, @snippet), class: "btn very_small", target: "_blank"
-  .file_content.code
+      = link_to "raw", raw_project_snippet_path(@project, @snippet), class: "btn tiny", target: "_blank"
+  .file-content.code
     - unless @snippet.content.empty?
       %div{class: user_color_scheme_class}
         = raw @snippet.colorize(formatter: :gitlab)
     - else
-      %p.nothing_here_message Empty file
+      %p.nothing-here-message Empty file

--- a/app/views/snippets/index.html.haml
+++ b/app/views/snippets/index.html.haml
@@ -2,7 +2,7 @@
 
 - if can? current_user, :write_snippet, @project
   .alert-message.block-message
-    = link_to new_project_snippet_path(@project), class: "btn small add_new right", title: "New Snippet" do
+    = link_to new_project_snippet_path(@project), class: "btn small add-new right", title: "New Snippet" do
       Add new snippet
     Share code pastes with others if it can't be in a git repository
     %br
@@ -18,4 +18,4 @@
   - if @snippets.fresh.empty?
     %tr
       %td{colspan: 3}
-        %h3.nothing_here_message Nothing here.
+        %h3.nothing-here-message Nothing here.

--- a/app/views/team_members/_form.html.haml
+++ b/app/views/team_members/_form.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   = "New Team member(s)"
 %hr
 = form_for @team_member, as: :team_member, url: project_team_members_path(@project, @team_member) do |f|

--- a/app/views/team_members/_show.html.haml
+++ b/app/views/team_members/_show.html.haml
@@ -1,6 +1,6 @@
 - user = member.user
 - allow_admin = can? current_user, :admin_project, @project
-%tr{id: dom_id(member), class: "team_member_row user_#{user.id}"}
+%tr{id: dom_id(member), class: "team-member-row user-#{user.id}"}
   %td.span6
     = link_to project_team_member_path(@project, member), title: user.name, class: "dark" do
       = image_tag gravatar_icon(user.email, 40), class: "avatar s32"
@@ -18,7 +18,7 @@
       - elsif user.blocked
         %span.btn.disabled.blocked Blocked
       - elsif allow_admin
-        = link_to project_team_member_path(project_id: @project, id: member.id), confirm: remove_from_team_message(@project, member), method: :delete, class: "very_small btn danger" do
+        = link_to project_team_member_path(project_id: @project, id: member.id), confirm: remove_from_team_message(@project, member), method: :delete, class: "tiny btn danger" do
           %i.icon-minus.icon-white
 
     - if allow_admin

--- a/app/views/team_members/import.html.haml
+++ b/app/views/team_members/import.html.haml
@@ -1,6 +1,6 @@
 = render "projects/project_head"
 
-%h3.page_title
+%h3.page-title
   = "Import team from another project"
 %hr
 %p.slead

--- a/app/views/team_members/index.html.haml
+++ b/app/views/team_members/index.html.haml
@@ -1,5 +1,5 @@
 = render "projects/project_head"
-%h3.page_title
+%h3.page-title
   Team Members
   %small (#{@project.users_projects.count})
 

--- a/app/views/team_members/show.html.haml
+++ b/app/views/team_members/show.html.haml
@@ -1,10 +1,10 @@
 - allow_admin = can? current_user, :admin_project, @project
 - user = @team_member.user
 
-.team_member_show
+.team-member-show
   - if can? current_user, :admin_project, @project
     = link_to 'Remove from team', project_team_member_path(project_id: @project, id: @team_member.id), confirm: 'Are you sure?', method: :delete, class: "right btn danger"
-  .profile_avatar_holder
+  .profile-avatar-holder
     = image_tag gravatar_icon(user.email, 60), class: "borders"
   %h3
     = user.name
@@ -12,7 +12,7 @@
       = user.email
 
   %hr
-  .back_link
+  .back-link
     %br
     = link_to project_team_index_path(@project), class: "" do
       &larr; To team list

--- a/app/views/tree/_blob.html.haml
+++ b/app/views/tree/_blob.html.haml
@@ -1,7 +1,7 @@
-.file_holder
-  .file_title
+.file-holder
+  .file-title
     %i.icon-file
-    %span.file_name
+    %span.file-name
       = blob.name
       %small= number_to_human_size blob.size
     %span.options= render "tree/blob_actions"

--- a/app/views/tree/_blob_actions.html.haml
+++ b/app/views/tree/_blob_actions.html.haml
@@ -1,12 +1,12 @@
 .btn-group.tree-btn-group
   -# only show edit link for text files
   - if @tree.text?
-    = link_to "edit", edit_project_tree_path(@project, @id), class: "btn very_small", disabled: !allowed_tree_edit?
-  = link_to "raw", project_blob_path(@project, @id), class: "btn very_small", target: "_blank"
+    = link_to "edit", edit_project_tree_path(@project, @id), class: "btn tiny", disabled: !allowed_tree_edit?
+  = link_to "raw", project_blob_path(@project, @id), class: "btn tiny", target: "_blank"
   -# only show normal/blame view links for text files
   - if @tree.text?
     - if current_page? project_blame_path(@project, @id)
-      = link_to "normal view", project_tree_path(@project, @id), class: "btn very_small"
+      = link_to "normal view", project_tree_path(@project, @id), class: "btn tiny"
     - else
-      = link_to "blame", project_blame_path(@project, @id), class: "btn very_small"
-  = link_to "history", project_commits_path(@project, @id), class: "btn very_small"
+      = link_to "blame", project_blame_path(@project, @id), class: "btn tiny"
+  = link_to "history", project_commits_path(@project, @id), class: "btn tiny"

--- a/app/views/tree/_readme.html.haml
+++ b/app/views/tree/_readme.html.haml
@@ -1,8 +1,8 @@
-.file_holder#README
-  .file_title
+.file-holder#README
+  .file-title
     %i.icon-file
     = readme.name
-  .file_content.wiki
+  .file-content.wiki
     - if gitlab_markdown?(readme.name)
       = preserve do
         = markdown(readme.data)

--- a/app/views/tree/_tree.html.haml
+++ b/app/views/tree/_tree.html.haml
@@ -8,18 +8,18 @@
     %li= link
 
 .clear
-%div.tree_progress
+%div.tree-progress
 
 %div#tree-content-holder.tree-content-holder
   - if tree.is_blob?
     = render "tree/blob", blob: tree
   - else
-    %table#tree-slider{class: "table_#{@hex_path} tree-table" }
+    %table#tree-slider{class: "table-#{@hex_path} tree-table" }
       %thead
         %th Name
         %th Last Update
         %th Last Commit
-        %th= link_to "history", project_commits_path(@project, @id), class: "btn very_small right"
+        %th= link_to "history", project_commits_path(@project, @id), class: "btn tiny right"
 
       - if tree.up_dir?
         %tr.tree-item

--- a/app/views/tree/_tree_commit_column.html.haml
+++ b/app/views/tree/_tree_commit_column.html.haml
@@ -1,2 +1,2 @@
-%span.tree_author= commit.author_link avatar: true
+%span.tree-author= commit.author_link avatar: true
 = link_to_gfm truncate(commit.title, length: 80), project_commit_path(@project, commit.id), class: "tree-commit-link"

--- a/app/views/tree/_tree_item.html.haml
+++ b/app/views/tree/_tree_item.html.haml
@@ -2,8 +2,8 @@
   %td.tree-item-file-name
     = tree_icon(type)
     %strong= link_to truncate(tree_item.name, length: 40), project_tree_path(@project, tree_join(@id || @commit.id, tree_item.name))
-  %td.tree_time_ago.cgray
-    %span.log_loading.hide
+  %td.tree-time-ago.cgray
+    %span.log-loading.hide
       Loading commit data...
       = image_tag "ajax_loader_tree.gif", width: 14
-  %td.tree_commit{ colspan: 2 }
+  %td.tree-commit{ colspan: 2 }

--- a/app/views/tree/blob/_download.html.haml
+++ b/app/views/tree/blob/_download.html.haml
@@ -1,4 +1,4 @@
-.file_content.blob_file
+.file-content.blob-file
   %center
     = link_to project_blob_path(@project, @id) do
       %div.padded

--- a/app/views/tree/blob/_image.html.haml
+++ b/app/views/tree/blob/_image.html.haml
@@ -1,2 +1,2 @@
-.file_content.image_file
+.file-content.image-file
   %img{ src: "data:#{blob.mime_type};base64,#{Base64.encode64(blob.data)}"}

--- a/app/views/tree/blob/_text.html.haml
+++ b/app/views/tree/blob/_text.html.haml
@@ -1,14 +1,14 @@
 - if gitlab_markdown?(blob.name)
-  .file_content.wiki
+  .file-content.wiki
     = preserve do
       = markdown(blob.data)
 - elsif markup?(blob.name)
-  .file_content.wiki
+  .file-content.wiki
     = raw GitHub::Markup.render(blob.name, blob.data)
 - else
-  .file_content.code
+  .file-content.code
     - unless blob.empty?
       %div{class: user_color_scheme_class}
         = raw blob.colorize(formatter: :gitlab)
     - else
-      %p.nothing_here_message Empty file
+      %p.nothing-here-message Empty file

--- a/app/views/tree/edit.html.haml
+++ b/app/views/tree/edit.html.haml
@@ -1,17 +1,17 @@
 .file-editor
   = form_tag(project_tree_path(@project, @id), method: :put, class: "form-horizontal") do
-    .file_holder
-      .file_title
+    .file-holder
+      .file-title
         %i.icon-file
-        %span.file_name
+        %span.file-name
           = @tree.path
           %small
             on
             %strong= @ref
         %span.options
           .btn-group.tree-btn-group
-            = link_to "Cancel", project_tree_path(@project, @id), class: "btn very_small cancel-btn", confirm: "Are you sure?"
-      .file_content.code
+            = link_to "Cancel", project_tree_path(@project, @id), class: "btn tiny cancel-btn", confirm: "Are you sure?"
+      .file-content.code
         %pre#editor= @tree.data
 
     .control-group.commit_message-group

--- a/app/views/wikis/_form.html.haml
+++ b/app/views/wikis/_form.html.haml
@@ -6,12 +6,12 @@
         - @wiki.errors.full_messages.each do |msg|
           %li= msg
 
-  .main_box
-    .top_box_content
+  .main-box
+    .top-box-content
       = f.label :title
       .input= f.text_field :title, class: 'span8'
       = f.hidden_field :slug
-    .middle_box_content
+    .middle-box-content
       .input
         %span.cgray
           Wiki content is parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
@@ -19,7 +19,7 @@
           %code [Link Title](page-slug)
           \.
 
-    .bottom_box_content
+    .bottom-box-content
       = f.label :content
       .input= f.text_area :content, class: 'span8 js-gfm-input'
   .actions

--- a/app/views/wikis/edit.html.haml
+++ b/app/views/wikis/edit.html.haml
@@ -1,3 +1,3 @@
-%h3.page_title Editing page
+%h3.page-title Editing page
 %hr
 = render 'form'

--- a/app/views/wikis/empty.html.haml
+++ b/app/views/wikis/empty.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title Empty page
+%h3.page-title Empty page
 %hr
 .alert-message.block-message.warning
   %span You are not allowed to create wiki pages

--- a/app/views/wikis/history.html.haml
+++ b/app/views/wikis/history.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   %span.cgray History for
   = @wikis.last.title
 %br

--- a/app/views/wikis/pages.html.haml
+++ b/app/views/wikis/pages.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title All Pages
+%h3.page-title All Pages
 %br
 %table
   %thead

--- a/app/views/wikis/show.html.haml
+++ b/app/views/wikis/show.html.haml
@@ -1,4 +1,4 @@
-%h3.page_title
+%h3.page-title
   = @wiki.title
   %span.right
     = link_to pages_project_wikis_path(@project), class: "btn small grouped" do
@@ -10,8 +10,8 @@
         %i.icon-edit
         Edit
 %br
-.file_holder
-  .file_content.wiki
+.file-holder
+  .file-content.wiki
     = preserve do
       = markdown @wiki.content
 
@@ -21,4 +21,4 @@
     Delete this page
 
 %hr
-.wiki_notes#notes= render "notes/notes_with_form", tid: @wiki.id, tt: "wiki"
+.wiki-notes#notes= render "notes/notes_with_form", tid: @wiki.id, tt: "wiki"

--- a/features/steps/dashboard/dashboard.rb
+++ b/features/steps/dashboard/dashboard.rb
@@ -110,7 +110,7 @@ class Dashboard < Spinach::FeatureSteps
   end
 
   Then 'I should see 1 project at group list' do
-    page.find('span.last_activity/span').should have_content('1')
+    page.find('span.last-activity/span').should have_content('1')
   end
 
 end

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -69,8 +69,8 @@ class Profile < Spinach::FeatureSteps
   end
 
   Then "I should see the theme change immediately" do
-    page.should have_selector('body.ui_color')
-    page.should_not have_selector('body.ui_basic')
+    page.should have_selector('body.ui-color')
+    page.should_not have_selector('body.ui-basic')
   end
 
   Then "I should receive feedback that the changes were saved" do

--- a/features/steps/project/project_team_management.rb
+++ b/features/steps/project/project_team_management.rb
@@ -29,26 +29,26 @@ class ProjectTeamManagement < Spinach::FeatureSteps
 
   Then 'I should see "Mike" in team list as "Reporter"' do
     user = User.find_by_name("Mike")
-    role_id = find(".user_#{user.id} #team_member_project_access").value
+    role_id = find(".user-#{user.id} #team_member_project_access").value
     role_id.should == UsersProject.access_roles["Reporter"].to_s
   end
 
   Given 'I should see "Sam" in team list as "Developer"' do
     user = User.find_by_name("Sam")
-    role_id = find(".user_#{user.id} #team_member_project_access").value
+    role_id = find(".user-#{user.id} #team_member_project_access").value
     role_id.should == UsersProject.access_roles["Developer"].to_s
   end
 
   And 'I change "Sam" role to "Reporter"' do
     user = User.find_by_name("Sam")
-    within ".user_#{user.id}" do
+    within ".user-#{user.id}" do
       select "Reporter", :from => "team_member_project_access"
     end
   end
 
   And 'I should see "Sam" in team list as "Reporter"' do
     user = User.find_by_name("Sam")
-    role_id = find(".user_#{user.id} #team_member_project_access").value
+    role_id = find(".user-#{user.id} #team_member_project_access").value
     role_id.should == UsersProject.access_roles["Reporter"].to_s
   end
 

--- a/features/steps/shared/active_tab.rb
+++ b/features/steps/shared/active_tab.rb
@@ -2,7 +2,7 @@ module SharedActiveTab
   include Spinach::DSL
 
   def ensure_active_main_tab(content)
-    page.find('ul.main_menu li.active').should have_content(content)
+    page.find('ul.main-menu li.active').should have_content(content)
   end
 
   def ensure_active_sub_tab(content)
@@ -10,7 +10,7 @@ module SharedActiveTab
   end
 
   And 'no other main tabs should be active' do
-    page.should have_selector('ul.main_menu li.active', count: 1)
+    page.should have_selector('ul.main-menu li.active', count: 1)
   end
 
   And 'no other sub tabs should be active' do

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -150,7 +150,7 @@ module Gitlab
     def reference_user(identifier)
       if user = @project.users.where(name: identifier).first
         member = @project.users_projects.where(user_id: user).first
-        link_to("@#{identifier}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
+        link_to("@#{identifier}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team-member #{html_options[:class]}")) if member
       end
     end
 
@@ -162,7 +162,7 @@ module Gitlab
 
     def reference_merge_request(identifier)
       if merge_request = @project.merge_requests.where(id: identifier).first
-        link_to("!#{identifier}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}"))
+        link_to("!#{identifier}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge-request #{html_options[:class]}"))
       end
     end
 

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -150,7 +150,7 @@ module Gitlab
     def reference_user(identifier)
       if user = @project.users.where(name: identifier).first
         member = @project.users_projects.where(user_id: user).first
-        link_to("@#{identifier}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team-member #{html_options[:class]}")) if member
+        link_to("@#{identifier}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
       end
     end
 
@@ -162,7 +162,7 @@ module Gitlab
 
     def reference_merge_request(identifier)
       if merge_request = @project.merge_requests.where(id: identifier).first
-        link_to("!#{identifier}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge-request #{html_options[:class]}"))
+        link_to("!#{identifier}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}"))
       end
     end
 

--- a/lib/gitlab/theme.rb
+++ b/lib/gitlab/theme.rb
@@ -2,11 +2,11 @@ module Gitlab
   class Theme
     def self.css_class_by_id(id)
       themes = {
-        1 => "ui_basic",
-        2 => "ui_mars",
-        3 => "ui_modern",
-        4 => "ui_gray",
-        5 => "ui_color"
+        1 => "ui-basic",
+        2 => "ui-mars",
+        3 => "ui-modern",
+        4 => "ui-gray",
+        5 => "ui-color"
       }
 
       id ||= 1

--- a/spec/requests/admin/admin_hooks_spec.rb
+++ b/spec/requests/admin/admin_hooks_spec.rb
@@ -12,7 +12,7 @@ describe "Admin::Hooks" do
   describe "GET /admin/hooks" do
     it "should be ok" do
       visit admin_root_path
-      within ".main_menu" do
+      within ".main-menu" do
         click_on "Hooks"
       end
       current_path.should == admin_hooks_path

--- a/spec/requests/gitlab_flavored_markdown_spec.rb
+++ b/spec/requests/gitlab_flavored_markdown_spec.rb
@@ -62,7 +62,7 @@ describe "Gitlab Flavored Markdown" do
     it "should render title in refs#tree", js: true do
       visit project_tree_path(project, @branch_name)
 
-      within(".tree_commit") do
+      within(".tree-commit") do
         page.should have_link("##{issue.id}")
       end
     end
@@ -70,7 +70,7 @@ describe "Gitlab Flavored Markdown" do
     it "should render title in refs#blame" do
       visit project_blame_path(project, File.join(@branch_name, @test_file))
 
-      within(".blame_commit") do
+      within(".blame-commit") do
         page.should have_link("##{issue.id}")
       end
     end


### PR DESCRIPTION
I could sum up al my commit messages here, but basically it comes down to a more uniform SCSS and some more declarative naming of mixins and variables. 
And my main reason to do this; the clutter of different definitions of classnames on elements. Before half of all were separated with underscores `_` and the other half with dashes `-`.  Now its all dashes. 

Ultimately there should be some kind of code quality control in GitLab for SASS like https://github.com/twitter/recess for LESS
