### PR TITLE
API: creating last project before limit returns 404

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -146,7 +146,7 @@ class Project < ActiveRecord::Base
   end
 
   def saved?
-    id && valid?
+    id && persisted?
   end
 
   def import?

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -44,7 +44,7 @@ module Gitlab
                                     :merge_requests_enabled,
                                     :wiki_enabled]
         @project = ::Projects::CreateContext.new(current_user, attrs).execute
-        if @project.persisted?
+        if @project.saved?
           present @project, with: Entities::Project
         else
           not_found!

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -44,7 +44,7 @@ module Gitlab
                                     :merge_requests_enabled,
                                     :wiki_enabled]
         @project = ::Projects::CreateContext.new(current_user, attrs).execute
-        if @project.saved?
+        if @project.persisted?
           present @project, with: Entities::Project
         else
           not_found!


### PR DESCRIPTION
When the last project is created before the limit is reached, the API (`POST /projects`) returns a 404 error instead of status code 201 (Created). The project itself gets created and is available in the database.

A similar behaviour can be observed via web client when the user creates the last project, he receives a notification that the limit is reached. As before the project itself gets created.

Tests are added to check the behaviour and the fix solves the issue for the API.
