### PR TITLE
Additional Admin APIs

### DIFF
--- a/doc/api/groups.md
+++ b/doc/api/groups.md
@@ -43,3 +43,14 @@ Parameters:
 
 Will return created group with status `201 Created` on success, or `404 Not found` on fail.
 
+## Transfer project to group
+
+Transfer a project to the Group namespace. Available only for admin
+
+```
+POST  /groups/:id/projects/:project_id
+```
+
+Parameters:
++ `id` (required) - The ID of a group
++ `project_id (required) - The ID of a project

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -113,6 +113,28 @@ Parameters:
 Will return created project with status `201 Created` on success, or `404 Not
 found` on fail.
 
+## Create project for user
+
+Create new project owned by user. Available only for admin
+
+```
+POST /projects/user/:user_id
+```
+
+Parameters:
+
++ `user_id` (required) - user_id of owner
++ `name` (required) - new project name
++ `description` (optional) - short project description
++ `default_branch` (optional) - 'master' by default
++ `issues_enabled` (optional) - enabled by default
++ `wall_enabled` (optional) - enabled by default
++ `merge_requests_enabled` (optional) - enabled by default
++ `wiki_enabled` (optional) - enabled by default
+
+Will return created project with status `201 Created` on success, or `404 Not
+found` on fail.
+
 ## List project team members
 
 Get a list of project team members.

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -220,6 +220,23 @@ Parameters:
 Will return created key with status `201 Created` on success, or `404 Not
 found` on fail.
 
+## Add SSH key for user
+
+Create new key owned by specified user. Available only for admin
+
+```
+POST /users/:id/keys
+```
+
+Parameters:
+
++ `id` (required) - id of specified user
++ `title` (required) - new SSH Key's title
++ `key` (required) - new SSH key
+
+Will return created key with status `201 Created` on success, or `404 Not
+found` on fail.
+
 ## Delete SSH key
 
 Delete key owned by currently authenticated user

--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -51,6 +51,24 @@ module Gitlab
           not_found!
         end
       end
+
+      # Transfer a project to the Group namespace
+      #
+      # Parameters:
+      #   id - group id
+      #   project_id  - project id
+      # Example Request:
+      #   POST /groups/:id/projects/:project_id
+      post ":id/projects/:project_id" do
+        authenticated_as_admin!
+        @group = Group.find(params[:id])
+        project = Project.find(params[:project_id])
+        if project.transfer(@group)
+          present @group
+        else
+          not_found!
+        end
+      end 
     end
   end
 end

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -52,6 +52,38 @@ module Gitlab
         end
       end
 
+      # Create new project for a specified user.  Only available to admin users.
+      #
+      # Parameters:
+      #   user_id (required) - The ID of a user
+      #   name (required) - name for new project
+      #   description (optional) - short project description
+      #   default_branch (optional) - 'master' by default
+      #   issues_enabled (optional) - enabled by default
+      #   wall_enabled (optional) - enabled by default
+      #   merge_requests_enabled (optional) - enabled by default
+      #   wiki_enabled (optional) - enabled by default
+      # Example Request
+      #   POST /projects/user/:user_id
+      post "user/:user_id" do
+        authenticated_as_admin!
+        user = User.find(params[:user_id])
+        attrs = attributes_for_keys [:name,
+                                    :description,
+                                    :default_branch,
+                                    :issues_enabled,
+                                    :wall_enabled,
+                                    :merge_requests_enabled,
+                                    :wiki_enabled]
+        @project = ::Projects::CreateContext.new(user, attrs).execute
+        if @project.saved?
+          present @project, with: Entities::Project
+        else
+          not_found!
+        end
+      end
+
+
       # Get a project team members
       #
       # Parameters:

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -77,6 +77,26 @@ module Gitlab
         end
       end
 
+      # Add ssh key to a specified user. Only available to admin users.
+      #
+      # Parameters:
+      # id (required) - The ID of a user
+      # key (required) - New SSH Key
+      # title (required) - New SSH Key's title
+      # Example Request:
+      # POST /users/:id/keys
+      post ":id/keys" do
+        authenticated_as_admin!
+        user = User.find(params[:id])
+        attrs = attributes_for_keys [:title, :key]
+        key = user.keys.new attrs
+        if key.save
+          present key, with: Entities::SSHKey
+        else
+          not_found!
+        end
+      end
+
       # Delete user. Available only for admin
       #
       # Example Request:

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -90,4 +90,27 @@ describe Gitlab::API do
       end
     end
   end
+
+  describe "POST /groups/:id/projects/:project_id" do
+    let(:project) { create(:project) }
+    before(:each) do
+       project.stub!(:transfer).and_return(true) 
+       Project.stub(:find).and_return(project) 
+    end
+
+
+    context "when authenticated as user" do
+      it "should not transfer project to group" do
+        post api("/groups/#{group1.id}/projects/#{project.id}", user2)
+        response.status.should == 403
+      end
+    end
+
+    context "when authenticated as admin" do
+      it "should transfer project to group" do
+        project.should_receive(:transfer)
+        post api("/groups/#{group1.id}/projects/#{project.id}", admin)
+      end
+    end
+  end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -6,6 +6,7 @@ describe Gitlab::API do
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
+  let(:admin) { create(:admin) }
   let!(:hook) { create(:project_hook, project: project, url: "http://example.com") }
   let!(:project) { create(:project, namespace: user.namespace ) }
   let!(:snippet) { create(:snippet, author: user, project: project, title: 'example') }
@@ -82,6 +83,46 @@ describe Gitlab::API do
       })
 
       post api("/projects", user), project
+
+      project.each_pair do |k,v|
+        next if k == :path
+        json_response[k.to_s].should == v
+      end
+    end
+  end
+
+  describe "POST /projects/user/:id" do
+    before { admin }
+
+    it "should create new project without path" do
+      expect { post api("/projects/user/#{user.id}", admin), name: 'foo' }.to change {Project.count}.by(1)
+    end
+
+    it "should not create new project without name" do
+      expect { post api("/projects/user/#{user.id}", admin) }.to_not change {Project.count}
+    end
+
+    it "should respond with 201 on success" do
+      post api("/projects/user/#{user.id}", admin), name: 'foo'
+      response.status.should == 201
+    end
+
+    it "should respond with 404 on failure" do
+      post api("/projects/user/#{user.id}", admin)
+      response.status.should == 404
+    end
+
+    it "should assign attributes to project" do
+      project = attributes_for(:project, {
+        description: Faker::Lorem.sentence,
+        default_branch: 'stable',
+        issues_enabled: false,
+        wall_enabled: false,
+        merge_requests_enabled: false,
+        wiki_enabled: false
+      })
+
+      post api("/projects/user/#{user.id}", admin), project
 
       project.each_pair do |k,v|
         next if k == :path

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -105,6 +105,22 @@ describe Gitlab::API do
     end
   end
 
+  describe "POST /users/:id/keys" do
+    before { admin }
+
+    it "should not create invalid ssh key" do
+      post api("/users/#{user.id}/keys", admin), { title: "invalid key" }
+      response.status.should == 404
+    end
+
+    it "should create ssh key" do
+      key_attrs = attributes_for :key
+      expect {
+        post api("/users/#{user.id}/keys", admin), key_attrs
+      }.to change{ user.keys.count }.by(1)
+    end
+  end
+
   describe "DELETE /users/:id" do
     before { admin }
 


### PR DESCRIPTION
Additional Admin only APIs as follows:
- Transfer a project to the Group namespace
- Create new project for a specified user.
- Add ssh key to a specified user

These are useful for migrating away from GitHub to GitLab
