### PR TITLE
support for running in non-root directory/path (RAILS_RELATIVE_URL_ROOT)

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -6,6 +6,7 @@ class Notify < ActionMailer::Base
   default_url_options[:host]     = Gitlab.config.gitlab.host
   default_url_options[:protocol] = Gitlab.config.gitlab.protocol
   default_url_options[:port]     = Gitlab.config.gitlab.port if Gitlab.config.gitlab_on_non_standard_port?
+  default_url_options[:script_name] = Gitlab.config.gitlab.relative_url_root
 
   default from: Gitlab.config.gitlab.email_from
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run Gitlab::Application
+
+map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
+  run Gitlab::Application
+end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -18,6 +18,9 @@ gitlab:
   host: localhost
   port: 80
   https: false
+  # uncomment and customize to run in non-root path
+  # note that ENV['RAILS_RELATIVE_URL_ROOT'] in config/unicorn.rb may need to be changed
+  # relative_url_root: /gitlab
 
   ## Email settings
   # Email address used in the "From" field in mails sent by GitLab

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -25,7 +25,8 @@ class Settings < Settingslogic
       [ gitlab.protocol,
         "://",
         gitlab.host,
-        custom_port
+        custom_port,
+        gitlab.relative_url_root
       ].join('')
     end
   end
@@ -45,6 +46,7 @@ Settings.gitlab['default_projects_limit'] ||=  10
 Settings.gitlab['host']       ||= 'localhost'
 Settings.gitlab['https']      ||= false
 Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80
+Settings.gitlab['relative_url_root'] ||= ''
 Settings.gitlab['protocol']   ||= Settings.gitlab.https ? "https" : "http"
 Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Gitlab::Application.routes.draw do
     project_root: Gitlab.config.gitolite.repos_path,
     upload_pack:  Gitlab.config.gitolite.upload_pack,
     receive_pack: Gitlab.config.gitolite.receive_pack
-  }), at: '/:path', constraints: { path: /[-\/\w\.-]+\.git/ }
+  }), at: '/', constraints: lambda { |request| /[-\/\w\.-]+\.git/.match(request.path_info) }
 
   #
   # Help

--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -1,3 +1,7 @@
+# uncomment and customize to run in non-root path
+# note that config/gitlab.yml web path should also be changed
+# ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+
 app_dir = "/home/gitlab/gitlab/"
 worker_processes 2
 working_directory app_dir

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -17,10 +17,6 @@ module Grack
       # Pass Gitolite update hook
       ENV['GL_BYPASS_UPDATE_HOOK'] = "true"
 
-      # Need this patch due to the rails mount
-      @env['PATH_INFO'] = @request.path
-      @env['SCRIPT_NAME'] = ""
-
       # Find project by PATH_INFO from env
       if m = /^\/([\w\.\/-]+)\.git/.match(@request.path_info).to_a
         self.project = Project.find_with_namespace(m.last)


### PR DESCRIPTION
I've made some small changes to more robustly and generically allow running gitlab in non-root context-path (i.e. /gitlab) for hostname (and therefore SSL cert) multitenancy. I've been running it in this configuration with apache+mod_proxy and unicorn at work for a couple weeks and everything seems to work, including links in emails, but it's possible there's some darker corners of the app were missed. 

I found that in at least some cases executing `bundle exec rake assets:clean` was required to make sure paths embedded within assets (css urls, etc) were regenerated properly.

Edit:
To be clear, this requires that `ENV['RAILS_RELATIVE_URL_ROOT']` be specified in `config/unicorn.rb`, `config/environments/*.rb`, or elsewhere, as well as a matching "relative_url_root" item in `config/gitlab.yml`.
