### PR TITLE
Fix a tiny typo in database install instructions.

### DIFF
--- a/doc/install/databases.md
+++ b/doc/install/databases.md
@@ -20,7 +20,7 @@ GitLab supports the following databases:
     # Create the GitLab production database
     mysql> CREATE DATABASE IF NOT EXISTS `gitlabhq_production` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_unicode_ci`;
 
-    # Grant the GitLab user necessary permissopns on the table.
+    # Grant the GitLab user necessary permissions on the table.
     mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON `gitlabhq_production`.* TO 'gitlab'@'localhost';
 
     # Quit the database session


### PR DESCRIPTION
Just read it while installing and figured I'd fix it.
