### PR TITLE
Fork v5

### DIFF
--- a/app/contexts/projects/fork_context.rb
+++ b/app/contexts/projects/fork_context.rb
@@ -1,0 +1,34 @@
+module Projects
+  class ForkContext < BaseContext
+    def initialize(project, user)
+      @from_project, @current_user = project, user
+    end
+
+    def execute
+      project = Project.new
+      project.initialize_dup(@from_project)
+      project.name = @from_project.name
+      project.path = @from_project.path 
+      project.namespace = current_user.namespace
+
+      Project.transaction do
+        #First save the DB entries as they can be rolled back if the repo fork fails
+        project.creator = current_user
+        if project.save
+          project.users_projects.create(project_access: UsersProject::MASTER, user: current_user)
+          project.create_forked_project_link(forked_to_project_id: project.id, forked_from_project_id: @from_project.id)
+        end
+
+        #Now fork the repo
+        @from_project.repository.fork_repo(project.path_with_namespace)
+        project.ensure_satellite_exists
+
+      end
+      project
+    rescue => ex
+      project.errors.add(:base, "Can't fork project. Please try again later")
+      project
+    end
+
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -78,4 +78,19 @@ class ProjectsController < ProjectResourceController
       format.html { redirect_to root_path }
     end
   end
+
+  def fork
+    @project = ::Projects::ForkContext.new(project, current_user).execute
+
+    respond_to do |format|
+      format.html do
+        if @project.saved? && @project.forked?
+          redirect_to(@project, notice: 'Project was successfully forked.')
+        else
+          render action: "new"
+        end
+      end
+      format.js
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,7 +60,8 @@ class Ability
         :read_note,
         :write_project,
         :write_issue,
-        :write_note
+        :write_note,
+        :fork_project
       ]
     end
 

--- a/app/models/forked_project_link.rb
+++ b/app/models/forked_project_link.rb
@@ -1,0 +1,8 @@
+class ForkedProjectLink < ActiveRecord::Base
+  attr_accessible :forked_from_project_id, :forked_to_project_id
+
+  # Relations
+  belongs_to :forked_to_project, class_name: Project
+  belongs_to :forked_from_project, class_name: Project
+
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,6 +43,8 @@ class Project < ActiveRecord::Base
 
   has_one :last_event, class_name: 'Event', order: 'events.created_at DESC', foreign_key: 'project_id'
   has_one :gitlab_ci_service, dependent: :destroy
+  has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
+  has_one :forked_from_project, through: :forked_project_link
 
   has_many :events,             dependent: :destroy
   has_many :merge_requests,     dependent: :destroy
@@ -399,4 +401,9 @@ class Project < ActiveRecord::Base
   def protected_branch? branch_name
     protected_branches.map(&:name).include?(branch_name)
   end
+
+  def forked?
+    !(forked_project_link.nil? || forked_project_link.forked_from_project.nil?)
+  end
+
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -166,4 +166,9 @@ class Repository
   def cache_key(type)
     "#{type}:#{path_with_namespace}"
   end
+  
+  def fork_repo(to_path)
+    to_path_full = File.join(Gitlab.config.gitlab_shell.repos_path, to_path) + ".git"
+    result = repo.fork_bare(to_path_full)
+  end
 end

--- a/app/views/projects/_clone_panel.html.haml
+++ b/app/views/projects/_clone_panel.html.haml
@@ -5,6 +5,9 @@
     .span4.pull-right
       .pull-right
         - unless @project.empty_repo?
+          - if can? current_user, :fork_project, @project
+            = link_to fork_project_path(@project), title: "Fork", class: "btn small grouped", method: "POST" do
+              Fork
           - if can? current_user, :download_code, @project
             = link_to archive_project_repository_path(@project), class: "btn-small btn grouped" do
               %i.icon-download-alt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,10 @@ Gitlab::Application.routes.draw do
   # Project Area
   #
   resources :projects, constraints: { id: /(?:[a-zA-Z.0-9_\-]+\/)?[a-zA-Z.0-9_\-]+/ }, except: [:new, :create, :index], path: "/" do
