### PR TITLE
Fix replace return with next in rake rask

### DIFF
--- a/lib/tasks/gitlab/enable_automerge.rake
+++ b/lib/tasks/gitlab/enable_automerge.rake
@@ -11,7 +11,7 @@ namespace :gitlab do
     print "Creating satellites for ..."
     unless Project.count > 0
       puts "skipping, because you have no projects".magenta
-      return
+      next
     end
     puts ""
 


### PR DESCRIPTION
block doesn't support return replacing it with next.
