### PR TITLE
Fix the Cancel button on the Edit Wiki page.

### DIFF
--- a/app/views/wikis/_form.html.haml
+++ b/app/views/wikis/_form.html.haml
@@ -30,4 +30,7 @@
       .input= f.text_field :message, class: 'span8'
   .actions
     = f.submit 'Save', class: "btn-save btn"
-    = link_to "Cancel", project_wiki_path(@project, :index), class: "btn btn-cancel"
+    - if @wiki && @wiki.persisted?
+      = link_to "Cancel", project_wiki_path(@project, @wiki), class: "btn btn-cancel"
+    - else
+      = link_to "Cancel", project_wiki_path(@project, :home), class: "btn btn-cancel"

--- a/features/project/wiki.feature
+++ b/features/project/wiki.feature
@@ -8,12 +8,23 @@ Feature: Project Wiki
     Given I create the Wiki Home page
     Then I should see the newly created wiki page
 
+  Scenario: Pressing Cancel while editing a brand new Wiki
+    Given I click on the Cancel button
+    Then I should be redirected back to the Edit Home Wiki page
+
   Scenario: Edit existing page
     Given I have an existing Wiki page
     And I browse to that Wiki page
     And I click on the Edit button
     And I change the content
     Then I should see the updated content
+
+  Scenario: Pressing Cancel while editing an existing Wiki page
+    Given I have an existing Wiki page
+    And I browse to that Wiki page
+    And I click on the Edit button
+    And I click on the Cancel button
+    Then I should be redirected back to that Wiki page
 
   Scenario: View page history
     Given I have an existing wiki page

--- a/features/steps/project/project_wiki.rb
+++ b/features/steps/project/project_wiki.rb
@@ -4,6 +4,17 @@ class ProjectWiki < Spinach::FeatureSteps
   include SharedNote
   include SharedPaths
 
+  Given 'I click on the Cancel button' do
+    within(:css, ".actions") do
+      click_on "Cancel"
+    end
+  end
+
+  Then 'I should be redirected back to the Edit Home Wiki page' do
+    url = URI.parse(current_url)
+    url.path.should == project_wiki_path(project, :home)
+  end
+
   Given 'I create the Wiki Home page' do
     fill_in "Content", :with => '[link test](test)'
     click_on "Save"
@@ -37,6 +48,11 @@ class ProjectWiki < Spinach::FeatureSteps
 
   Then 'I should see the updated content' do
     page.should have_content "Updated Wiki Content"
+  end
+
+  Then 'I should be redirected back to that Wiki page' do
+    url = URI.parse(current_url)
+    url.path.should == project_wiki_path(project, @page)
   end
 
   And 'That page has two revisions' do


### PR DESCRIPTION
The Cancel button on the Edit Wiki page was still redirecting back
to the "Index" page which is no longer the default Wiki page.

This commit changes the Cancel button in the following ways:
- Pressing Cancel while editing an existing Wiki page will now
  redirect you back to the latest version of that page.
- Pressing Cancel while editing a brand new Wiki home page that
  does not yet exist will redirect you to back to the same Edit
  Wiki Home page.
