### PR TITLE
ldap filters

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -48,6 +48,8 @@ ldap:
   base: '_the_base_where_you_search_for_users'
   port: 636
   uid: 'sAMAccountName'
+  ## or use a filter
+  ## filter: '(&(uid=%{username})(memberOf=cn=gitlab,ou=groups,dc=mydomain))'
   method: 'ssl' # "ssl" or "plain"
   bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
   password: '_the_password_of_the_bind_user'

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -47,9 +47,10 @@ ldap:
   host: '_your_ldap_server'
   base: '_the_base_where_you_search_for_users'
   port: 636
+  # If you are planning on using LDAP filters, comment out "uid" line and 
+  # uncomment "filter"
   uid: 'sAMAccountName'
-  ## or use a filter
-  ## filter: '(&(uid=%{username})(memberOf=cn=gitlab,ou=groups,dc=mydomain))'
+  # filter: '(&(uid=%{username})(memberOf=cn=gitlab,ou=groups,dc=mydomain))'
   method: 'ssl' # "ssl" or "plain"
   bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
   password: '_the_password_of_the_bind_user'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -210,6 +210,7 @@ Devise.setup do |config|
       :host     => Gitlab.config.ldap['host'],
       :base     => Gitlab.config.ldap['base'],
       :uid      => Gitlab.config.ldap['uid'],
+      :filter   => Gitlab.config.ldap['filter'],
       :port     => Gitlab.config.ldap['port'],
       :method   => Gitlab.config.ldap['method'],
       :bind_dn  => Gitlab.config.ldap['bind_dn'],


### PR DESCRIPTION
This pull request will enable filter queries against ldap which is particularly useful when you have a big ldap directory and want to give access only to a subset of your users to your gitlab instance.

This pull request will enable this feature/functionality after this pull (https://github.com/gitlabhq/omniauth-ldap/pull/3) request is merged in.

Details of mentioned pull request:
Please note that this pull request was migrated from omniauth-ldap project pull request 22 which was developed and authored by sdeframond and can be accessed at this link: intridea#22
