### PR TITLE
Prevent bots & crawlers from accessing Gitlab

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
 #
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-Agent: *
-# Disallow: /
+# Prevent bots from accessing Gitlab
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
Since Gitlab is intended to be used for private Git hosting, I think it's reasonably right to prevent bots and crawlers to index Gitlab.

What's your point about this?
