### PR TITLE
Do not set the config for one (empty) repository global.

### DIFF
--- a/app/views/projects/empty.html.haml
+++ b/app/views/projects/empty.html.haml
@@ -5,8 +5,8 @@
     %legend Git global setup:
     %pre.dark
       = preserve do
-        git config --global user.name "#{current_user.name}"
-        git config --global user.email "#{current_user.email}"
+        git config user.name "#{current_user.name}"
+        git config user.email "#{current_user.email}"
 
   %fieldset
     %legend Create Repository


### PR DESCRIPTION
The option --global were removed, because it is not common to make the options for one repository (or one remote) global. Quiet unusual.