+    member do
+      post "fork"
+    end
+
     resources :blob,    only: [:show], constraints: {id: /.+/}
     resources :tree,    only: [:show, :edit, :update], constraints: {id: /.+/}
     resources :commit,  only: [:show], constraints: {id: /[[:alnum:]]{6,40}/}

--- a/db/migrate/20130319214458_create_forked_project_links.rb
+++ b/db/migrate/20130319214458_create_forked_project_links.rb
@@ -1,0 +1,11 @@
+class CreateForkedProjectLinks < ActiveRecord::Migration
+  def change
+    create_table :forked_project_links do |t|
+      t.integer :forked_to_project_id, :null => false
+      t.integer :forked_from_project_id, :null => false
+
+      t.timestamps
+    end
+    add_index :forked_project_links, :forked_to_project_id, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130318212250) do
+ActiveRecord::Schema.define(:version => 20130319214458) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(:version => 20130318212250) do
   add_index "events", ["project_id"], :name => "index_events_on_project_id"
   add_index "events", ["target_id"], :name => "index_events_on_target_id"
   add_index "events", ["target_type"], :name => "index_events_on_target_type"
+
+  create_table "forked_project_links", :force => true do |t|
+    t.integer  "forked_to_project_id",   :null => false
+    t.integer  "forked_from_project_id", :null => false
+    t.datetime "created_at",             :null => false
+    t.datetime "updated_at",             :null => false
+  end
+
+  add_index "forked_project_links", ["forked_to_project_id"], :name => "index_forked_project_links_on_forked_to_project_id", :unique => true
 
   create_table "issues", :force => true do |t|
     t.string   "title"

--- a/features/project/fork_project.feature
+++ b/features/project/fork_project.feature
@@ -1,0 +1,19 @@
+Feature: Fork Project
+  In order to get a personal fork of a project
+  A user with ability to fork a project
+  Should be able to fork a project into their own namespace
+
+  Scenario: User fork a project
+    Given I sign in as a user
+    And I am a member of project "Shop"
+    When I visit project "Shop" page
+    And I click link "Fork"
+    Then I should see the forked project page
+    And I should see a non-empty project page
+
+  Scenario: User already has forked the project
+    Given I sign in as a user
+    And I already have a project named "Shop" in my namespace
+    When I visit project "Shop" page
+    And I click link "Fork"
+    Then I should see a "Name has already been taken" warning

--- a/features/steps/project/project_fork.rb
+++ b/features/steps/project/project_fork.rb
@@ -1,0 +1,34 @@
+class ForkProject < Spinach::FeatureSteps
+  include SharedAuthentication
+  include SharedPaths
+  include SharedProject
+
+  step 'I click link "Fork"' do
+    click_link "Fork"
+  end
+
+  step 'I am a member of project "Shop"' do
+    @project = Project.find_by_name "Shop"
+    @project ||= create(:project, name: "Shop")
+    @project.team << [@user, :reporter]
+  end
+
+  step 'I should see the forked project page' do
+    page.should have_content "Project was successfully forked."
+    current_path.should include current_user.namespace.path
+  end
+
+  step 'I should see a non-empty project page' do
+    page.should_not have_content "Empty"
+    page.should have_link "Files"
+  end
+
+  step 'I already have a project named "Shop" in my namespace' do
+    @my_project = create(:project, name: "Shop", namespace: current_user.namespace)
+  end
+
+  step 'I should see a "Name has already been taken" warning' do
+    page.should have_content "Name has already been taken"
+  end
+
+end

