### PR TITLE
Allow connection to Redis via unix socket

### DIFF
--- a/config/initializers/4_sidekiq.rb
+++ b/config/initializers/4_sidekiq.rb
@@ -4,19 +4,19 @@ config_file = Rails.root.join('config', 'resque.yml')
 resque_url = if File.exists?(config_file)
                YAML.load_file(config_file)[Rails.env]
              else
-               "localhost:6379"
+               "redis://localhost:6379"
              end
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: "redis://#{resque_url}",
+    url: resque_url,
     namespace: 'resque:gitlab'
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: "redis://#{resque_url}",
+    url: resque_url,
     namespace: 'resque:gitlab'
   }
 end

--- a/config/resque.yml.example
+++ b/config/resque.yml.example
@@ -1,3 +1,3 @@
-development: localhost:6379
-test: localhost:6379
-production: redis.example.com:6379
+development: redis://localhost:6379
+test: redis://localhost:6379
+production: redis://redis.example.com:6379

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -288,7 +288,7 @@ a different host, you can configure its connection string via the
 `config/resque.yml` file.
 
     # example
-    production: redis.example.tld:6379
+    production: redis://redis.example.tld:6379
 
 ## Custom SSH Connection
 


### PR DESCRIPTION
Allow connection to Redis via unix socket, using
unix:/var/run/redis/redis.sock for example.

Default behaviour does not change, except that the full Redis URL must
be configured, with redis:// for tcp or unix: for unix socket.
