### PR TITLE
add username to team_member page

### DIFF
--- a/app/views/team_members/show.html.haml
+++ b/app/views/team_members/show.html.haml
@@ -8,8 +8,7 @@
     = image_tag gravatar_icon(user.email, 60), class: "borders"
   %h3
     = user.name
-    %small
-      = user.email
+    %small (@#{user.username})
 
   %hr
   .back_link


### PR DESCRIPTION
Since #2208, user are referenced with User#username in GFM. User#username is not displayed in the the app so I added it to team_member page. 
