### PR TITLE
Fix Error 500 if Pygments can not hilight a code block in the Readme

### DIFF
--- a/lib/redcarpet/render/gitlab_html.rb
+++ b/lib/redcarpet/render/gitlab_html.rb
@@ -11,7 +11,7 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
 
   def block_code(code, language)
     options = { options: {encoding: 'utf-8'} }
-    options.merge!(lexer: language.downcase) if Pygments::Lexer.find(language.downcase)
+    options.merge!(lexer: language.downcase) if Pygments::Lexer.find(language)
 
     # New lines are placed to fix an rendering issue
     # with code wrapped inside <h1> tag for next case:

--- a/lib/redcarpet/render/gitlab_html.rb
+++ b/lib/redcarpet/render/gitlab_html.rb
@@ -11,7 +11,7 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
 
   def block_code(code, language)
     options = { options: {encoding: 'utf-8'} }
-    options.merge!(lexer: language.downcase) if Pygments::Lexer.find(language)
+    options.merge!(lexer: language.downcase) if Pygments::Lexer.find(language.downcase)
 
     # New lines are placed to fix an rendering issue
     # with code wrapped inside <h1> tag for next case:
@@ -20,11 +20,19 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
     #
     #     ruby code here
     #
-    <<-HTML
+    begin
+      <<-HTML
 
-       <div class="#{h.user_color_scheme_class}">#{Pygments.highlight(code, options)}</div>
+         <div class="#{h.user_color_scheme_class}">#{Pygments.highlight(code, options)}</div>
 
-    HTML
+      HTML
+    rescue
+      <<-HTML
+
+         <div class="#{h.user_color_scheme_class}"><pre>#{code}</pre></div>
+
+      HTML
+    end
   end
 
   def link(link, title, content)


### PR DESCRIPTION
When browsing a project file tree and there is a Readme file in the repository in some cases the Pygments syntaxhilighter can not process some code blocks and throws an exception (when python interpreter is not called python2). So I included a simple safeguard around the syntax hilighter to fall back to a standard 'pre'-block if Pygments raises an exception. So it renders the page at least not throwing a "500 Internal Server Error".

I know about https://github.com/gitlabhq/gitlabhq/issues/2214#issuecomment-11137058 but i think fixing this such a way it falls back to not hilighted simple code blocks could be a better option than to explode and throw a 500.
