### PR TITLE
Store event filters at cookies

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,0 +1,27 @@
+/**
+ * Init dashboard page
+ *
+ */
+function dashboardPage(){ 
+  $(".event_filter_link").bind('click',(function(){
+    enableFilter(this.id);
+  }));
+}
+
+function enableFilter(sender_id){
+  var event_filters = $.cookie('event_filter');
+  var filter = sender_id.split('_')[0];
+  if (!event_filters) {
+    event_filters = new Array();
+  } else {
+    event_filters = event_filters.split(',');
+  }
+  var index = event_filters.indexOf(filter);
+  if (index == -1) {
+    event_filters.push(filter);
+  } else {
+    event_filters.splice(index, 1);
+  }
+  $.cookie('event_filter', event_filters.join(','));
+};
+

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -58,7 +58,8 @@ class DashboardController < ApplicationController
   end
 
   def event_filter
-    @event_filter ||= EventFilter.new(params[:event_filter])
+    filters = cookies['event_filter'].split(',') if cookies['event_filter']
+    @event_filter ||= EventFilter.new(filters)
   end
 
   def dashboard_filter items

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -46,7 +46,7 @@ module EventsHelper
                end
 
     content_tag :div, class: "filter_icon #{inactive}" do
-      link_to dashboard_path(event_filter: filter), class: 'has_tooltip', 'data-original-title' => tooltip do
+      link_to dashboard_path(event_filter: filter), class: 'has_tooltip', id: "#{key}_event_filter", 'data-original-title' => tooltip do
         image_tag "event_filter_#{key}.png"
       end
     end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -36,9 +36,6 @@ module EventsHelper
 
   def event_filter_link key, tooltip
     key = key.to_s
-
-    filter = @event_filter.options key
-
     inactive = if @event_filter.active? key
                  nil
                else
@@ -46,7 +43,7 @@ module EventsHelper
                end
 
     content_tag :div, class: "filter_icon #{inactive}" do
-      link_to dashboard_path(event_filter: filter), class: 'has_tooltip', id: "#{key}_event_filter", 'data-original-title' => tooltip do
+      link_to dashboard_path, class: 'has_tooltip event_filter_link', id: "#{key}_event_filter", 'data-original-title' => tooltip do
         image_tag "event_filter_#{key}.png"
       end
     end

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,3 +1,4 @@
+= javascript_include_tag 'dashboard'
 - if @projects.any?
   .projects
     .activities.span8
@@ -45,6 +46,8 @@
     - else
       If you will be added to project - it will be displayed here
 
-
 :javascript
-  $(function(){ Pager.init(20); });
+  $(function(){ 
+    dashboardPage();
+    Pager.init(20);
+  });

--- a/features/dashboard/event_filters.feature
+++ b/features/dashboard/event_filters.feature
@@ -9,6 +9,23 @@ Feature: Event filters
 
   Scenario: I should see all events
     Then I should see push event
-    Then I should see new member event
-    Then I should see merge request event
+    And I should see new member event
+    And I should see merge request event
 
+  Scenario: I should see only pushed events
+    When I click "push" event filter 
+    Then I should see push event
+    And I should not see new member event
+    And I should not see merge request event
+
+  Scenario: I should see only joined events
+    When I click "team" event filter
+    Then I should see new member event
+    And I should not see push event
+    And I should not see merge request event
+
+  Scenario: I should see only merged events
+    When I click "merge" event filter
+    Then I should see merge request event
+    And I should not see push event
+    And I should not see new member event

--- a/features/dashboard/event_filters.feature
+++ b/features/dashboard/event_filters.feature
@@ -12,20 +12,39 @@ Feature: Event filters
     And I should see new member event
     And I should see merge request event
 
+  @javascript
   Scenario: I should see only pushed events
     When I click "push" event filter 
     Then I should see push event
     And I should not see new member event
     And I should not see merge request event
 
+  @javascript
   Scenario: I should see only joined events
     When I click "team" event filter
     Then I should see new member event
     And I should not see push event
     And I should not see merge request event
 
+  @javascript
   Scenario: I should see only merged events
     When I click "merge" event filter
     Then I should see merge request event
     And I should not see push event
     And I should not see new member event
+
+  @javascript
+  Scenario: I should see only selected events while page reloaded
+    When I click "push" event filter
+    And I visit dashboard page
+    Then I should see push event
+    And I should not see new member event
+    When I click "team" event filter
+    And I visit dashboard page
+    Then I should see push event
+    And I should see new member event
+    And I should not see merge request event
+    When I click "push" event
+    Then I should not see push event
+    And I should see new member event
+    And I should not see merge request event

--- a/features/dashboard/event_filters.feature
+++ b/features/dashboard/event_filters.feature
@@ -44,7 +44,7 @@ Feature: Event filters
     Then I should see push event
     And I should see new member event
     And I should not see merge request event
-    When I click "push" event
+    When I click "push" event filter
     Then I should not see push event
     And I should see new member event
     And I should not see merge request event

