### PR TITLE
Added ability to reference any issue in markdown

### DIFF
--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -152,8 +152,8 @@ module Gitlab
     end
 
     def reference_issue(identifier)
-      if issue = @project.issues.where(id: identifier).first
-        link_to("##{identifier}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}"))
+      if issue = Issue.where(id: identifier).first
+        link_to("##{identifier}", project_issue_path(issue.project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}"))
       end
     end
 


### PR DESCRIPTION
We have a couple related projects and it would be nice to have ability to reference any issue in commit (not just from current project)
