### PR TITLE
Initial take for generic issue fields

### DIFF
--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -11,14 +11,13 @@
   }
   .issue_middle_block {
     @extend .middle_box_content;
-    height: 30px;
     .issue_assignee {
       @extend .span6;
-      float: left;
     }
     .issue_milestone {
       @extend .span4;
-      float: left;
+    }
+    .issue_generic_issue_fields {
     }
   }
   .issue_description {

--- a/app/controllers/generic_issue_fields_controller.rb
+++ b/app/controllers/generic_issue_fields_controller.rb
@@ -1,0 +1,62 @@
+class GenericIssueFieldsController < ProjectResourceController
+  before_filter :module_enabled
+  before_filter :authorize_admin_generic_issue_fields!
+  before_filter :generic_issue_field, only: [:edit, :update, :destroy, :show]
+  respond_to :html
+
+  def index
+    @generic_issue_fields = @project.generic_issue_fields
+  end
+
+  def new
+    @generic_issue_field = @project.generic_issue_fields.new
+    respond_with(@generic_issue_field)
+  end
+
+  def edit
+    respond_with(@generic_issue_field)
+  end
+
+  def create
+    @generic_issue_field = @project.generic_issue_fields.new(params[:generic_issue_field])
+
+    if @generic_issue_field.save
+      redirect_to project_generic_issue_fields_path(@project)
+    else
+      render :new
+    end
+  end
+
+  def show
+    redirect_to project_generic_issue_fields_path(@project)
+  end
+
+  def update
+    @generic_issue_field.update_attributes(params[:generic_issue_field])
+
+    if @generic_issue_field.valid?
+      redirect_to project_generic_issue_fields_path(@project)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @generic_issue_field.destroy
+    redirect_to project_generic_issue_fields_path(@project)
+  end
+
+  protected
+
+  def generic_issue_field
+    @generic_issue_field ||= @project.generic_issue_fields.find(params[:id])
+  end
+
+  def authorize_admin_generic_issue_fields!
+    return access_denied! unless can?(current_user, :admin_generic_issue_fields, @project)
+  end
+
+  def module_enabled
+    return render_404 unless @project.issues_enabled
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -88,6 +88,7 @@ class Ability
         :modify_merge_request,
         :admin_issue,
         :admin_milestone,
+        :admin_generic_issue_fields,
         :admin_snippet,
         :admin_team_member,
         :admin_merge_request,

--- a/app/models/generic_issue_field.rb
+++ b/app/models/generic_issue_field.rb
@@ -1,0 +1,50 @@
+# == Schema Information
+#
+# Table name: generic_issue_fields
+#
+#  id          :integer          not null, primary key
+#  title       :string(255)      not null
+#  project_id  :integer          not null
+#  description :string(255)
+#
+# Table name: generic_issue_field_values
+
+class GenericIssueField < ActiveRecord::Base
+  attr_accessible :title, :generic_issue_field_values_string, :generic_issue_field_value_ids, :generic_issue_field_values
+  belongs_to :project
+  has_many :generic_issue_field_values, :dependent => :destroy
+
+  validates :title, presence: true
+  validates :project_id, presence: true
+
+  # this is the name of the attribute on an Issue instance that can be 
+  # used to set or retrieve the value of this issue field
+  def symbol_for_field
+    return ('generic_issue_field_%s' % id).to_s
+  end
+
+  # this is the name of the attribute on an Issue instance that can be
+  # used to get the id of that same value
+  def symbol_for_field_value_id
+    return ('generic_issue_field_%s_value_id' % id).to_s
+  end
+
+  # this is an attribute to get/set all the titles of the values
+  # in one go as a newline separated list of titles
+  def generic_issue_field_values_string
+    return generic_issue_field_values.collect{|v| v.title}.join("\n")
+  end
+
+  def generic_issue_field_values_string= titles_string
+    new_titles = titles_string.split("\n").collect{|v| v.chomp}
+    ids_to_keep = generic_issue_field_value_ids.find{|id| new_titles.include? GenericIssueFieldValue.find_by_id(id).title}
+    generic_issue_field_value_ids = ids_to_keep
+    current_titles = generic_issue_field_values.collect{|v| v.title}
+    new_titles.each do |t|
+      if not current_titles.include? t then 
+        generic_issue_field_values<<GenericIssueFieldValue.new(:generic_issue_field_id => id, :title => t)
+      end
+    end
+  end
+end
+

--- a/app/models/generic_issue_field_value.rb
+++ b/app/models/generic_issue_field_value.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: generic_issue_field_values
+#
+#  id                      :integer          not null, primary key
+#  generic_field_value_id  :integer          not null
+#  title                   :string(255)      not null
+#  description             :string(255)
+
+class GenericIssueFieldValue < ActiveRecord::Base
+  attr_accessible :generic_issue_field, :generic_issue_field_id, :title
+  belongs_to :generic_issue_field, :dependent => :destroy
+  has_many :issue_generic_issue_field_values, :dependent => :destroy
+  has_many :issues, :through => :issue_generic_issue_field_values
+
+  validates :title, presence: true
+  validates :generic_issue_field, presence: true
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -30,4 +30,66 @@ class Issue < ActiveRecord::Base
   def self.open_for(user)
     opened.assigned(user)
   end
+
+  has_many :issue_generic_issue_field_values, :dependent => :destroy
+  has_many :generic_issue_field_values, :through => :issue_generic_issue_field_values, :before_add => :clear_other_values
+  belongs_to :project
+
+  # we have to make sure that we clear the associations to other values
+  # of the same field
+  def clear_other_values new_generic_issue_field_value
+    to_delete = generic_issue_field_values.find(:all, :conditions=>['generic_issue_field_id = ?', new_generic_issue_field_value.generic_issue_field.id])
+    generic_issue_field_values.delete(to_delete)
+  end
+
+  # this method allows us to access the generic issue fields as if they are normal
+  # attributes of an Issue instance. In reality, the number of fields and their
+  # possible values are dynamically stored in tables and can be set by the administrator
+  # on a per-project basis
+  # Possible improvement: it would be nice to be able to abstract this logic away
+  # from the Issue class and into its own namespace somewhere
+  def method_missing(name, *args)
+    method = (name.instance_of? Symbol) ? name.to_s : name
+    # We compare the name of the method to all symbols for all the project's
+    # generic issue fields
+    project.generic_issue_fields.each do |generic_issue_field|
+      if method == generic_issue_field.symbol_for_field.to_s
+        # get a GenericIssueFieldValue
+        return generic_issue_field_values.find(:first, :conditions=>['generic_issue_field_id = ?', generic_issue_field.id])
+      elsif method.chomp("=") == generic_issue_field.symbol_for_field.to_s
+        # set a GenericIssueFieldValue
+        generic_issue_field_values << args[0]
+        return
+      elsif method == generic_issue_field.symbol_for_field_value_id.to_s
+        # get the id of a generic_issue_field_value (useful for forms and such)
+        return generic_issue_field_values.find(:first, :conditions=>['generic_issue_field_id = ?', generic_issue_field.id]).id
+      elsif method.chomp('=') == generic_issue_field.symbol_for_field_value_id.to_s
+        # set the id of a generic_issue_field_value (useful for forms and such)
+        generic_issue_field_values << GenericIssueFieldValue.find_by_id(args[0])
+        return
+      end
+    end
+    super
+  end
+
+  # we have to override update_attributes because it chokes on the
+  # dynamical attributes, for some reason. We update those in this
+  # override and then call the superclass.
+  def update_attributes (attributes)
+    attributes.each do |key, value|
+      project.generic_issue_fields.each do |generic_issue_field|
+        if generic_issue_field.symbol_for_field == key then
+          assigner = (generic_issue_field.symbol_for_field.to_s + '=').to_sym
+          send(assigner, value)
+          attributes.delete(key)
+        elsif generic_issue_field.symbol_for_field_value_id == key then
+          assigner = (generic_issue_field.symbol_for_field_value_id.to_s + '=').to_sym
+          send(assigner, value)
+          attributes.delete(key)
+        end
+      end
+    end
+    super
+  end
+
 end

--- a/app/models/issue_generic_issue_field_value.rb
+++ b/app/models/issue_generic_issue_field_value.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: issue_generic_issue_field_values
+#
+#  issue_id                     :integer not null
+#  generic_issue_field_value_id :integer not null
+#
+
+class IssueGenericIssueFieldValue < ActiveRecord::Base
+  belongs_to :generic_issue_field_value
+  belongs_to :issue
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,6 +48,7 @@ class Project < ActiveRecord::Base
   has_many :deploy_keys,    dependent: :destroy, foreign_key: "project_id", class_name: "Key"
   has_many :hooks,          dependent: :destroy, class_name: "ProjectHook"
   has_many :wikis,          dependent: :destroy
+  has_many :generic_issue_fields
   has_many :protected_branches, dependent: :destroy
   has_one :last_event, class_name: 'Event', order: 'events.created_at DESC', foreign_key: 'project_id'
   has_one :gitlab_ci_service, dependent: :destroy

--- a/app/views/generic_issue_fields/_form.html.haml
+++ b/app/views/generic_issue_fields/_form.html.haml
@@ -1,0 +1,19 @@
+%div.issue-form-holder
+  %h3.page_title= @generic_issue_field.new_record? ? "New Issue Field" : "Edit Issue Field"
+  = form_for [@project, @generic_issue_field], html: {class: "new_generic_issue_field form-vertical"} do |f|
+    .clearfix
+      = f.label :title do
+        %strong
+        Title:
+      .input
+        = f.text_field :title, autofocus: true
+    .clearfix
+      = f.label :generic_issue_field_values_string do
+        %strong
+        Values:
+      .input
+        = f.text_area :generic_issue_field_values_string, autofocus: true
+    .actions
+      = f.submit 'Submit', class: "btn save-btn"
+      = link_to "Cancel", project_generic_issue_fields_path(@project), class: 'btn cancel-btn'
+     

--- a/app/views/generic_issue_fields/_generic_issue_field.html.haml
+++ b/app/views/generic_issue_fields/_generic_issue_field.html.haml
@@ -1,0 +1,13 @@
+%li.wll
+  - if can?(current_user, :admin_generic_issue_fields, @project)
+    .right
+      = link_to edit_project_generic_issue_field_path(generic_issue_field.project, generic_issue_field), class: "btn edit-issue-link grouped" do
+        %i.icon-edit
+        Edit
+      = link_to 'Delete', project_generic_issue_field_path(@project, generic_issue_field), method: :delete, class: "btn grouped close_issue", title: "Delete Issue Field"
+
+  %strong
+    = generic_issue_field.title
+  %div
+    = generic_issue_field.generic_issue_field_values.collect{ |v| v.title}.join(" / ")
+

--- a/app/views/generic_issue_fields/edit.html.haml
+++ b/app/views/generic_issue_fields/edit.html.haml
@@ -1,0 +1,1 @@
+= render "form"

--- a/app/views/generic_issue_fields/index.html.haml
+++ b/app/views/generic_issue_fields/index.html.haml
@@ -1,0 +1,20 @@
+= render "issues/head"
+
+%h3.page_title
+  Issue fields
+  - if can?(current_user, :admin_generic_issue_fields, @project)
+    .right
+      .span5
+        = link_to new_project_generic_issue_field_path(@project), class: "right btn", title: "New Issue Field", id: "new_generic_issue_field_link" do
+          .icon-plus
+            New Issue Field
+%br
+%div.ui-box
+  %ul.unstyled.labels-table
+    - @generic_issue_fields.each do |generic_issue_field|
+      = render 'generic_issue_field', generic_issue_field: generic_issue_field
+
+    - unless @generic_issue_fields.present?
+      %li
+        %h3.nothing_here_message Nothing to show here
+

--- a/app/views/generic_issue_fields/new.html.haml
+++ b/app/views/generic_issue_fields/new.html.haml
@@ -1,0 +1,1 @@
+= render "form"

--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -24,6 +24,13 @@
             %i.icon-time
             Milestone
           .input= f.select(:milestone_id, @project.milestones.active.all.collect {|p| [ p.title, p.id ] }, { include_blank: "Select milestone" }, {class: 'chosen'})
+        .issue_generic_issue_fields
+          - @project.generic_issue_fields.each do |generic_issue_field|
+            .issue_generic_issue_field
+              = f.label generic_issue_field.symbol_for_field_value_id do
+                = generic_issue_field.title
+              - items = generic_issue_field.generic_issue_field_values.collect { |p| [p.title, p.id] }
+              .input= f.select(generic_issue_field.symbol_for_field_value_id, items, {}, {class: 'chosen'})
 
       .issue_description
         .clearfix

--- a/app/views/issues/_head.html.haml
+++ b/app/views/issues/_head.html.haml
@@ -5,6 +5,8 @@
     = link_to 'Milestones', project_milestones_path(@project), class: "tab"
   = nav_link(controller: :labels) do
     = link_to 'Labels', project_labels_path(@project), class: "tab"
+  = nav_link(controller: :generic_issue_fields) do
+    = link_to 'Issue fields', project_generic_issue_fields_path(@project), class: "tab"
   %li.right
     %span.rss-icon
       = link_to project_issues_path(@project, :atom, { private_token: current_user.private_token }) do

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -48,6 +48,15 @@
       %cite.cgray and attached to milestone
       %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
 
+    %div
+      - need_a_comma = @issue.generic_issue_field_values.length
+      - @issue.generic_issue_field_values.each do |issue_field_value|
+        %cite.cgray= issue_field_value.generic_issue_field.title + ':'
+        %strong= issue_field_value.title
+        - need_a_comma = need_a_comma - 1
+        - if need_a_comma > 0
+          ,
+
     .right
       - @issue.labels.each do |label|
         %span.label.label-issue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Gitlab::Application.routes.draw do
 
     resources :team, controller: 'team_members', only: [:index]
     resources :milestones
+    resources :generic_issue_fields
     resources :labels, only: [:index]
     resources :issues do
       collection do

--- a/db/fixtures/development/011_generic_issue_fields.rb
+++ b/db/fixtures/development/011_generic_issue_fields.rb
@@ -1,0 +1,24 @@
+GenericIssueField.seed(:id, [
+  { :id => 1,  :project_id => 2, :title => 'severity', :description => 'how bad is it?',
+         :default_value => 3, :mandatory => true },
+  { :id => 2,  :project_id => 2, :title => 'component', :description => 'pick the component',
+         :default_value => 7, :mandatory => false }
+])
+
+GenericIssueFieldValue.seed(:id, [
+ { :id => 1, :generic_issue_field_id => 1, :title => 'enhancement', :description => 'no bug'},
+ { :id => 2, :generic_issue_field_id => 1, :title => 'minor' , :description => 'a trivial flaw'},
+ { :id => 3, :generic_issue_field_id => 1, :title => 'major', :description => 'a normal bug' },
+ { :id => 4, :generic_issue_field_id => 1, :title => 'blocker', :description => 'something very bad' },
+ { :id => 5, :generic_issue_field_id => 1, :title => 'critical' , :description => 'a crash or security thing' },
+ { :id => 6, :generic_issue_field_id => 2, :title => 'algebra',  :description => ''},
+ { :id => 7, :generic_issue_field_id => 2, :title => 'packages' , :description => ''},
+ { :id => 8, :generic_issue_field_id => 2, :title => 'geometry', :description => '' }
+])
+
+IssueGenericIssueFieldValue.seed(:generic_issue_field_value_id, [
+ { :issue_id => 1, :generic_issue_field_value_id => 2 },
+ { :issue_id => 1, :generic_issue_field_value_id => 6 },
+ { :issue_id => 2, :generic_issue_field_value_id => 1 },
+ { :issue_id => 2, :generic_issue_field_value_id => 8 }
+])

--- a/db/migrate/20121129201441_add_generic_issue_fields.rb
+++ b/db/migrate/20121129201441_add_generic_issue_fields.rb
@@ -1,0 +1,22 @@
+class AddGenericIssueFields < ActiveRecord::Migration
+  def change
+    create_table :generic_issue_fields do |t|
+      t.integer     :id, :null => false
+      t.integer     :project_id, :null => false
+      t.string      :title, :null => false
+      t.string      :description
+      t.integer     :default_value
+      t.boolean     :mandatory
+    end
+    create_table :generic_issue_field_values do |t|
+      t.integer    :id, :null => false
+      t.integer    :generic_issue_field_id, :null => false
+      t.string     :title, :null => false
+      t.string     :description
+    end
+    create_table :issue_generic_issue_field_values do |t|
+      t.integer    :issue_id, :null => false
+      t.integer    :generic_issue_field_value_id, :null => false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121123164910) do
+ActiveRecord::Schema.define(:version => 20121129201441) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -23,6 +23,25 @@ ActiveRecord::Schema.define(:version => 20121123164910) do
     t.datetime "updated_at",  :null => false
     t.integer  "action"
     t.integer  "author_id"
+  end
+
+  create_table "generic_issue_field_values", :force => true do |t|
+    t.integer "generic_issue_field_id", :null => false
+    t.string  "title",                  :null => false
+    t.string  "description"
+  end
+
+  create_table "generic_issue_fields", :force => true do |t|
+    t.integer "project_id",    :null => false
+    t.string  "title",         :null => false
+    t.string  "description"
+    t.integer "default_value"
+    t.boolean "mandatory"
+  end
+
+  create_table "issue_generic_issue_field_values", :force => true do |t|
+    t.integer "issue_id",                     :null => false
+    t.integer "generic_issue_field_value_id", :null => false
   end
 
   create_table "issues", :force => true do |t|


### PR DESCRIPTION
I'm exploring the possibility for the math project [Sage](http://www.sagemath.org) to use gitlab as soon as it migrates to git. 

One feature that is currently missing (and that would be a dealbreaker, probably) is the fact that gitlab doesn't allow extra fields for issues. The current trac server allows the reporter to classify issues by severity (enhancement/minor/major/blocker) or by component (algebra/calculus/packages/etc).

I've tried to make a start implementing this, but before polishing I'm interested to know whether you would be willing to merge such a feature upstream.

I'd love to hear your feedback!
Timo
