### PR TITLE
Spork support added

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---colour
+--colour --drb

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,8 @@ group :development, :test do
 
   # PhantomJS driver for Capybara
   gem 'poltergeist', '1.1.0'
+
+  gem 'spork', '~> 1.0rc'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,6 +447,7 @@ GEM
       capybara (~> 2.0.0)
       railties (>= 3)
       spinach (>= 0.4)
+    spork (1.0.0rc3)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -574,6 +575,7 @@ DEPENDENCIES
   six
   slim
   spinach-rails (= 0.2.0)
+  spork (~> 1.0rc)
   stamp
   state_machine
   test_after_commit

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,47 +1,62 @@
-require 'simplecov' unless ENV['CI']
+require 'rubygems'
+require 'spork'
 
-if ENV['TRAVIS']
-  require 'coveralls'
-  Coveralls.wear!
+Spork.prefork do
+  require 'simplecov' unless ENV['CI']
+
+  if ENV['TRAVIS']
+    require 'coveralls'
+    Coveralls.wear!
+  end
+
+  # This file is copied to spec/ when you run 'rails generate rspec:install'
+  ENV["RAILS_ENV"] ||= 'test'
+  require File.expand_path("../../config/environment", __FILE__)
+  require 'rspec/rails'
+  require 'capybara/rails'
+  require 'capybara/rspec'
+  require 'webmock/rspec'
+  require 'email_spec'
+  require 'sidekiq/testing/inline'
+  require 'capybara/poltergeist'
+
+  # Loading more in this block will cause your tests to run faster. However,
+
+  # if you change any configuration or code from libraries loaded here, you'll
+  # need to restart spork for it take effect.
+  Capybara.javascript_driver = :poltergeist
+  Capybara.default_wait_time = 10
+
+  # Requires supporting ruby files with custom matchers and macros, etc,
+  # in spec/support/ and its subdirectories.
+  Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+
+  WebMock.disable_net_connect!(allow_localhost: true)
+
+  RSpec.configure do |config|
+    config.mock_with :rspec
+
+    config.include LoginHelpers, type: :feature
+    config.include LoginHelpers, type: :request
+    config.include FactoryGirl::Syntax::Methods
+    config.include Devise::TestHelpers, type: :controller
+
+    # If you're not using ActiveRecord, or you'd prefer not to run each of your
+    # examples within a transaction, remove the following line or assign false
+    # instead of true.
+    config.use_transactional_fixtures = false
+
+    config.before do
+      # Use tmp dir for FS manipulations
+      temp_repos_path = Rails.root.join('tmp', 'test-git-base-path')
+      Gitlab.config.gitlab_shell.stub(repos_path: temp_repos_path)
+      FileUtils.rm_rf temp_repos_path
+      FileUtils.mkdir_p temp_repos_path
+    end
+  end
 end
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../../config/environment", __FILE__)
-require 'rspec/rails'
-require 'capybara/rails'
-require 'capybara/rspec'
-require 'webmock/rspec'
-require 'email_spec'
-require 'sidekiq/testing/inline'
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
-Capybara.default_wait_time = 10
+Spork.each_run do
+  # This code will be run each time you run your specs.
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
-WebMock.disable_net_connect!(allow_localhost: true)
-
-RSpec.configure do |config|
-  config.mock_with :rspec
-
-  config.include LoginHelpers, type: :feature
-  config.include LoginHelpers, type: :request
-  config.include FactoryGirl::Syntax::Methods
-  config.include Devise::TestHelpers, type: :controller
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
-
-  config.before do
-    # Use tmp dir for FS manipulations
-    temp_repos_path = Rails.root.join('tmp', 'test-git-base-path')
-    Gitlab.config.gitlab_shell.stub(repos_path: temp_repos_path)
-    FileUtils.rm_rf temp_repos_path
-    FileUtils.mkdir_p temp_repos_path
-  end
 end


### PR DESCRIPTION
I can no longer pay attention to the fact that the test running in a project takes a lot of time. It is awful, especially if you work everything out on the virtual machine.

I think that I would be supported by a lot of people that the spork implementation will cut the time  required to load the environment.

I cannot provide the test performance for all the tests because I do not have enough patience to  wait until all the tests  pass on my machine.

```
vagrant:~/projects/my_gitlabhq spring
→ time rspec spec/models/issue_spec.rb
No DRb server is running. Running in local process instead ...
.......

Finished in 16.06 seconds
7 examples, 0 failures
Coverage report generated for Cucumber Features, RSpec, Unknown Test Framework to /home/vagrant/projects/my_gitlabhq/coverage. 2120 / 5123 LOC (41.38%) covered.

real    2m32.973s
user    0m10.385s
sys 0m3.956s
```

Run spork and:

```
vagrant:~/projects/my_gitlabhq spork
→ time rspec spec/models/issue_spec.rb
.......

Finished in 12.95 seconds
7 examples, 0 failures

real    0m16.117s
user    0m0.704s
sys 0m0.096s
```
