### PR TITLE
Improve usability and quit spamming

### DIFF
--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -6,6 +6,10 @@
     = @issue.created_at.stamp("Aug 21, 2011")
 
   %span.right
+    - if can? current_user, :write_issue, @project
+      = link_to new_project_issue_path(@project, issue: { assignee_id: params[:assignee_id], milestone_id: params[:milestone_id]}), class: "btn grouped" do
+        %i.icon-plus
+        New Issue
     - if can?(current_user, :admin_project, @project) || @issue.author == current_user
       - if @issue.closed
         = link_to 'Reopen', project_issue_path(@project, @issue, issue: {closed: false }, status_only: true), method: :put,  class: "btn grouped reopen_issue"

--- a/app/views/notes/_common_form.html.haml
+++ b/app/views/notes/_common_form.html.haml
@@ -22,12 +22,12 @@
       .span4.notify_opts
         %h6.left Notify via email:
         = label_tag :notify do
-          = check_box_tag :notify, 0, @note.noteable_type != "Commit"
+          = check_box_tag :notify, 1, false
           %span Project team
 
         - if @note.notify_only_author?(current_user)
           = label_tag :notify_author do
-            = check_box_tag :notify_author, 0 , @note.noteable_type == "Commit"
+            = check_box_tag :notify_author, 1 , false
             %span Commit author
       .span5.attachments
         %h6.left Attachment:

--- a/app/views/notes/_common_form.html.haml
+++ b/app/views/notes/_common_form.html.haml
@@ -22,12 +22,12 @@
       .span4.notify_opts
         %h6.left Notify via email:
         = label_tag :notify do
-          = check_box_tag :notify, 1, @note.noteable_type != "Commit"
+          = check_box_tag :notify, 0, @note.noteable_type != "Commit"
           %span Project team
 
         - if @note.notify_only_author?(current_user)
           = label_tag :notify_author do
-            = check_box_tag :notify_author, 1 , @note.noteable_type == "Commit"
+            = check_box_tag :notify_author, 0 , @note.noteable_type == "Commit"
             %span Commit author
       .span5.attachments
         %h6.left Attachment:

--- a/app/views/notes/_per_line_form.html.haml
+++ b/app/views/notes/_per_line_form.html.haml
@@ -23,12 +23,12 @@
                 %h6.left Notify via email:
                 .labels
                   = label_tag :notify do
-                    = check_box_tag :notify, 1, @note.noteable_type != "Commit"
+                    = check_box_tag :notify, 0, @note.noteable_type != "Commit"
                     %span Project team
 
                   - if @note.notify_only_author?(current_user)
                     = label_tag :notify_author do
-                      = check_box_tag :notify_author, 1 , @note.noteable_type == "Commit"
+                      = check_box_tag :notify_author, 0 , @note.noteable_type == "Commit"
                       %span Commit author
 
 :javascript

--- a/app/views/notes/_per_line_form.html.haml
+++ b/app/views/notes/_per_line_form.html.haml
@@ -23,12 +23,12 @@
                 %h6.left Notify via email:
                 .labels
                   = label_tag :notify do
-                    = check_box_tag :notify, 0, @note.noteable_type != "Commit"
+                    = check_box_tag :notify, 1, false
                     %span Project team
 
                   - if @note.notify_only_author?(current_user)
                     = label_tag :notify_author do
-                      = check_box_tag :notify_author, 0 , @note.noteable_type == "Commit"
+                      = check_box_tag :notify_author, 1 , false
                       %span Commit author
 
 :javascript


### PR DESCRIPTION
Please disable the checked box for notice the whole team on any new comment. Most comments are not that important.

Please add an button to open a new issue from within another issue. Speeds up the creation of issues.
