### PR TITLE
API: fixes visibility of project hook

### DIFF
--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -155,6 +155,7 @@ module Gitlab
       # Example Request:
       #   GET /projects/:id/hooks/:hook_id
       get ":id/hooks/:hook_id" do
+        authorize! :admin_project, user_project
         @hook = user_project.hooks.find(params[:hook_id])
         present @hook, with: Entities::Hook
       end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -196,22 +196,44 @@ describe Gitlab::API do
   end
 
   describe "GET /projects/:id/hooks" do
-    it "should return project hooks" do
-      get api("/projects/#{project.id}/hooks", user)
+    context "authorized user" do
+      it "should return project hooks" do
+        get api("/projects/#{project.id}/hooks", user)
+        response.status.should == 200
 
-      response.status.should == 200
+        json_response.should be_an Array
+        json_response.count.should == 1
+        json_response.first['url'].should == "http://example.com"
+      end
+    end
 
-      json_response.should be_an Array
-      json_response.count.should == 1
-      json_response.first['url'].should == "http://example.com"
+    context "unauthorized user" do
+      it "should not access project hooks" do
+        get api("/projects/#{project.id}/hooks", user3)
+        response.status.should == 403
+      end
     end
   end
 
   describe "GET /projects/:id/hooks/:hook_id" do
-    it "should return a project hook" do
-      get api("/projects/#{project.id}/hooks/#{hook.id}", user)
-      response.status.should == 200
-      json_response['url'].should == hook.url
+    context "authorized user" do
+      it "should return a project hook" do
+        get api("/projects/#{project.id}/hooks/#{hook.id}", user)
+        response.status.should == 200
+        json_response['url'].should == hook.url
+      end
+
+      it "should return a 404 error if hook id is not available" do
+        get api("/projects/#{project.id}/hooks/1234", user)
+        response.status.should == 404
+      end
+    end
+
+    context "unauthorized user" do
+      it "should not access an existing hook" do
+        get api("/projects/#{project.id}/hooks/#{hook.id}", user3)
+        response.status.should == 403
+      end
     end
   end
 


### PR DESCRIPTION
An unauthorized user can access project hooks individually.

For example if access to `GET /projects/:id/hooks` fails and returns a `403 Unauthorized` error it is still possible to access a hook directly via `GET /projects/:id/hooks/:hook_id`.

Fixes access, also added tests to check access and status codes of hooks.
