### PR TITLE
Remove travis icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to GitLab [![build status](https://secure.travis-ci.org/gitlabhq/gitlabhq.png)](https://travis-ci.org/gitlabhq/gitlabhq) [![build status](https://secure.travis-ci.org/gitlabhq/grit.png)](https://travis-ci.org/gitlabhq/grit) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/gitlabhq/gitlabhq) [![Dependency Status](https://gemnasium.com/gitlabhq/gitlabhq.png)](https://gemnasium.com/gitlabhq/gitlabhq)
+# Welcome to GitLab [![build status](https://secure.travis-ci.org/gitlabhq/grit.png)](https://travis-ci.org/gitlabhq/grit) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/gitlabhq/gitlabhq) [![Dependency Status](https://gemnasium.com/gitlabhq/gitlabhq.png)](https://gemnasium.com/gitlabhq/gitlabhq)
 
 GitLab is a free project and repository management application
 
@@ -32,7 +32,7 @@ Checkout wiki pages for installation information, migration, etc.
 Twitter:
 
  * @gitlabhq
- * @dzaporozhets 
+ * @dzaporozhets
 
 Email
 


### PR DESCRIPTION
Since we have failing builds on Travis but builds on GitLab CI are working

Old subject: Remove travis icon since we have failing builds.
