### PR TITLE
Add anchor to commit note link for note event.

### DIFF
--- a/app/views/events/event/_note.html.haml
+++ b/app/views/events/event/_note.html.haml
@@ -3,7 +3,7 @@
   %span.event_label commented on #{event.note_target_type}
   - if event.note_target
     - if event.note_commit?
-      = link_to event.note_short_commit_id, project_commit_path(event.project, event.note_commit_id), class: "commit_short_id"
+      = link_to event.note_short_commit_id, project_commit_path(event.project, event.note_commit_id, anchor: "note_#{event.target.id}"), class: "commit_short_id"
     - else
       = link_to [event.project, event.note_target] do
         %strong= truncate event.note_target_id


### PR DESCRIPTION
Added "#note_{note id}" anchor to commit comment link on dashboard.
