### PR TITLE
Fixed broken link to developer guide, fixes #2380

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ Email
 
 ## Contribute
 
-[Development Tips](https://github.com/gitlabhq/gitlabhq/blob/master/doc/development.md)
+[Developer Guide](https://github.com/gitlabhq/gitlabhq/wiki/Developer-Guide)
 Want to help - send a pull request.
 We'll accept good pull requests.


### PR DESCRIPTION
Updated `README.md` to link to develop guide instead of `DEVELOPMENT.md`
