### PR TITLE
Don't include namespace in zip root path

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -137,7 +137,8 @@ class Repository
     file_path = File.join(storage_path, self.path_with_namespace, file_name)
 
     # Put files into a directory before archiving
-    prefix = self.path_with_namespace + "/"
+    path_without_namespace = self.path_with_namespace.split("/")[-1]
+    prefix = path_without_namespace + "/"
 
     # Create file if not exists
     unless File.exists?(file_path)


### PR DESCRIPTION
This patch will turn `namespace_project-sha.zip/namespace/project/` into just `namespace_project-sha.zip/project/`. This will keep uniformity between results of `git clone` and `unzip` commands.
