### PR TITLE
Fix gitolite installation path in gitlab:env:info (based on b6568db)

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -91,6 +91,7 @@ backup:
 
 ## Gitolite settings
 gitolite:
+  install_path: /home/git/gitolite/src/ # if not defined, defaults to 'repos_path/../gitolite/src/'
   admin_uri: git@localhost:gitolite-admin
   # repos_path must not be a symlink
   repos_path: /home/git/repositories/

--- a/lib/tasks/gitlab/info.rake
+++ b/lib/tasks/gitlab/info.rake
@@ -68,13 +68,18 @@ namespace :gitlab do
 
 
       # check Gitolite version
-      gitolite_version_file = "#{Gitlab.config.gitolite.repos_path}/../gitolite/src/VERSION"
+      gitolite_install_path = "#{Gitlab.config.gitolite.install_path}"
+      if Dir[gitolite_install_path] == [] 
+         gitolite_install_path = "#{Gitlab.config.gitolite.repos_path}/../gitolite/src/"
+      end
+      gitolite_version_file = "#{gitolite_install_path}/VERSION"
       if File.exists?(gitolite_version_file) && File.readable?(gitolite_version_file)
         gitolite_version = File.read(gitolite_version_file)
       end
 
       puts ""
       puts "Gitolite information".yellow
+      puts "Installation:\t#{gitolite_install_path}"
       puts "Version:\t#{gitolite_version || "unknown".red}"
       puts "Admin URI:\t#{Gitlab.config.gitolite.admin_uri}"
       puts "Admin Key:\t#{Gitlab.config.gitolite.admin_key}"


### PR DESCRIPTION
(related to #2480 and #2503)

This tasks presume of a fixed path for gitolite, relative to repos_path.
info.rake uses "#{Gitlab.config.gitolite.repos_path}/../gitolite/src/VERSION"

However, you can install gitolite wherever you want.
Hence this pathc:

M config/gitlab.yml.example:
  Add 'install_path' in 'gitolite' section
M lib/tasks/gitlab/info.rake:
  Uses '"#{Gitlab.config.gitolite.install_path}
