### PR TITLE
Force https upon all visitors. Provided the web server is set up for https.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,11 @@ module Gitlab
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+
+    #Enable this if you wish to force https. Only use if you have set up https in your web server 
+    #config.force_ssl = true
+
+
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/models/concerns)
 


### PR DESCRIPTION
If you have setup https in your web server and wish to use https with Gitlab, enabling this will force https to all visitors. 
