### PR TITLE
Fix ConvertClosedToStateInMergeRequest migration

### DIFF
--- a/db/migrate/20130218141327_convert_closed_to_state_in_merge_request.rb
+++ b/db/migrate/20130218141327_convert_closed_to_state_in_merge_request.rb
@@ -1,9 +1,9 @@
 class ConvertClosedToStateInMergeRequest < ActiveRecord::Migration
   def up
     MergeRequest.transaction do
-      MergeRequest.where("closed = 1 AND merged = 1").update_all("state = 'merged'")
-      MergeRequest.where("closed = 1 AND merged = 0").update_all("state = 'closed'")
-      MergeRequest.where("closed = 0").update_all("state = 'opened'")
+      MergeRequest.where("closed = true AND merged = true").update_all("state = 'merged'")
+      MergeRequest.where("closed = true AND merged = false").update_all("state = 'closed'")
+      MergeRequest.where("closed = false").update_all("state = 'opened'")
     end
   end
 


### PR DESCRIPTION
It was MySQL only. Running on PostgreSQL was resulting in:

```
==  ConvertClosedToStateInMergeRequest: migrating =============================
rake aborted!
An error has occurred, this and all later migrations canceled:

PG::Error: ERROR:  operator does not exist: boolean = integer
LINE 1: ...erge_requests" SET state = 'merged' WHERE (closed = 1 AND me...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: UPDATE "merge_requests" SET state = 'merged' WHERE (closed = 1 AND merged = 1)
```

Replacing `0` with `false` and `1` with `true` should make it both
PostgreSQL and MySQL compatible.
