### PR TITLE
Projects/Gitolite: Make the default branch the real default.

### DIFF
--- a/app/contexts/project_update_context.rb
+++ b/app/contexts/project_update_context.rb
@@ -17,7 +17,12 @@ class ProjectUpdateContext < BaseContext
       end
     end
 
-    project.update_attributes(params[:project], as: role)
+    if params[:project]["default_branch"] != project.default_branch
+      project.update_attributes(params[:project], as: role)
+      project.update_repository
+    else
+      project.update_attributes(params[:project], as: role)
+    end
   end
 end
 

--- a/lib/gitlab/backend/gitolite_config.rb
+++ b/lib/gitlab/backend/gitolite_config.rb
@@ -161,6 +161,9 @@ module Gitlab
       # Add sharedRepository config
       repo.set_git_config("core.sharedRepository", "0660")
 
+      # Update the repository HEAD to point to the default branch
+      system("ssh git@#{Gitlab.config.gitolite.ssh_host} 'symbolic-ref #{project.path_with_namespace} HEAD refs/heads/#{project.default_branch}'")
+
       repo
     end
 


### PR DESCRIPTION
Gitlab will now tell gitolite to update the HEAD pointer over ssh using
the symbolic-ref command - this ensures that when performing a git
clone, the branch you receive if none is specified will actually be the
one you configured as default.

This also resolves breakage when your repo lacks any branch named
"master.

Depends on gitlabhq/gitolite#4
