### PR TITLE
Admin Privileges Based on LDAP Groups

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -51,6 +51,9 @@ ldap:
   method: 'ssl' # "ssl" or "plain"
   bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
   password: '_the_password_of_the_bind_user'
+  # List of LDAP gid numbers to be made admin when user is created
+  # Leave as [] or null to disable
+  # admin_gids: [gid1, gid2]
 
 ## Omniauth settings
 omniauth:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -36,6 +36,7 @@ end
 # Default settings
 Settings['ldap'] ||= Settingslogic.new({})
 Settings.ldap['enabled'] ||= false
+Settings.ldap['admin_gids'] ||= []
 
 Settings['omniauth'] ||= Settingslogic.new({})
 Settings.omniauth['enabled']    ||= false

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -44,6 +44,9 @@ module Gitlab
       if Gitlab.config.omniauth['block_auto_created_users'] && !ldap
         @user.blocked = true
       end
+      # Check if user is in an LDAP group specified to be admins in gitlab.yml
+      gid = auth.info.gid.to_i
+      @user.admin = Gitlab.config.ldap['admin_gids'].include?(gid)
       @user.save!
       @user
     end


### PR DESCRIPTION
New config option in gitlab.yml allows users in specified LDAP groups to automatically be granted admin privileges when the user is created. The config option is "admin_gids", which is an array of LDAP gids to be considered automatic admins.

**Note:** This pull request is dependent on gitlabhq/omniauth-ldap#4 in order for the LDAP strategy to obtain gid information.
