### PR TITLE
Added global config setting to change number of commits to display per event

### DIFF
--- a/app/views/events/event/_push.html.haml
+++ b/app/views/events/event/_push.html.haml
@@ -13,13 +13,14 @@
   - project = event.project
   .event-body
     %ul.well-list.event_commits
-      - few_commits = event.commits[0...2]
+      - max_commit_num = Gitlab.config.gitlab.commits_to_display_per_event
+      - few_commits = event.commits[0...max_commit_num]
       - few_commits.each do |commit|
         = render "events/commit", commit: commit, project: project
 
       - if event.commits_count > 1
         %li.commits-stat
-          - if event.commits_count > 2
-            %span ... and #{event.commits_count - 2} more commits.
+          - if event.commits_count > max_commit_num
+            %span ... and #{event.commits_count - max_commit_num} more commits.
           = link_to project_compare_path(event.project, from: event.parent_commit.id, to: event.last_commit.id) do
             %strong Compare &rarr; #{event.parent_commit.id[0..7]}...#{event.last_commit.id[0..7]}

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -37,6 +37,8 @@ production: &base
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
     # username_changing_enabled: false # default: true - User can change her username/namespace
 
+    # How many commits to list individually before writing ".. and # more commits" (default: 2)
+    # commits_to_display_per_event: 2
 
   ## External issues trackers
   issues_tracker:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -60,6 +60,7 @@ Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'git'
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
+Settings.gitlab['commits_to_display_per_event'] ||= 2
 
 #
 # Gravatar


### PR DESCRIPTION
Previously, the dashboard would display at most 2 commits per push event, with a link to see more ("... and N more commits").  I found the default limiting for my team's workflow, so wanted to increase it.

This is a fairly trivial change - it adds a new gitlab.yml setting:

```
commits_to_display_per_event: 2
```

That setting defaults to 2 if not declared.
