### PR TITLE
Fixed: gitlab-shell version check error message

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -640,7 +640,7 @@ namespace :gitlab do
     if gitlab_shell_version.strip == '1.2.0'
       puts 'OK (1.2.0)'.green
     else
-      puts 'FAIL. Please update gitlab-shell to v1.1.0'.red
+      puts 'FAIL. Please update gitlab-shell to v1.2.0'.red
     end
   end
 end


### PR DESCRIPTION
The gitlab-shell version check error message instructed users to install version 1.1.0 still, should be 1.2.0.
