### PR TITLE
Fix sending commit note email to id instead email

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -63,12 +63,12 @@ class Notify < ActionMailer::Base
   # Note
   #
 
-  def note_commit_email(commit_autor_email, note_id)
+  def note_commit_email(recipient_id, note_id)
     @note = Note.find(note_id)
     @commit = @note.noteable
     @commit = CommitDecorator.decorate(@commit)
     @project = @note.project
-    mail(to: commit_autor_email, subject: subject("note for commit #{@commit.short_id}", @commit.title))
+    mail(to: recipient(recipient_id), subject: subject("note for commit #{@commit.short_id}", @commit.title))
   end
 
   def note_issue_email(recipient_id, note_id)

--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -11,7 +11,7 @@ class NoteObserver < ActiveRecord::Observer
       notify_team(note)
     elsif note.notify_author
       # Notify only author of resource
-      Notify.delay.note_commit_email(note.noteable.author_email, note.id)
+      Notify.delay.note_commit_email(note.commit_author.id, note.id)
     else
       # Otherwise ignore it
       nil


### PR DESCRIPTION
Please consider cherry picking @randx's commit.
