### PR TITLE
Fix timeout error while showing the network graph.

### DIFF
--- a/app/models/network/graph.rb
+++ b/app/models/network/graph.rb
@@ -25,15 +25,7 @@ module Network
     def collect_commits
       refs_cache = build_refs_cache
 
-      Grit::Commit.find_all(
-        @repo,
-        nil,
-        {
-          date_order: true,
-          max_count: self.class.max_count,
-          skip: count_to_display_commit_in_center
-        }
-      )
+      find_commits(count_to_display_commit_in_center)
       .map do |commit|
           # Decorate with app/model/network/commit.rb
           Network::Commit.new(commit, refs_cache[commit.id])
@@ -74,7 +66,7 @@ module Network
 
     # Skip count that the target commit is displayed in center.
     def count_to_display_commit_in_center
-      commit_index = Grit::Commit.find_all(@repo, nil, {date_order: true}).index do |c|
+      commit_index = find_commits.index do |c|
         c.id == @commit.id
       end
 
@@ -84,6 +76,18 @@ module Network
       else
         0
       end
+    end
+
+    def find_commits(skip = 0)
+      Grit::Commit.find_all(
+        @repo,
+        nil,
+        {
+          date_order: true,
+          max_count: self.class.max_count,
+          skip: skip
+        }
+      )
     end
 
     def commits_sort_by_ref

--- a/app/models/network/graph.rb
+++ b/app/models/network/graph.rb
@@ -66,13 +66,30 @@ module Network
 
     # Skip count that the target commit is displayed in center.
     def count_to_display_commit_in_center
-      commit_index = find_commits.index do |c|
-        c.id == @commit.id
+      offset = -1
+      skip = 0
+      while offset == -1
+        tmp_commits = find_commits(skip)
+        if tmp_commits.size > 0
+          index = tmp_commits.index do |c|
+            c.id == @commit.id
+          end
+
+          if index
+            # Find the target commit
+            offset = index + skip
+          else
+            skip += self.class.max_count
+          end
+        else
+          # Cant't find the target commit in the repo.
+          offset = 0
+        end
       end
 
-      if commit_index && (self.class.max_count / 2 < commit_index) then
+      if self.class.max_count / 2 < offset then
         # get max index that commit is displayed in the center.
-        commit_index - self.class.max_count / 2
+        offset - self.class.max_count / 2
       else
         0
       end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -28,8 +28,8 @@ require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 Spinach.hooks.on_tag("javascript") do
   ::Capybara.current_driver = ::Capybara.javascript_driver
-  ::Capybara.default_wait_time = 5
 end
+Capybara.default_wait_time = 10
 
 
 DatabaseCleaner.strategy = :truncation

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -11,7 +11,7 @@ describe "Projects" do
     end
 
     it "should be correct path" do
-      expect { click_link "Remove" }.to change {Project.count}.by(-1)
+      expect { click_link "Remove project" }.to change {Project.count}.by(-1)
     end
   end
 end

--- a/spec/features/security/project_access_spec.rb
+++ b/spec/features/security/project_access_spec.rb
@@ -230,14 +230,17 @@ describe "Application access" do
     end
 
     describe "GET /project_code/files" do
-      subject { files_project_path(project) }
+      pending("ProjectsController#files have been deleted.") do
 
-      it { should be_allowed_for master }
-      it { should be_allowed_for reporter }
-      it { should be_denied_for :admin }
-      it { should be_denied_for guest }
-      it { should be_denied_for :user }
-      it { should be_denied_for :visitor }
+        subject { files_project_path(project) }
+
+        it { should be_allowed_for master }
+        it { should be_allowed_for reporter }
+        it { should be_denied_for :admin }
+        it { should be_denied_for guest }
+        it { should be_denied_for :user }
+        it { should be_denied_for :visitor }
+      end
     end
   end
 end


### PR DESCRIPTION
Grit::Git::GitTimeout is occured, if the very large repo like git repo is shown on the network graph.
