### PR TITLE
api/internal: Add admin check

### DIFF
--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -40,6 +40,23 @@ module Gitlab
       end
 
       #
+      # Check if ssh key belongs to an admin
+      #
+      # Params:
+      #   key_id - SSH Key id
+      #
+      get "/admin" do
+        key = Key.find(params[:key_id])
+
+        if key.is_deploy_key
+          return false
+        else
+          user = key.user
+          return user.admin? && !user.blocked?
+        end
+      end
+
+      #
       # Discover user by ssh key
       #
       get "/discover" do


### PR DESCRIPTION
This adds an internal API to check if a specific SSH key belongs
to an admin.

This is needed for [GitShell pull request #15](https://github.com/gitlabhq/gitlab-shell/pull/15)
which allows admins to full ssh access instead of being limited
to just remote git commands.
