### PR TITLE
Show only ≤16 lines of codes in a discussion in a MR (issue #2860).

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -57,6 +57,31 @@ module CommitsHelper
     end
   end
 
+  def each_diff_line_near(diff, index, expected_line_code)
+    max_number_of_lines = 16
+
+    prev_match_line = nil
+    prev_lines = []
+
+    each_diff_line(diff, index) do |full_line, type, line_code, line_new, line_old|
+      line = [full_line, type, line_code, line_new, line_old]
+      if line_code != expected_line_code
+        if type == "match"
+          prev_lines.clear
+          prev_match_line = line
+        else
+          prev_lines.push(line)
+          prev_lines.shift if prev_lines.length >= max_number_of_lines
+        end
+      else
+        yield(prev_match_line) if !prev_match_line.nil?
+        prev_lines.each { |ln| yield(ln) }
+        yield(line)
+        break
+      end
+    end
+  end
+
   def image_diff_class(diff)
     if diff.deleted_file
       "deleted"

--- a/app/views/notes/_discussion_diff.html.haml
+++ b/app/views/notes/_discussion_diff.html.haml
@@ -9,7 +9,7 @@
   %br/
 .content
   %table
-    - each_diff_line(diff, note.diff_file_index) do |line, type, line_code, line_new, line_old|
+    - each_diff_line_near(diff, note.diff_file_index, note.line_code) do |line, type, line_code, line_new, line_old|
       %tr.line_holder{ id: line_code }
         - if type == "match"
           %td.old_line= "..."
@@ -22,4 +22,3 @@
 
           - if line_code == note.line_code
             = render "notes/diff_notes_with_reply", notes: discussion_notes
-            - break # cut off diff after notes


### PR DESCRIPTION
The code shown in a discussion will now be trimmed to include only the previous 16 lines or the closest '@@' line, whichever comes first (like GitHub). This allows user able to reach the discussion without scrolling through all irrelevant changes in the MR page.

This PR fixes #2860.

![screenshot](https://f.cloud.github.com/assets/103023/121115/6eaecde8-6d71-11e2-8e62-e1790508d733.png)
