### PR TITLE
fix post_receive hook and workers

### DIFF
--- a/app/workers/post_receive.rb
+++ b/app/workers/post_receive.rb
@@ -2,9 +2,6 @@ class PostReceive
   @queue = :post_receive
 
   def self.perform(repo_path, oldrev, newrev, ref, identifier)
-    repo_path = repo_path.gsub(Gitlab.config.git_base_path, "")
-    repo_path = repo_path.gsub(/.git$/, "")
-
     project = Project.find_with_namespace(repo_path)
     return false if project.nil?
 

--- a/lib/hooks/post-receive
+++ b/lib/hooks/post-receive
@@ -6,6 +6,5 @@
 while read oldrev newrev ref
 do
   # For every branch or tag that was pushed, create a Resque job in redis.
-  repo_path=`pwd`
-  env -i redis-cli rpush "resque:gitlab:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$repo_path\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
+  env -i redis-cli rpush "resque:gitlab:queue:post_receive" "{\"class\":\"PostReceive\",\"args\":[\"$GL_REPO\",\"$oldrev\",\"$newrev\",\"$ref\",\"$GL_USER\"]}" > /dev/null 2>&1
 done

--- a/spec/workers/post_receive_spec.rb
+++ b/spec/workers/post_receive_spec.rb
@@ -14,27 +14,32 @@ describe PostReceive do
     let(:key_id) { key.identifier }
 
     it "fetches the correct project" do
-      Project.should_receive(:find_by_path).with(project.path).and_return(project)
-      PostReceive.perform(project.path, 'sha-old', 'sha-new', 'refs/heads/master', key_id)
+      Project.should_receive(:find_with_namespace).with(project.to_param).and_return(project)
+
+      PostReceive.perform(project.to_param, 'sha-old', 'sha-new', 'refs/heads/master', key_id)
+    end
+
+    it "does trigger hooks" do
+      Project.any_instance.should_receive(:trigger_post_receive)
+
+      PostReceive.perform(project.to_param, 'sha-old', 'sha-new', 'refs/heads/master', key_id)
     end
 
     it "does not run if the author is not in the project" do
       Key.stub(find_by_identifier: nil)
 
-      project.should_not_receive(:observe_push)
-      project.should_not_receive(:execute_hooks)
+      Project.any_instance.should_not_receive(:trigger_post_receive)
 
-      PostReceive.perform(project.path, 'sha-old', 'sha-new', 'refs/heads/master', key_id).should be_false
+      PostReceive.perform(project.to_param, 'sha-old', 'sha-new', 'refs/heads/master', key_id).should be_false
     end
 
     it "asks the project to trigger all hooks" do
-      Project.stub(find_by_path: project)
-      project.should_receive(:execute_hooks)
-      project.should_receive(:execute_services)
-      project.should_receive(:update_merge_requests)
-      project.should_receive(:observe_push)
+      Project.any_instance.should_receive(:observe_push)
+      Project.any_instance.should_receive(:update_merge_requests)
+      Project.any_instance.should_receive(:execute_hooks)
+      Project.any_instance.should_receive(:execute_services)
 
-      PostReceive.perform(project.path, 'sha-old', 'sha-new', 'refs/heads/master', key_id)
+      PostReceive.perform(project.to_param, 'sha-old', 'sha-new', 'refs/heads/master', key_id)
     end
   end
 end


### PR DESCRIPTION
Current master (80e984ee5e6d29431a4a87ed26105fb0e8987ffb) spec is failing when PostReceive worker fail at filtering 'git base path'. 

This fixes it by using $GL_REPO (= `namespace/repo`) instead of the full repo path.
This removes the need to filter the git base path and final `.git`.
