### PR TITLE
Updates web hooks to process via queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec unicorn_rails -p $PORT
-worker: bundle exec sidekiq -q post_receive,mailer,system_hook,common,default
+worker: bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,common,default

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -340,7 +340,7 @@ class Project < ActiveRecord::Base
   end
 
   def execute_hooks(data)
-    hooks.each { |hook| hook.execute(data) }
+    hooks.each { |hook| hook.async_execute(data) }
   end
 
   def execute_services(data)

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -34,4 +34,8 @@ class WebHook < ActiveRecord::Base
                    basic_auth: {username: parsed_url.user, password: parsed_url.password})
     end
   end
+
+  def async_execute(data)
+    Sidekiq::Client.enqueue(ProjectWebHookWorker, id, data)
+  end
 end

--- a/app/workers/project_web_hook_worker.rb
+++ b/app/workers/project_web_hook_worker.rb
@@ -1,0 +1,9 @@
+class ProjectWebHookWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :project_web_hook
+
+  def perform(hook_id, data)
+    WebHook.find(hook_id).execute data
+  end
+end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -6,7 +6,7 @@ namespace :sidekiq do
 
   desc "GITLAB | Start sidekiq"
   task :start do
-    run "nohup bundle exec sidekiq -q post_receive,mailer,system_hook,common,default -e #{Rails.env} -P #{pidfile} >> #{Rails.root.join("log", "sidekiq.log")} 2>&1 &"
+    run "nohup bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,common,default -e #{Rails.env} -P #{pidfile} >> #{Rails.root.join("log", "sidekiq.log")} 2>&1 &"
   end
 
   def pidfile


### PR DESCRIPTION
A new queue of "project_web_hook" is used to process web hooks asynchronously, allowing each to succeed/fail (and be retried) independently.

Basically, project web hooks now process the same as system hooks.

Fixes #2767
