### PR TITLE
Fix WebHook and special symbols in credentials

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -28,10 +28,14 @@ class WebHook < ActiveRecord::Base
       WebHook.post(url, body: data.to_json, headers: { "Content-Type" => "application/json" })
     else
       post_url = url.gsub("#{parsed_url.userinfo}@", "")
+      auth = {
+        username: URI.decode(parsed_url.user),
+        password: URI.decode(parsed_url.password),
+      }
       WebHook.post(post_url,
                    body: data.to_json,
                    headers: {"Content-Type" => "application/json"},
-                   basic_auth: {username: parsed_url.user, password: parsed_url.password})
+                   basic_auth: auth)
     end
   end
 


### PR DESCRIPTION
When using web hook with credentials secured web resource, one needs to
put the credentials in the hook URL.

If the credentials contain special symbols (e.g. @ or #), it should be
URL-quoted (e.g. %40 instead of @).

But when Gitlab is making a request, it should unquote the symbols
before base64-encoding them.

P.S. I'm not sure how to write tests for this, so if anyone can help me, it'd be much appreciated.
