### PR TITLE
fix: wrong number of arguments

### DIFF
--- a/app/observers/merge_request_observer.rb
+++ b/app/observers/merge_request_observer.rb
@@ -20,6 +20,6 @@ class MergeRequestObserver < BaseObserver
   end
 
   def after_update(merge_request)
-    notification.reassigned_merge_request(merge_request) if merge_request.is_being_reassigned?
+    notification.reassigned_merge_request(merge_request, current_user) if merge_request.is_being_reassigned?
   end
 end


### PR DESCRIPTION
maybe a typo?

```
ArgumentError (wrong number of arguments (1 for 2)):
app/services/notification_service.rb:62:in `reassigned_merge_request'
```
