### PR TITLE
Fix to pages links

### DIFF
--- a/app/views/wikis/pages.html.haml
+++ b/app/views/wikis/pages.html.haml
@@ -10,7 +10,7 @@
     - @wikis.each_with_index do |wiki_page, i|
       %tr
         %td
-          = link_to wiki_page.title, project_wiki_path(@project, wiki_page, old_page_id: wiki_page.id)
+          = link_to wiki_page.title, project_wiki_path(@project, wiki_page)
           (#{time_ago_in_words(wiki_page.created_at)}
           ago)
         %td= wiki_page.slug


### PR DESCRIPTION
In the pages page of the wiki of a project you have links to all the wiki pages that are created. These links are to the first version of the created page and not the current version of the page. 

This patch changes the links to the last version of the page instead of the first created version.
