### PR TITLE
Fix error handling of missing new_issue_url config in url_for_new_issue.

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -61,6 +61,7 @@ module IssuesHelper
       url = new_project_issue_path project_id: @project
     else
       url = Gitlab.config.issues_tracker[@project.issues_tracker]["new_issue_url"]
+      url = "" if url.nil?
       url.gsub(':project_id', @project.id.to_s)
         .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
     end


### PR DESCRIPTION
Found this while digging into test failures in the vagrant environment. gitlabhq/gitlab-vagrant-vm#40

This changes that error from:

```
1) IssuesHelper url_for_new_issue should return path to external tracker
     Failure/Error: url_for_new_issue.should match(ext_expected)
     NoMethodError:
       undefined method `gsub' for nil:NilClass
     # ./app/helpers/issues_helper.rb:64:in `url_for_new_issue'
     # ./spec/helpers/issues_helper_spec.rb:96:in `block (3 levels) in <top (required)>'
```

to:

```
  1) IssuesHelper url_for_new_issue should return path to external tracker
     Failure/Error: let(:issues_url) { Gitlab.config.issues_tracker.redmine.new_issue_url}
     Settingslogic::MissingSetting:
       Missing setting 'new_issue_url' in 'redmine' section in 'issues_tracker' section in /home/vagrant/gitlabhq/config/gitlab.yml
     # ./spec/helpers/issues_helper_spec.rb:81:in `block (3 levels) in <top (required)>'
     # ./spec/helpers/issues_helper_spec.rb:83:in `block (3 levels) in <top (required)>'
     # ./spec/helpers/issues_helper_spec.rb:96:in `block (3 levels) in <top (required)>'
```

Which is much more helpful in figuring out that there's a config problem. :)
