### PR TITLE
Skipping colors to get more contrast between colors

### DIFF
--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -57,7 +57,9 @@
   
   BranchGraph.prototype.collectColors = function(){
     for (var k = 0; k < this.mspace; k++) {
-      this.colors.push(Raphael.getColor());
+      this.colors.push(Raphael.getColor(.8));
+      // Skipping a few colors in the spectrum to get more contrast between colors
+      Raphael.getColor();Raphael.getColor();
     }
   };
 


### PR DESCRIPTION
More contrast in the graph colors makes the lines more distinguishable.

See screenshot with before and after.

![before-after](https://f.cloud.github.com/assets/351038/29022/94483048-4d1a-11e2-9e47-c8d4a948fb38.jpg)
