### PR TITLE
Allow the OmniAuth provider args parameter to pass through

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -66,6 +66,8 @@ omniauth:
   # Uncomment the lines and fill in the data of the auth provider you want to use
   # If your favorite auth provider is not listed you can user others:
   # see https://github.com/gitlabhq/gitlabhq/wiki/Using-Custom-Omniauth-Providers
+  # The 'app_id' and 'app_secret' parameters are always passed as the first two
+  # arguments, followed by optional 'args' which can be either a hash or an array.
   providers:
     # - { name: 'google_oauth2', app_id: 'YOUR APP ID',
     #     app_secret: 'YOUR APP SECRET',

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -217,6 +217,15 @@ Devise.setup do |config|
   end
 
   Gitlab.config.omniauth.providers.each do |provider|
-    config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret']
+    case provider['args']
+    when Array
+      # An Array from the configuration will be expanded.
+      config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret'], *provider['args']
+    when Hash
+      # A Hash from the configuration will be passed as is.
+      config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret'], provider['args']
+    else
+      config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret']
+    end
   end
 end


### PR DESCRIPTION
The gitlab.yml.example has said for a long time that you can add an additional 'args' parameter to configure an OmniAuth provider, however this was never passed through to omniauth. The additional parameters are required to correctly configure Google OAuth2 and many other providers.

Configuration example that has been in gitlab.yml.example since the original omniauth PR a64aff2f1c1ddc77b00211489d74fbc23c0c2fa2 and after this PR it will work.

``` yaml
  omniauth:
    ...

    providers:
       - { name: 'google_oauth2', app_id: 'YOUR APP ID',
           app_secret: 'YOUR APP SECRET',
           args: { access_type: 'offline', approval_prompt: '' } }
```
