### PR TITLE
Fix not displaying day on commits history

### DIFF
--- a/app/views/commits/_commits.html.haml
+++ b/app/views/commits/_commits.html.haml
@@ -1,6 +1,6 @@
 - @commits.group_by { |c| c.committed_date.to_date }.each do |day, commits|
   %div.ui-box
     %h5.title
-      %i.icon-calendar
+      %i.icon-calendar= ' '
       = day.stamp("28 Aug, 2010")
     %ul.well-list= render commits


### PR DESCRIPTION
Attention:
This problem is not occured on development mode.
I have tested by chrome.

Before:
![fix_display_day_before](https://f.cloud.github.com/assets/72138/92614/909277d2-65e4-11e2-9557-036caeea983a.png)

After:
![fix_display_day_after](https://f.cloud.github.com/assets/72138/92617/9bd890f4-65e4-11e2-8807-3dd00b2ee108.png)

Closes #1145
