### PR TITLE
Fix overflow of text in the project summary box in Chrome and Safari

### DIFF
--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -13,6 +13,7 @@
   background: #F9F9F9;
   margin-bottom: 25px;
   border: 1px solid #CCC;
+  word-wrap: break-word;
   @include solid-shade;
 
   &.ui-box-show {
@@ -41,7 +42,6 @@
   .ui-box-body,
   .ui-box-bottom {
     padding: 15px;
-    word-wrap: break-word;
 
     .clearfix {
       margin: 0;


### PR DESCRIPTION
This fixes overflow of text in summary box on project home page.

As you can see from the attached images, long words like URLs in summary box overflows.
This happens in Chrome and Safari (probably WebKit based browsers).
### Before:

![Before](https://f.cloud.github.com/assets/83656/293616/7fcfa678-9392-11e2-8801-6fcc7e475843.png)
### Fixed:

![Fixed](https://f.cloud.github.com/assets/83656/293617/cb30f41e-9392-11e2-863d-2453f5056059.png)
