### PR TITLE
Add alternative merge type and merge notes to merge requests

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -26,6 +26,9 @@ gitlab:
   ## Project settings
   default_projects_limit: 10
 
+  ## Merge request behavior
+  merge_ff_only: false
+
 ## Gravatar
 gravatar:
   enabled: true                 # Use user avatar images from Gravatar.com (default: true)

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -27,6 +27,7 @@ gitlab:
   default_projects_limit: 10
 
   ## Merge request behavior
+  add_merge_notes: false
   merge_ff_only: false
 
 ## Gravatar

--- a/lib/gitlab/satellite/merge_action.rb
+++ b/lib/gitlab/satellite/merge_action.rb
@@ -26,6 +26,13 @@ module Gitlab
       def merge!
         in_locked_and_timed_satellite do |merge_repo|
           if merge_in_satellite!(merge_repo)
+            if Gitlab.config.gitlab.add_merge_notes
+              merge_repo.commits_between("origin/#{merge_request.target_branch}", merge_request.target_branch).each do |c|
+                merge_repo.git.notes({raise: true, timeout: true}, "--ref=merge", "add", "-f", "-m", "Merge-By: #{@user.name} <#{@user.email}>", c)
+              end
+              merge_repo.git.push({raise: true, timeout: true}, :origin, "refs/notes/merge:refs/notes/merge")
+            end
+
             # push merge back to Gitolite
             # will raise CommandFailed when push fails
             merge_repo.git.push({raise: true, timeout: true}, :origin, merge_request.target_branch)

--- a/lib/gitlab/satellite/merge_action.rb
+++ b/lib/gitlab/satellite/merge_action.rb
@@ -61,7 +61,11 @@ module Gitlab
 
         # merge the source branch from Gitolite into the satellite
         # will raise CommandFailed when merge fails
-        repo.git.pull({raise: true, timeout: true, no_ff: true}, :origin, merge_request.source_branch)
+        if Gitlab.config.gitlab.merge_ff_only
+          repo.git.merge({raise: true, timeout: true, ff_only: true}, "origin/#{merge_request.source_branch}")
+        else
+          repo.git.pull({raise: true, timeout: true, no_ff: true}, :origin, merge_request.source_branch)
+        end
       rescue Grit::Git::CommandFailed => ex
         Gitlab::GitLogger.error(ex.message)
         false

--- a/lib/gitlab/satellite/satellite.rb
+++ b/lib/gitlab/satellite/satellite.rb
@@ -92,6 +92,9 @@ module Gitlab
       # Note: this will only update remote branches (i.e. origin/*)
       def update_from_source!
         repo.git.fetch({timeout: true}, :origin)
+       if Gitlab.config.gitlab.add_merge_notes
+         repo.git.fetch({timeout: true, force: true}, :origin, "refs/notes/merge:refs/notes/merge")
+       end
       end
     end
   end


### PR DESCRIPTION
This adds two minor, optional features to merge requests that were necessary for our workflow and might be useful for others.

"merge_ff_only": Instead of the default "pull --no-ff" that creates a merge commit, do "merge --ff-only" on merge requests. This means the resulting history on the destination branch will be linear, and also that non-ff merge requests will be marked as unmergeable until rebased.

"add_merge_notes": With the above strategy we won't get the merge commit indicating who did the merge. Instead, this adds notes to refs/notes/merge to each merged commit with the text "Merge-By: Full Name email@example.com" which can be pulled and examined after the fact.

I'll be keeping this as a local patch either way, so if there's no interest from the community for these features, feel free to close the pull request.
