### PR TITLE
Changed the word 'authentification' to 'authentication'

### DIFF
--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -54,7 +54,7 @@
                       %span.descr
                         If checked, this project can be cloned
                         %em without any
-                        authentification.
+                        authentication.
                         It will also be listed on the #{link_to "public access directory", public_root_path}.
 
               %fieldset.features


### PR DESCRIPTION
I know it's nitpicking, but I don't think authentification is a word, so I changed the text to say 'authentication' instead. Here is a summary of the change:

``` diff
diff --git a/app/views/projects/_form.html.haml b/app/views/projects/_form.html.haml
index 01fb6a6..b25cfda 100644
--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -54,7 +54,7 @@
                       %span.descr
                         If checked, this project can be cloned
                         %em without any
-                        authentification.
+                        authentication.
                         It will also be listed on the #{link_to "public access directory", public_root_path}.

               %fieldset.features
```
