### PR TITLE
Remove relative_url_root from path. Fixes #2602

### DIFF
--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -50,6 +50,8 @@ module ExtractsPath
 
     return pair unless @project
 
+    # Remove relative_url_root from path
+    input.gsub!(/^#{Gitlab.config.gitlab.relative_url_root}/, "")
     # Remove project, actions and all other staff from path
     input.gsub!(/^\/#{Regexp.escape(@project.path_with_namespace)}/, "")
     input.gsub!(/^\/(tree|commits|blame|blob|refs)\//, "") # remove actions

--- a/spec/lib/extracts_path_spec.rb
+++ b/spec/lib/extracts_path_spec.rb
@@ -73,5 +73,28 @@ describe ExtractsPath do
         extract_ref('/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG?_=12354435').should == ['v2.0.0', 'CHANGELOG']
       end
     end
+
+    context "with a fullpath and a relative_url_root" do
+      before do
+        Gitlab.config.gitlab.stub(relative_url_root: '/relative')
+      end
+
+      it "extracts a valid branch with relative_url_root" do
+        extract_ref('/relative/gitlab/gitlab-ci/tree/foo/bar/baz/CHANGELOG').should == ['foo/bar/baz', 'CHANGELOG']
+      end
+
+      it "extracts a valid tag" do
+        extract_ref('/relative/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG').should == ['v2.0.0', 'CHANGELOG']
+      end
+
+      it "extracts a valid commit SHA" do
+        extract_ref('/relative/gitlab/gitlab-ci/tree/f4b14494ef6abf3d144c28e4af0c20143383e062/CHANGELOG').should ==
+          ['f4b14494ef6abf3d144c28e4af0c20143383e062', 'CHANGELOG']
+      end
+
+      it "extracts a timestamp" do
+        extract_ref('/relative/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG?_=12354435').should == ['v2.0.0', 'CHANGELOG']
+      end
+    end
   end
 end


### PR DESCRIPTION
Files and Commits render a 404 when running with relative_url_root.
