### PR TITLE
Development doc in repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,32 @@ Feature suggestions don't belong in issues but can go to [Feedback forum](http:/
 
 ## Pull requests
 
-Code speaks louder than words. If you can please submit a pull request with the fix including tests. Starting point would be the [Developer Guide](https://github.com/gitlabhq/gitlabhq/wiki/Developer-Guide)
+Code speaks louder than words. If you can please submit a pull request with the fix including tests. The workflow to make a pull request is a follows:
+
+1. Fork the project on GitHub
+1. Create a feature branch
+1. Write tests and code
+1. If you have multiple commits please combine them into one commit by [squashing them](http://git-scm.com/book/en/Git-Tools-Rewriting-History#Squashing-Commits)
+1. Push the commit to your fork
+1. Submit a pull request
+
+We will accept pull requests if:
+
+* The code has proper tests and all tests pass
+* It can be merged without problems (if not please use: git rebase master to fix this)
+* It won't break any existing functionality
+* It's quality code that conforms to the [Rails style guide](https://github.com/bbatsov/rails-style-guide) and best practices
+* You describe your PR properly please give a motive for your change and the method you used to achieve it
+* It keeps the GitLab code base clean and well structured
+* We think other users need the same functionality
+* If it makes changes to the UI it should have screen shots
+
+For examples of feedback on pull requests please look at our already [closed pull requests](https://github.com/gitlabhq/gitlabhq/pulls?direction=desc&page=1&sort=created&state=closed).
 
 ## Submitting via GitHub's issue tracker
 
 * For obvious bugs or misbehavior in GitLab in the master branch. Please include the revision id and a reproducible test case.
-* For problematic or insufficient documentation. Please include a suggestion to improve it.
+* For problematic or insufficient documentation. Please give a suggestion on how to improve it.
 
 If you're unsure where to post, post it to the [Support Forum](https://groups.google.com/forum/#!forum/gitlabhq) first.
 There are a lot of helpful GitLab users there who may be able to help you quickly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Feature suggestions don't belong in issues but can go to [Feedback forum](http:/
 
 ## Pull requests
 
-Code speaks louder than words. If you can please submit a pull request with the fix including tests. The workflow to make a pull request is a follows:
+Code speaks louder than words. If you can please submit a pull request with the fix including tests. The workflow to make a pull request is as follows:
 
 1. Fork the project on GitHub
 1. Create a feature branch
@@ -41,15 +41,15 @@ Code speaks louder than words. If you can please submit a pull request with the 
 We will accept pull requests if:
 
 * The code has proper tests and all tests pass
-* It can be merged without problems (if not please use: git rebase master to fix this)
-* It won't break any existing functionality
+* It can be merged without problems (if not please use: git rebase master)
+* It doesn't break any existing functionality
 * It's quality code that conforms to the [Rails style guide](https://github.com/bbatsov/rails-style-guide) and best practices
-* You describe your PR properly please give a motive for your change and the method you used to achieve it
+* The description includes a motive for your change and the method you used to achieve it
 * It keeps the GitLab code base clean and well structured
-* We think other users need the same functionality
-* If it makes changes to the UI it should have screen shots
+* We think other users will need the same functionality
+* If it makes changes to the UI the pull request should include screenshots
 
-For examples of feedback on pull requests please look at our already [closed pull requests](https://github.com/gitlabhq/gitlabhq/pulls?direction=desc&page=1&sort=created&state=closed).
+For examples of feedback on pull requests please look at already [closed pull requests](https://github.com/gitlabhq/gitlabhq/pulls?direction=desc&page=1&sort=created&state=closed).
 
 ## Submitting via GitHub's issue tracker
 

--- a/README.md
+++ b/README.md
@@ -57,36 +57,39 @@ You can either follow the "ordinary" Installation guide to install it on a machi
 
 1. The Installation guide contains instructions to download an init script and run that on boot. After configuring the init script you can run
 
-sudo service gitlab start
+> sudo service gitlab start
 
 or
 
-sudo /etc/init.d/gitlab restart
+> sudo /etc/init.d/gitlab restart
 
-2. With [foreman](https://github.com/ddollar/foreman)
+2. Start it with [Foreman](https://github.com/ddollar/foreman)
 
 bundle exec foreman start -p 3000
 
 3. Start it manually
 
-bundle exec rails s
-bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
+> bundle exec rails s
+> bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
 
 ### Running the tests
 
 * Seed the database with
 
-bundle exec rake db:setup RAILS_ENV=test
-bundle exec rake db:seed_fu RAILS_ENV=test
+> bundle exec rake db:setup RAILS_ENV=test
+> bundle exec rake db:seed_fu RAILS_ENV=test
 
 * Run all tests
-bundle exec rake gitlab:test
+
+> bundle exec rake gitlab:test
 
 * Rspec unit and functional tests
-bundle exec rake spec
+
+> bundle exec rake spec
 
 * Spinach integration tests
-bundle exec rake spinach
+
+> bundle exec rake spinach
 
 ### Getting help
 
@@ -108,7 +111,13 @@ Each month on the 22th a new version is released together with an upgrade guide.
 
 * [Roadmap](https://github.com/gitlabhq/gitlabhq/blob/master/ROADMAP.md)
 
+### Other documentation
+
 * [GitLab API](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/README.md)
+
+* [Rake tasks](https://github.com/gitlabhq/gitlabhq/tree/master/doc/raketasks)
+
+* [GitLab recipes](https://github.com/gitlabhq/gitlab-recipes)
 
 ### Getting in touch
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@
 
 * More details are in the [requirements doc](https://github.com/gitlabhq/gitlabhq/blob/master/doc/install/requirements.md)
 
-### Getting started
+### Installation
+
+You can either follow the "ordinary" Installation guide to install it on a machine or use the Vagrant virtual machine. The Installation guide is recommended to set up a production server. The Vargrant virtual machine is recommended for development since it makes it much easier to set up all the dependencies for integration testing.
 
 * [Installation guide for latest stable release](https://github.com/gitlabhq/gitlabhq/blob/4-2-stable/doc/install/installation.md)
 
@@ -51,13 +53,40 @@
 
 * [Vagrant virtual machine](https://github.com/gitlabhq/gitlab-vagrant-vm)
 
-* [Developer guide](https://github.com/gitlabhq/gitlabhq/wiki/Developer-Guide)
+### Starting
 
-* [Upgrade guides](https://github.com/gitlabhq/gitlabhq/wiki)
+1. The Installation guide contains instructions to download an init script and run that on boot. After configuring the init script you can run
 
-* [Roadmap](https://github.com/gitlabhq/gitlabhq/blob/master/ROADMAP.md)
+sudo service gitlab start
 
-* [GitLab API](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/README.md)
+or
+
+sudo /etc/init.d/gitlab restart
+
+2. With [foreman](https://github.com/ddollar/foreman)
+
+bundle exec foreman start -p 3000
+
+3. Start it manually
+
+bundle exec rails s
+bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
+
+### Running the tests
+
+* Seed the database with
+
+bundle exec rake db:setup RAILS_ENV=test
+bundle exec rake db:seed_fu RAILS_ENV=test
+
+* Run all tests
+bundle exec rake gitlab:test
+
+* Rspec unit and functional tests
+bundle exec rake spec
+
+* Spinach integration tests
+bundle exec rake spinach
 
 ### Getting help
 
@@ -70,6 +99,16 @@
 * [Paid support](http://blog.gitlab.com/support/)
 
 * [Paid services](http://blog.gitlab.com/services/)
+
+### New versions and the API
+
+Each month on the 22th a new version is released together with an upgrade guide.
+
+* [Upgrade guides](https://github.com/gitlabhq/gitlabhq/wiki)
+
+* [Roadmap](https://github.com/gitlabhq/gitlabhq/blob/master/ROADMAP.md)
+
+* [GitLab API](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/README.md)
 
 ### Getting in touch
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can either follow the "ordinary" Installation guide to install it on a machi
 
 ### Starting
 
-1. The Installation guide contains instructions to download an init script and run that on boot. After configuring the init script you can run
+1. The Installation guide contains instructions to download an init script and run that on boot. With the init script you can also start GitLab with:
 
 > sudo service gitlab start
 
@@ -63,14 +63,14 @@ or
 
 > sudo /etc/init.d/gitlab restart
 
-2. Start it with [Foreman](https://github.com/ddollar/foreman)
+2. Start it with [Foreman](https://github.com/ddollar/foreman) in development model
 
 bundle exec foreman start -p 3000
 
-3. Start it manually
+3. Start it manually in development mode
 
 > bundle exec rails s
-> bundle exec rake environment resque:work QUEUE=* VVERBOSE=1
+> bundle exec rake sidekiq:start
 
 ### Running the tests
 


### PR DESCRIPTION
I would like to replace https://github.com/gitlabhq/gitlabhq/wiki/Developer-Guide with this commit. This moves the information in the relevant sections and people can send pull requests to improve the information. I also tried to make everything more readable.
