### PR TITLE
Update info.rake to be able to run successfully on SuSE.

### DIFF
--- a/lib/tasks/gitlab/info.rake
+++ b/lib/tasks/gitlab/info.rake
@@ -12,6 +12,9 @@ namespace :gitlab do
                     debian_version = File.read('/etc/debian_version')
                     "Debian #{debian_version}"
                   end
+      os_name ||= if File.readable?('/etc/SuSE-release')
+                    File.read('/etc/SuSE-release')
+                  end
       os_name.squish!
 
       # check if there is an RVM environment


### PR DESCRIPTION
The rake task gitlab:env:info fails on a SuSE Linux system. 

I updated the task to allow for suse systems to be detected.

The failing line was os_name.squish! on line 18 (with this patch, 15 without), os_name was nil so squish! was failing, thinking it may be better to refactor this a skosh to say:

> os_name = "unknown".red
> os_name ||= run("lsb_release -irs")

To allow for Linux distributions that lack the lsb_release command to work. And then changing the puts line later to:

> puts "System:\t\t#{os_name}

I can submit that as a refactoring separately if desired. But this works as-is. No other changes were made to get things running on SuSE 11. Note I haven't tested what run() outputs when nothing is there yet, just offering it up as an idea.

Output on a SuSE 11 service pack 2 system after the change:

> bundle exec rake gitlab:env:info RAILS_ENV=production --trace
> *\* Invoke gitlab:env:info (first_time)
> *\* Invoke environment (first_time)
> *\* Execute environment
> *\* Execute gitlab:env:info
> 
> System information
> System:       SUSE Linux Enterprise Server 11 (x86_64) VERSION = 11 PATCHLEVEL = 2
> Current User: gitlab
> Using RVM:    no
> Ruby Version: 1.9.3p327
> Gem Version:  1.8.23
> Bundler Version:1.2.3
> Rake Version: 10.0.1
> 
> GitLab information
> Version:  4.0.0
> Revision: c68540e
> Directory:    /infra/app/gitlab/gitlab
> DB Adapter:   postgresql
> URL:      http://hostname
> HTTP Clone URL:   http://hostname/some-project.git
> SSH Clone URL:    git@hostname:some-project.git
> Using LDAP:   no
> Using Omniauth:   no
> 
> Gitolite information
> Version:  v3.04-42-g2d29cf7
> Admin URI:    git@localhost:gitolite-admin
> Admin Key:    gitlab
> Repositories: /infra/app/git/repositories/
> Hooks:        /infra/app/git/.gitolite/hooks/
> Git:      /usr/bin/git
