### PR TITLE
Nil guard owner on project deletion

### DIFF
--- a/app/services/system_hooks_service.rb
+++ b/app/services/system_hooks_service.rb
@@ -27,9 +27,11 @@ class SystemHooksService
         name: model.name,
         path: model.path,
         project_id: model.id,
+      })
+      data.merge!({
         owner_name: model.owner.name,
         owner_email: model.owner.email
-      })
+      }) unless model.owner.nil?
     when User
       data.merge!({
         name: model.name,


### PR DESCRIPTION
It's possible to delete a project after the owner has left, this project will have a nil owner, this nil guards against that
