### PR TITLE
Add an option to only notify masters for a note

### DIFF
--- a/app/contexts/notes/create_context.rb
+++ b/app/contexts/notes/create_context.rb
@@ -5,6 +5,7 @@ module Notes
       note.author = current_user
       note.notify = params[:notify].present?
       note.notify_author = params[:notify_author].present?
+      note.notify_masters = params[:notify_masters].present?
       note.save
       note
     end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -24,6 +24,7 @@ class Note < ActiveRecord::Base
 
   attr_accessor :notify
   attr_accessor :notify_author
+  attr_accessor :notify_masters
 
   belongs_to :project
   belongs_to :noteable, polymorphic: true
@@ -149,6 +150,10 @@ class Note < ActiveRecord::Base
 
   def notify_author
     @notify_author ||= false
+  end
+
+  def notify_masters
+    @notify_masters ||= false
   end
 
   # Returns true if this is an upvote note,

--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -7,7 +7,9 @@ class NoteObserver < ActiveRecord::Observer
 
   def send_notify_mails(note)
     if note.notify
-      notify_team(note)
+      notify_team(note, false)
+    elsif note.notify_masters
+      notify_team(note, true)
     elsif note.notify_author
       # Notify only author of resource
       if note.commit_author
@@ -20,16 +22,25 @@ class NoteObserver < ActiveRecord::Observer
   end
 
   # Notifies the whole team except the author of note
-  def notify_team(note)
+  def notify_team(note, masters_only)
     # Note: wall posts are not "attached" to anything, so fall back to "Wall"
     noteable_type = note.noteable_type.presence || "Wall"
     notify_method = "note_#{noteable_type.underscore}_email".to_sym
 
     if Notify.respond_to? notify_method
-      team_without_note_author(note).map do |u|
+      if (masters_only)
+        members = team_masters_without_note_author(note)
+      else
+        members = team_without_note_author(note)
+      end
+      members.map do |u|
         Notify.delay.send(notify_method, u.id, note.id)
       end
     end
+  end
+
+  def team_masters_without_note_author(note)
+    note.project.team.masters.reject { |u| u.id == note.author.id }
   end
 
   def team_without_note_author(note)

--- a/app/views/notes/_form.html.haml
+++ b/app/views/notes/_form.html.haml
@@ -31,6 +31,10 @@
         = check_box_tag :notify, 1, !@note.for_commit?
         %span.light Notify team via email
 
+      = label_tag :notify_masters do
+        = check_box_tag :notify_masters, 1, !@note.for_commit?
+        %span.light Notify project masters via email
+
       .js-notify-commit-author
         = label_tag :notify_author do
           = check_box_tag :notify_author, 1 , @note.for_commit?


### PR DESCRIPTION
Some projects may have a very large team, in which case it doesn't necessarily
make sense to notify all members of the team.  Instead, it makes sense to
only notify the masters for the project, since that's usually a smaller subset
of more knowledgeable team members.
