### PR TITLE
Reinstate the project description field and show this on the public project page listing

### DIFF
--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -11,6 +11,11 @@
     .input
       = f.text_field :name, placeholder: "Example Project", class: "xxlarge"
 
+    = f.label :description do
+      Project description is
+    .input
+      = f.text_area :description, placeholder: "", class: "xxlarge"
+
   - if project.repo_exists?
     %fieldset.adv_settings
       %legend Advanced settings:

--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -9,8 +9,11 @@
       %h5
         %i.icon-share
         = project.name_with_namespace
+        
         .pull-right
           %pre.dark.tiny git clone #{project.http_url_to_repo}
-
+      %p
+        = project.description
 
 = paginate @projects, theme: "admin"
+


### PR DESCRIPTION
User the current project description field in the database on the project form to allow the creator to provide details about the project, then include this description on the public page so others can understand what the project is about without having to download the repository to find out.
![2013-03-01_16-00-17](https://f.cloud.github.com/assets/750699/211385/20f19732-82b3-11e2-92d5-f7dfb2ba166a.png)
![2013-03-01_16-00-40](https://f.cloud.github.com/assets/750699/211386/20f562e0-82b3-11e2-8d4c-ac07330387f6.png)
