### PR TITLE
Expose MergeRequest object as a notable in the API to allow for easy ret...

### DIFF
--- a/lib/api/notes.rb
+++ b/lib/api/notes.rb
@@ -3,7 +3,7 @@ module Gitlab
   class Notes < Grape::API
     before { authenticate! }
 
-    NOTEABLE_TYPES = [Issue, Snippet]
+    NOTEABLE_TYPES = [Issue, MergeRequest, Snippet]
 
     resource :projects do
       # Get a list of project wall notes


### PR DESCRIPTION
Exposed the MergeRequest object as a notable in the API. This is slightly redundant with the API endpoint in mergerequests.rb which allows for posting of comments to a MergeRequest but both mechanisms work correctly. I chose to go down this route as it was more in line with the other types of notable objects. 

The primary purpose of this request is to allow for users to programmatically read in all of the comments from a specific merge request.
