### PR TITLE
Update installation.md

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -49,7 +49,7 @@ edited by hand. But, you can use any editor you like instead.
 
 Install the required packages:
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server postfix checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev
+    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server postfix checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev mysql-client libmysqlclient-dev
 
 Make sure you have the right version of Python installed.
 


### PR DESCRIPTION
We need mysql-client and libmysqlclient-dev. Without these packages the bundle install will fail with  'An error occurred while installing mysql2 (0.3.11), and Bundler cannot continue.'
