### PR TITLE
Gitlab incorrectly routes blobs to the compare controller depending on filename.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,12 +166,12 @@ Gitlab::Application.routes.draw do
       get "files"
     end
 
+    resources :blob,    only: [:show], constraints: {id: /.+/}
     resources :tree,    only: [:show, :edit, :update], constraints: {id: /.+/}
     resources :commit,  only: [:show], constraints: {id: /[[:alnum:]]{6,40}/}
     resources :commits, only: [:show], constraints: {id: /.+/}
     resources :compare, only: [:index, :create]
     resources :blame,   only: [:show], constraints: {id: /.+/}
-    resources :blob,    only: [:show], constraints: {id: /.+/}
     resources :graph,   only: [:show], constraints: {id: /.+/}
     match "/compare/:from...:to" => "compare#show", as: "compare",
                     :via => [:get, :post], constraints: {from: /.+/, to: /.+/}

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -392,6 +392,7 @@ end
 describe BlobController, "routing" do
   it "to #show" do
     get("/gitlabhq/blob/master/app/models/project.rb").should route_to('blob#show', project_id: 'gitlabhq', id: 'master/app/models/project.rb')
+    get("/gitlabhq/blob/master/app/models/compare.rb").should route_to('blob#show', project_id: 'gitlabhq', id: 'master/app/models/compare.rb')
   end
 end
 


### PR DESCRIPTION
When a repository contains a file such as "compare.png", the user cannot view the raw file as gitlab tries to route to the compare controller.
