### PR TITLE
OS X support for gitlab:check rake tasks

### DIFF
--- a/lib/tasks/gitlab/task_helpers.rake
+++ b/lib/tasks/gitlab/task_helpers.rake
@@ -77,8 +77,7 @@ namespace :gitlab do
   end
 
   def gid_for(group_name)
-    group_line = File.read("/etc/group").lines.select{|l| l.start_with?("#{group_name}:")}.first
-    group_line.split(":")[2].to_i
+    Etc.getgrnam(group_name).gid
   end
 
   def warn_user_is_not_gitlab


### PR DESCRIPTION
The `gitlab:check` (and other `:check`) rake tasks currently fail on OS X due to the `gid_for` method in TaskHelpers.rake manually parsing the /etc/group file:

```
$ bundle exec rake gitlab:check RAILS_ENV=production
Checking Environment ...

gitlab user is in gitg group? ... yes
Has no "-e" in ~git/.profile ... yes
Git configured for gitlab user? ... yes
Has python2? ... yes
python2 is supported version? ... yes

Checking Environment ... Finished

Checking Gitolite ...

Using recommended version ... yes
Repo umask is 0007 in .gitolite.rc? ... yes
Allow all Git config keys in .gitolite.rc ... yes
Config directory exists? ... yes
Config directory owned by git:gitg ... rake aborted!
undefined method `split' for nil:NilClass
/Users/gitlab/gitlab/lib/tasks/gitlab/task_helpers.rake:81:in `gid_for'
/Users/gitlab/gitlab/lib/tasks/gitlab/check.rake:533:in `check_dot_gitolite_user_and_group'
/Users/gitlab/gitlab/lib/tasks/gitlab/check.rake:400:in `block (3 levels) in <top (required)>'
Tasks: TOP => gitlab:check => gitlab:gitolite:check
(See full trace by running task with --trace)
```

While the `/etc/group` file exists on OS X it's only used for system services, with all user-created users and groups using Directory Services instead.

This simple pull request replaces the manual parsing of `/etc/group` with an equivalent call to the platform-independent [`Etc` class](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/etc/rdoc/Etc.html) from the standard library.

All tests continue to pass after this amend.
