### PR TITLE
Add a config option for the default namespace (fixes #2859)

### DIFF
--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -20,6 +20,8 @@ module NamespacesHelper
 
     if selected == :current_user && current_user.namespace
       selected = current_user.namespace.id
+    elsif selected == :global
+      selected = Namespace.global_id
     end
 
     grouped_options_for_select(options, selected)

--- a/app/views/projects/_new_form.html.haml
+++ b/app/views/projects/_new_form.html.haml
@@ -14,7 +14,7 @@
       = f.label :namespace_id do
         %span Namespace
       .input
-        = f.select :namespace_id, namespaces_options(params[:namespace_id] || :current_user), {}, {class: 'chosen'}
+        = f.select :namespace_id, namespaces_options(params[:namespace_id] || Gitlab.config.gitlab.default_namespace.to_sym), {}, {class: 'chosen'}
 
 
   .clearfix

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -36,6 +36,7 @@ production: &base
     default_projects_limit: 10
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
     # username_changing_enabled: false # default: true - User can change her username/namespace
+    # default_namespace: global   # default: current_user - When creating a new project, the default selected namespace.
 
 
   ## External issues trackers

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -49,6 +49,7 @@ Settings['issues_tracker']  ||= {}
 #
 Settings['gitlab'] ||= Settingslogic.new({})
 Settings.gitlab['default_projects_limit'] ||=  10
+Settings.gitlab['default_namespace'] ||= :current_user
 Settings.gitlab['host']       ||= 'localhost'
 Settings.gitlab['https']        = false if Settings.gitlab['https'].nil?
 Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80


### PR DESCRIPTION
This commit makes it configurable what the default namespace is. This has been talked about in issue #2859

Fixes #2859
