### PR TITLE
fix grack accessing files beginning with .git

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Gitlab::Application.routes.draw do
     project_root: Gitlab.config.gitolite.repos_path,
     upload_pack:  Gitlab.config.gitolite.upload_pack,
     receive_pack: Gitlab.config.gitolite.receive_pack
-  }), at: '/', constraints: lambda { |request| /[-\/\w\.-]+\.git/.match(request.path_info) }
+  }), at: '/', constraints: lambda { |request| /[-\/\w\.-]+\.git\//.match(request.path_info) }
 
   #
   # Help


### PR DESCRIPTION
when accessing a file called `.git[something]`  in the file browser (in the root folder or any other folder), grack is invoked.

with this fix grack is only invoked, if the http-git url `http://mydomain.tld/[NAMESPACE]/[REPO].git` is cloned.

Accessing 
`http://mydomain.tld/[NAMESPACE]/[REPO]/tree/master/.gitignore` or `http://mydomain.tld/[NAMESPACE]/[REPO]/tree/master/subfolder/subfolder/.gitkeep` or 
`http://mydomain.tld/[NAMESPACE]/[REPO]/tree/master/subfolder/.gitrules`
is now possible and does not invoke grack anymore.

solves part of #2449
