### PR TITLE
Added a nil guard for groups without owners

### DIFF
--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -30,7 +30,7 @@
       %td= group.path
       %td= group.projects.count
       %td
-        = link_to group.owner_name, admin_user_path(group.owner)
+        = link_to group.owner_name, admin_user_path(group.owner) unless group.owner.nil?
       %td.bgred
         = link_to 'Edit', edit_admin_group_path(group), id: "edit_#{dom_id(group)}", class: "btn btn-small"
         = link_to 'Destroy', [:admin, group], confirm: "REMOVE #{group.name}? Are you sure?", method: :delete, class: "btn btn-small btn-remove"


### PR DESCRIPTION
-You can delete a user, and the group will still be present, this page would cause errors
