### PR TITLE
Patch backup

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -13,7 +13,7 @@ namespace :gitlab do
       # saving additional informations
       s = {}
       s[:db_version]         = "#{ActiveRecord::Migrator.current_version}"
-      s[:backup_created_at]  = "#{Time.now}"
+      s[:backup_created_at]  = "#{Time.now}".force_encoding("UTF-8")
       s[:gitlab_version]     = %x{git rev-parse HEAD}.gsub(/\n/,"")
       s[:tar_version]        = %x{tar --version | head -1}.gsub(/\n/,"")
 

--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -10,14 +10,14 @@ namespace :gitlab do
       Rake::Task["gitlab:backup:db:create"].invoke
       Rake::Task["gitlab:backup:repo:create"].invoke
 
-      Dir.chdir(Gitlab.config.backup.path)
-
       # saving additional informations
       s = {}
       s[:db_version]         = "#{ActiveRecord::Migrator.current_version}"
       s[:backup_created_at]  = "#{Time.now}"
       s[:gitlab_version]     = %x{git rev-parse HEAD}.gsub(/\n/,"")
       s[:tar_version]        = %x{tar --version | head -1}.gsub(/\n/,"")
+
+      Dir.chdir(Gitlab.config.backup.path)
 
       File.open("#{Gitlab.config.backup.path}/backup_information.yml", "w+") do |file|
         file << s.to_yaml.gsub(/^---\n/,'')


### PR DESCRIPTION
I decided to store the backups generated with `bundle exec rake gitlab:backup:create RAILS_ENV=production` to a folder outside of the git repo.

This way, the git version determinationed needed for the metadata file backup_information.yml fails. The commit 067a8d5ff7bd736f996c81c245f5ce0936470669 solves this issue.

Beside this, the timestamp is given in binary. The problem is explained here: http://astrails.com/blog/2012/10/30/yaml-encodings-and-binary-strings

```
:backup_created_at: !binary |-
  MjAxMy0wMy0xOSAxMzozMzozOSArMDEwMA==
```

The commit 7df78a9298667ee3333d834829bbdcf74d6706d3 solves this second issue.
