### PR TITLE
Improve setup task, by making it less dangerous

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -260,7 +260,7 @@ used for the `email.from` setting in `config/gitlab.yml`)
 
 ## Initialise Database and Activate Advanced Features
 
-    sudo -u gitlab -H bundle exec rake gitlab:app:setup RAILS_ENV=production
+    sudo -u gitlab -H bundle exec rake gitlab:setup RAILS_ENV=production
 
 
 ## Install Init Script

--- a/doc/raketasks/maintenance.md
+++ b/doc/raketasks/maintenance.md
@@ -1,16 +1,3 @@
-### Setup production application
-
-Runs the following rake tasks:
-
-* db:setup (Create the database, load the schema, and initialize with the seed data)
-* db:seed_fu (Loads seed data for the current environment.)
-* gitlab:app:enable_automerge (see "Features")
-
-```
-bundle exec rake gitlab:app:setup RAILS_ENV=production
-```
-
-
 ### Gather information about GitLab and the system it runs on
 
 This command gathers information about your GitLab installation and the System

--- a/lib/tasks/gitlab/setup.rake
+++ b/lib/tasks/gitlab/setup.rake
@@ -1,10 +1,24 @@
 namespace :gitlab do
   namespace :app do
     desc "GITLAB | Setup production application"
-    task :setup => [
-      'db:setup',
-      'db:seed_fu',
-      'gitlab:enable_automerge'
-    ]
+    task :setup => :environment do
+      setup
+    end
+
+    def setup
+      warn_user_is_not_gitlab
+
+      puts "This will create the necessary database tables and seed the database."
+      puts "You will lose any previous data stored in the database."
+      ask_to_continue
+      puts ""
+
+      Rake::Task["db:setup"].invoke
+      Rake::Task["db:seed_fu"].invoke
+      Rake::Task["gitlab:enable_automerge"].invoke
+    rescue Gitlab::TaskAbortedByUserError
+      puts "Quitting...".red
+      exit 1
+    end
   end
 end

--- a/lib/tasks/gitlab/setup.rake
+++ b/lib/tasks/gitlab/setup.rake
@@ -1,24 +1,22 @@
 namespace :gitlab do
-  namespace :app do
-    desc "GITLAB | Setup production application"
-    task :setup => :environment do
-      setup
-    end
+  desc "GITLAB | Setup production application"
+  task :setup => :environment do
+    setup
+  end
 
-    def setup
-      warn_user_is_not_gitlab
+  def setup
+    warn_user_is_not_gitlab
 
-      puts "This will create the necessary database tables and seed the database."
-      puts "You will lose any previous data stored in the database."
-      ask_to_continue
-      puts ""
+    puts "This will create the necessary database tables and seed the database."
+    puts "You will lose any previous data stored in the database."
+    ask_to_continue
+    puts ""
 
-      Rake::Task["db:setup"].invoke
-      Rake::Task["db:seed_fu"].invoke
-      Rake::Task["gitlab:enable_automerge"].invoke
-    rescue Gitlab::TaskAbortedByUserError
-      puts "Quitting...".red
-      exit 1
-    end
+    Rake::Task["db:setup"].invoke
+    Rake::Task["db:seed_fu"].invoke
+    Rake::Task["gitlab:enable_automerge"].invoke
+  rescue Gitlab::TaskAbortedByUserError
+    puts "Quitting...".red
+    exit 1
   end
 end

--- a/lib/tasks/gitlab/task_helpers.rake
+++ b/lib/tasks/gitlab/task_helpers.rake
@@ -1,4 +1,17 @@
+module Gitlab
+  class TaskAbortedByUserError < StandardError; end
+end
+
 namespace :gitlab do
+
+  # Ask if the user wants to continue
+  #
+  # Returns "yes" the user chose to continue
+  # Raises Gitlab::TaskAbortedByUserError if the user chose *not* to continue
+  def ask_to_continue
+    answer = prompt("Do you want to continue (yes/no)? ".blue, %w{yes no})
+    raise Gitlab::TaskAbortedByUserError unless answer == "yes"
+  end
 
   # Check which OS is running
   #
@@ -20,6 +33,20 @@ namespace :gitlab do
                   "Mac OS X #{os_x_version}"
                 end
     os_name.try(:squish!)
+  end
+
+  # Prompt the user to input something
+  #
+  # message - the message to display before input
+  # choices - array of strings of acceptible answers or nil for any answer
+  #
+  # Returns the user's answer
+  def prompt(message, choices = nil)
+    begin
+      print(message)
+      answer = STDIN.gets.chomp
+    end while choices.present? && !choices.include?(answer)
+    answer
   end
 
   # Runs the given command and matches the output agains the given pattern


### PR DESCRIPTION
- adds a warning prompt before actually running the setup task
- rename `gitlab:app:setup` to `gitlab:setup`
- remove setup task from maintenance docs (setup is not maintenance!)

In succession of #2338
Actually fixes #1844
