### PR TITLE
remove incorrect information about the api version

### DIFF
--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -10,7 +10,7 @@ If no, or an invalid, `private_token` is provided then an error message will be 
 }
 ```
 
-API requests should be prefixed with `api` and the API version. The API version is equal to the GitLab major version number, which is defined in `lib/api.rb`.
+API requests should be prefixed with `api` and the API version. The API version is defined in `lib/api.rb`.
 
 Example of a valid API request:
 


### PR DESCRIPTION
The API version is currently not equal to the gitlab major version number. Gitlab 4.1 
still uses API version 3. Point to the lib/api.rb file instead which contains the
autoritative information.
