### PR TITLE
install documentation: install database development packages

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -180,9 +180,11 @@ Make sure to update username/password in config/database.yml.
     sudo gem install charlock_holmes --version '0.6.9'
 
     # For MySQL (note, the option says "without")
+    sudo apt-get install libmysqlclient-dev
     sudo -u git -H bundle install --deployment --without development test postgres
 
     # Or for PostgreSQL
+    sudo apt-get install libpq-dev
     sudo -u git -H bundle install --deployment --without development test mysql
 
 


### PR DESCRIPTION
Hi,

Packages needed to build the database tools are not listed in the installation guide. This branch adds the information.
