### PR TITLE
Fix json view files

### DIFF
--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -50,16 +50,6 @@ module ExtractsPath
 
     return pair unless @project
 
-    # Remove relative_url_root from path
-    input.gsub!(/^#{Gitlab.config.gitlab.relative_url_root}/, "")
-    # Remove project, actions and all other staff from path
-    input.gsub!(/^\/#{Regexp.escape(@project.path_with_namespace)}/, "")
-    input.gsub!(/^\/(tree|commits|blame|blob|refs|graph)\//, "") # remove actions
-    input.gsub!(/\?.*$/, "") # remove stamps suffix
-    input.gsub!(/.atom$/, "") # remove rss feed
-    input.gsub!(/.json$/, "") # remove json suffix
-    input.gsub!(/\/edit$/, "") # remove edit route part
-
     if input.match(/^([[:alnum:]]{40})(.+)/)
       # If the ref appears to be a SHA, we're done, just split the string
       pair = $~.captures
@@ -105,7 +95,7 @@ module ExtractsPath
   # Automatically renders `not_found!` if a valid tree path could not be
   # resolved (e.g., when a user inserts an invalid path or ref).
   def assign_ref_vars
-    path = CGI::unescape(request.fullpath.dup)
+    path = CGI::unescape(request.filtered_parameters["id"].dup)
 
     @ref, @path = extract_ref(path)
 

--- a/spec/lib/extracts_path_spec.rb
+++ b/spec/lib/extracts_path_spec.rb
@@ -54,47 +54,5 @@ describe ExtractsPath do
         extract_ref('stable/CHANGELOG').should == ['stable', 'CHANGELOG']
       end
     end
-
-    context "with a fullpath" do
-      it "extracts a valid branch" do
-        extract_ref('/gitlab/gitlab-ci/tree/foo/bar/baz/CHANGELOG').should == ['foo/bar/baz', 'CHANGELOG']
-      end
-
-      it "extracts a valid tag" do
-        extract_ref('/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG').should == ['v2.0.0', 'CHANGELOG']
-      end
-
-      it "extracts a valid commit SHA" do
-        extract_ref('/gitlab/gitlab-ci/tree/f4b14494ef6abf3d144c28e4af0c20143383e062/CHANGELOG').should ==
-          ['f4b14494ef6abf3d144c28e4af0c20143383e062', 'CHANGELOG']
-      end
-
-      it "extracts a timestamp" do
-        extract_ref('/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG?_=12354435').should == ['v2.0.0', 'CHANGELOG']
-      end
-    end
-
-    context "with a fullpath and a relative_url_root" do
-      before do
-        Gitlab.config.gitlab.stub(relative_url_root: '/relative')
-      end
-
-      it "extracts a valid branch with relative_url_root" do
-        extract_ref('/relative/gitlab/gitlab-ci/tree/foo/bar/baz/CHANGELOG').should == ['foo/bar/baz', 'CHANGELOG']
-      end
-
-      it "extracts a valid tag" do
-        extract_ref('/relative/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG').should == ['v2.0.0', 'CHANGELOG']
-      end
-
-      it "extracts a valid commit SHA" do
-        extract_ref('/relative/gitlab/gitlab-ci/tree/f4b14494ef6abf3d144c28e4af0c20143383e062/CHANGELOG').should ==
-          ['f4b14494ef6abf3d144c28e4af0c20143383e062', 'CHANGELOG']
-      end
-
-      it "extracts a timestamp" do
-        extract_ref('/relative/gitlab/gitlab-ci/tree/v2.0.0/CHANGELOG?_=12354435').should == ['v2.0.0', 'CHANGELOG']
-      end
-    end
   end
 end


### PR DESCRIPTION
``` ruby
#<ActionDispatch::Request:0x00000004aae160
@env={"REMOTE_ADDR"=>"127.0.0.1", "REQUEST_METHOD"=>"GET", "REQUEST_PATH"=>"/project_path_with_namespace/tree/master/full/path/to/file.json", "PATH_INFO"=>"/project_path_with_namespace">
@request_method="GET",
@filtered_parameters={"action"=>"show", "controller"=>"tree", "project_id"=>"project_path_with_namespace", "id"=>"master/full/path/to/file.json"},
@method="GET",
@fullpath="/project_path_with_namespace/tree/master/full/path/to/file.json">
```

Correctly extract refs from `id`. Rails can parse request better than we do it.

Related #3330
