### PR TITLE
Optimize Projects sidebar performance

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,9 +148,8 @@ module ApplicationHelper
   end
 
   def project_last_activity project
-    activity = project.last_activity
-    if activity && activity.created_at
-      time_ago_in_words(activity.created_at) + " ago"
+    if project.last_activity_date != project.created_at
+      time_ago_in_words(project.last_activity_date) + " ago"
     else
       "Never"
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -38,7 +38,7 @@ class Event < ActiveRecord::Base
   delegate :title, to: :merge_request, prefix: true, allow_nil: true
 
   belongs_to :author, class_name: "User"
-  belongs_to :project
+  belongs_to :project, touch: true
   belongs_to :target, polymorphic: true
 
   # For Hash only

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -230,7 +230,8 @@ class Project < ActiveRecord::Base
   end
 
   def last_activity_date
-    last_event.try(:created_at) || updated_at
+    # touched when any associated event is saved
+    updated_at
   end
 
   def project_id

--- a/db/migrate/20121227190440_touch_projects_last_activity.rb
+++ b/db/migrate/20121227190440_touch_projects_last_activity.rb
@@ -1,0 +1,18 @@
+class TouchProjectsLastActivity < ActiveRecord::Migration
+  def up
+    Project.record_timestamps = false
+
+    Project.find_each do |project|
+      last_event = project.events.order(:created_at).last
+      if last_event and last_event.created_at > project.updated_at
+        project.update_attribute(:updated_at, last_event.created_at)
+      end
+    end
+
+    Project.record_timestamps = true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121219095402) do
+ActiveRecord::Schema.define(:version => 20121227190440) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -30,6 +30,17 @@ describe Event do
     it { should respond_to(:commits) }
   end
 
+  describe "Save" do
+    let(:event) { create(:event) }
+    let(:project) { create(:project) }
+
+    it "should touch associated project" do
+      event.stub(project: project)
+      event.project.should_receive(:touch)
+      event.save!
+    end
+  end
+
   describe "Push event" do
     before do
       project = create(:project)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -163,22 +163,18 @@ describe Project do
 
   describe "last_activity methods" do
     let(:project)    { create(:project) }
-    let(:last_event) { double(created_at: Time.now) }
+    let(:last_event) { create(:event) }
 
     describe "last_activity" do
-      it "should alias last_activity to last_event"do
+      it "should alias last_activity to last_event" do
         project.stub(last_event: last_event)
         project.last_activity.should == last_event
       end
     end
 
-    describe 'last_activity_date' do
-      it 'returns the creation date of the project\'s last event if present' do
-        project.stub(last_event: last_event)
-        project.last_activity_date.should == last_event.created_at
-      end
-
-      it 'returns the project\'s last update date if it has no events' do
+    describe "last_activity_date" do
+      it "should alias last_activity_date to updated_at" do
+        project.stub(updated_at: Time.now)
         project.last_activity_date.should == project.updated_at
       end
     end


### PR DESCRIPTION
Projects on sidebar contains their last activity, i.e. creation date of the last event associated with the project. Performance issue with the current implementation is that it generates extra query for every project in sidebar and every time when user open the Dashboard page. I have about 30 projects in my sidebar so that means 30 hits to database just to get last activity date of projects.

``` sql
SELECT "events".* FROM "events" WHERE "events"."project_id" = 7 AND (author_id IS NOT NULL) ORDER BY events.created_at DESC LIMIT 1
```

This patch eliminates these extra queries entirely and thus significantly reduces load time of sidebar with many projects. Instead of querying for the last event to read its `created_at`, we can just read project’s `updated_at` attribute which is _touched_ (i.e. updated) while any event that belongs to the project is saved (see http://goo.gl/X4mOJ for example).

_Note: I’ve run tests on my machine with MRI 1.9.3-p327 and all passed._
