### PR TITLE
Update app/contexts/test_hook_context.rb

### DIFF
--- a/app/contexts/test_hook_context.rb
+++ b/app/contexts/test_hook_context.rb
@@ -2,7 +2,7 @@ class TestHookContext < BaseContext
   def execute
     hook = project.hooks.find(params[:id])
     commits = project.repository.commits(project.default_branch, nil, 3)
-    data = project.post_receive_data(commits.last.id, commits.first.id, "refs/heads/#{project.default_branch}", current_user)
+    data = GitPushService.new.execute(project, current_user, commits.last.id, commits.first.id, "refs/heads/#{project.default_branch}")
     hook.execute(data)
   end
 end


### PR DESCRIPTION
"Test Hook" did not work (http://gitlabserver/someproject/hooks/1/test resulting in HTTP 500: Internal Server Error)
related to the changes in 7bab81b199936597e1c762278bd16167de073342.

Before I fixed it I had this error in log/production.log:

```
Started GET "/someproject/hooks/1/test" for 192.168.1.100 at 2013-02-26 15:24:26 +0100
Processing by HooksController#test as HTML
  Parameters: {"project_id"=>"someproject", "id"=>"1"}
Completed 500 Internal Server Error in 118ms

NoMethodError (undefined method `post_receive_data' for #<Project:0x00000004e1ec28>):
  app/contexts/test_hook_context.rb:5:in `execute'
  app/controllers/hooks_controller.rb:26:in `test'
```
