### PR TITLE
Fix not showing tooltip on network graph

### DIFF
--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -65,15 +65,15 @@
 
   BranchGraph.prototype.buildGraph = function(){
     var graphWidth = $(this.element).width()
-      , ch = this.mspace * 20 + 20
-      , cw = Math.max(graphWidth, this.mtime * 20 + 20)
+      , ch = this.mspace * 20 + 100
+      , cw = Math.max(graphWidth, this.mtime * 20 + 260)
       , r = Raphael(this.element.get(0), cw, ch)
       , top = r.set()
       , cuday = 0
       , cumonth = ""
       , offsetX = 20
       , offsetY = 60
-      , barWidth = Math.max(graphWidth, this.dayCount * 20 + 80);
+      , barWidth = Math.max(graphWidth, this.dayCount * 20 + 320);
     
     this.raphael = r;
     


### PR DESCRIPTION
Before:
![network_tooltip_before](https://f.cloud.github.com/assets/72138/97817/584fc98a-6709-11e2-8fd8-d6a8acfd582d.png)

After:
![network_tooltip_after](https://f.cloud.github.com/assets/72138/97819/6434bba2-6709-11e2-8e5e-27029692082c.png)
