### PR TITLE
Fix overlapping test case names.

### DIFF
--- a/spec/controllers/merge_requests_controller_spec.rb
+++ b/spec/controllers/merge_requests_controller_spec.rb
@@ -12,7 +12,7 @@ describe MergeRequestsController do
   end
 
   describe "#show" do
-    shared_examples "export as" do |format|
+    shared_examples "export merge as" do |format|
       it "should generally work" do
         get :show, project_id: project.code, id: merge_request.id, format: format
 
@@ -44,7 +44,7 @@ describe MergeRequestsController do
     end
 
     describe "as diff" do
-      include_examples "export as", :diff
+      include_examples "export merge as", :diff
       let(:format) { :diff }
 
       it "should really only be a git diff" do
@@ -55,7 +55,7 @@ describe MergeRequestsController do
     end
 
     describe "as patch" do
-      include_examples "export as", :patch
+      include_examples "export merge as", :patch
       let(:format) { :patch }
 
       it "should really be a git email patch with commit" do


### PR DESCRIPTION
This clears a warning generated by rspec and prevents some cases where test failures could be suppressed.
