### PR TITLE
Install gems with user `git`, not `gitlab`

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -306,7 +306,7 @@ GitLab uses [Omniauth](http://www.omniauth.org/) for authentication and already 
 These steps are fairly general and you will need to figure out the exact details from the Omniauth provider's documentation.
 
 * Add `gem "omniauth-your-auth-provider"` to the [Gemfile](https://github.com/gitlabhq/gitlabhq/blob/master/Gemfile#L18)
-* Run `sudo -u gitlab -H bundle install` to install the new gem(s)
+* Run `sudo -u git -H bundle install` to install the new gem(s)
 * Add provider specific configuration options to your `config/gitlab.yml` (you can use the [auth providers section of the example config](https://github.com/gitlabhq/gitlabhq/blob/master/config/gitlab.yml.example#L53) as a reference)
 * Add icons for the new provider into the [vendor/assets/images/authbuttons](https://github.com/gitlabhq/gitlabhq/tree/master/vendor/assets/images/authbuttons) directory (you can find some more popular ones over at https://github.com/intridea/authbuttons)
 * Restart GitLab


### PR DESCRIPTION
One code snippet incorrectly ran sudo with the user **gitlab** instead of the (correct) user **git**.
