### PR TITLE
Render submodule bugfix

### DIFF
--- a/app/views/tree/_submodule_item.html.haml
+++ b/app/views/tree/_submodule_item.html.haml
@@ -1,6 +1,6 @@
 - url = submodule_item.url(@ref) rescue ''
 - name = submodule_item.basename
-- return unless url
+- return '' unless url
 %tr{ class: "tree-item", url: url }
   %td.tree-item-file-name
     = image_tag "submodule.png"


### PR DESCRIPTION
Have this error when submodule url is nil.

```
ActionView::Template::Error (can't convert nil into String):
    31:           %td
    32:           %td
    33:
    34:       = render_tree(tree.contents)
    35:
    36:     - if tree.readme
    37:       = render "tree/readme", readme: tree.readme
  app/helpers/tree_helper.rb:18:in `+'
  app/helpers/tree_helper.rb:18:in `block in render_tree'
  app/helpers/tree_helper.rb:15:in `each'
  app/helpers/tree_helper.rb:15:in `render_tree'
  app/views/tree/_tree.html.haml:34:in `_app_views_tree__tree_html_haml__1071874968_86634150'
  app/views/tree/show.html.haml:3:in `_app_views_tree_show_html_haml___680544721_79735610'
  app/controllers/tree_controller.rb:17:in `show'
```

Render empty string instead of nil fix this error.

P.S. right now I have no time to add tests on this case.
