### PR TITLE
Better init.d script check

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -142,10 +142,10 @@ namespace :gitlab do
         return
       end
 
-      recipe_content = `curl https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab 2>/dev/null`
+      target_version = '4.1'
       script_content = File.read(script_path)
 
-      if recipe_content == script_content
+      if script_content =~ /^# App Version: ([0-9]+(\.[0-9]+)*)$/ and "#{$1}" == target_version
         puts "yes".green
       else
         puts "no".red


### PR DESCRIPTION
Hi, 

i've got a small update for the init.d script check, so that it checks only the version of the script and not the whole content. The old check always failed for me, because my gitlab path is not within /home/gitlab/gitlab, so i had to edit the init.d script

Cheers,
