### PR TITLE
contribution guidelines: no feature requests on the Github issue tracker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Issues and pull requests not in line with the guidelines listed in this document
 
 The [issue tracker](https://github.com/gitlabhq/gitlabhq/issues) is only for obvious bugs or misbehavior in the master branch of GitLab. When submitting an issue please conform to the issue submission guidelines listed below.
 
+Do not use the issue tracker for feature requests. We have a specific
+[Feedback and suggestions forum](http://feedback.gitlab.com) for this purpose.
+
 Please send a pull request with a tested solution or a pull request with a failing test instead of opening an issue if you can. If you're unsure where to post, post to the [Support Forum](https://groups.google.com/forum/#!forum/gitlabhq) first. There are a lot of helpful GitLab users there who may be able to help you quickly. If your particular issue turns out to be a bug, it will find its way from there.
 
 ### Issue tracker guidelines


### PR DESCRIPTION
State clearly that the issue tracker is not used for feature requests
and link to http://feedback.gitlab.com.
