### PR TITLE
fix http push 401 and 500 with some git clients

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -76,13 +76,17 @@ module Grack
     end
 
     def validate_get_request
-      project.public || can?(user, :download_code, project)
+      validate_request(@request.params['service'])
     end
 
     def validate_post_request
-      if @request.path_info.end_with?('git-upload-pack')
+      validate_request(File.basename(@request.path))
+    end
+
+    def validate_request(service)
+      if service == 'git-upload-pack'
         project.public || can?(user, :download_code, project)
-      elsif @request.path_info.end_with?('git-receive-pack')
+      elsif service == 'git-receive-pack'
         action = if project.protected_branch?(current_ref)
                    :push_code_to_protected_branches
                  else

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -109,6 +109,8 @@ module Grack
       else
         input = @request.body.read
       end
+      # force utf-8 encoding
+      input.encode!('UTF-8', 'UTF-8', invalid: :replace, undef: :replace, replace: '')
       # Need to reset seek point
       @request.body.rewind
       /refs\/heads\/([\w\.-]+)/.match(input).to_a.last

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -109,11 +109,9 @@ module Grack
       else
         input = @request.body.read
       end
-      # force utf-8 encoding
-      input.encode!('UTF-8', 'UTF-8', invalid: :replace, undef: :replace, replace: '')
       # Need to reset seek point
       @request.body.rewind
-      /refs\/heads\/([\w\.-]+)/.match(input).to_a.last
+      /refs\/heads\/([\w\.-]+)/n.match(input.force_encoding('ascii-8bit')).to_a.last
     end
 
     def project


### PR DESCRIPTION
### This patch fix:

Some git clients(eclipse egit, some git version..) report `http 401, rpc failed` and don't ask user for username & password if server return `true` on `GET /myrepo.git/info/refs?service=git-receive-pack` but `false` on `POST /myrepo.git/git-receive-pack`. This cause git client do `Counting objects` first and then ask you for username & password or report `http 401, rpc failed`. **It should ask for username & password first and then `Counting objects` ?**

When push with eclipse egit on windows, Server may response with 500 error cause of `invalid byte sequence in UTF-8` .
