### PR TITLE
Public HTTP clones and remove auth request for public projects

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -2,30 +2,42 @@ module Grack
   class Auth < Rack::Auth::Basic
     attr_accessor :user, :project
 
-    def valid?
-      # Find project by PATH_INFO from env
-      if m = /^\/([\w\.\/-]+)\.git/.match(@request.path_info).to_a
-        self.project = Project.find_with_namespace(m.last)
-        return false unless project
-      end
+    def call(env)
+      @env = env
+      @request = Rack::Request.new(env)
+      @auth = Request.new(env)
 
-      if @request.get? && project.public
-        return true
-      end
-
-      # Authentication with username and password
-      login, password = @auth.credentials
-
-      self.user = User.find_by_email(login) || User.find_by_username(login)
-
-      return false unless user.try(:valid_password?, password)
-
-      email = user.email
-
-      # Set GL_USER env variable
-      ENV['GL_USER'] = email
       # Pass Gitolite update hook
       ENV['GL_BYPASS_UPDATE_HOOK'] = "true"
+
+      # Need this patch due to the rails mount
+      @env['PATH_INFO'] = @request.path
+      @env['SCRIPT_NAME'] = ""
+
+      return render_not_found unless project
+      return unauthorized unless project.public || @auth.provided?
+      return bad_request if @auth.provided? && !@auth.basic?
+
+      if valid?
+        if @auth.provided?
+          @env['REMOTE_USER'] = @auth.username
+        end
+        return @app.call(env)
+      else
+        unauthorized
+      end
+    end
+
+    def valid?
+      if @auth.provided?
+        # Authentication with username and password
+        login, password = @auth.credentials
+        self.user = User.find_by_email(login) || User.find_by_username(login)
+        return false unless user.try(:valid_password?, password)
+
+        # Set GL_USER env variable
+        ENV['GL_USER'] = user.email
+      end
 
       # Git upload and receive
       if @request.get?
@@ -38,12 +50,12 @@ module Grack
     end
 
     def validate_get_request
-      can?(user, :download_code, project)
+      project.public || can?(user, :download_code, project)
     end
 
     def validate_post_request
       if @request.path_info.end_with?('git-upload-pack')
-        can?(user, :download_code, project)
+        project.public || can?(user, :download_code, project)
       elsif @request.path_info.end_with?('git-receive-pack')
         action = if project.protected_branch?(current_ref)
                    :push_code_to_protected_branches
@@ -70,6 +82,22 @@ module Grack
       # Need to reset seek point
       @request.body.rewind
       /refs\/heads\/([\w\.-]+)/.match(input).to_a.first
+    end
+
+    def project
+      unless instance_variable_defined? :@project
+        # Find project by PATH_INFO from env
+        if m = /^\/([\w\.\/-]+)\.git/.match(@request.path_info).to_a
+          @project = Project.find_with_namespace(m.last)
+        end
+      end
+      return @project
+    end
+
+    PLAIN_TYPE = {"Content-Type" => "text/plain"}
+
+    def render_not_found
+      [404, PLAIN_TYPE, ["Not Found"]]
     end
 
     protected


### PR DESCRIPTION
This resolves issues #2582 and #2583.  This change pulls a small amount of code from the grack project into the grack_auth module for the purpose of checking for a public project earlier that the validation step.  This resolves issue #2583 by not presenting the auth request for public projects.
