### PR TITLE
Fix Wiki migration task and add more test coverage.

### DIFF
--- a/lib/tasks/gitlab/migrate_wiki.rake
+++ b/lib/tasks/gitlab/migrate_wiki.rake
@@ -16,5 +16,27 @@ namespace :gitlab do
       wiki_migrator = WikiToGollumMigrator.new
       wiki_migrator.migrate!
     end
+
+    # This task will destroy all of the Wiki repos
+    # that the Wiki migration task created. Run this
+    # to clean up your environment if you experienced
+    # problems during the original migration. After
+    # executing this task, you can attempt the original
+    # migration again.
+    #
+    # Notes:
+    #  * This will not affect Wikis that have been created
+    #    as Gollum Wikis only. It will only remove the wikis
+    #    for the repositories that have old Wiki data in the
+    #    dataabase.
+    #  * If you have any repositories already named
+    #    namespace/project.wiki that you do not wish
+    #    to be removed you may want to perform a manual
+    #    cleanup instead.
+    desc "GITLAB | Remove the Wiki repositories created by the `gitlab:wiki:migrate` task."
+    task :rollback => :environment do
+      wiki_migrator = WikiToGollumMigrator.new
+      wiki_migrator.rollback!
+    end
   end
 end


### PR DESCRIPTION
Check the commit message for details on what has been added. I threw in a ton more test coverage for every weird case I could think of. I did find an error in the code that has now been fixed. I'm hoping that error was the root cause of the problem.

Unfortunately, I was unable to reproduce the exact stack trace that was shown in issue #3234. I did figure out that the error was not related to my original guess. The migration task was already set up to ignore changes in the page title and keep the page title matching the page slug.

I also added more verbosity to the logging so if someone does experience another problem after this bug fix is in place it will be much easier to tell which Wiki page is causing the issue.
#### Rollback From First Migration

I also added a migration rollback task that removes the repositories created by the first pass of the wiki migration task. This command should be executed before attempting the migration again.

If you have already attempted a migration previously...

```
bundle exec rake gitlab:wiki:rollback RAILS_ENV=production
# then run
bundle exec rake gitlab:wiki:migrate RAILS_ENV=production
```

This should complete a successful migration without any duplication.
