### PR TITLE
Add custom ssh port support and fix a small permission problem

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -361,6 +361,21 @@ a different host, you can configure its connection string via the
     # example
     production: redis.example.tld:6379
 
+## Custom SSH Connection
+
+If your ssh port is a non-standard port, you must configure the ssh config of 
+user *gitlab*.
+
+    su gitlab
+    vim ~/.ssh/config
+    
+    # Edit this file
+    host localhost
+        user git
+        port 888    # Your port number
+        hostname YOUR_SERVER_NAME or IP;     # e.g., source.example.com or 127.0.0.1;
+
+Of course, you should change the ssh port of `config\gitlab.yml` to your custom port.
 
 ## User-contributed Configurations
 

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -139,7 +139,7 @@ GitLab assumes *full and unshared* control over this Gitolite installation.
 Fix the directory permissions for the configuration directory:
 
     # Make sure the Gitolite config dir is owned by git
-    sudo chmod 750 /home/git/.gitolite/
+    sudo chmod -R 750 /home/git/.gitolite/
     sudo chown -R git:git /home/git/.gitolite/
 
 Fix the directory permissions for the repositories:


### PR DESCRIPTION
First about `sudo chmod -R 750 /home/git/.gitolite/`. When I first install gitlab as the Guide. The check program always say `post-receive exists? ............NO`. And I found that User GitLab can not even see the post-receive file. So I add this option and then the problem is solved. I don't know if there is better choice to fix this. Maybe somebody else have a better idea?

Second I add the custom SSH port support. In many VPS systems, the SSH port is sometimes not 22. So I think this is very important. After create the config file, the git will work correctly.
