### PR TITLE
remove hardcoded app_dir from unicorn.rb.example

### DIFF
--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -2,7 +2,7 @@
 # note that config/gitlab.yml web path should also be changed
 # ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
 
-app_dir = "/home/gitlab/gitlab/"
+app_dir = File.expand_path '../../', __FILE__
 worker_processes 2
 working_directory app_dir
 


### PR DESCRIPTION
uses `File.expand_path '../../', __FILE__` instead.
