### PR TITLE
Added support manage access to repositories via git protocol

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -10,6 +10,7 @@ class Admin::ProjectsController < Admin::ApplicationController
     @projects = @projects.where(namespace_id: nil) if params[:namespace_id] == Namespace.global_id
     @projects = @projects.search(params[:name]) if params[:name].present?
     @projects = @projects.includes(:namespace).order("namespaces.path, projects.name ASC").page(params[:page]).per(20)
+    check_git_protocol
   end
 
   def show
@@ -17,9 +18,11 @@ class Admin::ProjectsController < Admin::ApplicationController
     @users = User.active
     @users = @users.not_in_project(@project) if @project.users.present?
     @users = @users.all
+    check_git_protocol
   end
 
   def edit
+    check_git_protocol
   end
 
   def team_update
@@ -54,5 +57,9 @@ class Admin::ProjectsController < Admin::ApplicationController
 
     @project = Project.find_with_namespace(id)
     @project || render_404
+  end
+
+  def check_git_protocol
+    @git_protocol_enabled ||= Gitlab.config.gitlab.git_daemon_enabled
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,6 +14,7 @@ class ProjectsController < ProjectResourceController
   end
 
   def edit
+    check_git_protocol
   end
 
   def create
@@ -52,6 +53,7 @@ class ProjectsController < ProjectResourceController
   end
 
   def show
+    check_git_protocol
     limit = (params[:limit] || 20).to_i
     @events = @project.events.recent.limit(limit).offset(params[:offset] || 0)
 
@@ -77,5 +79,11 @@ class ProjectsController < ProjectResourceController
     respond_to do |format|
       format.html { redirect_to root_path }
     end
+  end
+
+  protected
+
+  def check_git_protocol
+    @git_protocol_enabled ||= Gitlab.config.gitlab.git_daemon_enabled
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -80,7 +80,7 @@ class Ability
     end
 
     def project_master_rules
-      project_dev_rules + [
+      rules = project_dev_rules << [
         :push_code_to_protected_branches,
         :modify_issue,
         :modify_snippet,
@@ -94,6 +94,9 @@ class Ability
         :admin_wiki,
         :admin_project
       ]
+
+      rules = project_dev_rules << [:change_public_via_git_mode] if Gitlab.config.gitlab.git_daemon_enabled
+      rules
     end
 
     def project_admin_rules

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -95,8 +95,8 @@ class Ability
         :admin_project
       ]
 
-      rules = project_dev_rules << [:change_public_via_git_mode] if Gitlab.config.gitlab.git_daemon_enabled
-      rules
+      rules << [:change_public_via_git_mode] if Gitlab.config.gitlab.git_daemon_enabled
+      rules.flatten
     end
 
     def project_admin_rules

--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -10,6 +10,21 @@ class ProjectObserver < ActiveRecord::Observer
 
   def after_update(project)
     project.send_move_instructions if project.namespace_id_changed?
+    if project.git_protocol_enabled_changed?
+      if project.git_protocol_enabled
+        log_info("#{project.owner.name} granted public access via git protocol for project \"#{project.name_with_namespace}\"")
+        GitlabShellWorker.perform_async(
+          :enable_git_protocol,
+          project.path_with_namespace
+        )
+      else
+        log_info("#{project.owner.name} removed public access via git protocol for project \"#{project.name_with_namespace}\"")
+        GitlabShellWorker.perform_async(
+          :disable_git_protocol,
+          project.path_with_namespace
+        )
+      end
+    end
   end
 
   def after_destroy(project)

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -52,12 +52,18 @@
       = f.label :wiki_enabled, "Wiki"
       .input= f.check_box :wiki_enabled
 
+
   %fieldset.features
     %legend Public mode:
     .clearfix
       = f.label :public do
         %span Allow public http clone
       .input= f.check_box :public
+
+    .clearfix
+      = f.label :git_protocol_enabled, "Access via git protocol"
+      .input= f.check_box :git_protocol_enabled
+
 
   %fieldset.features
     %legend Transfer:

