### PR TITLE
Easy to find commit on network graph

### DIFF
--- a/app/controllers/graph_controller.rb
+++ b/app/controllers/graph_controller.rb
@@ -10,7 +10,7 @@ class GraphController < ProjectResourceController
     respond_to do |format|
       format.html
       format.json do
-        graph = Gitlab::Graph::JsonBuilder.new(project, @ref)
+        graph = Gitlab::Graph::JsonBuilder.new(project, @ref, @commit)
         render :json => graph.to_json
       end
     end

--- a/app/controllers/graph_controller.rb
+++ b/app/controllers/graph_controller.rb
@@ -7,6 +7,16 @@ class GraphController < ProjectResourceController
   before_filter :require_non_empty_project
 
   def show
+    if params.has_key?(:q) && params[:q].blank?
+      redirect_to project_graph_path(@project, params[:id])
+      return
+    end
+
+    if params.has_key?(:q)
+      @q = params[:q]
+      @commit = @project.repository.commit(@q) || @commit
+    end
+
     respond_to do |format|
       format.html
       format.json do

--- a/app/views/graph/_head.html.haml
+++ b/app/views/graph/_head.html.haml
@@ -1,0 +1,9 @@
+%ul.nav.nav-tabs
+  %li
+    = render partial: 'shared/ref_switcher', locals: {destination: 'graph', path: @path}
+  %li.pull-right.search
+    = form_tag project_graph_path(@project, params[:id]), method: :get, class: 'navbar-form' do |f|
+      = label_tag :search , "Looking for commit:"
+      = text_field_tag :q, @q, placeholder: "Input SHA", class: "search-input"
+
+%h3.page_title Project Network Graph

--- a/app/views/graph/show.html.haml
+++ b/app/views/graph/show.html.haml
@@ -14,6 +14,7 @@
     branch_graph = new BranchGraph($("#holder"), {
       url: '#{project_graph_path(@project, @ref, format: :json)}',
       commit_url: '#{project_commit_path(@project, 'ae45ca32').gsub("ae45ca32", "%s")}',
-      ref: '#{@ref}'
+      ref: '#{@ref}',
+      commit_id: '#{@commit && @commit.id}'
     });
   });

--- a/app/views/graph/show.html.haml
+++ b/app/views/graph/show.html.haml
@@ -1,7 +1,4 @@
-%h3.page_title Project Network Graph
-%br
-= render partial: 'shared/ref_switcher', locals: {destination: 'graph', path: @path}
-%br
+= render "head"
 .graph_holder
   %h4
     %small You can move around the graph by using the arrow keys.
@@ -12,9 +9,9 @@
   var branch_graph;
   $(function(){
     branch_graph = new BranchGraph($("#holder"), {
-      url: '#{project_graph_path(@project, @ref, format: :json)}',
+      url: '#{project_graph_path(@project, @ref, q: @q, format: :json)}',
       commit_url: '#{project_commit_path(@project, 'ae45ca32').gsub("ae45ca32", "%s")}',
       ref: '#{@ref}',
-      commit_id: '#{@commit && @commit.id}'
+      commit_id: '#{@commit.id}'
     });
   });

--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -117,7 +117,10 @@ module ExtractsPath
 
     @id = File.join(@ref, @path)
 
-    @commit = CommitDecorator.decorate(@project.repository.commit(@ref))
+    # It is used "@project.repository.commits(@ref, @path, 1, 0)",
+    # because "@project.repository.commit(@ref)" returns wrong commit when @ref is tag name.
+    commits = @project.repository.commits(@ref, @path, 1, 0)
+    @commit = CommitDecorator.decorate(commits.first)
 
     @tree = Tree.new(@commit.tree, @ref, @path)
     @tree = TreeDecorator.new(@tree)

--- a/lib/gitlab/graph/json_builder.rb
+++ b/lib/gitlab/graph/json_builder.rb
@@ -49,7 +49,7 @@ module Gitlab
       # list of commits. As well as returns date list
       # corelated with time set on commits.
       #
-      # @param [Array<Graph::Commit>] comits to index
+      # @param [Array<Graph::Commit>] commits to index
       #
       # @return [Array<TimeDate>] list of commit dates corelated with time on commits
       def index_commits

--- a/lib/gitlab/graph/json_builder.rb
+++ b/lib/gitlab/graph/json_builder.rb
@@ -113,7 +113,7 @@ module Gitlab
 
       def include_ref?(commit)
         heads = commit.refs.select do |ref|
-          ref.is_a?(Grit::Head) or ref.is_a?(Grit::Remote)
+          ref.is_a?(Grit::Head) or ref.is_a?(Grit::Remote) or ref.is_a?(Grit::Tag)
         end
 
         heads.map! do |head|

--- a/lib/gitlab/graph/json_builder.rb
+++ b/lib/gitlab/graph/json_builder.rb
@@ -33,7 +33,7 @@ module Gitlab
       #
       def collect_commits
 
-        @commits = Grit::Commit.find_all(repo, nil, {max_count: self.class.max_count, skip: to_commit}).dup
+        @commits = Grit::Commit.find_all(repo, nil, {topo_order: true, max_count: self.class.max_count, skip: to_commit}).dup
 
         # Decorate with app/models/commit.rb
         @commits.map! { |commit| ::Commit.new(commit) }
@@ -86,7 +86,7 @@ module Gitlab
 
       # Skip count that the target commit is displayed in center.
       def to_commit
-        commits = Grit::Commit.find_all(repo, nil)
+        commits = Grit::Commit.find_all(repo, nil, {topo_order: true})
         commit_index = commits.index do |c|
           c.id == @commit.id
         end

--- a/vendor/assets/javascripts/branch-graph.js
+++ b/vendor/assets/javascripts/branch-graph.js
@@ -161,14 +161,23 @@
       
       if (this.commits[i].refs) {
         this.appendLabel(x, y, this.commits[i].refs);
-
-        // The main branch is displayed in the center.
-        re = new RegExp('(^| )' + this.options.ref + '( |$)');
-        if (this.commits[i].refs.match(re)) {
-          scrollLeft = x - graphWidth / 2;
-        }
       }
       
+      // mark commit and displayed in the center
+      if (this.commits[i].id == this.options.commit_id) {
+        r.path([
+            'M', x, y - 5,
+            'L', x + 4, y - 15,
+            'L', x - 4, y - 15,
+            'Z'
+            ]).attr({
+              "fill": "#000",
+              "fill-opacity": .7,
+              "stroke": "none"
+              });
+        scrollLeft = x - graphWidth / 2;
+      }
+
       this.appendAnchor(top, this.commits[i], x, y);
     }
     top.toFront();


### PR DESCRIPTION
1. The commit is marked and displayed in the center.
2. Enable to display the commit older than 650th commit.
3. Add search box for the commit.
### Screenshot

![easy-to-find-commit-on-network-graph](https://f.cloud.github.com/assets/72138/126531/0a435e22-6f61-11e2-949f-4c0055c13bfe.png)
