### PR TITLE
Fix gitlab:setup task on fresh installation

### DIFF
--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -10,7 +10,7 @@ module Gitlab
     #   add_repository("gitlab/gitlab-ci")
     #
     def add_repository(name)
-      system("/home/git/gitlab-shell/bin/gitlab-projects add-project #{name}.git")
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects add-project #{name}.git")
     end
 
     # Import repository
@@ -21,7 +21,7 @@ module Gitlab
     #   import_repository("gitlab/gitlab-ci", "https://github.com/randx/six.git")
     #
     def import_repository(name, url)
-      system("/home/git/gitlab-shell/bin/gitlab-projects import-project #{name}.git #{url}")
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects import-project #{name}.git #{url}")
     end
 
     # Remove repository from file system
@@ -32,7 +32,7 @@ module Gitlab
     #   remove_repository("gitlab/gitlab-ci")
     #
     def remove_repository(name)
-      system("/home/git/gitlab-shell/bin/gitlab-projects rm-project #{name}.git")
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects rm-project #{name}.git")
     end
 
     # Add new key to gitlab-shell
@@ -41,7 +41,7 @@ module Gitlab
     #   add_key("key-42", "sha-rsa ...")
     #
     def add_key(key_id, key_content)
-      system("/home/git/gitlab-shell/bin/gitlab-keys add-key #{key_id} \"#{key_content}\"")
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-keys add-key #{key_id} \"#{key_content}\"")
     end
 
     # Remove ssh key from gitlab shell
@@ -50,11 +50,16 @@ module Gitlab
     #   remove_key("key-342", "sha-rsa ...")
     #
     def remove_key(key_id, key_content)
-      system("/home/git/gitlab-shell/bin/gitlab-keys rm-key #{key_id} \"#{key_content}\"")
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-keys rm-key #{key_id} \"#{key_content}\"")
     end
 
     def url_to_repo path
       Gitlab.config.gitlab_shell.ssh_path_prefix + "#{path}.git"
     end
+   
+    def gitlab_shell_user_home
+      File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
+    end
+
   end
 end

--- a/lib/tasks/gitlab/setup.rake
+++ b/lib/tasks/gitlab/setup.rake
@@ -1,10 +1,10 @@
 namespace :gitlab do
   desc "GITLAB | Setup production application"
   task :setup => :environment do
-    setup
+    setup_db
   end
 
-  def setup
+  def setup_db
     warn_user_is_not_gitlab
 
     puts "This will create the necessary database tables and seed the database."

--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -25,12 +25,13 @@ namespace :gitlab do
   def setup
     warn_user_is_not_gitlab
 
+    gitlab_shell_authorized_keys = File.join(File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}"),'.ssh/authorized_keys')
     puts "This will rebuild an authorized_keys file."
-    puts "You will lose any data stored in /home/git/.ssh/authorized_keys."
+    puts "You will lose any data stored in #{gitlab_shell_authorized_keys}."
     ask_to_continue
     puts ""
 
-    system("echo '# Managed by gitlab-shell' > /home/git/.ssh/authorized_keys")
+    system("echo '# Managed by gitlab-shell' > #{gitlab_shell_authorized_keys}")
 
     Key.find_each(batch_size: 1000) do |key|
       if Gitlab::Shell.new.add_key(key.shell_id, key.key)


### PR DESCRIPTION
Fresh installation from master throws below error on gitlab:setup task

```
$bundle exec rake gitlab:setup RAILS_ENV=production

This will rebuild an authorized_keys file.                                  
You will lose any data stored in /home/git/.ssh/authorized_keys.            
Do you want to continue (yes/no)? yes                                       

Mysql2::Error: Table 'gitlabhq_production.keys' doesn't exist: SHOW FULL FIELDS FROM `keys`
/home/git/gitlab/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `query'
......................[truncated trace] ....
/home/git/gitlab/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.12/lib/active_record/querying.rb:8:in `find_each'
/home/git/gitlab/lib/tasks/gitlab/shell.rake:35:in `setup'
/home/git/gitlab/lib/tasks/gitlab/setup.rake:4:in `block (2 levels) in <top (required)>'
Tasks: TOP => gitlab:setup
(See full trace by running task with --trace)
```

This looks like task gitlab:setup invokes wrong setup method..  aparent from trace (/home/git/gitlab/lib/tasks/gitlab/shell.rake:35:in `setup') and falls over because there no tables on db.

Further verified by running

```
$bundle exec rake gitlab:shell:setup RAILS_ENV=production 
```

This simple pull request is to rename setup to setup_db so that it does not collide with setup method in  shell.rake

I have verified this changes and successfully installed gitlab from master with gitlab-shell.
