### PR TITLE
Gitlab/Gitolite: Support anonymous access through the git daemon

### DIFF
--- a/app/contexts/project_update_context.rb
+++ b/app/contexts/project_update_context.rb
@@ -16,8 +16,13 @@ class ProjectUpdateContext < BaseContext
         project.transfer(namespace)
       end
     end
-
-    project.update_attributes(params[:project], as: role)
+    
+    if params[:project]["anon_clone"].to_i.zero? == project.anon_clone
+      project.update_attributes(params[:project], as: role)
+      project.update_repository
+    else
+      project.update_attributes(params[:project], as: role)
+    end
   end
 end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,6 +9,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  private_flag           :boolean          default(TRUE), not null
+#  anon_clone             :boolean          default(FALSE), not null
 #  owner_id               :integer
 #  default_branch         :string(255)
 #  issues_enabled         :boolean          default(TRUE), not null
@@ -30,7 +31,7 @@ class Project < ActiveRecord::Base
   class TransferError < StandardError; end
 
   attr_accessible :name, :path, :description, :default_branch, :issues_enabled,
-                  :wall_enabled, :merge_requests_enabled, :wiki_enabled, as: [:default, :admin]
+                  :wall_enabled, :merge_requests_enabled, :wiki_enabled, :anon_clone, as: [:default, :admin]
 
   attr_accessible :namespace_id, :owner_id, as: :admin
 
@@ -69,7 +70,7 @@ class Project < ActiveRecord::Base
             format: { with: Gitlab::Regex.path_regex,
                       message: "only letters, digits & '_' '-' '.' allowed. Letter should be first" }
   validates :issues_enabled, :wall_enabled, :merge_requests_enabled,
-            :wiki_enabled, inclusion: { in: [true, false] }
+            :wiki_enabled, :anon_clone, inclusion: { in: [true, false] }
 
   validates_uniqueness_of :name, scope: :namespace_id
   validates_uniqueness_of :path, scope: :namespace_id

--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -201,6 +201,10 @@ module Repository
   def http_url_to_repo
     http_url = [Gitlab.config.gitlab.url, "/", path_with_namespace, ".git"].join('')
   end
+  
+  def gitd_url_to_repo
+    gitd_url = url_to_repo.gsub(/^.+@/,'git://')
+  end
 
   # Check if current branch name is marked as protected in the system
   def protected_branch? branch_name

--- a/app/roles/repository.rb
+++ b/app/roles/repository.rb
@@ -203,7 +203,7 @@ module Repository
   end
   
   def gitd_url_to_repo
-    gitd_url = url_to_repo.gsub(/^.+@/,'git://')
+    gitd_url = http_url_to_repo.gsub(/^.+:\/\//,'git://')
   end
 
   # Check if current branch name is marked as protected in the system

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -42,6 +42,10 @@
     .clearfix
       = f.label :wiki_enabled, "Wiki"
       .input= f.check_box :wiki_enabled
+      
+    .clearfix
+      = f.label :anon_clone, "Anonymous clone via Git Daemon protocol"
+      .input= f.check_box :anon_clone
 
   %fieldset.features
     %legend Transfer:

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -92,6 +92,12 @@
   %tr
     %td
       %b
+        Git Read-Only:
+    %td
+      = link_to @project.gitd_url_to_repo
+  %tr
+    %td
+      %b
         Last commit at:
     %td
       = last_commit(@project)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -49,7 +49,12 @@
       .controls
         = f.check_box :wiki_enabled
         %span.descr Pages for project documentation
-
+        
+    .control-group
+      = f.label :anon_clone, "Anonymous Git Clone", class: 'control-label'
+      .controls
+        = f.check_box :anon_clone
+        %span.descr Enables anonymous cloning of the repository over the git:// protocol
 
   - if can? current_user, :change_namespace, @project
     %fieldset.features

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,5 +1,6 @@
 .input-prepend.project_clone_holder
   %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
   %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.gitlab.protocol.upcase
-  @project.anon_clone? ? %button{class: "btn", :"data-clone" => @project.gitd_url_to_repo} Git Read-Only : ""
+  - if @project.anon_clone? 
+    %button{class: "btn", :"data-clone" => @project.gitd_url_to_repo} Git Read-Only
   = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select input-xxlarge"

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,4 +1,5 @@
 .input-prepend.project_clone_holder
   %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
   %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.gitlab.protocol.upcase
+  @project.anon_clone? ? %button{class: "btn", :"data-clone" => @project.gitd_url_to_repo} Git Read-Only : ""
   = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select input-xxlarge"

--- a/db/migrate/20130110143240_add_anon_clone_to_projects.rb
+++ b/db/migrate/20130110143240_add_anon_clone_to_projects.rb
@@ -1,0 +1,5 @@
+class AddAnonCloneToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :anon_clone, :boolean, :default => false, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121219095402) do
+ActiveRecord::Schema.define(:version => 20130110143240) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(:version => 20121219095402) do
     t.boolean  "merge_requests_enabled", :default => true, :null => false
     t.boolean  "wiki_enabled",           :default => true, :null => false
     t.integer  "namespace_id"
+    t.boolean  "anon_clone",             :default => false, :null => false
   end
 
   add_index "projects", ["namespace_id"], :name => "index_projects_on_namespace_id"

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -330,6 +330,12 @@ Make sure to edit the config file to match your setup:
 
     sudo /etc/init.d/nginx restart
 
+# 8. Anonymous Git access (optional)
+
+Configure your git daemon instance to point to /home/git/repositories and
+ensure it executes as the same user as gitolite does to avoid any possible
+issues.
+
 
 # Done!
 

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -33,6 +33,7 @@ module Gitlab
       #   wall_enabled (optional) - enabled by default
       #   merge_requests_enabled (optional) - enabled by default
       #   wiki_enabled (optional) - enabled by default
+      #   anon_clone (optional) - disabled by default
       # Example Request
       #   POST /projects
       post do
@@ -42,7 +43,8 @@ module Gitlab
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled]
+                                    :wiki_enabled,
+                                    :anon_clone]
         @project = Project.create_by_user(attrs, current_user)
         if @project.saved?
           present @project, with: Entities::Project

--- a/lib/gitlab/backend/gitolite.rb
+++ b/lib/gitlab/backend/gitolite.rb
@@ -44,6 +44,10 @@ module Gitlab
     def enable_automerge
       config.admin_all_repo!
     end
+    
+    def set_anonclone allowed
+      config.set_anonclone(allowed)
+    end
 
     def update_repositories projects
       config.apply do |config|

--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -129,11 +129,7 @@ module Gitlab
       end
     end
 
-    def update_project_config(project, conf)
-      update_project_config_anon(project, conf, project.anon_clone)
-    end
-
-    def update_project_config_anon(project, conf, anon_clone)
+    def update_project_config(project, conf, anon_clone = project.anon_clone)
       repo_name = project.path_with_namespace
 
       repo = if conf.has_repo?(repo_name)


### PR DESCRIPTION
This adds the option for enabling and disabling anonymous access to a
repo via adding the pseudo-user "daemon" to gitolite's access list.

If anonymous Git access is enabled, GitLab will display the access link
on the repo.

Obviously, your GitD must be configured with the correct base directory
and execute as the appropriate user (probably git).
