### PR TITLE
Fix column heading order in group admin view

### DIFF
--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -16,8 +16,8 @@
       %th
         Name
         %i.icon-sort-down
-      %th Path
       %th Description
+      %th Path
       %th Projects
       %th Owner
       %th.cred Danger Zone!


### PR DESCRIPTION
Path and description column headings were in the wrong order.
