### PR TITLE
Keeping ref of link in navigation when showing commit page.

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -15,6 +15,9 @@ class CommitsController < ProjectResourceController
     @commits = @repo.commits(@ref, @path, @limit, @offset)
     @commits = CommitDecorator.decorate(@commits)
 
+    # keeping ref of nav when showing commit page.
+    flash[:ref] = @ref
+
     respond_to do |format|
       format.html # index.html.erb
       format.js

--- a/app/helpers/project_resource_helper.rb
+++ b/app/helpers/project_resource_helper.rb
@@ -1,0 +1,5 @@
+module ProjectResourceHelper
+  def ref
+    flash[:ref] || @ref || @repository.root_ref
+  end
+end

--- a/app/views/layouts/project_resource.html.haml
+++ b/app/views/layouts/project_resource.html.haml
@@ -18,11 +18,11 @@
         - if @project.repo_exists?
           - if can? current_user, :download_code, @project
             = nav_link(controller: %w(tree blob blame)) do
-              = link_to 'Files', project_tree_path(@project, @ref || @repository.root_ref)
+              = link_to 'Files', project_tree_path(@project, ref)
             = nav_link(controller: %w(commit commits compare repositories protected_branches)) do
-              = link_to "Commits", project_commits_path(@project, @ref || @repository.root_ref)
+              = link_to "Commits", project_commits_path(@project, ref)
             = nav_link(controller: %w(graph)) do
-              = link_to "Network", project_graph_path(@project, @ref || @repository.root_ref)
+              = link_to "Network", project_graph_path(@project, ref)
 
         - if @project.issues_enabled
           = nav_link(controller: %w(issues milestones labels)) do


### PR DESCRIPTION
The ref of link in navigation is reset by root_ref, when showing commit page.
I think that it is different behavior from GitHub.
