### PR TITLE
Fix image url for emoji.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,7 +160,7 @@ module ApplicationHelper
   end
 
   def image_url(source)
-    root_url + path_to_image(source)
+    root_url.sub(/#{root_path}$/,'') + path_to_image(source)
   end
   alias_method :url_to_image, :image_url
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,7 +160,8 @@ module ApplicationHelper
   end
 
   def image_url(source)
-    root_url.sub(/#{root_path}$/,'') + path_to_image(source)
+    # prevent relative_root_path being added twice (it's part of root_url and path_to_image)
+    root_url.sub(/#{root_path}$/, path_to_image(source))
   end
   alias_method :url_to_image, :image_url
 end


### PR DESCRIPTION
If you set relative_root_path to '/gitlab' you'll end up with this:
http://example.com/gitlab//gitlab/assets/emoji/sparkles-25874eff8e1c26ef723a423d02c0a72a.png

This fix removes the duplication of relative root in url while preserving the full image url.
