### PR TITLE
Split CSS files

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,9 +2,7 @@
  * This is a manifest file that'll automatically include all the stylesheets available in this directory
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
- *= require jquery.ui.gitlab
- *= require jquery.atwho
- *= require chosen
- *= require_self
+ *= require vendor
  *= require main
+ *= require_self
 */

--- a/app/assets/stylesheets/vendor.css
+++ b/app/assets/stylesheets/vendor.css
@@ -1,0 +1,5 @@
+/*
+ *= require jquery.ui.gitlab
+ *= require jquery.atwho
+ *= require chosen
+ */

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -4,7 +4,10 @@
     GitLab
     = " > #{title}" if defined?(title)
   = favicon_link_tag 'favicon.ico'
-  = stylesheet_link_tag    "application"
+  = stylesheet_link_tag "application"
+  /[if lte IE 9]
+    -# will only be recognized by IE<=9
+    = stylesheet_link_tag  "vendor", "main"
   = javascript_include_tag "application"
   -# Atom feed
   - if controller_name == 'projects' && action_name == 'index'


### PR DESCRIPTION
This is an **ugly** hack trying to split the CSS files to stay [below 4096 selectors per file](http://stackoverflow.com/questions/9906794/internet-explorers-css-rules-limits) necessary for IE. This is only meant as a _temporary solution_.

The problem:
- Bootstrap is **big**
- We override quite some stuff of it
- We use `@extend` for importing style rules
- Our styles are really sensitive to order

Bootstrap + our overrides are 3400+ selectors!!!

I have tried splitting the one big CSS file into several smaller ones:
- `vendor.css` includes all CSS from `vendor/assets` (luckily they have no dependencies) **296 selectors**
- `highlight.scss` contains the Pygments highlight styles (depends only on color variables) **246 selectors**
- `gitlab_bootstrap.scss` contains the pulled together Bootstrap styles + our overrides (ugly, big and brittle) **3438 selectors**
- `sections.scss` contains all section styles **without** `@extends` **223 selectors**
- `sections_extended.scss` contains all section styles **with** `@extends` (this means `gitlab_bootstrap.scss` needs to be included here) :/ **4050 selectors**
- `main.scss` conains the rest (headers, themes, common definitions) (also depends on `gitlab_bootstrap.scss`) **3841 selectors**
- `application.css` aggregates all of them (includes Bootstrap twice :shit: ) **8657 selectors**

Selectors counted with [this](http://snippet.bevey.com/css/selectorCount.php).

What we get:
- Non-IE browsers get served `application.css` as before.
- IE downloads the CSS files separately.

Caveat:
- `gitlab_bootstrap.scss` is included **twice**: in `main.scss` and `sections_extended.scss`
- You **can't** combine all styles depending on `gitlab_bootstrap.scss` into one, because it would be too big again :(

Fixes #1842 
Fixes #2073 
