### PR TITLE
Validates presence of User#name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,7 @@ class User < ActiveRecord::Base
   has_many :assigned_issues, class_name: "Issue", foreign_key: :assignee_id, dependent: :destroy
   has_many :assigned_merge_requests, class_name: "MergeRequest", foreign_key: :assignee_id, dependent: :destroy
 
+  validates :name, presence: true
   validates :bio, length: { within: 0..255 }
   validates :extern_uid, allow_blank: true, uniqueness: {scope: :provider}
   validates :projects_limit, presence: true, numericality: {greater_than_or_equal_to: 0}

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -75,7 +75,7 @@ POST /users
 Parameters:
 + `email` (required)                  - Email
 + `password` (required)               - Password
-+ `name`                              - Name
++ `name` (required)                   - Name
 + `skype`                             - Skype ID
 + `linkedin`                          - Linkedin
 + `twitter`                           - Twitter account

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -101,8 +101,6 @@ module Gitlab
         key = current_user.keys.find params[:id]
         key.delete
       end
-
-
     end
   end
 end


### PR DESCRIPTION
The 2 reasons are :
- creation of user fail if name is empty : in after_save, it tries to create a
  namespace with namespace.name = user.name and namespece validates presence
  Namespace#name
- in the web app links to team members are broken with empty User#name because
  they are of the form <a href'...'> user.name </a>
