### PR TITLE
Fixing request.fullpath URL encoding

### DIFF
--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -108,7 +108,7 @@ module ExtractsPath
       request.format = :atom
     end
 
-    path = request.fullpath.dup
+    path = CGI::unescape(request.fullpath.dup)
 
     @ref, @path = extract_ref(path)
 


### PR DESCRIPTION
Let's assume your path is = "project/tree/master/This%20Is%20valid"
In this case gitlab renders a 404.

To fix this we should decode the path so that it looks like
"project/tree/master/This Is valid"
