### PR TITLE
Fix failure of cheking a merge request after conflict.

### DIFF
--- a/lib/gitlab/satellite/satellite.rb
+++ b/lib/gitlab/satellite/satellite.rb
@@ -24,8 +24,8 @@ module Gitlab
       def clear_and_update!
         raise_no_satellite unless exists?
 
-        delete_heads!
         clear_working_dir!
+        delete_heads!
         update_from_source!
       end
 


### PR DESCRIPTION
Once a merge request conflicts, the next check will also fail even if the request can be merged,
because clearing a conflicting satellite fails.

We should reset worktree first in order to checkout the parking branch and delete all branches correctly.
