### PR TITLE
Adding an option to allow developers to accept merge requests

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
         rules << project_master_rules
 
       elsif team.developers.include?(user)
-        rules << project_dev_rules
+        rules << project_dev_rules(project)
 
       elsif team.reporters.include?(user)
         rules << project_report_rules
@@ -62,10 +62,11 @@ class Ability
       ]
     end
 
-    def project_dev_rules
+    def project_dev_rules(project=nil)
       project_report_rules + [
         :write_wiki,
-        :push_code
+        :push_code,
+        (:accept_mr if project.try(:merge_request_for_developers_enabled?))
       ]
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,8 @@ class Project < ActiveRecord::Base
   class TransferError < StandardError; end
 
   attr_accessible :name, :path, :description, :default_branch, :issues_enabled,
-                  :wall_enabled, :merge_requests_enabled, :wiki_enabled, as: [:default, :admin]
+                  :wall_enabled, :merge_requests_enabled, :merge_request_for_developers_enabled,
+                  :wiki_enabled, as: [:default, :admin]
 
   attr_accessible :namespace_id, :creator_id, as: :admin
 

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -39,6 +39,12 @@
         %span.descr Submit changes to be merged upstream.
 
     .control-group
+      = f.label :merge_request_for_developers_enabled, "Merge Requests for developers", class: 'control-label'
+      .controls
+        = f.check_box :merge_request_for_developers_enabled
+        %span.descr Also developers can close merge request
+
+    .control-group
       = f.label :wall_enabled, "Wall", class: 'control-label'
       .controls
         = f.check_box :wall_enabled

--- a/db/migrate/20130107083056_add_merge_requests_for_developers_enabled_to_projects.rb
+++ b/db/migrate/20130107083056_add_merge_requests_for_developers_enabled_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMergeRequestsForDevelopersEnabledToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :merge_request_for_developers_enabled, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130102143055) do
+ActiveRecord::Schema.define(:version => 20130107083056) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -145,16 +145,17 @@ ActiveRecord::Schema.define(:version => 20130102143055) do
     t.string   "name"
     t.string   "path"
     t.text     "description"
-    t.datetime "created_at",                               :null => false
-    t.datetime "updated_at",                               :null => false
-    t.boolean  "private_flag",           :default => true, :null => false
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
+    t.boolean  "private_flag",                         :default => true,  :null => false
     t.integer  "creator_id"
     t.string   "default_branch"
-    t.boolean  "issues_enabled",         :default => true, :null => false
-    t.boolean  "wall_enabled",           :default => true, :null => false
-    t.boolean  "merge_requests_enabled", :default => true, :null => false
-    t.boolean  "wiki_enabled",           :default => true, :null => false
+    t.boolean  "issues_enabled",                       :default => true,  :null => false
+    t.boolean  "wall_enabled",                         :default => true,  :null => false
+    t.boolean  "merge_requests_enabled",               :default => true,  :null => false
+    t.boolean  "wiki_enabled",                         :default => true,  :null => false
     t.integer  "namespace_id"
+    t.boolean  "merge_request_for_developers_enabled", :default => false, :null => false
   end
 
   add_index "projects", ["creator_id"], :name => "index_projects_on_owner_id"


### PR DESCRIPTION
We like to use merge requests for our code reviews, but not all code reviews are done by masters. This option gives non masters the same flexibility of automatic merging.
