### PR TITLE
No need to install custom phantomjs for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ env:
   - DB=mysql
 before_install:
   - sudo apt-get install libicu-dev -y
-  - wget -P /tmp http://phantomjs.googlecode.com/files/phantomjs-1.7.0-linux-i686.tar.bz2
-  - tar -xf  /tmp/phantomjs-1.7.0-linux-i686.tar.bz2 -C /tmp/
-  - sudo rm -rf /usr/local/phantomjs
-  - sudo mv /tmp/phantomjs-1.7.0-linux-i686 /usr/local/phantomjs
   - gem install charlock_holmes -v="0.6.9"
 branches:
   only:


### PR DESCRIPTION
Travis uses PhantomJS 1.7.0 for some time now.

Evidence:
https://github.com/travis-ci/travis-cookbooks/blob/master/ci_environment/phantomjs/attributes/default.rb#L1
