### PR TITLE
fix dark code preview background when displaying long lines

### DIFF
--- a/app/assets/stylesheets/highlight/dark.scss
+++ b/app/assets/stylesheets/highlight/dark.scss
@@ -2,6 +2,7 @@
   pre {
     background-color: #333;
     color: #eee;
+    float: left;
   }
 
   .hll { display: block; background-color: darken($hover, 65%) }


### PR DESCRIPTION
If you are using the dark code preview
And a file has a long line
And you scroll to the right
The following display-error occurs:

Tested in Firefox, Chrome.
Internet Explorer 8-10 ( :) )
IE9 no background before/after.
Opera had no issue before and after the change.

**before**

Snippets:
![Snippet error](https://dl.dropbox.com/s/vdigr5nkt6mgchy/Bildschirmfoto%20vom%202012-12-07%2013%3A05%3A00.png)

File Source
![File Source error](https://dl.dropbox.com/s/416hljbvd9yupuz/Bildschirmfoto%20vom%202012-12-07%2012%3A28%3A58.png)

**after**

Snippets:
![Snippet error](https://dl.dropbox.com/s/0bmmgojwibzqf5y/Bildschirmfoto%20vom%202012-12-07%2013%3A12%3A47.png)
