### PR TITLE
Switchable the main branch on network graph

### DIFF
--- a/app/controllers/graph_controller.rb
+++ b/app/controllers/graph_controller.rb
@@ -1,0 +1,18 @@
+class GraphController < ProjectResourceController
+  include ExtractsPath
+
+  # Authorize
+  before_filter :authorize_read_project!
+  before_filter :authorize_code_access!
+  before_filter :require_non_empty_project
+
+  def show
+    respond_to do |format|
+      format.html
+      format.json do
+        graph = Gitlab::Graph::JsonBuilder.new(project, @ref)
+        render :json => graph.to_json
+      end
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -90,16 +90,6 @@ class ProjectsController < ProjectResourceController
     end
   end
 
-  def graph
-    respond_to do |format|
-      format.html
-      format.json do
-        graph = Gitlab::Graph::JsonBuilder.new(project)
-        render :json => graph.to_json
-      end
-    end
-  end
-
   def destroy
     return access_denied! unless can?(current_user, :remove_project, project)
 

--- a/app/controllers/refs_controller.rb
+++ b/app/controllers/refs_controller.rb
@@ -13,6 +13,8 @@ class RefsController < ProjectResourceController
       format.html do
         new_path = if params[:destination] == "tree"
                      project_tree_path(@project, (@ref + "/" + params[:path]))
+                   elsif params[:destination] == "graph"
+                     project_graph_path(@project, @ref)
                    else
                      project_commits_path(@project, @ref)
                    end

--- a/app/views/graph/show.html.haml
+++ b/app/views/graph/show.html.haml
@@ -1,6 +1,7 @@
 %h3.page_title Project Network Graph
 %br
-
+= render partial: 'shared/ref_switcher', locals: {destination: 'graph', path: @path}
+%br
 .graph_holder
   %h4
     %small You can move around the graph by using the arrow keys.
@@ -11,7 +12,8 @@
   var branch_graph;
   $(function(){
     branch_graph = new BranchGraph($("#holder"), {
-      url: '#{url_for controller: 'projects', action: 'graph', format: :json}',
-      commit_url: '#{project_commit_path(@project, 'ae45ca32').gsub("ae45ca32", "%s")}'
+      url: '#{project_graph_path(@project, @ref, format: :json)}',
+      commit_url: '#{project_commit_path(@project, 'ae45ca32').gsub("ae45ca32", "%s")}',
+      ref: '#{@ref}'
     });
   });

--- a/app/views/layouts/project_resource.html.haml
+++ b/app/views/layouts/project_resource.html.haml
@@ -20,8 +20,8 @@
               = link_to 'Files', project_tree_path(@project, @ref || @repository.root_ref)
             = nav_link(controller: %w(commit commits compare repositories protected_branches)) do
               = link_to "Commits", project_commits_path(@project, @ref || @repository.root_ref)
-            = nav_link(path: 'projects#graph') do
-              = link_to "Network", graph_project_path(@project)
+            = nav_link(controller: %w(graph)) do
+              = link_to "Network", project_graph_path(@project, @ref || @repository.root_ref)
 
         - if @project.issues_enabled
           = nav_link(controller: %w(issues milestones labels)) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,7 +163,6 @@ Gitlab::Application.routes.draw do
   resources :projects, constraints: { id: /[a-zA-Z.0-9_\-\/]+/ }, except: [:new, :create, :index], path: "/" do
     member do
       get "wall"
-      get "graph"
       get "files"
     end
 
@@ -173,6 +172,7 @@ Gitlab::Application.routes.draw do
     resources :compare, only: [:index, :create]
     resources :blame,   only: [:show], constraints: {id: /.+/}
     resources :blob,    only: [:show], constraints: {id: /.+/}
+    resources :graph,   only: [:show], constraints: {id: /.+/}
     match "/compare/:from...:to" => "compare#show", as: "compare",
                     :via => [:get, :post], constraints: {from: /.+/, to: /.+/}
 

--- a/features/steps/project/project_network_graph.rb
+++ b/features/steps/project/project_network_graph.rb
@@ -14,6 +14,6 @@ class ProjectNetworkGraph < Spinach::FeatureSteps
     Gitlab::Graph::JsonBuilder.stub(max_count: 10)
 
     project = Project.find_by_name("Shop")
-    visit graph_project_path(project)
+    visit project_graph_path(project, "master")
   end
 end

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -141,7 +141,7 @@ module SharedPaths
     # Stub Graph::JsonBuilder max_size to speed up test (10 commits vs. 650)
     Gitlab::Graph::JsonBuilder.stub(max_count: 10)
 
-    visit graph_project_path(@project)
+    visit project_graph_path(@project, root_ref)
   end
 
   Given "I visit my project's issues page" do

--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -54,9 +54,10 @@ module ExtractsPath
     input.gsub!(/^#{Gitlab.config.gitlab.relative_url_root}/, "")
     # Remove project, actions and all other staff from path
     input.gsub!(/^\/#{Regexp.escape(@project.path_with_namespace)}/, "")
-    input.gsub!(/^\/(tree|commits|blame|blob|refs)\//, "") # remove actions
+    input.gsub!(/^\/(tree|commits|blame|blob|refs|graph)\//, "") # remove actions
     input.gsub!(/\?.*$/, "") # remove stamps suffix
     input.gsub!(/.atom$/, "") # remove rss feed
+    input.gsub!(/.json$/, "") # remove json suffix
     input.gsub!(/\/edit$/, "") # remove edit route part
 
     if input.match(/^([[:alnum:]]{40})(.+)/)

--- a/lib/gitlab/graph/json_builder.rb
+++ b/lib/gitlab/graph/json_builder.rb
@@ -9,8 +9,9 @@ module Gitlab
         @max_count ||= 650
       end
 
-      def initialize project
+      def initialize project, ref
         @project = project
+        @ref = ref
         @repo = project.repo
         @ref_cache = {}
 
@@ -66,9 +67,9 @@ module Gitlab
         heads.select!{|h| h.is_a? Grit::Head or h.is_a? Grit::Remote}
         # sort heads so the master is top and current branches are closer
         heads.sort! do |a,b|
-          if a.name == "master"
+          if a.name == @ref
             -1
-          elsif b.name == "master"
+          elsif b.name == @ref
             1
           else
             b.commit.committed_date <=> a.commit.committed_date

--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -73,7 +73,8 @@
       , cumonth = ""
       , offsetX = 20
       , offsetY = 60
-      , barWidth = Math.max(graphWidth, this.dayCount * 20 + 320);
+      , barWidth = Math.max(graphWidth, this.dayCount * 20 + 320)
+      , scrollLeft = cw;
     
     this.raphael = r;
     
@@ -145,12 +146,18 @@
       
       if (this.commits[i].refs) {
         this.appendLabel(x, y, this.commits[i].refs);
+
+        // The main branch is displayed in the center.
+        re = new RegExp('(^| )' + this.options.ref + '( |$)');
+        if (this.commits[i].refs.match(re)) {
+          scrollLeft = x - graphWidth / 2;
+        }
       }
       
       this.appendAnchor(top, this.commits[i], x, y);
     }
     top.toFront();
-    this.element.scrollLeft(cw);
+    this.element.scrollLeft(scrollLeft);
     this.bindEvents();
   };
   


### PR DESCRIPTION
Switchable the main branch on network graph is convenient, when "A successful Git branching model" is employed.

Screenshot:

![switchable-main-branch-on-network-graph](https://f.cloud.github.com/assets/72138/106700/91434a90-6a07-11e2-8593-8495f0ff5eae.png)
