### PR TITLE
API: Fixes return code when accessing non existent branch (#2922)

### DIFF
--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -79,6 +79,9 @@ Parameters:
 }
 ```
 
+Will return status code `200` on success or `404 Not found` if the branch is not available.
+
+
 ## Protect a project repository branch
 
 Protect a single project repository branch.

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -230,6 +230,7 @@ module Gitlab
       #   GET /projects/:id/repository/branches/:branch
       get ":id/repository/branches/:branch" do
         @branch = user_project.repo.heads.find { |item| item.name == params[:branch] }
+        error!("Branch does not exist", 404) if @branch.nil?
         present @branch, with: Entities::RepoObject, project: user_project
       end
 

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -230,7 +230,7 @@ module Gitlab
       #   GET /projects/:id/repository/branches/:branch
       get ":id/repository/branches/:branch" do
         @branch = user_project.repo.heads.find { |item| item.name == params[:branch] }
-        error!("Branch does not exist", 404) if @branch.nil?
+        not_found!("Branch does not exist") if @branch.nil?
         present @branch, with: Entities::RepoObject, project: user_project
       end
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -109,6 +109,11 @@ describe Gitlab::API do
       json_response['commit']['id'].should == '621491c677087aa243f165eab467bfdfbee00be1'
       json_response['protected'].should == false
     end
+
+    it "should return a 404 error if branch is not available" do
+      get api("/projects/#{project.id}/repository/branches/unknown", user)
+      response.status.should == 404
+    end
   end
 
   describe "PUT /projects/:id/repository/branches/:branch/protect" do


### PR DESCRIPTION
Accessing a non-existent repository branch via API returned a status code 200 and content `null`. Now a 404 error code is returned. Added a test to check the status code. See issue #2922.
