### PR TITLE
Add option to disable username changing

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,7 +51,9 @@ class ProfilesController < ApplicationController
   end
 
   def update_username
-    @user.update_attributes(username: params[:user][:username])
+    if @user.can_change_username?
+      @user.update_attributes(username: params[:user][:username])
+    end
 
     respond_to do |format|
       format.js

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,10 @@ class User < ActiveRecord::Base
     keys.count == 0
   end
 
+  def can_change_username?
+    Gitlab.config.gitlab.username_changing_enabled
+  end
+
   def can_create_project?
     projects_limit > personal_projects.count
   end

--- a/app/views/profiles/account.html.haml
+++ b/app/views/profiles/account.html.haml
@@ -53,29 +53,30 @@
 
 
 
-%fieldset.update-username
-  %legend
-    Username
-    %small.cred.pull-right
-      Changing your username can have unintended side effects!
-  = form_for @user, url: update_username_profile_path,  method: :put, remote: true do |f|
-    .padded
-      = f.label :username
-      .input
-        = f.text_field :username, required: true
-        &nbsp;
-        %span.loading-gif.hide= image_tag "ajax_loader.gif"
-        %span.update-success.cgreen.hide
-          %i.icon-ok
-          Saved
-        %span.update-failed.cred.hide
-          %i.icon-remove
-          Failed
-        %ul.cred
-          %li It will change web url for personal projects.
-          %li It will change the git path to repositories for personal projects.
-      .input
-        = f.submit 'Save username', class: "btn btn-save"
+- if current_user.can_change_username?
+  %fieldset.update-username
+    %legend
+      Username
+      %small.cred.pull-right
+        Changing your username can have unintended side effects!
+    = form_for @user, url: update_username_profile_path,  method: :put, remote: true do |f|
+      .padded
+        = f.label :username
+        .input
+          = f.text_field :username, required: true
+          &nbsp;
+          %span.loading-gif.hide= image_tag "ajax_loader.gif"
+          %span.update-success.cgreen.hide
+            %i.icon-ok
+            Saved
+          %span.update-failed.cred.hide
+            %i.icon-remove
+            Failed
+          %ul.cred
+            %li It will change web url for personal projects.
+            %li It will change the git path to repositories for personal projects.
+        .input
+          = f.submit 'Save username', class: "btn btn-save"
 
 - if Gitlab.config.gitlab.signup_enabled
   %fieldset.remove-account

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -35,6 +35,7 @@ production: &base
     ## Project settings
     default_projects_limit: 10
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
+    # username_changing_enabled: false # default: true - User can change her username/namespace
 
   ## Gravatar
   gravatar:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -57,6 +57,7 @@ Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'git'
 Settings.gitlab['signup_enabled'] ||= false
+Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 
 #
 # Gravatar


### PR DESCRIPTION
This option allows to disable users from changing their username.

This is very usefull in environments using strong internal authentication methods like ldap, pam or shibboleth.

You can allow users to change theyr username in these environments, but then new users (users loging in first time) is blocked from gitlab is her username exists.

And this is PR to master as it should have been last time...
