### PR TITLE
Update app/views/projects/_new_form.html.haml

### DIFF
--- a/app/views/projects/_new_form.html.haml
+++ b/app/views/projects/_new_form.html.haml
@@ -16,7 +16,7 @@
       = f.label :path do
         Git Clone
       .input
-        .input-prepend
+        .input-prepend.input-append
           %span.add-on= Gitlab.config.ssh_path
           = f.text_field :path, placeholder: "example_project", disabled: !@project.new_record?
           %span.add-on= ".git"


### PR DESCRIPTION
"Git clone" input field was with prepended "git@localhost:" and appended ".git" blocks
and with .input-prepend class but without input-append class. Adding .input-append class 
makes input field without right border radius.
