### PR TITLE
Fix: API 500 error when project does not exists

### DIFF
--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -15,6 +15,7 @@ module Gitlab
         key = Key.find(params[:key_id])
         project = Project.find_with_namespace(params[:project])
         git_cmd = params[:action]
+        return false unless project
 
         if key.is_deploy_key
           project == key.project && git_cmd == 'git-upload-pack'


### PR DESCRIPTION
This error happens when I push to a nonexistent project（typing error of a project's ssh url）. Maybe you can't see it at any page, bug it will be in the log file.
