### PR TITLE
MySQL Placeholder password

### DIFF
--- a/doc/install/databases.md
+++ b/doc/install/databases.md
@@ -14,7 +14,8 @@ GitLab supports the following databases:
     # Login to MySQL
     $ mysql -u root -p
 
-    # Create a user for GitLab. (change $password to a real password)
+    # Create a user for GitLab.
+    # (Change $password to a real password)
     mysql> CREATE USER 'gitlab'@'localhost' IDENTIFIED BY '$password';
 
     # Create the GitLab production database


### PR DESCRIPTION
Move filler password warning to second line to make sure users read information.

Does an interrupt character exist for MySQL? This command can be entered without issue which probably causes a few users to copy and paste this command then need to go back and modify the password later.
