### PR TITLE
Add namespace_id to project creation via API

### DIFF
--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -42,7 +42,8 @@ module Gitlab
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled]
+                                    :wiki_enabled
+                                    :namespace_id]
         @project = ::Projects::CreateContext.new(current_user, attrs).execute
         if @project.saved?
           present @project, with: Entities::Project

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -42,7 +42,7 @@ module Gitlab
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled
+                                    :wiki_enabled,
                                     :namespace_id]
         @project = ::Projects::CreateContext.new(current_user, attrs).execute
         if @project.saved?


### PR DESCRIPTION
This allows you to set the namespace ID for projects via the the API. 

By default it is created for the current user. You can assign it to the global namespace by passing `GLN` which translates to 'Global Namespace'. You can also assign another group or namespace ID that has been already created.
