### PR TITLE
Fixed a grammar mistake in alert-message.block-message

### DIFF
--- a/app/views/commits/_diffs.html.haml
+++ b/app/views/commits/_diffs.html.haml
@@ -1,7 +1,7 @@
 - if @suppress_diff
   .alert-message.block-message
     %p
-      %strong Warning! Large commit with more then #{Commit::DIFF_SAFE_SIZE} files changed.
+      %strong Warning! Large commit with more than #{Commit::DIFF_SAFE_SIZE} files changed.
     %p To prevent performance issue we rejected diff information.
     %p
       But if you still want to see diff


### PR DESCRIPTION
Fixed a grammar mistake in alert-message.block-message
