### PR TITLE
Devise locale updated to stay consistent with GitLab

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
   devise:
     failure:
       already_authenticated: 'You are already signed in.'
-      unauthenticated: 'You need to sign in or sign up before continuing.'
+      unauthenticated: 'You need to sign in before continuing.'
       unconfirmed: 'You have to confirm your account before continuing.'
       locked: 'Your account is locked.'
       invalid: 'Invalid email or password.'


### PR DESCRIPTION
Login page states you should sign in or sign up before continuing, you can't sign up in Gitlab unless whoever hosts it makes it so you can...
