### PR TITLE
Fix git group detection for gitolite ssh user.

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -29,6 +29,9 @@ gitlab:
   ## Project settings
   default_projects_limit: 10
 
+  ## Account used for GitLab installation ('gitlab' if undefined)
+  user: gitlab
+
 ## Gravatar
 gravatar:
   enabled: true                 # Use user avatar images from Gravatar.com (default: true)
@@ -100,6 +103,7 @@ gitolite:
   receive_pack: true
   ssh_user: git
   ssh_host: localhost
+  group: git # default: 'git' if undefined
   # ssh_port: 22
   # config_file: gitolite.conf
 

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -50,6 +50,7 @@ Settings.gitlab['relative_url_root'] ||= ''
 Settings.gitlab['protocol']   ||= Settings.gitlab.https ? "https" : "http"
 Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
+Settings.gitlab['user']        ||= 'gitlab'
 
 Settings['gravatar'] ||= Settingslogic.new({})
 Settings.gravatar['enabled']    ||= true
@@ -67,6 +68,7 @@ Settings.gitolite['upload_pack']  ||= (Settings.gitolite['upload_pack'] != false
 Settings.gitolite['ssh_host']     ||= (Settings.gitlab.host || 'localhost')
 Settings.gitolite['ssh_port']     ||= 22
 Settings.gitolite['ssh_user']     ||= 'git'
+Settings.gitolite['group']        ||= 'git'
 Settings.gitolite['ssh_path_prefix'] ||= Settings.send(:build_gitolite_ssh_path_prefix)
 
 Settings['backup'] ||= Settingslogic.new({})

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -295,15 +295,16 @@ namespace :gitlab do
     end
 
     def check_gitlab_in_git_group
-      gitolite_ssh_user = Gitlab.config.gitolite.ssh_user
-      print "gitlab user is in #{gitolite_ssh_user} group? ... "
+      gitlab_user = Gitlab.config.gitlab.user
+      gitolite_group = Gitlab.config.gitolite.group
+      print "gitlab user '#{gitlab_user}' has git group '#{gitolite_group}'? ... "
 
-      if run_and_match("id -rnG", /\Wgit\W/)
+      if run_and_match("id -rnG", /^#{gitolite_group}\W|\W#{gitolite_group}\W|\W#{gitolite_group}$/)
         puts "yes".green
       else
         puts "no".red
         try_fixing_it(
-          "sudo usermod -a -G #{gitolite_ssh_user} gitlab"
+          "sudo usermod -a -G #{gitolite_group} #{gitlab_user}"
         )
         for_more_information(
           see_installation_guide_section "System Users"


### PR DESCRIPTION
The tasks gitlab:env:info mixes user and group, and presume as a group 'git'.
However, gitolite group name can be anything.

That patch add the git group name in the config,
and check gitolite.ssh_user group against git.group
(which defaults to 'git', as before this patch, if undefined).

M config/gitlab.yml.example:
  Add 'group' in 'git' section
  Mention default value for the two extra settings
M lib/tasks/gitlab/check.rake:
  Check that gitolite.ssh_user _group_ is the one defined in git.group.
  Make sure to default to 'git' as the expected group
    if said group is undefined in the config.
  Note: uses a more complete regexp for the group detection
        (the group can start, end or be in the middle or the list of groups
         of gitolite.ssh_user)
