### PR TITLE
Fix RESTfulness of project hook deletions by API

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -265,7 +265,7 @@ Will return status `201 Created` on success, or `404 Not found` on fail.
 Delete hook from project
 
 ```
-DELETE /projects/:id/hooks
+DELETE /projects/:id/hooks/:hook_id
 ```
 
 Parameters:

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -205,8 +205,8 @@ module Gitlab
       #   id (required) - The ID of a project
       #   hook_id (required) - The ID of hook to delete
       # Example Request:
-      #   DELETE /projects/:id/hooks
-      delete ":id/hooks" do
+      #   DELETE /projects/:id/hooks/:hook_id
+      delete ":id/hooks/:hook_id" do
         authorize! :admin_project, user_project
         @hook = user_project.hooks.find(params[:hook_id])
         @hook.destroy

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -275,11 +275,10 @@ describe Gitlab::API do
     end
   end
 
-
-  describe "DELETE /projects/:id/hooks" do
+  describe "DELETE /projects/:id/hooks/:hook_id" do
     it "should delete hook from project" do
       expect {
-        delete api("/projects/#{project.id}/hooks", user),
+        delete api("/projects/#{project.id}/hooks/#{hook.id}", user),
           hook_id: hook.id
       }.to change {project.hooks.count}.by(-1)
     end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -261,7 +261,7 @@ describe Gitlab::API do
     it "should add hook to project" do
       expect {
         post api("/projects/#{project.id}/hooks", user),
-          "url" => "http://example.com"
+          url: "http://example.com"
       }.to change {project.hooks.count}.by(1)
     end
   end
@@ -278,8 +278,7 @@ describe Gitlab::API do
   describe "DELETE /projects/:id/hooks/:hook_id" do
     it "should delete hook from project" do
       expect {
-        delete api("/projects/#{project.id}/hooks/#{hook.id}", user),
-          hook_id: hook.id
+        delete api("/projects/#{project.id}/hooks/#{hook.id}", user)
       }.to change {project.hooks.count}.by(-1)
     end
   end


### PR DESCRIPTION
Provides `hook_id` as part of the URL. Fixes #2878.
