### PR TITLE
API: system hook request functions and documentation updated

### DIFF
--- a/doc/api/system_hooks.md
+++ b/doc/api/system_hooks.md
@@ -8,7 +8,10 @@ Get list of system hooks
 GET /hooks
 ```
 
-Will return hooks with status `200 OK` on success, or `404 Not found` on fail.
+Parameters:
+
++ **none**
+
 
 ## Add new system hook hook
 
@@ -20,7 +23,6 @@ Parameters:
 
 + `url` (required) - The hook URL
 
-Will return status `201 Created` on success, or `404 Not found` on fail.
 
 ## Test system hook
 
@@ -32,9 +34,11 @@ Parameters:
 
 + `id` (required) - The ID of hook
 
-Will return hook with status `200 OK` on success, or `404 Not found` on fail.
 
 ## Delete system hook
+
+Deletes a system hook. This is an idempotent API function and returns `200 Ok` even if the hook
+is not available. If the hook is deleted it is also returned as JSON.
 
 ```
 DELETE /hooks/:id
@@ -43,5 +47,3 @@ DELETE /hooks/:id
 Parameters:
 
 + `id` (required) - The ID of hook
-
-Will return status `200 OK` on success, or `404 Not found` on fail.

--- a/spec/requests/api/system_hooks_spec.rb
+++ b/spec/requests/api/system_hooks_spec.rb
@@ -10,6 +10,13 @@ describe Gitlab::API do
   before { stub_request(:post, hook.url) }
 
   describe "GET /hooks" do
+    context "when no user" do
+      it "should return authentication error" do
+        get api("/hooks")
+        response.status.should == 401
+      end
+    end
+
     context "when not an admin" do
       it "should return forbidden error" do
         get api("/hooks", user)
@@ -34,9 +41,9 @@ describe Gitlab::API do
       }.to change { SystemHook.count }.by(1)
     end
 
-    it "should respond with 404 on failure" do
+    it "should respond with 400 if url not given" do
       post api("/hooks", admin)
-      response.status.should == 404
+      response.status.should == 400
     end
 
     it "should not create new hook without url" do
@@ -64,6 +71,11 @@ describe Gitlab::API do
       expect {
         delete api("/hooks/#{hook.id}", admin)
       }.to change { SystemHook.count }.by(-1)
+    end
+
+    it "should return success if hook id not found" do
+      delete api("/hooks/12345", admin)
+      response.status.should == 200
     end
   end
 end


### PR DESCRIPTION
The documentation of the system hooks API is updated, the info to return codes reside in the `README.md` file. A bit of information is added to the documentation and also as code comments to the API functions. Fixed also a small issue when using the system hook API requests without a valid user, it returned a `500 Server Error` instead of `401`. Added tests to check the behaviour.
