### PR TITLE
Use discover default branch to fix #2217

### DIFF
--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -13,7 +13,7 @@ module Repository
   end
 
   def commit(commit_id = nil)
-    Commit.find_or_first(repo, commit_id, root_ref)
+    Commit.find_or_first(repo, commit_id, discover_default_branch)
   end
 
   def fresh_commits(n = 10)


### PR DESCRIPTION
As the title says, using `discover_default_branch` to determine the `root_ref`

Fixes #2217
