### PR TITLE
Minor: Change html input type to "email" on sign-in view

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
 - else
   = form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f|
     = image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo"
-    = f.text_field :email, :class => "text top", :placeholder => "Email"
+    = f.email_field :email, :class => "text top", :placeholder => "Email"
     = f.password_field :password, :class => "text bottom", :placeholder => "Password"
     - if devise_mapping.rememberable?
       .clearfix.inputs-list

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
 - else
   = form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f|
     = image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo"
-    = f.email_field :email, :class => "text top", :placeholder => "Email"
+    = f.email_field :email, :class => "text top", :placeholder => "Email", :autofocus => "autofocus"
     = f.password_field :password, :class => "text bottom", :placeholder => "Password"
     - if devise_mapping.rememberable?
       .clearfix.inputs-list


### PR DESCRIPTION
As long as the username is the user's email address it makes sense to use input="email" helper for the email field. This allows HTML5 capable (mobile) devices to bring up an email input keyboard instead of the default one.
