### PR TITLE
Distorted lines in `diff`

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -100,8 +100,9 @@
       }
     }
     .line_content {
+      display: block;
       white-space: pre;
-      height: 14px;
+      height: 18px;
       margin: 0px;
       padding: 0px;
       border: none;


### PR DESCRIPTION
Distorted lines in `diff` when viewing files `windows-style-line-separator: \r\n`
