### PR TITLE
fix one of the possible causes of build failures

### DIFF
--- a/features/steps/group/group.rb
+++ b/features/steps/group/group.rb
@@ -28,7 +28,7 @@ class Groups < Spinach::FeatureSteps
 
   Then 'I should see merge requests from this group assigned to me' do
     assigned_to_me(:merge_requests).each do |issue|
-      page.should have_content issue.title
+      page.should have_content issue.title[0..80]
     end
   end
 


### PR DESCRIPTION
- _merge_request partial truncates the title of the merge request to 80 char ('first 80 char' + '...')
- `page should_have mr.title` searches the page against the full title

Sometimes, merge request is generated with a title with more than 80 char and spec fail because it can't find the trucated title as it searches the untrucated title. 

See [origial travis failure](https://travis-ci.org/gitlabhq/gitlabhq/builds/3593153).
