### PR TITLE
gitignore updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ config/gitlab.yml
 config/database.yml
 config/initializers/omniauth.rb
 config/unicorn.rb
+config/resque.yml
 db/data.yml
 .idea
 .DS_Store


### PR DESCRIPTION
Most yml files are ignored in gitlab/config/, except resque.yml
=> add it to the list of ignored files.

If one is using gitlab in a https://xxx/gitlab (RAILS_RELATIVE_URL_ROOT)
one can add a symlink 'gitlab' pointing to 'public'
=> ignore '/gitlab' (i.e. a file at the root directory of the git repo,
pointing to 'public', should the user choose to create said symlink)
