### PR TITLE
Displaying commit on a new window, when clicking commit on network graph.

### DIFF
--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -260,7 +260,7 @@
       cursor: "pointer"
     })
     .click(function(){
-      window.location = options.commit_url.replace('%s', commit.id);
+      window.open(options.commit_url.replace('%s', commit.id), '_blank');
     })
     .hover(function(){
       this.tooltip = r.commitTooltip(x, y + 5, commit);


### PR DESCRIPTION
Displaying commit on a current window is inconvenient, when clicking commit on network graph.
Because A position on network graph will be reset when it has gone back from commit. 
