### PR TITLE
Add feature to support email-less omniauth backends

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -207,13 +207,14 @@ Devise.setup do |config|
 
   if Gitlab.config.ldap.enabled
     config.omniauth :ldap,
-      :host     => Gitlab.config.ldap['host'],
-      :base     => Gitlab.config.ldap['base'],
-      :uid      => Gitlab.config.ldap['uid'],
-      :port     => Gitlab.config.ldap['port'],
-      :method   => Gitlab.config.ldap['method'],
-      :bind_dn  => Gitlab.config.ldap['bind_dn'],
-      :password => Gitlab.config.ldap['password']
+      :host         => Gitlab.config.ldap['host'],
+      :base         => Gitlab.config.ldap['base'],
+      :uid          => Gitlab.config.ldap['uid'],
+      :port         => Gitlab.config.ldap['port'],
+      :method       => Gitlab.config.ldap['method'],
+      :bind_dn      => Gitlab.config.ldap['bind_dn'],
+      :password     => Gitlab.config.ldap['password'],
+      :email_domain => Gitlab.config.ldap['email_domain']
   end
 
   Gitlab.config.omniauth.providers.each do |provider|

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -22,7 +22,7 @@ module Gitlab
       uid = auth.info.uid || auth.uid
       uid = uid.to_s.force_encoding("utf-8")
       name = auth.info.name.to_s.force_encoding("utf-8")
-      email = auth.info.email.to_s.downcase unless auth.info.email.nil?
+      email = email_from_omniauth(auth)
 
       ldap_prefix = ldap ? '(LDAP) ' : ''
       raise OmniAuth::Error, "#{ldap_prefix}#{provider} does not provide an email"\
@@ -50,7 +50,7 @@ module Gitlab
 
     def find_or_new_for_omniauth(auth)
       provider, uid = auth.provider, auth.uid
-      email = auth.info.email.downcase unless auth.info.email.nil?
+      email = email_from_omniauth(auth)
 
       if @user = User.find_by_provider_and_extern_uid(provider, uid)
         @user
@@ -67,6 +67,21 @@ module Gitlab
 
     def log
       Gitlab::AppLogger
+    end
+
+    private
+
+    def email_from_omniauth(auth)
+      provider = auth.provider.intern
+      email = auth.info.email.to_s.downcase unless auth.info.email.nil?
+
+      # we can workaround missing emails in omniauth provider backend
+      # by setting email_domain option for that provider
+      if email.nil? and not Devise.omniauth_configs[provider].options[:email_domain].nil?
+        email = auth.info.nickname + "@" + Devise.omniauth_configs[provider].options[:email_domain]
+      end
+
+      email
     end
   end
 end


### PR DESCRIPTION
If backend do not provide auth.info.email, We generate it from auth.info.nickname and email_domain option passed to omniauth provider (if it's passed).

You should be able to pass this option to all allready implemented omniauth providers and this commit fixes it for ldap.

This feature is usefull in environments wherre login is done by LDAP, pam, shibboleth or similar and that backend is not providing email. (ldap is missing email field. pam can't normally know it. etc..)

This more generalized version of #2589

This PR is untested, but it's copy-paste from version that is in production in our system (https://github.com/raphendyr/gitlabhq/commit/c5c9136bb469137f40aae7019b97fe199e78bf9e).
