### PR TITLE
Disable user creation mails if ldap auth is used

### DIFF
--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -2,7 +2,7 @@ class UserObserver < ActiveRecord::Observer
   def after_create(user)
     log_info("User \"#{user.name}\" (#{user.email}) was created")
 
-    Notify.delay.new_user_email(user.id, user.password)
+    Notify.delay.new_user_email(user.id, user.password) unless Gitlab.config.ldap.enabled
   end
 
   def after_destroy user


### PR DESCRIPTION
Users were complaining of a confusing mail they received with a gitlab password, while they had to use ldap auth.

There is no point in sending the user a password which they shouldn't use (and can't use unless they choose "other auth method" in the login screen, which only increases the confusion)
