### PR TITLE
Expose to API: merge_request.state, merge_request.commits

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -65,7 +65,7 @@ module Gitlab
     end
 
     class MergeRequest < Grape::Entity
-      expose :id, :target_branch, :source_branch, :project_id, :title, :closed, :merged
+      expose :id, :target_branch, :source_branch, :project_id, :title, :closed, :merged, :state
       expose :author, :assignee, using: Entities::UserBasic
     end
 

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -36,6 +36,26 @@ module Gitlab
         present merge_request, with: Entities::MergeRequest
       end
 
+      # Show MR commits
+      #
+      # Parameters:
+      #   id (required)               - The ID or code name of a project
+      #   merge_request_id (required) - The ID of MR
+      #
+      # Example:
+      #   GET /projects/:id/merge_request/:merge_request_id/commits
+      #
+      get ":id/merge_request/:merge_request_id/commits" do
+        merge_request = user_project.merge_requests.find(params[:merge_request_id])
+
+        authorize! :read_merge_request, merge_request
+        authorize! :download_code, user_project
+
+        commits = merge_request.unmerged_commits
+        present CommitDecorator.decorate(commits), with: Entities::RepoCommit
+
+      end
+
       # Create MR
       #
       # Parameters:


### PR DESCRIPTION
This exposes merge requests commits and state to the API, so that the merge-request tool [Pulley-GitLab](https://github.com/doublerebel/pulley-gitlab) can be used to make pretty merge commits.  Here is [an example of a commit made with Pulley](https://github.com/jeresig/pulley/commit/bd3dc6f848dc6b23ceb8dacfc9293ee445511c1f).

I have modified John Resig's [original Pulley for Github](https://github.com/jeresig/pulley) to make it compatible with these GitLab API changes.  I have published [Pulley-GitLab to npm](https://npmjs.org/package/pulley-gitlab), so feel free to try it out.

One of the features of **Pulley/Pulley-Gitlab** is supporting other Issue Trackers, [a feature I desire and use](https://github.com/gitlabhq/gitlabhq/issues/97#issuecomment-9185334).  Here is my working **pulley-gitlab.json** as example:

```
{
    "interactive": false,
    "remote": "gitlab",
    "server": "http://gitlab.myhost.com",
    "repos": {
        "repo_name": "http://redmine.myhost.com/redmine/doublerebel/issues/"
    }
}
```

Note that unlike **Pulley**, **Pulley-GitLab** looks for its config file in the current project directory, rather in the node_modules install directory.

GitLab has been very helpful for my work, so I hope this helps others.  I'm much more experienced with JS than Ruby, perhaps it would be best for someone more familiar with the project to write the appropriate tests for these minor changes.

Thanks!

**Charles**
