### PR TITLE
gem mysql2 require 'libmysqlclient-dev'

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -246,6 +246,7 @@ Make sure to update username/password in config/database.yml.
     sudo gem install charlock_holmes --version '0.6.9'
 
     # For mysql db
+    apt-get install libmysqlclient-dev
     sudo -u gitlab -H bundle install --deployment --without development test postgres
 
     # Or For postgres db


### PR DESCRIPTION
Mysql2 install failed. On Ubuntu i need to install 'libmysqlclient-dev' before.
