### PR TITLE
Add deployment keys to gitlab:shell:setup

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -125,6 +125,12 @@ production: &base
     repos_path: /home/git/repositories/
     hooks_path: /home/git/gitlab-shell/hooks/
 
+    # Deployment keys:
+    # A file (in authorized_keys format) containing keys
+    # for deploying gitlab itself.
+    # DO NOT ADD ANY GITLAB DEPLOYMENT KEYS INTO GitLab ITSELF
+    deployment_key_file: /home/git/deployment_key_file
+
     # Git over HTTP
     upload_pack: true
     receive_pack: true

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -82,6 +82,7 @@ Settings.gitlab_shell['ssh_port']     ||= 22
 Settings.gitlab_shell['ssh_user']     ||= Settings.gitlab.user
 Settings.gitlab_shell['owner_group']  ||= Settings.gitlab.user
 Settings.gitlab_shell['ssh_path_prefix'] ||= Settings.send(:build_gitlab_shell_ssh_path_prefix)
+Settings.gitlab_shell['deployment_key_file'] ||= '/home/git/deployment_key_file'
 
 #
 # Backup


### PR DESCRIPTION
For people who need access to the 'git' account via SSH (needed for Capistrano for example) you can copy a unique SSH public key into config/deployment_authorized_keys and run `rake gitlab:shell:setup`

This is an alternative to [Gitshell #15](https://github.com/gitlabhq/gitlab-shell/pull/15) that should address all of @randx's concerns, specifically that if someone steals an admin account they will not gain full ssh access.
