### PR TITLE
Abilities added to /user and /sign_in requests

### DIFF
--- a/doc/api/session.md
+++ b/doc/api/session.md
@@ -17,7 +17,17 @@ Parameters:
   "email": "john@example.com",
   "name": "John Smith",
   "private_token": "dd34asd13as",
+  "blocked": false,
   "created_at": "2012-05-23T08:00:58Z",
-  "blocked": true
+  "bio": null,
+  "skype": "",
+  "linkedin": "",
+  "twitter": "",
+  "dark_scheme": false,
+  "theme_id": 1
+  "is_admin": false,
+  "can_create_group" : true,
+  "can_create_team" : true,
+  "can_create_project" : true
 }
 ```

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -154,6 +154,7 @@ GET /user
   "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
+  "private_token": "dd34asd13as",
   "blocked": false,
   "created_at": "2012-05-23T08:00:58Z",
   "bio": null,
@@ -162,6 +163,10 @@ GET /user
   "twitter": "",
   "dark_scheme": false,
   "theme_id": 1
+  "is_admin": false,
+  "can_create_group" : true,
+  "can_create_team" : true,
+  "can_create_project" : true
 }
 ```
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -13,7 +13,7 @@ module Gitlab
       expose :id, :username, :email, :name, :state, :created_at
     end
 
-    class UserLogin < UserBasic
+    class UserLogin < User
       expose :private_token
       expose :is_admin?, as: :is_admin
       expose :can_create_group?, as: :can_create_group

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -15,6 +15,10 @@ module Gitlab
 
     class UserLogin < UserBasic
       expose :private_token
+      expose :is_admin?, as: :is_admin
+      expose :can_create_group?, as: :can_create_group
+      expose :can_create_project?, as: :can_create_project
+      expose :can_create_team?, as: :can_create_team
     end
 
     class Hook < Grape::Entity
@@ -31,7 +35,7 @@ module Gitlab
     end
 
     class ProjectMember < UserBasic
-      expose :project_access, :as => :access_level do |user, options|
+      expose :project_access, as: :access_level do |user, options|
         options[:project].users_projects.find_by_user_id(user.id).project_access
       end
     end

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -191,7 +191,7 @@ module Gitlab
         unless team_member.nil?
           team_member.destroy
         else
-          {:message => "Access revoked", :id => params[:user_id].to_i}
+          {message: "Access revoked", id: params[:user_id].to_i}
         end
       end
 
@@ -322,7 +322,7 @@ module Gitlab
         protected = user_project.protected_branches.find_by_name(@branch.name)
 
         unless protected
-          user_project.protected_branches.create(:name => @branch.name)
+          user_project.protected_branches.create(name: @branch.name)
         end
 
         present @branch, with: Entities::RepoObject, project: user_project

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -124,7 +124,7 @@ module Gitlab
       # Example Request:
       #   GET /user
       get do
-        present @current_user, with: Entities::User
+        present @current_user, with: Entities::UserLogin
       end
 
       # Get currently authenticated user's keys

--- a/spec/requests/api/session_spec.rb
+++ b/spec/requests/api/session_spec.rb
@@ -13,6 +13,10 @@ describe Gitlab::API do
 
         json_response['email'].should == user.email
         json_response['private_token'].should == user.private_token
+        json_response['is_admin'].should == user.is_admin?
+        json_response['can_create_team'].should == user.can_create_team?
+        json_response['can_create_project'].should == user.can_create_project?
+        json_response['can_create_group'].should == user.can_create_group?
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -214,6 +214,10 @@ describe Gitlab::API do
       get api("/user", user)
       response.status.should == 200
       json_response['email'].should == user.email
+      json_response['is_admin'].should == user.is_admin?
+      json_response['can_create_team'].should == user.can_create_team?
+      json_response['can_create_project'].should == user.can_create_project?
+      json_response['can_create_group'].should == user.can_create_group?
     end
 
     it "should return 401 error if user is unauthenticated" do


### PR DESCRIPTION
Added few additional fields to the user entity

```
can_create_group
can_create_team
can_create_project
is_admin
```

Additional fields appears only for current user.
