### PR TITLE
Synchronize the user name.

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -413,3 +413,9 @@
   padding: 4px;
   background-color: #EEE;
 }
+
+.commit-description {
+  background: none;
+  border: none;
+  margin: 0;
+}

--- a/app/views/blame/_head.html.haml
+++ b/app/views/blame/_head.html.haml
@@ -1,7 +1,2 @@
-%ul.nav.nav-tabs
-  %li
-    = render partial: 'shared/ref_switcher', locals: {destination: 'tree', path: params[:path]}
-  = nav_link(controller: :refs) do
-    = link_to 'Source', project_tree_path(@project, @ref)
-  %li.pull-right
-    = render "shared/clone_panel"
+%div.tree-ref-holder
+  = render 'shared/ref_switcher', destination: 'tree', path: params[:path]

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -38,11 +38,11 @@
                   - current_line += 1
                 - else
                   - lines.each do |line|
-                    :preserve
-                      #{current_line}
+                    = current_line
+                    \
                     - current_line += 1
             %td.lines
               %pre
                 - lines.each do |line|
-                  :preserve
-                    #{line}
+                  = line
+                  \

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -3,7 +3,7 @@
 #tree-holder.tree-holder
   %ul.breadcrumb
     %li
-      %span.arrow
+      %i.icon-angle-right
       = link_to project_tree_path(@project, @ref) do
         = @project.name
     - @tree.breadcrumbs(6) do |link|

--- a/app/views/blame/show.html.haml
+++ b/app/views/blame/show.html.haml
@@ -38,9 +38,11 @@
                   - current_line += 1
                 - else
                   - lines.each do |line|
-                    = current_line
+                    :preserve
+                      #{current_line}
                     - current_line += 1
             %td.lines
               %pre
                 - lines.each do |line|
-                  = line
+                  :preserve
+                    #{line}

--- a/doc/install/databases.md
+++ b/doc/install/databases.md
@@ -38,10 +38,10 @@ GitLab supports the following databases:
     sudo -u postgres psql -d template1
 
     # Create a user for GitLab. (change $password to a real password)
-    template1=# CREATE USER gitlab WITH PASSWORD '$password';
+    template1=# CREATE USER git WITH PASSWORD '$password';
 
     # Create the GitLab production database & grant all privileges on database
-    template1=# CREATE DATABASE gitlabhq_production OWNER gitlab;
+    template1=# CREATE DATABASE gitlabhq_production OWNER git;
 
     # Quit the database session
     template1=# \q

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -1,6 +1,6 @@
 This installation guide was created for Debian/Ubuntu and tested on it. Please read [`doc/install/requirements.md`](./requirements.md) for hardware and platform requirements.
 
-This installation guide is recommended to set up a production server. If you want a development environment please use the [Vargrant virtual machine](https://github.com/gitlabhq/gitlab-vagrant-vm) since it makes it much easier to set up all the dependencies for integration testing.
+This installation guide is recommended to set up a production server. If you want a development environment please use the [Vagrant virtual machine](https://github.com/gitlabhq/gitlab-vagrant-vm) since it makes it much easier to set up all the dependencies for integration testing.
 
 **Important Note:**
 The following steps have been known to work.


### PR DESCRIPTION
In the [installation.md](https://github.com/gitlabhq/gitlabhq/blob/5-0-stable/doc/install/installation.md#3-system-users) it creates a `git` user for Gitlab and peer authentication only works for a system user of the same name.
