### PR TITLE
Fix regression in deploy key uniqueness check

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -23,7 +23,7 @@ class Key < ActiveRecord::Base
   before_validation :strip_white_space
 
   validates :title, presence: true, length: { within: 0..255 }
-  validates :key, presence: true, length: { within: 0..5000 }, format: { :with => /ssh-.{3} / }, uniqueness: true
+  validates :key, presence: true, length: { within: 0..5000 }, format: { :with => /ssh-.{3} / }, uniqueness: { scope: :project_id }
   validate :fingerprintable_key
 
   delegate :name, :email, to: :user, prefix: true


### PR DESCRIPTION
There appears to have been a regression in 48628d31d59f007fbf4b6958eb2a48adedaef8e4 that made checking uniqueness of deploy keys global instead of scoped within a project.