--- a/app/views/admin/projects/_form.html.haml
+++ b/app/views/admin/projects/_form.html.haml
@@ -59,10 +59,10 @@
       = f.label :public do
         %span Allow public http clone
       .input= f.check_box :public
-
-    .clearfix
-      = f.label :git_protocol_enabled, "Access via git protocol"
-      .input= f.check_box :git_protocol_enabled
+    - if @git_protocol_enabled
+      .clearfix
+        = f.label :git_protocol_enabled, "Access via git protocol"
+        .input= f.check_box :git_protocol_enabled
 
 
   %fieldset.features

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -50,12 +50,12 @@
               %i.icon-share
             - else
               %i.icon-lock.cgreen
-            %span.cblue
-            - if project.git_protocol_enabled
-              %i.icon-ok
-            - else
-              %i.icon-off
-            Git protocol access
+            - if @git_protocol_enabled
+              %span.cblue
+              - if project.git_protocol_enabled
+                %i.icon-ok
+              - else
+                %i.icon-off
 
             = link_to project.name_with_namespace, [:admin, project]
             .pull-right

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -50,6 +50,13 @@
               %i.icon-share
             - else
               %i.icon-lock.cgreen
+            %span.cblue
+            - if project.git_protocol_enabled
+              %i.icon-ok
+            - else
+              %i.icon-off
+            Git protocol access
+
             = link_to project.name_with_namespace, [:admin, project]
             .pull-right
               = link_to 'Edit', edit_admin_project_path(project), id: "edit_#{dom_id(project)}", class: "btn btn-small"

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -63,9 +63,15 @@
     %tr.bgred
       %td
         %b
-          Public Read-Only Code access:
+          Public Read-Only Code access via HTTP(s):
       %td
         = check_box_tag 'public', nil, @project.public
+  - if @git_protocol_enabled
+    %tr.bgred
+      %td
+        %b
+          Public Read-Only Code access via GIT:
+      %td
         = check_box_tag 'git_protocol', nil, @project.git_protocol_enabled
 
 - if @repository

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -66,6 +66,7 @@
           Public Read-Only Code access:
       %td
         = check_box_tag 'public', nil, @project.public
+        = check_box_tag 'git_protocol', nil, @project.git_protocol_enabled
 
 - if @repository
   %table.zebra-striped

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -36,10 +36,11 @@
                   .input
                     = f.text_area :description, placeholder: "awesome project", class: "span5", rows: 3, maxlength: 250
 
-                - unless @repository.heads.empty?
-                  .clearfix
-                    = f.label :default_branch, "Default Branch"
-                    .input= f.select(:default_branch, @repository.heads.map(&:name), {}, style: "width:210px;")
+                - if @repository
+                  - unless @repository.heads.empty?
+                    .clearfix
+                      = f.label :default_branch, "Default Branch"
+                      .input= f.select(:default_branch, @repository.heads.map(&:name), {}, style: "width:210px;")
 
 
               - if can?(current_user, :change_public_mode, @project)
@@ -55,7 +56,20 @@
                         If checked, this project can be cloned
                         %em without any
                         authentification.
-                        It will also be listed on the #{link_to "public access directory", public_root_path}.
+                  - if @git_protocol_enabled
+                    .control-group
+                      = f.label :git_protocol_enabled, class: 'control-label' do
+                        %span Access via git protocol
+                      .controls
+                        = f.check_box :git_protocol_enabled
+                        %span.descr
+                          If checked, this project can be cloned
+                          %em without any
+                          authentification via git protocol.
+                  .control-group
+                    %span.span9
+                      Projects with enabled public clone will also be listed on the #{link_to "public access directory", public_root_path}
+
 
               %fieldset.features
                 %legend

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -24,6 +24,13 @@
             %span.cgreen
               %i.icon-lock
               Private
