### PR TITLE
Added os_name support for systems running systemd.

### DIFF
--- a/lib/tasks/gitlab/task_helpers.rake
+++ b/lib/tasks/gitlab/task_helpers.rake
@@ -16,7 +16,7 @@ namespace :gitlab do
   # Check which OS is running
   #
   # It will primarily use lsb_relase to determine the OS.
-  # It has fallbacks to Debian, SuSE and OS X.
+  # It has fallbacks to Debian, SuSE, OS X and systems running systemd.
   def os_name
     os_name = run("lsb_release -irs")
     os_name ||= if File.readable?('/etc/system-release')
@@ -31,6 +31,9 @@ namespace :gitlab do
                 end
     os_name ||= if os_x_version = run("sw_vers -productVersion")
                   "Mac OS X #{os_x_version}"
+                end
+    os_name ||= if File.readable?('/etc/os-release')
+                  File.read('/etc/os-release').match(/PRETTY_NAME=\"(.+)\"/)[1]
                 end
     os_name.try(:squish!)
   end


### PR DESCRIPTION
When checking the system information, OSes running [systemd](http://www.freedesktop.org/wiki/Software/systemd) that don't have an `/etc/$name-release` can now be recognized with their real name instead of unknown, as systemd ships with [os-release](http://www.freedesktop.org/software/systemd/man/os-release.html) including the relevant information. Info is taken from the `PRETTY_NAME` string.

`/etc/os-release` examples:
#### Archlinux

```
NAME="Arch Linux"
ID=arch
PRETTY_NAME="Arch Linux"
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
```
#### Fedora

```
NAME=Fedora
VERSION="18 (Spherical Cow)"
ID=fedora
VERSION_ID=18
PRETTY_NAME="Fedora 18 (Spherical Cow)"
ANSI_COLOR="0;34"
CPE_NAME="cpe:/o:fedoraproject:fedora:18"
```
