### PR TITLE
Strike out closed or blocked references in GLF markdown

### DIFF
--- a/app/observers/issue_observer.rb
+++ b/app/observers/issue_observer.rb
@@ -15,7 +15,7 @@ class IssueObserver < ActiveRecord::Observer
     status = 'reopened' if issue.is_being_reopened?
     if status
       Note.create_status_change_note(issue, current_user, status)
-      [issue.author, issue.assignee].compact.each do |recipient|
+      [issue.author, issue.assignee].compact.uniq.each do |recipient|
         Notify.delay.issue_status_changed_email(recipient.id, issue.id, status, current_user.id)
       end
     end

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -145,21 +145,25 @@ module Gitlab
       send("reference_#{type}", identifier)
     end
 
+    def score_out str, condition
+      condition ? content_tag(:del, str) : str
+    end
+
     def reference_user(identifier)
       if member = @project.users_projects.joins(:user).where(users: { username: identifier }).first
-        link_to("@#{identifier}", project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
+        link_to(score_out("@#{identifier}", member.blocked?), project_team_member_path(@project, member), html_options.merge(class: "gfm gfm-team_member #{html_options[:class]}")) if member
       end
     end
 
     def reference_issue(identifier)
       if issue = @project.issues.where(id: identifier).first
-        link_to("##{identifier}", project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}"))
+        link_to(score_out("##{identifier}", issue.closed?), project_issue_path(@project, issue), html_options.merge(title: "Issue: #{issue.title}", class: "gfm gfm-issue #{html_options[:class]}"))
       end
     end
 
     def reference_merge_request(identifier)
       if merge_request = @project.merge_requests.where(id: identifier).first
-        link_to("!#{identifier}", project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}"))
+        link_to(score_out("!#{identifier}", merge_request.closed?), project_merge_request_path(@project, merge_request), html_options.merge(title: "Merge Request: #{merge_request.title}", class: "gfm gfm-merge_request #{html_options[:class]}"))
       end
     end
 


### PR DESCRIPTION
I really missed some sort of indication on (psydo-)references to closed commits, etc.

![GitLab sandbox](https://f.cloud.github.com/assets/218011/71407/8c142136-5fe7-11e2-91cc-6eb9b53711e1.png)
