### PR TITLE
fix notify_team on wall

### DIFF
--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -21,7 +21,7 @@ class NoteObserver < ActiveRecord::Observer
   # Notifies the whole team except the author of note
   def notify_team(note)
     # Note: wall posts are not "attached" to anything, so fall back to "Wall"
-    noteable_type = note.noteable_type || "Wall"
+    noteable_type = note.noteable_type.presence || "Wall"
     notify_method = "note_#{noteable_type.underscore}_email".to_sym
 
     if Notify.respond_to? notify_method


### PR DESCRIPTION
see #2212

if a comment on the wall was posted, inside _notify_team_ the var **noteable_type** was empty,
so the var **notify_method** was = **note__email** and no email was sent.

with this fix **noteable_type** will be "Wall" if _note.noteable_type_ is empty or nil
