### PR TITLE
fix gfm autocomplete for usernames

### DIFF
--- a/app/assets/javascripts/gfm_auto_complete.js.coffee
+++ b/app/assets/javascripts/gfm_auto_complete.js.coffee
@@ -1,52 +1,58 @@
 # Creates the variables for setting up GFM auto-completion
 
 window.GitLab ?= {}
-GitLab.GfmAutoComplete ?= {}
-
-# Emoji
-data      = []
-template  = "<li data-value='${insert}'>${name} <img alt='${name}' height='20' src='${image}' width='20' /></li>"
-GitLab.GfmAutoComplete.Emoji = {data, template}
-
-# Team Members
-data      = []
-url     = '';
-params  = {private_token: '', page: 1}
-GitLab.GfmAutoComplete.Members = {data, url, params}
-
-# Add GFM auto-completion to all input fields, that accept GFM input.
-GitLab.GfmAutoComplete.setup = ->
-  input = $('.js-gfm-input')
-
+GitLab.GfmAutoComplete =
   # Emoji
-  input.atWho ':',
-    data: GitLab.GfmAutoComplete.Emoji.data,
-    tpl: GitLab.GfmAutoComplete.Emoji.template
+  Emoji:
+    data: []
+    template: '<li data-value="${insert}">${name} <img alt="${name}" height="20" src="${image}" width="20" /></li>'
 
   # Team Members
-  input.atWho '@', (query, callback) ->
-    (getMoreMembers = ->
-      $.getJSON(GitLab.GfmAutoComplete.Members.url, GitLab.GfmAutoComplete.Members.params)
-        .success (members) ->
-          # pick the data we need
-          newMembersData = $.map(members, (m) -> m.name )
+  Members:
+    data: []
+    url: ''
+    params:
+      private_token: ''
+      page: 1
+    template: '<li data-value="${username}">${username} <small>${name}</small></li>'
 
-          # add the new page of data to the rest
-          $.merge(GitLab.GfmAutoComplete.Members.data, newMembersData)
+  # Add GFM auto-completion to all input fields, that accept GFM input.
+  setup: ->
+    input = $('.js-gfm-input')
 
-          # show the pop-up with a copy of the current data
-          callback(GitLab.GfmAutoComplete.Members.data[..])
+    # Emoji
+    input.atWho ':',
+      data: @Emoji.data
+      tpl: @Emoji.template
 
-          # are we past the last page?
-          if newMembersData.length is 0
-            # set static data and stop callbacks
-            input.atWho '@',
-              data: GitLab.GfmAutoComplete.Members.data
-              callback: null
-          else
-            # get next page
-            getMoreMembers()
+    # Team Members
+    input.atWho '@',
+      tpl: @Members.template
+      callback: (query, callback) =>
+        (getMoreMembers = =>
+          $.getJSON(@Members.url, @Members.params).done (members) =>
+            # pick the data we need
+            newMembersData = $.map(members, (m) ->
+              username: m.username
+              name: m.name
+            )
 
-      # so the next request gets the next page
-      GitLab.GfmAutoComplete.Members.params.page += 1
-    ).call()
+            # add the new page of data to the rest
+            $.merge(@Members.data, newMembersData)
+
+            # show the pop-up with a copy of the current data
+            callback(@Members.data[..])
+
+            # are we past the last page?
+            if newMembersData.length is 0
+              # set static data and stop callbacks
+              input.atWho '@',
+                data: @Members.data
+                callback: null
+            else
+              # get next page
+              getMoreMembers()
+
+          # so the next callback requests the next page
+          @Members.params.page += 1
+        ).call()

--- a/doc/api/issues.md
+++ b/doc/api/issues.md
@@ -18,6 +18,7 @@ GET /issues
     "assignee": null,
     "author": {
       "id": 1,
+      "username": "john_smith",
       "email": "john@example.com",
       "name": "John Smith",
       "blocked": false,
@@ -46,6 +47,7 @@ GET /issues
     },
     "assignee": {
       "id": 2,
+      "username": "jack_smith",
       "email": "jack@example.com",
       "name": "Jack Smith",
       "blocked": false,
@@ -53,6 +55,7 @@ GET /issues
     },
     "author": {
       "id": 1,
+      "username": "john_smith",
       "email": "john@example.com",
       "name": "John Smith",
       "blocked": false,
@@ -110,6 +113,7 @@ Parameters:
   },
   "assignee": {
     "id": 2,
+    "username": "jack_smith",
     "email": "jack@example.com",
     "name": "Jack Smith",
     "blocked": false,
@@ -117,6 +121,7 @@ Parameters:
   },
   "author": {
     "id": 1,
+    "username": "john_smith",
     "email": "john@example.com",
     "name": "John Smith",
     "blocked": false,

--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -22,6 +22,7 @@ Parameters:
         "merged":false,
         "author":{
             "id":1,
+            "username": "admin",
             "email":"admin@local.host",
             "name":"Administrator",
             "blocked":false,
@@ -29,6 +30,7 @@ Parameters:
         },
         "assignee":{
             "id":1,
+            "username": "admin",
             "email":"admin@local.host",
             "name":"Administrator",
             "blocked":false,
@@ -62,6 +64,7 @@ Parameters:
     "merged":false,
     "author":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -69,6 +72,7 @@ Parameters:
     },
     "assignee":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -105,6 +109,7 @@ Parameters:
     "merged":false,
     "author":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -112,6 +117,7 @@ Parameters:
     },
     "assignee":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -150,6 +156,7 @@ Parameters:
     "merged":false,
     "author":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -157,6 +164,7 @@ Parameters:
     },
     "assignee":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,
