### PR TITLE
Fix project transfer error

### DIFF
--- a/app/services/project_transfer_service.rb
+++ b/app/services/project_transfer_service.rb
@@ -25,7 +25,7 @@ class ProjectTransferService
 
       Gitlab::ProjectMover.new(project, old_dir, new_dir).execute
 
-      save!
+      project.save!
     end
   rescue Gitlab::ProjectMover::ProjectMoveError => ex
     raise Project::TransferError.new(ex.message)


### PR DESCRIPTION
When I change a project's namespace，an error occured:

```
NoMethodError at /admin/projects/tsl0922/jekyll
undefined method `save!' for #<ProjectTransferService:0x0000000877fb98>
```

this commit fixed this.
