### PR TITLE
Expose more information about open merge requests

### DIFF
--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -40,6 +40,107 @@ Parameters:
 ]
 ```
 
+## List open merge requests
+
+Get all open (i.e. non-closed, non-merged) MR for this project. This
+returns a more filled out merge request object that includes commit and
+note information.
+
+```
+GET /projects/:id/open_merge_requests
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
+
+```json
+[
+    {
+        "id":1,
+        "target_branch":"master",
+        "source_branch":"test1",
+        "project_id":3,
+        "title":"test1",
+        "closed":true,
+        "merged":false,
+        "author":{
+            "id":1,
+            "username": "admin",
+            "email":"admin@local.host",
+            "name":"Administrator",
+            "blocked":false,
+            "created_at":"2012-04-29T08:46:00Z"
+        },
+        "assignee":{
+            "id":1,
+            "username": "admin",
+            "email":"admin@local.host",
+            "name":"Administrator",
+            "blocked":false,
+            "created_at":"2012-04-29T08:46:00Z"
+        },
+        "mr_and_commit_notes": [
+            {
+                "attachment": {
+                    "url": null
+                },
+                "author_id": 5,
+                "commit_id": null,
+                "created_at": "2013-02-01T15:13:15Z",
+                "id": 159,
+                "line_code": null,
+                "note": ":-1: This needs more work.",
+                "noteable_id": 27,
+                "noteable_type": "MergeRequest",
+                "project_id": 39,
+                "updated_at": "2013-02-01T15:13:15Z"
+            },
+            {
+                "attachment": {
+                    "url": null
+                },
+                "author_id": 4,
+                "commit_id": "",
+                "created_at": "2013-02-02T09:59:57Z",
+                "id": 161,
+                "line_code": null,
+                "note": ":+1: Seems legit",
+                "noteable_id": 27,
+                "noteable_type": "MergeRequest",
+                "project_id": 39,
+                "updated_at": "2013-02-02T09:59:57Z"
+            }
+        ],
+        "unmerged_commits": [
+            {
+                "commit": {
+                    "id": "f8b1ebe1a21aebee3b5c19d5216e7de40b7db43f",
+                    "parents": [
+                        {
+                            "id": "10792ad4f8f42354aed2c5a4997b503171f5d1be"
+                        }
+                    ],
+                    "tree": "eeb3e324299e458fe1b6e6fc709900a8ed7e5d94",
+                    "message": "BUG: Don't frobble the quuxes.",
+                    "author": {
+                        "name": "johndoe",
+                        "email": "john.doe@example.com"
+                    },
+                    "committer": {
+                        "name": "johndoe",
+                        "email": "john.doe@example.com"
+                    },
+                    "authored_date": "2013-02-01T16:12:44+01:00",
+                    "committed_date": "2013-02-01T16:12:44+01:00"
+                },
+                "head": null
+            }
+        ]
+    }
+]
+```
+
 ## Show MR
 
 Show information about MR.

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -70,6 +70,11 @@ module Gitlab
       expose :author, :assignee, using: Entities::UserBasic
     end
 
+    class DetailedMergeRequest < MergeRequest
+      expose :unmerged_commits
+      expose :mr_and_commit_notes
+    end
+
     class Note < Grape::Entity
       expose :id
       expose :note, as: :body

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -19,6 +19,23 @@ module Gitlab
         present paginate(user_project.merge_requests), with: Entities::MergeRequest
       end
 
+      # List open merge requests
+      #
+      # Parameters:
+      #   id (required) - The ID of a project
+      #
+      # Example:
+      #   GET /projects/:id/open_merge_requests
+      #
+      # Returns a more detailed merge request object than the method above,
+      # including unmerged commits.
+      #
+      get ":id/open_merge_requests" do
+        authorize! :read_merge_request, user_project
+
+        present paginate(user_project.merge_requests.where(:closed => false, :merged => false)), with: Entities::DetailedMergeRequest
+      end
+
       # Show MR
       #
       # Parameters:


### PR DESCRIPTION
This adds a new API call per project that returns all open merge requests, including notes and commits. We use this to automatically evaluate merge requests for style etc and post a +1 or -1.

Since the existing merge requests call returns all MR:s (even those already closed or merged) and the new information I want to return might be expensive, I chose to add a new API call for only open requests instead of fleshing out the existing one.
