### PR TITLE
Change gollum repo to use https:// instead of git://

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem 'settingslogic'
 # github-linquist needs pygments 0.4.2 but Gollum 2.4.11
 # requires pygments 0.3.2. The latest master Gollum has been updated
 # to use pygments 0.4.2. Change this after next Gollum release.
-gem "gollum", "~> 2.4.0", git: "git://github.com/gollum/gollum.git", ref: "5dcd3c8c8f"
+gem "gollum", "~> 2.4.0", git: "https://github.com/gollum/gollum.git", ref: "5dcd3c8c8f"
 
 # Misc
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/gollum/gollum.git
+  remote: https://github.com/gollum/gollum.git
   revision: 5dcd3c8c8f68158e43ff79861279088ee56d0ebe
   ref: 5dcd3c8c8f
   specs:


### PR DESCRIPTION
A lot of people might have firewalls blocking the git:// protocol. Using https:// makes this easier and matches the other git repositories in the Gemfile.
