### PR TITLE
Use Ruby 1.8 syntax for the Gemfile, and add a required Ruby version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "http://rubygems.org"
 
+ruby "1.9.3"
+
 def darwin_only(require_as)
   RUBY_PLATFORM.include?('darwin') && require_as
 end
@@ -11,8 +13,8 @@ end
 gem "rails", "3.2.9"
 
 # Supported DBs
-gem "mysql2", group: :mysql
-gem "pg", group: :postgres
+gem "mysql2", :group => :mysql
+gem "pg", :group => :postgres
 
 # Auth
 gem "devise", "~> 2.1.0"
@@ -22,20 +24,20 @@ gem 'omniauth-twitter'
 gem 'omniauth-github'
 
 # GITLAB patched libs
-gem "grit",          git: "https://github.com/gitlabhq/grit.git",           ref: '7f35cb98ff17d534a07e3ce6ec3d580f67402837'
-gem "omniauth-ldap", git: "https://github.com/gitlabhq/omniauth-ldap.git",  ref: 'f038dd852d7bd473a557e385d5d7c2fd5dc1dc2e'
-gem 'yaml_db',       git: "https://github.com/gitlabhq/yaml_db.git",        ref: '98e9a5dca43e3fedd3268c76a73af40d1bdf1dfd'
-gem 'grack',         git: "https://github.com/gitlabhq/grack.git",          ref: 'ba46f3b0845c6a09d488ae6abdce6ede37e227e8'
-gem 'grit_ext',      git: "https://github.com/gitlabhq/grit_ext.git",       ref: '8e6afc2da821354774aa4d1ee8a1aa2082f84a3e'
+gem "grit",          :git => "https://github.com/gitlabhq/grit.git",           :ref => '7f35cb98ff17d534a07e3ce6ec3d580f67402837'
+gem "omniauth-ldap", :git => "https://github.com/gitlabhq/omniauth-ldap.git",  :ref => 'f038dd852d7bd473a557e385d5d7c2fd5dc1dc2e'
+gem 'yaml_db',       :git => "https://github.com/gitlabhq/yaml_db.git",        :ref => '98e9a5dca43e3fedd3268c76a73af40d1bdf1dfd'
+gem 'grack',         :git => "https://github.com/gitlabhq/grack.git",          :ref => 'ba46f3b0845c6a09d488ae6abdce6ede37e227e8'
+gem 'grit_ext',      :git => "https://github.com/gitlabhq/grit_ext.git",       :ref => '8e6afc2da821354774aa4d1ee8a1aa2082f84a3e'
 
 # Gitolite client (for work with gitolite-admin repo)
 gem "gitolite", '1.1.0'
 
 # Syntax highlighter
-gem "pygments.rb",  git: "https://github.com/gitlabhq/pygments.rb.git", branch: "master"
+gem "pygments.rb",  :git => "https://github.com/gitlabhq/pygments.rb.git", :branch => "master"
 
 # Language detection
-gem "github-linguist", "~> 2.3.4" , require: "linguist"
+gem "github-linguist", "~> 2.3.4" , :require => "linguist"
 
 # API
 gem "grape", "~> 0.2.1"
@@ -64,7 +66,7 @@ gem "seed-fu"
 
 # Markdown to HTML
 gem "redcarpet",     "~> 2.2.2"
-gem "github-markup", "~> 0.7.4", require: 'github/markup'
+gem "github-markup", "~> 0.7.4", :require => 'github/markup'
 
 # Servers
 gem "thin", '~> 1.5.0'
@@ -107,11 +109,11 @@ group :assets do
   gem "raphael-rails",    "1.5.2"
   gem 'bootstrap-sass',   "2.2.1.1"
   gem "font-awesome-sass-rails", "~> 2.0.0"
-  gem "gemoji", "~> 1.2.1", require: 'emoji/railtie'
+  gem "gemoji", "~> 1.2.1", :require => 'emoji/railtie'
 end
 
 group :development do
-  gem "annotate", git: "https://github.com/ctran/annotate_models.git"
+  gem "annotate", :git => "https://github.com/ctran/annotate_models.git"
   gem "letter_opener"
   gem 'quiet_assets', '~> 1.0.1'
   gem 'rack-mini-profiler'
@@ -133,16 +135,16 @@ group :development, :test do
   gem 'guard-spinach'
 
   # Notification
-  gem 'rb-fsevent', require: darwin_only('rb-fsevent')
-  gem 'growl',      require: darwin_only('growl')
-  gem 'rb-inotify', require: linux_only('rb-inotify')
+  gem 'rb-fsevent', :require => darwin_only('rb-fsevent')
+  gem 'growl',      :require => darwin_only('growl')
+  gem 'rb-inotify', :require => linux_only('rb-inotify')
 
   # PhantomJS driver for Capybara
-  gem 'poltergeist', git: 'https://github.com/jonleighton/poltergeist.git', ref: '5c2e092001074a8cf09f332d3714e9ba150bc8ca'
+  gem 'poltergeist', :git => 'https://github.com/jonleighton/poltergeist.git', :ref => '5c2e092001074a8cf09f332d3714e9ba150bc8ca'
 end
 
 group :test do
-  gem "simplecov", require: false
+  gem "simplecov", :require => false
   gem "shoulda-matchers", "1.3.0"
   gem 'email_spec'
   gem 'resque_spec'


### PR DESCRIPTION
This will make it easier for people to understand when they have a ruby version problem while trying to run bundle install.

If you run bundle install with ruby 1.8, you get this confusing error:

``` shell
12:46 ~/git/gitlabhq (master)$ bundle install
Gemfile syntax error:
/Users/aaronstone/git/gitlabhq/Gemfile:14: syntax error, unexpected ':', expecting $end
gem "mysql2", group: :mysql
                    ^
```

After this PR, you will get a very readable error message:

``` shell
12:48 ~/git/gitlabhq (master)$ bundle install
Your Ruby version is 1.8.7, but your Gemfile specified 1.9.3
```
