### PR TITLE
Make sure the run_and_match function will actuall match group.

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -300,7 +300,7 @@ namespace :gitlab do
       gitolite_owner_group = Gitlab.config.gitolite.owner_group
       print "#{gitlab_user} user is in #{gitolite_owner_group} group? ... "
 
-      if run_and_match("id -rnG", /^#{gitolite_owner_group}\W|\W#{gitolite_owner_group}\W|\W#{gitolite_owner_group}$/)
+      if run_and_match("id -rnG", /^#{gitolite_owner_group}\W.*|.*\W#{gitolite_owner_group}\W.*|.*\W#{gitolite_owner_group}$/)
         puts "yes".green
       else
         puts "no".red


### PR DESCRIPTION
https://github.com/gitlabhq/gitlabhq/pull/2543 works well except for
'check_gitlab_in_git_group' in 'lib/tasks/gitlab/check.rake'

Since if need to _match_ the gitolite owner group, you need to
add '.*' regexp in order to match the all string returned by `id -rnG`
