### PR TITLE
Change text_field to :login from :email in LDAP login page

### DIFF
--- a/app/views/devise/sessions/_new_ldap.html.haml
+++ b/app/views/devise/sessions/_new_ldap.html.haml
@@ -1,29 +1,29 @@
-= form_tag(user_omniauth_callback_path(:ldap), :class => "login-box", :id => 'new_ldap_user' ) do
-  = image_tag "login-logo.png", :width => "304", :height => "66", :class => "login-logo", :alt => "Login Logo"
-  = text_field_tag :username, nil, {:class => "text top", :placeholder => "LDAP Login", :autofocus => "autofocus"}
-  = password_field_tag :password, nil, {:class => "text bottom", :placeholder => "Password"}
+= form_tag(user_omniauth_callback_path(:ldap), class: "login-box", id: 'new_ldap_user' ) do
+  = image_tag "login-logo.png", width: "304", height: "66", class: "login-logo", alt: "Login Logo"
+  = text_field_tag :username, nil, {class: "text top", placeholder: "LDAP Login", autofocus: "autofocus"}
+  = password_field_tag :password, nil, {class: "text bottom", placeholder: "Password"}
   %br/
-  = submit_tag "LDAP Sign in", :class => "btn-primary btn"
+  = submit_tag "LDAP Sign in", class: "btn-primary btn"
   - if devise_mapping.omniauthable?
     - (resource_class.omniauth_providers - [:ldap]).each do |provider|
       %hr/
-      = link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), :class => "btn btn-primary"
+      = link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), class: "btn btn-primary"
       %br/
   %hr/
-  %a#other_form_toggle{:href => "#", :onclick => "javascript:$('#new_user').toggle();"} Other Sign in
+  %a#other_form_toggle{href: "#", onclick: "javascript:$('#new_user').toggle();"} Other Sign in
   :javascript
     $(function() {
       $('#new_user').toggle();
     });
-= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => { :class => "login-box" }) do |f|
-  = f.text_field :email, :class => "text top", :placeholder => "Email"
-  = f.password_field :password, :class => "text bottom", :placeholder => "Password"
+= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "login-box" }) do |f|
+  = f.text_field :login, class: "text top", placeholder: "Username or Email", autofocus: "autofocus"
+  = f.password_field :password, class: "text bottom", placeholder: "Password"
   - if devise_mapping.rememberable?
     .clearfix.inputs-list
-      %label.checkbox.remember_me{:for => "user_remember_me"}
+      %label.checkbox.remember_me{for: "user_remember_me"}
         = f.check_box :remember_me
         %span Remember me
   %br/
-  = f.submit "Sign in", :class => "btn-primary btn"
+  = f.submit "Sign in", class: "btn-primary btn"
   .pull-right
-    = render :partial => "devise/shared/links"
+    = render partial: "devise/shared/links"

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -83,6 +83,12 @@ production: &base
     bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
     password: '_the_password_of_the_bind_user'
 
+  # Optionally you may force username/email to be taken from
+  # specific LDAP attributes rather than heuristics:
+    # username: '_attribute_containing_username_'
+    # email: '_attribute_containing_email_'
+  # Also see: username_changing_enabled option above
+
   ## OmniAuth settings
   omniauth:
     # Allow login via Twitter, Google, etc. using OmniAuth providers


### PR DESCRIPTION
Change text_field to :login from :email in line with 9d92433a7c83432657faf4c02839bba1ba6f22ac to allow login as admin or non-ldap user when ldap is enabled

Also change haml style in line with that commit
