### PR TITLE
Focus on note textarea after clicking add note

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -286,6 +286,7 @@ var PerLineNotes = {
         $(this).closest("tr").after(form);
         form.find("#note_line_code").val($(this).data("lineCode"));
         form.show();
+        form.find('.line-note-text').focus();
         e.preventDefault();
       });
 


### PR DESCRIPTION
When I click add note on a merge request the note doesn't receive the focus, so I can't start typing right away. This commit apply focus when add note is clicked.
