### PR TITLE
Update lib/tasks/sidekiq.rake

### DIFF
--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -8,7 +8,12 @@ namespace :sidekiq do
   task :start do
     run "nohup bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,gitlab_shell,common,default -e #{Rails.env} -P #{pidfile} >> #{Rails.root.join("log", "sidekiq.log")} 2>&1 &"
   end
-
+  
+  desc "GITLAB | Start sidekiq with launchd on Mac OS X"
+  task :launchd do
+    run "bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,gitlab_shell,common,default -e #{Rails.env} -P #{pidfile} >> #{Rails.root.join("log", "sidekiq.log")} 2>&1"
+  end
+  
   def pidfile
     Rails.root.join("tmp", "pids", "sidekiq.pid")
   end


### PR DESCRIPTION
Mac OS uses launchd instead of /etc/init.d to start daemons and tasks to be started by launchd MUST NOT daemon itself. So "nohup" here won't work for Mac OS. 

Can we add a "launchd" task to the rake file so that we can start sidekiq as "bundle exec rake sidekiq:launchd" ?
