### PR TITLE
remove backticks that break Postgres for raw sql in backup create task

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -165,7 +165,7 @@ namespace :gitlab do
           print "#{tbl.yellow} ... "
           count = 1
           File.open(File.join(backup_path_db, tbl + ".yml"), "w+") do |file|
-            ActiveRecord::Base.connection.select_all("SELECT * FROM `#{tbl}`").each do |line|
+            ActiveRecord::Base.connection.select_all("SELECT * FROM #{tbl}").each do |line|
               line.delete_if{|k,v| v.blank?}
               output = {tbl + '_' + count.to_s => line}
               file << output.to_yaml.gsub(/^---\n/,'') + "\n"


### PR DESCRIPTION
I don't think this will break MySQL, but I haven't tested. If it does, then this fix will have to be slightly better. I didn't have any problems running the script after making this change for PSQL.
