### PR TITLE
Fixed Postgresql Notes search issue (integer vs string) v2.

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -19,6 +19,7 @@
 class Issue < ActiveRecord::Base
   include IssueCommonality
   include Votes
+  include Noteable
 
   attr_accessible :title, :assignee_id, :closed, :position, :description,
                   :milestone_id, :label_list, :author_id_of_changes

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -15,6 +15,7 @@
 
 class Snippet < ActiveRecord::Base
   include Linguist::BlobHelper
+  include Noteable
 
   attr_accessible :title, :content, :file_name, :expires_at
 

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -13,6 +13,8 @@
 #
 
 class Wiki < ActiveRecord::Base
+  include Noteable
+
   attr_accessible :title, :content, :slug
 
   belongs_to :project

--- a/app/roles/noteable.rb
+++ b/app/roles/noteable.rb
@@ -1,0 +1,13 @@
+# Contains search method as workaround for Postgresql
+# Override accessor for "has_many :notes"
+# Workaround for PostgreSQL: using integer ids on (text column) noteable_id in WHERE clause produces error
+# see https://github.com/gitlabhq/gitlabhq/issues/1957
+module Noteable
+  extend ActiveSupport::Concern
+
+  included do
+    def notes
+      Note.where(noteable_id: id.to_s, noteable_type: self.class.name)
+    end
+  end
+end


### PR DESCRIPTION
I created **app/roles/noteable.rb** where I implemented necessary changes. This file is included in **app/model/issue.rb**, **app/model/snippet.rb**, **app/model/wiki.rb**, and in **app/model/merge_request.rb** where I also changed _mr_and_commit_notes_. I hope everything is Ok now.

Improved #2234
Fixes #1957
