### PR TITLE
Cache event fragments and hence increase performance

### DIFF
--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -2,14 +2,14 @@
   %div.event-item
     %span.cgray.right
       #{time_ago_in_words(event.created_at)} ago.
+    - cache event do
+      = image_tag gravatar_icon(event.author_email), class: "avatar s24"
 
-    = image_tag gravatar_icon(event.author_email), class: "avatar s24"
-
-    - if event.push?
-      = render "events/event/push", event: event
-      .clearfix
-    - elsif event.note?
-      = render "events/event/note", event: event
-    - else
-      = render "events/event/common", event: event
+      - if event.push?
+        = render "events/event/push", event: event
+        .clearfix
+      - elsif event.note?
+        = render "events/event/note", event: event
+      - else
+        = render "events/event/common", event: event
 


### PR DESCRIPTION
Dashboard page and project’s main pages are very slow due to events. It’s not so expensive to load events itself, but all their associations to generate event view. However, events represents history of project’s activity and thus they’re practically* immutable. So why not cache them? I mean cache fragment of single event under _time ago_ (see `_event.html.haml`).

It’s practically one line change, but **reduce load time** of pages with events **avg. 2 times** (when all events are already cached)!

\* I think that we can consider event itself as immutable, but not some of its associations, e.g. user can change his name or change project’s name. However, these situations are quite rare and it’s not so big deal as events are “history”. Therefore I don’t even care about invalidation of these fragments. If anyone does, we can add some invalidation observers.
