### PR TITLE
Add settings for user permission defaults

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,7 +29,7 @@ class Admin::UsersController < Admin::ApplicationController
 
 
   def new
-    @admin_user = User.new({ projects_limit: Gitlab.config.gitlab.default_projects_limit }, as: :admin)
+    @admin_user = User.new.with_defaults
   end
 
   def edit

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -16,8 +16,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   def build_resource(hash=nil)
     super
-    self.resource.projects_limit = Gitlab.config.gitlab.default_projects_limit
-    self.resource
+    self.resource.with_defaults
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,6 +196,14 @@ class User < ActiveRecord::Base
     username
   end
 
+  def with_defaults
+    tap do |u|
+      u.projects_limit = Gitlab.config.gitlab.default_projects_limit
+      u.can_create_group = Gitlab.config.gitlab.default_can_create_group
+      u.can_create_team = Gitlab.config.gitlab.default_can_create_team
+    end
+  end
+
   def notification
     @notification ||= Notification.new(self)
   end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -34,7 +34,9 @@ production: &base
 
     ## Project settings
     default_projects_limit: 10
-    # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
+    # default_can_create_group: false  # default: true
+    # default_can_create_team: false   # default: true
+    # signup_enabled: true             # default: false - Account passwords are not sent via the email if signup is enabled.
     # username_changing_enabled: false # default: true - User can change her username/namespace
 
     ## Default project features settings

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -48,7 +48,9 @@ Settings['issues_tracker']  ||= {}
 # GitLab
 #
 Settings['gitlab'] ||= Settingslogic.new({})
-Settings.gitlab['default_projects_limit'] ||=  10
+Settings.gitlab['default_projects_limit'] ||= 10
+Settings.gitlab['default_can_create_group'] = true if Settings.gitlab['default_can_create_group'].nil?
+Settings.gitlab['default_can_create_team']  = true if Settings.gitlab['default_can_create_team'].nil?
 Settings.gitlab['host']       ||= 'localhost'
 Settings.gitlab['https']        = false if Settings.gitlab['https'].nil?
 Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80
@@ -111,3 +113,12 @@ Settings.satellites['path'] = File.expand_path(Settings.satellites['path'] || "t
 # Extra customization
 #
 Settings['extra'] ||= Settingslogic.new({})
+
+#
+# Testing settings
+#
+if Rails.env.test?
+  Settings.gitlab['default_projects_limit']   = 42
+  Settings.gitlab['default_can_create_group'] = false
+  Settings.gitlab['default_can_create_team']  = false
+end

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -39,8 +39,7 @@ module Gitlab
         email: email,
         password: password,
         password_confirmation: password,
-        projects_limit: Gitlab.config.gitlab.default_projects_limit,
-      }, as: :admin)
+      }, as: :admin).with_defaults
       @user.save!
 
       if Gitlab.config.omniauth['block_auto_created_users'] && !ldap

--- a/spec/features/admin/admin_users_spec.rb
+++ b/spec/features/admin/admin_users_spec.rb
@@ -33,6 +33,14 @@ describe "Admin::Users" do
       expect { click_button "Create user" }.to change {User.count}.by(1)
     end
 
+    it "should apply defaults to user" do
+      click_button "Create user"
+      user = User.last
+      user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
+      user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
+      user.can_create_team.should == Gitlab.config.gitlab.default_can_create_team
+    end
+
     it "should create user with valid data" do
       click_button "Create user"
       user = User.last

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -91,5 +91,15 @@ describe Gitlab::Auth do
       user.extern_uid.should == @info.uid
       user.provider.should == 'twitter'
     end
+
+    it "should apply defaults to user" do
+      @auth = mock(info: @info, provider: 'ldap')
+      user = gl_auth.create_from_omniauth(@auth, true)
+
+      user.should be_valid
+      user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
+      user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
+      user.can_create_team.should == Gitlab.config.gitlab.default_can_create_team
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -178,4 +178,22 @@ describe User do
     it { user.can_create_project?.should be_true }
     it { user.first_name.should == 'John' }
   end
+
+  describe 'without defaults' do
+    let(:user) { User.new }
+    it "should not apply defaults to user" do
+      user.projects_limit.should == 10
+      user.can_create_group.should == true
+      user.can_create_team.should == true
+    end
+  end
+
+  describe 'with defaults' do
+    let(:user) { User.new.with_defaults }
+    it "should apply defaults to user" do
+      user.projects_limit.should == 42
+      user.can_create_group.should == false
+      user.can_create_team.should == false
+    end
+  end
 end


### PR DESCRIPTION
“Can create groups” and “Can create teams” had hardcoded defaults to
`true`. Sometimes it is desirable to prohibit these for newly created
users by default.
