### PR TITLE
Update command to execute as git user

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -147,7 +147,7 @@ Fix the directory permissions for the repositories:
     # Make sure the repositories dir is owned by git and it stays that way
     sudo chmod -R ug+rwX,o-rwx /home/git/repositories/
     sudo chown -R git:git /home/git/repositories/
-    find /home/git/repositories -type d -print0 | sudo xargs -0 chmod g+s
+    sudo -u git -H find /home/git/repositories -type d -print0 | sudo xargs -0 chmod g+s
 
 
 ## Add domains to list to the list of known hosts


### PR DESCRIPTION
```
sudo chmod -R ug+rwX,o-rwx /home/git/repositories/
sudo chown -R git:git /home/git/repositories/
```

From the above conditions,

```
find /home/git/repositories -type d -print0
```

should be executed by git user or group.
