### PR TITLE
fix the gitlab-shell clone url in master installation doc

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -103,7 +103,7 @@ Create a `git` user for Gitlab:
     cd /home/git
 
     # clone gitlab shell
-    git clone https://dzaporozhets@dev.gitlab.org/gitlab/gitlab-shell.git
+    git clone https://github.com/gitlabhq/gitlab-shell.git
 
     # setup
     cd gitlab-shell


### PR DESCRIPTION
gitlab-shell clone location was dev.gitlab.org, changed it to the correct github location
