### PR TITLE
Fixed displaying of merge request counter in main menu

### DIFF
--- a/app/assets/stylesheets/sections/nav.scss
+++ b/app/assets/stylesheets/sections/nav.scss
@@ -31,6 +31,7 @@
       list-style-type: none;
       margin: 0;
       display: table-cell;
+      white-space: nowrap;
       width: 1%;
       &.active {
         border-bottom: 3px solid #777;


### PR DESCRIPTION
if value is more than 9 (two or more symbols) - counter is hidden, 'cause it is moved to new line, which is hidden by "overflow: hidden" rule.
