### PR TITLE
add default for Settings['satellites']

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -78,4 +78,5 @@ Settings.git['max_size']  ||= 5242880 # 5.megabytes
 Settings.git['bin_path']  ||= '/usr/bin/git'
 Settings.git['timeout']   ||= 10
 
+Settings['satellites'] ||= {}
 Settings.satellites['path']   ||= '/home/gitlab/gitlab/tmp/repo_satellites/'


### PR DESCRIPTION
Without the fix, the application won't load if this setting is missing. 
