### PR TITLE
Fixed migration ConvertClosedToStateInMergeRequest to work with postgresql

### DIFF
--- a/db/migrate/20130218141327_convert_closed_to_state_in_merge_request.rb
+++ b/db/migrate/20130218141327_convert_closed_to_state_in_merge_request.rb
@@ -1,16 +1,16 @@
 class ConvertClosedToStateInMergeRequest < ActiveRecord::Migration
   def up
     MergeRequest.transaction do
-      MergeRequest.where("closed = 1 AND merged = 1").update_all("state = 'merged'")
-      MergeRequest.where("closed = 1 AND merged = 0").update_all("state = 'closed'")
-      MergeRequest.where("closed = 0").update_all("state = 'opened'")
+      MergeRequest.where("closed = true AND merged = true").update_all("state = 'merged'")
+      MergeRequest.where("closed = true AND merged = false").update_all("state = 'closed'")
+      MergeRequest.where("closed = false").update_all("state = 'opened'")
     end
   end
 
   def down
     MergeRequest.transaction do
-      MergeRequest.where(state: :closed).update_all("closed = 1")
-      MergeRequest.where(state: :merged).update_all("closed = 1, merged = 1")
+      MergeRequest.where(state: :closed).update_all("closed = true")
+      MergeRequest.where(state: :merged).update_all("closed = true, merged = true")
     end
   end
 end


### PR DESCRIPTION
When I ran rake db:migrate with a postgresql database it failed like so:

```
==  ConvertClosedToStateInMergeRequest: migrating =============================
rake aborted!
An error has occurred, this and all later migrations canceled:

PG::Error: ERROR:  operator does not exist: boolean = integer
LINE 1: ...erge_requests" SET state = 'merged' WHERE (closed = 1 AND me...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: UPDATE "merge_requests" SET state = 'merged' WHERE (closed = 1 AND merged = 1)
/home/gitlab/gitlab/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgr
esql_adapter.rb:1153:in `async_exec'
```

I tested my fix against a mysql database. It worked there as well.
