### PR TITLE
Add a warning to the task.

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -1,3 +1,10 @@
+# This is not a full backup solution!
+# Restoring files from this backup might not yield a working app.
+# Consider backing up:
+#  - repositories by copying the contents of git/repositories directory
+#  - attachments
+#  - gitlab user ssh key
+
 require 'active_record/fixtures'
 
 namespace :gitlab do


### PR DESCRIPTION
There are couple of problems with the current backup.rake task.
- Backing up of the repositories doesn't take all files from the repository. If you try to restore repositories from the backup couple of files will be missing which will prevent a user from using the repository. For example, gl-conf is not backed up and after the project is restored from backup and git push attempted error

```
split conf set, gl-conf not present for REPO
```

will halt the attempted push. One solution is to backup the whole git/repositories directory by copying the whole directory.
- Attachments are not backed up. If there is a discussion in an issue that contains comments with attached files, after restore those attachments would be lost. This is a problem because it can harm the workflow established in the issue.
- Gitlab user ssh key is not backed up. After the backup is restored everyone who pushed to the repository would get a warning/failure about the host key change that would prevent them from pushing. Even though this problem is solved by removing the host from known_hosts on clients machine it can still be a problem in larger organizations.

These are the problems that I've encountered while restoring the backup. 
I wanted to expand the task to resolve the problems described( https://github.com/dosire/gitlabhq/compare/master...backup_keys_and_uploads ) however, more problems kept showing up so I've decided against it for now.
I do feel that a disclaimer of some sort needs to be added to the task. Something that would warn users that this rake task is not a complete backup solution and that they need to consider backing up other files as well.
