### PR TITLE
Fixes grack authentification under relative_url_root

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -9,8 +9,14 @@ module Grack
       @request = Rack::Request.new(env)
       @auth = Request.new(env)
 
+      unless Gitlab.config.gitlab.relative_url_root.empty?
+        #if website is mounted using relative_url_root need to remove it first
+        @env['PATH_INFO'] = @request.path.sub(Gitlab.config.gitlab.relative_url_root,'')
+      else
+        @env['PATH_INFO'] = @request.path
+      end
+
       # Need this patch due to the rails mount
-      @env['PATH_INFO'] = @request.path
       @env['SCRIPT_NAME'] = ""
 
       return render_not_found unless project

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -9,14 +9,16 @@ module Grack
       @request = Rack::Request.new(env)
       @auth = Request.new(env)
 
+      # Need this patch due to the rails mount
+
+      # Need this if under RELATIVE_URL_ROOT
       unless Gitlab.config.gitlab.relative_url_root.empty?
-        #if website is mounted using relative_url_root need to remove it first
+        # If website is mounted using relative_url_root need to remove it first
         @env['PATH_INFO'] = @request.path.sub(Gitlab.config.gitlab.relative_url_root,'')
       else
         @env['PATH_INFO'] = @request.path
       end
 
-      # Need this patch due to the rails mount
       @env['SCRIPT_NAME'] = ""
 
       return render_not_found unless project


### PR DESCRIPTION
grack fails under non relative_url_root . I tried to fix by stripping relative root if its is set. 

I tried to find spec / features for git smart http acces but did not found any. 

refs #1228
refs #3153
