### PR TITLE
Removed delete section in issues API documentation

### DIFF
--- a/doc/api/issues.md
+++ b/doc/api/issues.md
@@ -168,17 +168,3 @@ Parameters:
 
 Will return updated issue with status `200 OK` on success, or `404 Not found` on fail.
 
-## Delete issue
-
-Delete existing project issue.
-
-```
-DELETE /projects/:id/issues/:issue_id
-```
-
-Parameters:
-
-+ `id` (required) - The ID or code name of a project
-+ `issue_id` (required) - The ID of a project's issue
-
-Status code `200` will be returned on success.


### PR DESCRIPTION
I removed the delete section from the issues API documentation since this method is not allowed, I think it was deprecated, see [lib/api/issues.rb](https://github.com/gitlabhq/gitlabhq/blob/master/lib/api/issues.rb#L88).

Would you prefer to keep the section but to say that this feature has been deprecated and is not available anymore?

Regards,
Matt
