### PR TITLE
Fix link to owner of group and team in admin interface (4.2)

### DIFF
--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -28,7 +28,7 @@
       %td= group.path
       %td= group.projects.count
       %td
-        = link_to group.owner_name, admin_user_path(group.owner_id)
+        = link_to group.owner_name, admin_user_path(group.owner)
       %td.bgred
         = link_to 'Rename', edit_admin_group_path(group), id: "edit_#{dom_id(group)}", class: "btn btn-small"
         = link_to 'Destroy', [:admin, group], confirm: "REMOVE #{group.name}? Are you sure?", method: :delete, class: "btn btn-small btn-remove"

--- a/app/views/admin/teams/index.html.haml
+++ b/app/views/admin/teams/index.html.haml
@@ -30,7 +30,7 @@
       %td= team.projects.count
       %td= team.members.count
       %td
-        = link_to team.owner.name, admin_user_path(team.owner_id)
+        = link_to team.owner.name, admin_user_path(team.owner)
       %td.bgred
         = link_to 'Rename', edit_admin_team_path(team), id: "edit_#{dom_id(team)}", class: "btn btn-small"
         = link_to 'Destroy', admin_team_path(team), confirm: "REMOVE #{team.name}? Are you sure?", method: :delete, class: "btn btn-small btn-remove"


### PR DESCRIPTION
backported #3017 to 4.2-stable
