### PR TITLE
allow code contributions from reporters

### DIFF
--- a/app/roles/authority.rb
+++ b/app/roles/authority.rb
@@ -24,6 +24,12 @@ module Authority
     keys.map(&:identifier) + deploy_keys.map(&:identifier)
   end
 
+  def repository_contributor_name_keys
+    return users_projects.where("project_access = ?", UsersProject::REPORTER)
+           .collect { |user_project| user_project.user }
+           .collect { |user| [user.username, user.keys.map(&:identifier)] }
+  end
+
   def repository_writers
     keys = Key.joins({user: :users_projects}).
       where("users_projects.project_id = ? AND users_projects.project_access = ?", id, UsersProject::DEVELOPER)

--- a/app/views/help/permissions.html.haml
+++ b/app/views/help/permissions.html.haml
@@ -18,6 +18,7 @@
     %li Leave comments
     %li Write on project wall
     %li Pull project code
+    %li Push code contributions to personal branches
     %li Download project
     %li Create new merge request
     %li Create a code snippets

--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -151,6 +151,12 @@ module Gitlab
         repo.add_permission("-", pr_br.strip + "$ ", name_writers)
       end
 
+      # Add contributor permissions
+      project.repository_contributor_name_keys.each do |username, keys|
+        refex = "%s/.*" % Regexp.escape(username)
+        repo.add_permission("RW+", refex, keys) unless keys.blank?
+      end
+
       # Add read permissions
       repo.add_permission("R", "", name_readers) unless name_readers.blank?
 


### PR DESCRIPTION
This commit allows users with "Reporter" status to upload their own branches to the repository. They are only allowed to push to branches with their username as a prefix.

This goes with issue #2343
