### PR TITLE
Fix README when Run the Rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Start it with [Foreman](https://github.com/ddollar/foreman)
 
 * Run all tests
 
-        bundle exec rake gitlab:test
+        bundle exec rake gitlab:test RAILS_ENV=test
 
 * Rspec unit and functional tests
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Start it with [Foreman](https://github.com/ddollar/foreman)
 
 * Run all tests
 
-        bundle exec rake gitlab:test RAILS_ENV=test
+        bundle exec rake gitlab:test
 
 * Rspec unit and functional tests
 
-        bundle exec rake spec
+        bundle exec rake spec RAILS_ENV=test
 
 * Spinach integration tests
 


### PR DESCRIPTION
gitlab:test task set RAILS_ENV to test in spinach, but spec task dosen't do it.
So, when executing "rake spec", we should set RAILS_ENV to test.
