### PR TITLE
Repo import 4.1 fix (empty repositories)

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -44,7 +44,7 @@ namespace :gitlab do
             :name => path,
           }
 
-          project = Project.create_by_user(project_params, user)
+          project = Projects::CreateContext.new(user, project_params).execute
 
           if project.valid?
             puts " * Created #{project.name} (#{repo_name})".green

--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -42,6 +42,7 @@ namespace :gitlab do
 
           project_params = {
             :name => path,
+            :namespace_id => Namespace.global_id,
           }
 
           project = Projects::CreateContext.new(user, project_params).execute


### PR DESCRIPTION
Fix for #2830
Includes fix from #2695

Import all repos to global namespace, otherwise the new generated repositories are empty!
