### PR TITLE
Addition to installation instructions

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -413,3 +413,9 @@
   padding: 4px;
   background-color: #EEE;
 }
+
+.commit-description {
+  background: none;
+  border: none;
+  margin: 0;
+}

--- a/app/views/blame/_head.html.haml
+++ b/app/views/blame/_head.html.haml
@@ -1,7 +1,2 @@
-%ul.nav.nav-tabs
-  %li
-    = render partial: 'shared/ref_switcher', locals: {destination: 'tree', path: params[:path]}
-  = nav_link(controller: :refs) do
-    = link_to 'Source', project_tree_path(@project, @ref)
-  %li.pull-right
-    = render "shared/clone_panel"
+%div.tree-ref-holder
+  = render 'shared/ref_switcher', destination: 'tree', path: params[:path]

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -38,11 +38,11 @@
                   - current_line += 1
                 - else
                   - lines.each do |line|
-                    :preserve
-                      #{current_line}
+                    = current_line
+                    \
                     - current_line += 1
             %td.lines
               %pre
                 - lines.each do |line|
-                  :preserve
-                    #{line}
+                  = line
+                  \

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -3,7 +3,7 @@
 #tree-holder.tree-holder
   %ul.breadcrumb
     %li
-      %span.arrow
+      %i.icon-angle-right
       = link_to project_tree_path(@project, @ref) do
         = @project.name
     - @tree.breadcrumbs(6) do |link|

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -38,9 +38,11 @@
                   - current_line += 1
                 - else
                   - lines.each do |line|
-                    = current_line
+                    :preserve
+                      #{current_line}
                     - current_line += 1
             %td.lines
               %pre
                 - lines.each do |line|
-                  = line
+                  :preserve
+                    #{line}

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -91,7 +91,6 @@ Create a `git` user for Gitlab:
 
     sudo adduser --disabled-login --gecos 'GitLab' git
 
-
 # 4. GitLab shell
 
 GitLab Shell is a ssh access and repository management software developed specially for GitLab.
@@ -167,6 +166,10 @@ do so with caution!
 
     # Copy the example Unicorn config
     sudo -u git -H cp config/unicorn.rb.example config/unicorn.rb
+    
+    # Set username and email for the git user
+    sudo -u git -H git config --global user.name  "GitLab"
+    sudo -u git -H git config --global user.email "gitlab@your-domain.com"
 
 **Important Note:**
 Make sure to edit both files to match your setup.


### PR DESCRIPTION
Currently, when following the installation instructions, you get a warning during final check.

Git configured for git user? ... no
  Try fixing it:
  sudo -u git -H git config --global user.name  "GitLab"
  sudo -u git -H git config --global user.email "gitlab@your-domain.com"
  For more information see:
  doc/install/installation.md in section "GitLab"
  Please fix the error above and rerun the checks.

To fix this, add these commands to the installation instructions.