--- a/spec/contexts/fork_context_spec.rb
+++ b/spec/contexts/fork_context_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Projects::ForkContext do
+  describe :fork_by_user do
+    before do
+      @from_user = create :user
+      @from_project = create(:project, creator_id: @from_user.id)
+      @to_user = create :user
+    end
+
+    context 'fork project' do
+      before do
+        @to_project = fork_project(@from_project, @to_user)
+      end
+
+      it { @to_project.owner.should == @to_user }
+      it { @to_project.namespace.should == @to_user.namespace }
+    end
+
+    context 'fork project failure' do
+      before do
+        #corrupt the project so the attempt to fork will fail
+        @from_project = create(:project, path: "empty")
+        @to_project = fork_project(@from_project, @to_user)
+      end
+
+      it {@to_project.errors.should_not be_empty}
+      it {@to_project.errors[:base].should include("Can't fork project. Please try again later") }
+
+    end
+  end
+
+  def fork_project(from_project, user)
+    Projects::ForkContext.new(from_project, user).execute
+  end
+
+end

--- a/spec/factories/forked_project_links.rb
+++ b/spec/factories/forked_project_links.rb
@@ -1,0 +1,8 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :forked_project_link do
+    association :forked_to_project, factory: :project
+    association :forked_from_project, factory: :project
+  end
+end

--- a/spec/models/forked_project_link_spec.rb
+++ b/spec/models/forked_project_link_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe ForkedProjectLink, "add link on fork" do
+  let(:project_from) {create(:project)}
+  let(:user) {create(:user)}
+
+  before do
+    @project_to = fork_project(project_from, user)
+  end
+
+  it "project_to should know it is forked" do
+    @project_to.forked?.should be_true
+  end
+
+  it "project should know who it is forked from" do
+    @project_to.forked_from_project.should == project_from
+  end
+end
+
+describe :forked_from_project do
+  let(:forked_project_link) {build(:forked_project_link)}
+  let(:project_from) {create(:project)}
+  let(:project_to) {create(:project, forked_project_link: forked_project_link)}
+
+
+  before :each do
+    forked_project_link.forked_from_project = project_from
+    forked_project_link.forked_to_project = project_to
+    forked_project_link.save!
+  end
+
+
+  it "project_to should know it is forked" do
+    project_to.forked?.should be_true
+  end
+
+  it "project_from should not be forked" do
+    project_from.forked?.should be_false
+  end
+
+  it "project_to.destroy should destroy fork_link" do
+    forked_project_link.should_receive(:destroy)
+    project_to.destroy
+  end
+
+end
+
+def fork_project(from_project, user)
+  Projects::ForkContext.new(from_project, user).execute
+end
+

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -39,6 +39,7 @@ describe Project do
     it { should have_many(:hooks).dependent(:destroy) }
     it { should have_many(:wikis).dependent(:destroy) }
     it { should have_many(:protected_branches).dependent(:destroy) }
+    it { should have_one(:forked_project_link).dependent(:destroy) }
   end
 
   describe "Mass assignment" do
@@ -246,4 +247,5 @@ describe Project do
       ext_project.can_have_issues_tracker_id?.should be_false
     end
   end
+
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -55,6 +55,7 @@ end
 
 #      projects POST   /projects(.:format)     projects#create
 #   new_project GET    /projects/new(.:format) projects#new
+#  fork_project POST   /:id/fork(.:format)     projects#fork
 #  wall_project GET    /:id/wall(.:format)     projects#wall
 # files_project GET    /:id/files(.:format)    projects#files
 #  edit_project GET    /:id/edit(.:format)     projects#edit
@@ -68,6 +69,10 @@ describe ProjectsController, "routing" do
 
   it "to #new" do
     get("/projects/new").should route_to('projects#new')
+  end
+
+  it "to #fork" do
+    post("/gitlabhq/fork").should route_to('projects#fork', id: 'gitlabhq')
   end
 
   it "to #wall" do


### PR DESCRIPTION
This is an updated version of the previously rejected pull request: ![3145](https://github.com/gitlabhq/gitlabhq/pull/3145).
- "Fork" button on project page will create new project in user's namespace
- updated to use GitLab v5 rather than 4.2, including using gitlab-shell rather than gitolite
- improved test coverage
- addition of table forked_project_links to track which projects are forked from where
  - this will be important to enhance merge requests to go across forked repos
