### PR TITLE
Fix crash on project page

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -61,8 +61,10 @@ module IssuesHelper
       url = new_project_issue_path project_id: @project
     else
       url = Gitlab.config.issues_tracker[@project.issues_tracker]["new_issue_url"]
-      url.gsub(':project_id', @project.id.to_s)
-        .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
+      if url
+        url.gsub(':project_id', @project.id.to_s)
+          .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
Started GET "/spotty-ohg/spotty-android" for 127.0.0.1 at 2013-04-03 15:57:22 +0200
Processing by ProjectsController#show as HTML
  Parameters: {"id"=>"spotty-ohg/spotty-android"}
  Rendered shared/_clone_panel.html.haml (0.5ms)
  Rendered projects/_clone_panel.html.haml (20.9ms)
  Rendered projects/show.html.haml within layouts/project_resource (21.2ms)
Completed 500 Internal Server Error in 73ms

ActionView::Template::Error (undefined method `gsub' for nil:NilClass):
    13:             = link_to new_project_merge_request_path(@project), title: "New Merge Request", class: "btn-small btn grouped" do
    14:               Merge Request
    15:           - if @project.issues_enabled && can?(current_user, :write_issue, @project)
    16:             = link_to url_for_new_issue, title: "New Issue", class: "btn-small btn grouped" do
    17:               Issue
  app/helpers/issues_helper.rb:64:in`url_for_new_issue'
  app/views/projects/_clone_panel.html.haml:16:in `_app_views_projects__clone_panel_html_haml___3342724398662049053_57374700'
  app/views/projects/show.html.haml:1:in`_app_views_projects_show_html_haml___910950264290853202_35240260'
  app/controllers/projects_controller.rb:64:in `block (2 levels) in show'
  app/controllers/projects_controller.rb:58:in`show'
