### PR TITLE
Update gollum repository location in the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem 'settingslogic'
 # github-linquist needs pygments 0.4.2 but Gollum 2.4.11
 # requires pygments 0.3.2. The latest master Gollum has been updated
 # to use pygments 0.4.2. Change this after next Gollum release.
-gem "gollum", "~> 2.4.0", git: "git://github.com/github/gollum.git"
+gem "gollum", "~> 2.4.0", git: "git://github.com/gollum/gollum.git", ref: "5dcd3c8c8f"
 
 # Misc
 gem "foreman"


### PR DESCRIPTION
Github just moved the Gollum repository to it's own organization.
This commit updates the Gemfile to point to the new repo location.

I also added a specific ref pointer to a version that is known to
work well just in case they slip up and break their master branch
right at the same time someone happens to be installing or updating
Gitlab. This is about the safest we can get until they put out the
next release that resolves the Pygments dependency issue.
