### PR TITLE
show full commit message on mouse over

### DIFF
--- a/app/views/commits/_commit.html.haml
+++ b/app/views/commits/_commit.html.haml
@@ -6,7 +6,7 @@
     = link_to commit.short_id(8), project_commit_path(@project, commit), class: "commit_short_id"
     = commit.author_link avatar: true, size: 24
     &nbsp;
-    = link_to_gfm truncate(commit.title, length: 50), project_commit_path(@project, commit.id), class: "row_title"
+    = link_to_gfm truncate(commit.title, length: 50), project_commit_path(@project, commit.id), {class: "row_title", title: commit.title}
 
     %span.committed_ago
       = time_ago_in_words(commit.committed_date)


### PR DESCRIPTION
when commit message is more than 50 chars it gets truncated, on mouse over we could show the full commit message.
