### PR TITLE
Public projects (on gitlab 4.0)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
   end
 
   def project
-    @project ||= current_user.projects.find_by_code(params[:project_id] || params[:id])
+    @project ||= current_user.projects.find_by_code(params[:project_id] || params[:id]) || Project.find_by_code_and_private_flag(params[:project_id] || params[:id], false)
     @project || render_404
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,6 +6,7 @@ class DashboardController < ApplicationController
   def index
     @groups = Group.where(id: current_user.projects.pluck(:group_id))
     @projects = current_user.projects_sorted_by_activity
+    @public_projects = Project.find_all_by_private_flag(false) - @projects
     @projects = @projects.page(params[:page]).per(30)
 
     @events = Event.in_projects(current_user.project_ids)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,7 +9,7 @@ class DashboardController < ApplicationController
     @public_projects = Project.find_all_by_private_flag(false) - @projects
     @projects = @projects.page(params[:page]).per(30)
 
-    @events = Event.in_projects(current_user.project_ids)
+    @events = Event.recent_for_projects(@projects + @public_projects)
     @events = @event_filter.apply_filter(@events)
     @events = @events.limit(20).offset(params[:offset] || 0)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,13 +26,13 @@ class Ability
         :write_project,
         :write_issue,
         :write_note
-      ] if project.guest_access_for?(user)
+      ] if project.guest_access_for?(user) || project.public?
 
       rules << [
         :download_code,
         :write_merge_request,
         :write_snippet
-      ] if project.report_access_for?(user)
+      ] if project.report_access_for?(user) || project.public?
 
       rules << [
         :write_wiki,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -58,6 +58,14 @@ class Event < ActiveRecord::Base
     end
   end
 
+  def self.recent_for_user user
+    where(project_id: user.projects.map(&:id)).recent
+  end
+
+  def self.recent_for_projects projects
+    where(project_id: projects.map(&:id)).recent
+  end
+
   # Next events currently enabled for system
   #  - push
   #  - new issue

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -29,6 +29,7 @@ class Project < ActiveRecord::Base
 
   attr_accessible :name, :path, :description, :code, :default_branch, :issues_enabled,
                   :wall_enabled, :merge_requests_enabled, :wiki_enabled
+  attr_protected :owner_id
   attr_accessor :error_code
 
   # Relations

--- a/app/roles/authority.rb
+++ b/app/roles/authority.rb
@@ -21,7 +21,7 @@ module Authority
   def repository_readers
     keys = Key.joins({user: :users_projects}).
       where("users_projects.project_id = ? AND users_projects.project_access = ?", id, UsersProject::REPORTER)
-    keys.map(&:identifier) + deploy_keys.map(&:identifier)
+    keys.map(&:identifier) + deploy_keys.map(&:identifier) + (public? ? ['@all'] : [])
   end
 
   def repository_writers

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -60,6 +60,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix	
+        = f.label :private_flag, "Private"	
+        .input= f.check_box :private_flag
+
   - unless project.new_record?
     .actions
       = f.submit 'Save Project', class: "btn save-btn"

--- a/app/views/admin/projects/_new_form.html.haml
+++ b/app/views/admin/projects/_new_form.html.haml
@@ -27,3 +27,6 @@
         .input-prepend
           %span.add-on= web_app_url
           = f.text_field :code, placeholder: "example"
+    .clearfix 
+      = f.label :private_flag, "Private"  
+      .input= f.check_box :private_flag

--- a/app/views/dashboard/_projects.html.haml
+++ b/app/views/dashboard/_projects.html.haml
@@ -1,6 +1,6 @@
 .projects_box
   %h5
-    Projects
+    My Projects
     %small
       (#{projects.total_count})
     - if current_user.can_create_project?
@@ -19,3 +19,26 @@
             %strong Last activity:
             %span= project_last_activity(project)
   .bottom= paginate projects, theme: "gitlab"
+
+.projects_box
+  %h5
+    Public Projects
+    %small
+      (#{public_projects.count})
+  %ul.unstyled
+    - if public_projects.any?
+      - public_projects.each do |project|
+        %li.wll
+          = link_to project_path(project), class: dom_class(project) do
+            %strong.project_name= truncate(project.name, length: 25)
+            %span.arrow
+              &rarr;
+            %span.last_activity
+              %strong Last activity:
+              %span= project_last_activity(project)
+    - else
+      %h4
+        .project No Public Projects
+  .bottom= paginate projects, theme: "gitlab"
+
+%hr

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-- if @projects.any?
+- if @projects.any? || @public_projects.any?
   .projects
     .activities.span8
       = render "events/event_last_push", event: @last_push
@@ -18,7 +18,7 @@
     .side
       - if @groups.present?
         = render "groups", groups: @groups
-      = render "projects", projects: @projects
+      = render "projects", projects: @projects, public_projects: @public_projects
       %div
         %span.rss-icon
           = link_to dashboard_path(:atom, { private_token: current_user.private_token }) do

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -52,6 +52,10 @@
         = f.label :wiki_enabled, "Wiki"
         .input= f.check_box :wiki_enabled
 
+      .clearfix
+        = f.label :private_flag, "Private"
+        .input= f.check_box :private_flag
+
   %br
 
   .actions

--- a/app/views/projects/_new_form.html.haml
+++ b/app/views/projects/_new_form.html.haml
@@ -27,3 +27,6 @@
         .input-prepend
           %span.add-on= web_app_url
           = f.text_field :code, placeholder: "example"
+    .clearfix
+      = f.label :private_flag, "Private"
+      .input= f.check_box :private_flag

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,16 +107,16 @@ ActiveRecord::Schema.define(:version => 20121120113838) do
     t.string   "name"
     t.string   "path"
     t.text     "description"
-    t.datetime "created_at",                               :null => false
-    t.datetime "updated_at",                               :null => false
-    t.boolean  "private_flag",           :default => true, :null => false
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.boolean  "private_flag",           :default => false,    :null => false
     t.string   "code"
     t.integer  "owner_id"
     t.string   "default_branch"
-    t.boolean  "issues_enabled",         :default => true, :null => false
-    t.boolean  "wall_enabled",           :default => true, :null => false
-    t.boolean  "merge_requests_enabled", :default => true, :null => false
-    t.boolean  "wiki_enabled",           :default => true, :null => false
+    t.boolean  "issues_enabled",         :default => true,     :null => false
+    t.boolean  "wall_enabled",           :default => true,     :null => false
+    t.boolean  "merge_requests_enabled", :default => true,     :null => false
+    t.boolean  "wiki_enabled",           :default => true,     :null => false
     t.integer  "group_id"
   end
 


### PR DESCRIPTION
I realise you don't intend to add this functionality to GitLab, but also that it's often requested. 

I've pulled support for public repos up to 4.0, which others might like too.

**Details:**
- You can choose to make projects private when creating/editing. 
- Public projects are listed on the dashboard.