--- a/features/dashboard/event_filters.feature
+++ b/features/dashboard/event_filters.feature
@@ -1,0 +1,14 @@
+Feature: Event filters
+  Background:
+    Given I sign in as a user
+    And I own a project
+    And this project has push event
+    And this project has new member event
+    And this project has merge request event
+    And I visit dashboard page
+
+  Scenario: I should see all events
+    Then I should see push event
+    Then I should see new member event
+    Then I should see merge request event
+

--- a/features/steps/dashboard/dashboard_event_filters.rb
+++ b/features/steps/dashboard/dashboard_event_filters.rb
@@ -1,0 +1,63 @@
+class EventFilters < Spinach::FeatureSteps
+  include SharedAuthentication
+  include SharedPaths 
+  include SharedProject
+
+  Then 'I should see push event' do
+    page.find('span.pushed').should have_content('pushed')
+  end
+
+  Then 'I should see new member event' do
+    page.find('span.joined').should have_content('joined')
+  end
+
+  Then 'I should see merge request event' do
+    page.find('span.merged').should have_content('merged')
+  end
+
+  And 'this project has push event' do
+    data = {
+      before: "0000000000000000000000000000000000000000",
+      after: "0220c11b9a3e6c69dc8fd35321254ca9a7b98f7e",
+      ref: "refs/heads/new_design",
+      user_id: @user.id,
+      user_name: @user.name,
+      repository: {
+        name: @project.name,
+        url: "localhost/rubinius",
+        description: "",
+        homepage: "localhost/rubinius",
+        private: true
+      }
+    }
+
+    @event = Event.create(
+      project: @project,
+      action: Event::Pushed,
+      data: data,
+      author_id: @user.id
+    )
+  end
+
+  And 'this project has new member event' do
+    user = create(:user, {name: "John Doe"})
+    Event.create(
+      project: @project,
+      author_id: user.id,
+      action: Event::Joined
+    )
+  end
+
+  And 'this project has merge request event' do
+    merge_request = create :merge_request, author: @user, project: @project
+    Event.create(
+      project: @project,
+      action: Event::Merged,
+      target_id: merge_request.id,
+      target_type: "MergeRequest",
+      author_id: @user.id
+    )    
+  end
+
+end
+

--- a/features/steps/dashboard/dashboard_event_filters.rb
+++ b/features/steps/dashboard/dashboard_event_filters.rb
@@ -4,15 +4,27 @@ class EventFilters < Spinach::FeatureSteps
   include SharedProject
 
   Then 'I should see push event' do
-    page.find('span.pushed').should have_content('pushed')
+    page.has_selector?('span.pushed').should be_true
+  end
+  
+  Then 'I should not see push event' do
+    page.has_selector?('span.pushed').should be_false
   end
 
   Then 'I should see new member event' do
-    page.find('span.joined').should have_content('joined')
+    page.has_selector?('span.joined').should be_true
+  end
+
+  And 'I should not see new member event' do
+    page.has_selector?('span.joined').should be_false
   end
 
   Then 'I should see merge request event' do
-    page.find('span.merged').should have_content('merged')
+    page.has_selector?('span.merged').should be_true
+  end
+
+  And 'I should not see merge request event' do
+    page.has_selector?('span.merged').should be_false
   end
 
   And 'this project has push event' do
@@ -57,6 +69,18 @@ class EventFilters < Spinach::FeatureSteps
       target_type: "MergeRequest",
       author_id: @user.id
     )    
+  end
+
+  When 'I click "push" event filter' do
+    click_link("push_event_filter")
+  end
+
+  When 'I click "team" event filter' do
+    click_link("team_event_filter")
+  end
+
+  When 'I click "merge" event filter' do
+    click_link("merged_event_filter")
   end
 
 end

--- a/features/steps/dashboard/dashboard_event_filters.rb
+++ b/features/steps/dashboard/dashboard_event_filters.rb
@@ -4,27 +4,27 @@ class EventFilters < Spinach::FeatureSteps
   include SharedProject
 
   Then 'I should see push event' do
-    page.has_selector?('span.pushed').should be_true
+    page.should have_selector('span.pushed')
   end
   
   Then 'I should not see push event' do
-    page.has_selector?('span.pushed').should be_false
+    page.should_not have_selector('span.pushed')
   end
 
   Then 'I should see new member event' do
-    page.has_selector?('span.joined').should be_true
+    page.should have_selector('span.joined')
   end
 
   And 'I should not see new member event' do
-    page.has_selector?('span.joined').should be_false
+    page.should_not have_selector('span.joined')
   end
 
   Then 'I should see merge request event' do
-    page.has_selector?('span.merged').should be_true
+    page.should have_selector('span.merged')
   end
 
   And 'I should not see merge request event' do
-    page.has_selector?('span.merged').should be_false
+    page.should_not have_selector('span.merged')
   end
 
   And 'this project has push event' do


### PR DESCRIPTION
I think more useful to store the event filters at cookies, so user don't need to disable `team` events (or else) every time he comes dashboard page.
