### PR TITLE
Changed wording if milestone already expired

### DIFF
--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -29,7 +29,7 @@ class Milestone < ActiveRecord::Base
 
   def expired?
     if due_date
-      due_date < Date.today
+      due_date.past?
     else
       false
     end
@@ -58,7 +58,13 @@ class Milestone < ActiveRecord::Base
   end
 
   def expires_at
-    "expires at #{due_date.stamp("Aug 21, 2011")}" if due_date
+    if due_date
+      if due_date.past?
+        "expired at #{due_date.stamp("Aug 21, 2011")}"
+      else
+        "expires at #{due_date.stamp("Aug 21, 2011")}"  
+      end
+    end  
   end
 
   def can_be_closed?


### PR DESCRIPTION
Changed wording from "expires at" to "expired at" if milestone due date is over.

![Bildschirmfoto 2012-12-23 um 17 23 43](https://f.cloud.github.com/assets/278301/29037/4e6d30fc-4d1d-11e2-8e7f-0c8fe8e0e6a4.png)
![Bildschirmfoto 2012-12-23 um 17 24 07](https://f.cloud.github.com/assets/278301/29038/51802416-4d1d-11e2-88c8-ccdc12085278.png)
