### PR TITLE
in team views use `try` method to protect nil receiver  Fix issue #2331, 

### DIFF
--- a/app/views/team_members/_team.html.haml
+++ b/app/views/team_members/_team.html.haml
@@ -1,7 +1,7 @@
 - grouper_project_members(@project).each do |access, members|
   %fieldset
     %legend
-      = Project.access_options.key(access).pluralize
+      = Project.access_options.key(access).try(:pluralize)
       %small= members.size
     %ul.unstyled
       - members.each do |up|


### PR DESCRIPTION
protect against nil keys in projects
