### PR TITLE
rb-inotify gem is also needed for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,4 +164,5 @@ end
 
 group :production do
   gem "gitlab_meta", '4.0'
+  gem 'rb-inotify', require: linux_only('rb-inotify')
 end


### PR DESCRIPTION
Otherwise `bundle exec rake --tasks` fails when configured as `bundle install --without development test --deployment`

This is also proposed as a fix in https://github.com/gitlabhq/gitlabhq/issues/1768
