### PR TITLE
added warning message to doc/raketasks/maintenance.md

### DIFF
--- a/doc/raketasks/maintenance.md
+++ b/doc/raketasks/maintenance.md
@@ -1,10 +1,12 @@
 ### Setup production application
 
-Runs the following rake tasks:
+Runs the following rake tasks: 
 
 * db:setup (Create the database, load the schema, and initialize with the seed data)
 * db:seed_fu (Loads seed data for the current environment.)
 * gitlab:app:enable_automerge (see "Features")
+
+##### Warning: if you have already run this command, this will drop your database!
 
 ```
 bundle exec rake gitlab:app:setup RAILS_ENV=production


### PR DESCRIPTION
Unsuspecting users will run this command and drop their database. 

This is especially important, as setting up automatic backups is not part of the installation instructions.

This would solve a lot of community pain: #1844
