### PR TITLE
update grape to 0.3.1 for ruby 2.0 support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,8 @@ gem "pygments.rb",  git: "https://github.com/gitlabhq/pygments.rb.git", branch: 
 gem "github-linguist", "~> 2.3.4" , require: "linguist"
 
 # API
-gem "grape", "~> 0.2.1"
+gem "grape", "~> 0.3.1"
+gem "grape-entity", "~> 0.2.0"
 
 # Format dates and times
 # based on human-friendly examples

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,8 +182,9 @@ GEM
       pyu-ruby-sasl (~> 0.0.3.1)
       rubyntlm (~> 0.1.1)
     gitlab_yaml_db (1.0.0)
-    grape (0.2.2)
+    grape (0.3.1)
       activesupport
+      grape-entity (~> 0.2.0)
       hashie (~> 1.2)
       multi_json (>= 1.3.2)
       multi_xml
@@ -191,6 +192,7 @@ GEM
       rack-accept
       rack-mount
       virtus
+    grape-entity (0.2.0)
     growl (1.0.3)
     guard (1.5.4)
       listen (>= 0.4.2)
@@ -481,7 +483,8 @@ DEPENDENCIES
   gitlab_omniauth-ldap (= 1.0.2)
   gitlab_yaml_db (= 1.0.0)
   grack!
-  grape (~> 0.2.1)
+  grape (~> 0.3.1)
+  grape-entity (~> 0.2.0)
   grit!
   grit_ext!
   growl

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -9,7 +9,6 @@ module Gitlab
     end
 
     format :json
-    error_format :json
     helpers APIHelpers
     
     mount Groups


### PR DESCRIPTION
grape gem < 0.3.1 does not work on ruby 2.0 because of #respond_to? behaviour.

I confirmed that all spinach and spec tests passed on ruby 1.9.3p392 with this change, and also confirmed that all spec tests related to API passed on ruby 2.0.0p0.

Still 1 spinach test failure and 3 spec tests failures remain on ruby 2.0.0p0, but it should be safe to merge this change first.