@@ -184,6 +192,7 @@ Will return created note with status `201 Created` on success, or `404 Not found
 {
     "author":{
         "id":1,
+        "username": "admin",
         "email":"admin@local.host",
         "name":"Administrator",
         "blocked":false,

--- a/doc/api/notes.md
+++ b/doc/api/notes.md
@@ -15,6 +15,7 @@ GET /projects/:id/notes
     "body": "The solution is rather tricky",
     "author": {
       "id": 1,
+      "username": "john_smith",
       "email": "john@example.com",
       "name": "John Smith",
       "blocked": false,

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -17,6 +17,7 @@ GET /projects
     "default_branch": "master",
     "owner": {
       "id": 1,
+      "username": "john_smith",
       "email": "john@example.com",
       "name": "John Smith",
       "blocked": false,
@@ -38,6 +39,7 @@ GET /projects
     "default_branch": "api",
     "owner": {
       "id": 1,
+      "username": "john_smith",
       "email": "john@example.com",
       "name": "John Smith",
       "blocked": false,
@@ -75,6 +77,7 @@ Parameters:
   "default_branch": "api",
   "owner": {
     "id": 1,
+    "username": "john_smith",
     "email": "john@example.com",
     "name": "John Smith",
     "blocked": false,
@@ -141,6 +144,7 @@ Parameters:
 {
 
   "id": 1,
+  "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
   "blocked": false,

--- a/doc/api/session.md
+++ b/doc/api/session.md
@@ -13,6 +13,7 @@ Parameters:
 ```json
 {
   "id": 1,
+  "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
   "private_token": "dd34asd13as",

--- a/doc/api/snippets.md
+++ b/doc/api/snippets.md
@@ -30,6 +30,7 @@ Parameters:
   "file_name": "add.rb",
   "author": {
     "id": 1,
+    "username": "john_smith",
     "email": "john@example.com",
     "name": "John Smith",
     "blocked": false,

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -10,6 +10,7 @@ GET /users
 [
   {
     "id": 1,
+    "username": "john_smith",
     "email": "john@example.com",
     "name": "John Smith",
     "blocked": false,
@@ -23,6 +24,7 @@ GET /users
   },
   {
     "id": 2,
+    "username": "jack_smith",
     "email": "jack@example.com",
     "name": "Jack Smith",
     "blocked": false,
@@ -52,6 +54,7 @@ Parameters:
 ```json
 {
   "id": 1,
+  "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
   "blocked": false,
@@ -75,6 +78,7 @@ POST /users
 Parameters:
 + `email` (required)                  - Email
 + `password` (required)               - Password
++ `username` (required)               - Username
 + `name` (required)                   - Name
 + `skype`                             - Skype ID
 + `linkedin`                          - Linkedin
@@ -95,6 +99,7 @@ GET /user
 ```json
 {
   "id": 1,
+  "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
   "blocked": false,

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -1,12 +1,12 @@
 module Gitlab
   module Entities
     class User < Grape::Entity
-      expose :id, :email, :name, :bio, :skype, :linkedin, :twitter,
+      expose :id, :username, :email, :name, :bio, :skype, :linkedin, :twitter,
              :dark_scheme, :theme_id, :blocked, :created_at
     end
 
     class UserBasic < Grape::Entity
-      expose :id, :email, :name, :blocked, :created_at
+      expose :id, :username, :email, :name, :blocked, :created_at
     end
 
     class UserLogin < UserBasic


### PR DESCRIPTION
Since #2208 autocompletion for links to users in GFM is broken.

This fix replaces name by username for completion (name still displayed)

exemple:
![gfm_autocomplete.png](https://f.cloud.github.com/assets/1096799/3598/33a7b012-42d7-11e2-95ef-d5bfcc96e39d.png)
