### PR TITLE
archive download : namespace directory not created

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -141,7 +141,7 @@ class Repository
 
     # Create file if not exists
     unless File.exists?(file_path)
-      FileUtils.mkdir_p storage_path
+      FileUtils.mkdir_p File.dirname(file_path)
       file = self.repo.archive_to_file(ref, prefix,  file_path)
     end
 


### PR DESCRIPTION
in Repository#archive_repo

For instance, if the repository is "bob/revolution", the code must ensure the creation of the directory  `tmp/repositories/bob`. But it only creates `tmp/repositories`.
The fix is rather simple, and in the proposed microscopic patch.