+          - if @git_protocol_enabled
+            %span.cblue
+              - if @project.git_protocol_enabled
+                %i.icon-ok
+              - else
+                %i.icon-off
+              Git protocol access
 
         %p Repo Size: #{@project.repository.size} MB
         %p Created at: #{@project.created_at.stamp('Aug 22, 2013')}

--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -11,7 +11,10 @@
           %i.icon-share
           = project.name_with_namespace
           .pull-right
-            %pre.dark.tiny git clone #{project.http_url_to_repo}
+            - if project.public
+              %pre.dark.tiny git clone #{project.http_url_to_repo}
+            - if project.git_protocol_enabled
+              %pre.dark.tiny git clone #{project.git_url_to_repo}
         %p.description
           = project.description
     - unless @projects.present?

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,4 +1,6 @@
 .input-prepend.project_clone_holder
   %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
   %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= Gitlab.config.gitlab.protocol.upcase
+  - if @git_protocol_enabled && @project.git_protocol_enabled
+    %button{class: "btn", :"data-clone" => @project.git_url_to_repo} GIT
   = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select input-xxlarge", readonly: true

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -37,6 +37,10 @@ production: &base
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
     # username_changing_enabled: false # default: true - User can change her username/namespace
 
+    ## Enable support cloning projects via git protocol (git://)
+    # You need git daemon to use this feature!
+    # git_daemon_enabled: true
+
 
   ## External issues trackers
   issues_tracker:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -17,13 +17,14 @@ class Settings < Settingslogic
       end
     end
 
-    def build_gitlab_url
+    def build_gitlab_url(protocol = nil)
       if gitlab_on_non_standard_port?
         custom_port = ":#{gitlab.port}"
       else
         custom_port = nil
       end
-      [ gitlab.protocol,
+      protocol ||= gitlab.protocol
+      [ protocol,
         "://",
         gitlab.host,
         custom_port,
@@ -57,9 +58,11 @@ Settings.gitlab['protocol']   ||= Settings.gitlab.https ? "https" : "http"
 Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
+Settings.gitlab['git_url']    ||= Settings.send(:build_gitlab_url, "git")
 Settings.gitlab['user']       ||= 'git'
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
+Settings.gitlab['git_daemon_enabled'] ||= false
 
 #
 # Gravatar

--- a/db/migrate/20130321181228_add_git_protocol_enabled_field_to_project.rb
+++ b/db/migrate/20130321181228_add_git_protocol_enabled_field_to_project.rb
@@ -1,0 +1,5 @@
+class AddGitProtocolEnabledFieldToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :git_protocol_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130318212250) do
+ActiveRecord::Schema.define(:version => 20130321181228) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -156,6 +156,7 @@ ActiveRecord::Schema.define(:version => 20130318212250) do
     t.string   "issues_tracker",         :default => "gitlab", :null => false
     t.string   "issues_tracker_id"
     t.boolean  "snippets_enabled",       :default => true,     :null => false
+    t.boolean  "git_protocol_enabled"
   end
 
   add_index "projects", ["creator_id"], :name => "index_projects_on_owner_id"

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -132,5 +132,13 @@ module Gitlab
     def exists?(dir_name)
       File.exists?(full_path(dir_name))
     end
+
+    def enable_git_protocol(path)
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects enable-git-protocol #{path}.git")
+    end
+
+    def disable_git_protocol(path)
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects disable-git-protocol #{path}.git")
+    end
   end
 end


### PR DESCRIPTION
Not work without PR https://github.com/gitlabhq/gitlab-shell/pull/19

Add ability to use access to repositories via git protocol (without authorization)

Public project edit page:
![Public project edit](http://puu.sh/2lD1Q)

Public show page:
![Public show](http://puu.sh/2lDeQ)

Public page (list of public projects):
![Public page](http://puu.sh/2lD4a)

Admin page (little part %) ) :
![Admin list](http://puu.sh/2lD6v)

Admin project show:
![Admin show](http://puu.sh/2lD8I)

Admin edit page:
![Admin edit](http://puu.sh/2lDa3)

More description later
