### PR TITLE
Add a config option for markdown hard wrapping

### DIFF
--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -28,7 +28,7 @@ module GitlabMarkdownHelper
                           # see https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch-
                           filter_html: true,
                           with_toc_data: true,
-                          hard_wrap: true)
+                          hard_wrap: Gitlab.config.markdown.hard_wrap)
       @markdown = Redcarpet::Markdown.new(gitlab_renderer,
                       # see https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
                       no_intra_emphasis: true,

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -29,18 +29,19 @@
     .span8
       %h3 Differences from traditional Markdown
 
-      %h4 Newlines
+      - if Gitlab.config.markdown.hard_wrap
+        %h4 Newlines
 
-      %p
-        The biggest difference that GFM introduces is in the handling of linebreaks.
-        With traditional Markdown you can hard wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the cause of a huge number of unintentional formatting errors.
-        GFM treats newlines in paragraph-like content as real line breaks, which is probably what you intended.
+        %p
+          The biggest difference that GFM introduces is in the handling of linebreaks.
+          With traditional Markdown you can hard wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the cause of a huge number of unintentional formatting errors.
+          GFM treats newlines in paragraph-like content as real line breaks, which is probably what you intended.
 
 
-      %p The next paragraph contains two phrases separated by a single newline character:
-      %pre= "Roses are red\nViolets are blue"
-      %p becomes
-      = markdown "Roses are red\nViolets are blue"
+        %p The next paragraph contains two phrases separated by a single newline character:
+        %pre= "Roses are red\nViolets are blue"
+        %p becomes
+        = markdown "Roses are red\nViolets are blue"
 
       %h4 Multiple underscores in words
 

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -42,7 +42,8 @@ gravatar:
   # plain_url: "http://..."     # default: http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm
   # ssl_url:   "https://..."    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm
 
-
+markdown:
+  hard_wrap: true # treat newlines in paragraphs as real line breaks when rendering html
 
 #
 # 2. Auth settings

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -59,6 +59,9 @@ Settings.gravatar['enabled']      = true if Settings.gravatar['enabled'].nil?
 Settings.gravatar['plain_url']  ||= 'http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
 Settings.gravatar['ssl_url']    ||= 'https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
 
+Settings['markdown'] ||= Settingslogic.new({})
+Settings.markdown['hard_wrap'] = true if Settings.markdown['hard_wrap'].nil?
+
 Settings['gitolite'] ||= Settingslogic.new({})
 Settings.gitolite['admin_key']    ||= 'gitlab'
 Settings.gitolite['admin_uri']    ||= 'git@localhost:gitolite-admin'


### PR DESCRIPTION
This patch adds a config option to `gitlab.yaml` that allows disabling markdown hard wrapping when rendering HTML. The relevant paragraph in the help page is wrapped in a conditional so that it will not be shown if hard wrapping is disabled.
