### PR TITLE
Revise projects/new text

### DIFF
--- a/app/views/projects/_new_form.html.haml
+++ b/app/views/projects/_new_form.html.haml
@@ -17,4 +17,4 @@
         = f.select :namespace_id, namespaces_options(params[:namespace_id] || :current_user), {}, {class: 'chosen'}
   %hr
   %p.padded
-    All created project are private. You choose who can see project and commit to repository.
+    New projects are private by default. You choose who can see the project and commit to repository.


### PR DESCRIPTION
The previous text implied projects can only be private. Projects can now be private or public.
