### PR TITLE
Add option to disable username changing

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,7 +51,7 @@ class ProfilesController < ApplicationController
   end
 
   def update_username
-    if Gitlab.config.gitlab.username_changing_enabled
+    if @user.can_change_username?
       @user.update_attributes(username: params[:user][:username])
     end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,7 +51,9 @@ class ProfilesController < ApplicationController
   end
 
   def update_username
-    @user.update_attributes(username: params[:user][:username])
+    if Gitlab.config.gitlab.username_changing_enabled
+      @user.update_attributes(username: params[:user][:username])
+    end
 
     respond_to do |format|
       format.js

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -215,6 +215,10 @@ class User < ActiveRecord::Base
     keys.count == 0
   end
 
+  def can_change_username?
+    Gitlab.config.gitlab.username_changing_enabled
+  end
+
   def can_create_project?
     projects_limit > personal_projects.count
   end

--- a/app/views/profiles/account.html.haml
+++ b/app/views/profiles/account.html.haml
@@ -53,28 +53,29 @@
 
 
 
-%fieldset.update-username
-  %legend
-    Username
-    %small.cred.right
-      Changing your username can have unintended side effects!
-  = form_for @user, url: update_username_profile_path,  method: :put, remote: true do |f|
-    .padded
-      = f.label :username
-      .input
-        = f.text_field :username, required: true
-        &nbsp;
-        %span.loading-gif.hide= image_tag "ajax_loader.gif"
-        %span.update-success.cgreen.hide
-          %i.icon-ok
-          Saved
-        %span.update-failed.cred.hide
-          %i.icon-remove
-          Failed
-        %ul.cred
-          %li It will change web url for personal projects.
-          %li It will change the git path to repositories for personal projects.
-      .input
-        = f.submit 'Save username', class: "btn save-btn"
+- if Gitlab.config.gitlab.username_changing_enabled
+  %fieldset.update-username
+    %legend
+      Username
+      %small.cred.right
+        Changing your username can have unintended side effects!
+    = form_for @user, url: update_username_profile_path,  method: :put, remote: true do |f|
+      .padded
+        = f.label :username
+        .input
+          = f.text_field :username, required: true
+          &nbsp;
+          %span.loading-gif.hide= image_tag "ajax_loader.gif"
+          %span.update-success.cgreen.hide
+            %i.icon-ok
+            Saved
+          %span.update-failed.cred.hide
+            %i.icon-remove
+            Failed
+          %ul.cred
+            %li It will change web url for personal projects.
+            %li It will change the git path to repositories for personal projects.
+        .input
+          = f.submit 'Save username', class: "btn save-btn"
 
 

--- a/app/views/profiles/account.html.haml
+++ b/app/views/profiles/account.html.haml
@@ -53,7 +53,7 @@
 
 
 
-- if Gitlab.config.gitlab.username_changing_enabled
+- if current_user.can_change_username?
   %fieldset.update-username
     %legend
       Username

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -35,6 +35,7 @@ gitlab:
   ## Project settings
   default_projects_limit: 10
   # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
+  # username_changing_enabled: false # default: true - User can change her username/namespace
 
 ## Gravatar
 gravatar:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -53,6 +53,7 @@ Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'gitlab'
 Settings.gitlab['signup_enabled'] ||= false
+Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 
 Settings['gravatar'] ||= Settingslogic.new({})
 Settings.gravatar['enabled']      = true if Settings.gravatar['enabled'].nil?


### PR DESCRIPTION
When gitlab is used with ldap or pam for authentication, we might want to disable username changing.

We found out that you can reserve another users username before another user logs in first time and thus disabling the service from him.
