### PR TITLE
Adding button to Fork projects into personal namespace

### DIFF
--- a/app/contexts/projects/fork_context.rb
+++ b/app/contexts/projects/fork_context.rb
@@ -1,0 +1,31 @@
+module Projects
+  class ForkContext < BaseContext
+    def initialize(project, user)
+      @from_project, @current_user = project, user
+    end
+
+    def execute
+      project = Project.new
+      project.initialize_dup(@from_project)
+      project.name = @from_project.name
+      project.path = @from_project.path 
+      project.namespace = current_user.namespace
+
+      Project.transaction do
+        #First save the DB entries as they can be rolled back if the repo fork fails
+        project.creator = current_user
+        if project.save
+          project.users_projects.create(project_access: UsersProject::MASTER, user: current_user)
+        end
+
+        #Now fork the repo
+        @from_project.repository.fork(project.path_with_namespace)
+
+      end
+      project
+    rescue => ex
+      project.errors.add(:base, "Can't fork project. Please try again later")
+      project
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -98,4 +98,19 @@ class ProjectsController < ProjectResourceController
       format.html { redirect_to root_path }
     end
   end
+
+  def fork
+    @project = ::Projects::ForkContext.new(project, current_user).execute
+
+    respond_to do |format|
+      format.html do
+        if @project.saved?
+          redirect_to(@project, notice: 'Project was successfully forked.')
+        else
+          render action: "new"
+        end
+      end
+      format.js
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,7 +60,8 @@ class Ability
         :read_note,
         :write_project,
         :write_issue,
-        :write_note
+        :write_note,
+        :fork_project
       ]
     end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -147,4 +147,9 @@ class Repository
 
     file_path
   end
+
+  def fork(to_path)
+    to_path_full = File.join(Gitlab.config.gitolite.repos_path, to_path) + ".git"
+    result = repo.fork_bare(to_path_full)
+  end
 end

--- a/app/views/projects/_clone_panel.html.haml
+++ b/app/views/projects/_clone_panel.html.haml
@@ -5,6 +5,9 @@
     .span4.pull-right
       .pull-right
         - unless @project.empty_repo?
+          - if can? current_user, :fork_project, @project
+            = link_to fork_project_path(@project), title: "Fork", class: "btn small grouped", method: "POST" do
+              Fork
           - if can? current_user, :download_code, @project
             = link_to archive_project_repository_path(@project), class: "btn-small btn grouped" do
               %i.icon-download-alt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,7 @@ Gitlab::Application.routes.draw do
   #
   resources :projects, constraints: { id: /[a-zA-Z.0-9_\-\/]+/ }, except: [:new, :create, :index], path: "/" do
     member do
+      post "fork"
       get "wall"
       get "files"
     end

--- a/spec/contexts/fork_context_spec.rb
+++ b/spec/contexts/fork_context_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Projects::ForkContext do
+  describe :fork_by_user do
+    before do
+      @from_user = create :user
+      @from_project = create(:project, creator_id: @from_user.id)
+      @to_user = create :user
+    end
+
+    context 'fork project' do
+      before do
+        @to_project = fork_project(@from_project, @to_user)
+      end
+
+      it { @to_project.owner.should == @to_user }
+      it { @to_project.namespace.should == @to_user.namespace }
+    end
+  end
+
+  def fork_project(from_project, user)
+    Projects::ForkContext.new(from_project, user).execute
+  end
+end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -55,6 +55,7 @@ end
 
 #      projects POST   /projects(.:format)     projects#create
 #   new_project GET    /projects/new(.:format) projects#new
+#  fork_project POST   /:id/fork(.:format)     projects#fork
 #  wall_project GET    /:id/wall(.:format)     projects#wall
 # graph_project GET    /:id/graph(.:format)    projects#graph
 # files_project GET    /:id/files(.:format)    projects#files
@@ -69,6 +70,10 @@ describe ProjectsController, "routing" do
 
   it "to #new" do
     get("/projects/new").should route_to('projects#new')
+  end
+
+  it "to #fork" do
+    post("/gitlabhq/fork").should route_to('projects#fork', id: 'gitlabhq')
   end
 
   it "to #wall" do


### PR DESCRIPTION
This adds a "Fork" button on the Project show page.  When clicked, a clone of the new project is created in the namespace of the currently logged in user.
