### PR TITLE
Fixed UsersProject.in_projects

### DIFF
--- a/app/models/users_project.rb
+++ b/app/models/users_project.rb
@@ -38,7 +38,7 @@ class UsersProject < ActiveRecord::Base
   scope :masters,  -> { where(project_access: MASTER) }
 
   scope :in_project, ->(project) { where(project_id: project.id) }
-  scope :in_projects, ->(projects) { where(project_id: project_ids) }
+  scope :in_projects, ->(projects) { where(project_id: projects.map { |p| p.id }) }
   scope :with_user, ->(user) { where(user_id: user.id) }
 
   class << self

--- a/spec/models/user_team_spec.rb
+++ b/spec/models/user_team_spec.rb
@@ -14,5 +14,24 @@
 require 'spec_helper'
 
 describe UserTeam do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:team) { FactoryGirl.create :user_team }
+
+  context ".add_member" do
+    let(:user) { FactoryGirl.create :user }
+
+    it "should work" do
+      team.add_member(user, UsersProject::DEVELOPER, false)
+      team.members.should include(user)
+    end
+  end
+
+  context ".remove_member" do
+    let(:user) { FactoryGirl.create :user }
+    before { team.add_member(user, UsersProject::DEVELOPER, false) }
+
+    it "should work" do
+      team.remove_member(user)
+      team.members.should_not include(user)
+    end
+  end
 end


### PR DESCRIPTION
I discovered while trying to use UserTeam#remove_member() that
UsersProject.in_projects was broken.  So I wrote test cases to test what I was
trying to do and fixed the underlying problem.
