### PR TITLE
corrected URL for stable branch init script

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -200,7 +200,7 @@ Make sure to update username/password in config/database.yml.
 
 Download the init script (will be /etc/init.d/gitlab):
 
-    sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab
+    sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-0-stable/init.d/gitlab
     sudo chmod +x /etc/init.d/gitlab
 
 Make GitLab start on boot:


### PR DESCRIPTION
The URL for the init script in installation.md is pointing to the master branch rather than the stable branch.
