### PR TITLE
Disable hard wrapping in GFM

### DIFF
--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -33,8 +33,7 @@ module GitlabMarkdownHelper
       gitlab_renderer = Redcarpet::Render::GitlabHTML.new(self,
                           # see https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch-
                           filter_html: true,
-                          with_toc_data: true,
-                          hard_wrap: true)
+                          with_toc_data: true)
       @markdown = Redcarpet::Markdown.new(gitlab_renderer,
                       # see https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
                       no_intra_emphasis: true,

--- a/app/views/help/markdown.html.haml
+++ b/app/views/help/markdown.html.haml
@@ -29,19 +29,6 @@
     .span8
       %h3 Differences from traditional Markdown
 
-      %h4 Newlines
-
-      %p
-        The biggest difference that GFM introduces is in the handling of linebreaks.
-        With traditional Markdown you can hard wrap paragraphs of text and they will be combined into a single paragraph. We find this to be the cause of a huge number of unintentional formatting errors.
-        GFM treats newlines in paragraph-like content as real line breaks, which is probably what you intended.
-
-
-      %p The next paragraph contains two phrases separated by a single newline character:
-      %pre= "Roses are red\nViolets are blue"
-      %p becomes
-      = markdown "Roses are red\nViolets are blue"
-
       %h4 Multiple underscores in words
 
       %p


### PR DESCRIPTION
This is a follow-up to #2818 that disables the hard wrapping entirely with no config option.
