### PR TITLE
'namespace' should be exposed via the API

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -22,6 +22,7 @@ module Gitlab
       expose :owner, using: Entities::UserBasic
       expose :private_flag, as: :private
       expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :created_at
+      expose :namespace
     end
 
     class ProjectMember < UserBasic


### PR DESCRIPTION
Since it's now an integral part of the project name, it should be
visible via the API.
