### PR TITLE
customizable LDAP attribute mapping

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -121,6 +121,15 @@ production: &base
   #  email: ->(auth) { auth.info.email.to_s.downcase }
 
 
+  ## LDAP Field Mapping
+  # These fields allow you to specify which LDAP fields get mapped onto User.
+  #
+  #ldap_mapping:
+  #  name: 'cn'
+  #  username: 'uid'
+  #  email: 'companyEmail'  
+
+
   #
   # 3. Advanced settings
   # ==========================

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -110,6 +110,15 @@ production: &base
       # - { name: 'github', app_id: 'YOUR APP ID',
       #     app_secret: 'YOUR APP SECRET' }
 
+  ## User Mapping Procs
+  # These procs allow for custom mapping of user information from LDAP / Omniauth
+  # onto your user model.
+  #
+  # NOTE: name may need an appropriate name_proc in the ldap settings.
+  # user_mapping:
+  #  name: ->(auth) { auth.info.name.to_s }
+  #  username: ->(auth) { auth.info.email.to_s.downcase.match(/^[^@]*/)[0] }
+  #  email: ->(auth) { auth.info.email.to_s.downcase }
 
 
   #

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -20,13 +20,14 @@ module Gitlab
     def create_from_omniauth(auth, ldap = false)
       provider = auth.provider
       uid = auth.info.uid || auth.uid
-      uid = uid.to_s.force_encoding("utf-8")
-      name = auth.info.name.to_s.force_encoding("utf-8")
-      email = auth.info.email.to_s.downcase unless auth.info.email.nil?
+      uid = uid.to_s.force_encoding('utf-8')
+      name = extract(:name, auth).force_encoding('utf-8')
+      username = extract(:username, auth).force_encoding('utf-8')
+      email = extract(:email, auth)
 
       ldap_prefix = ldap ? '(LDAP) ' : ''
       raise OmniAuth::Error, "#{ldap_prefix}#{provider} does not provide an email"\
-        " address" if auth.info.email.blank?
+        " address" if email.blank?
 
       log.info "#{ldap_prefix}Creating user from #{provider} login"\
         " {uid => #{uid}, name => #{name}, email => #{email}}"
@@ -35,7 +36,7 @@ module Gitlab
         extern_uid: uid,
         provider: provider,
         name: name,
-        username: email.match(/^[^@]*/)[0],
+        username: username,
         email: email,
         password: password,
         password_confirmation: password,
@@ -70,5 +71,22 @@ module Gitlab
     def log
       Gitlab::AppLogger
     end
+
+    private
+
+    def extract(field_name, auth)
+      @mapper ||= begin
+        defaults = {
+          name: ->(auth) { auth.info.name.to_s },
+          username: ->(auth) { auth.info.email.to_s.downcase.match(/^[^@]*/)[0] },
+          email: ->(auth) { auth.info.email.to_s.downcase },
+        }
+        extras = Gitlab.config.user_mapping rescue Hash.new
+        defaults.merge(extras)
+      end
+
+      @mapper[field_name].call(auth)
+    end
+
   end
 end

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -74,9 +74,21 @@ describe Gitlab::Auth do
   end
 
   describe :create_from_omniauth do
+    before do
+      @raw_info = {
+        cn: 'john',
+        nickname: 'jonny'
+      }
+
+      @ldap_auth = mock(
+        info: @info,
+        extra: mock(raw_info: @raw_info),
+        provider: 'ldap'
+      )
+    end
+
     it "should create user from LDAP" do
-      @auth = mock(info: @info, provider: 'ldap')
-      user = gl_auth.create_from_omniauth(@auth, true)
+      user = gl_auth.create_from_omniauth(@ldap_auth, true)
 
       user.should be_valid
       user.extern_uid.should == @info.uid
@@ -92,10 +104,9 @@ describe Gitlab::Auth do
       user.provider.should == 'twitter'
     end
 
-    it "should still import without user mapping" do
+    it "should still import without extra mapping" do
       Gitlab.config.stub(omniauth: {})
-      @auth = mock(info: @info, provider: 'ldap')
-      user = gl_auth.create_from_omniauth(@auth, true)
+      user = gl_auth.create_from_omniauth(@ldap_auth, true)
 
       user.should be_valid
       user.extern_uid.should == @info.uid
@@ -108,9 +119,7 @@ describe Gitlab::Auth do
       Gitlab.config.user_mapping[:email] = ->(auth) { 'email@somewhere.com' }
       Gitlab.config.user_mapping[:username] = ->(auth) { 'TestUsername' }
 
-      @auth = mock(info: @info, provider: 'ldap')
-      user = gl_auth.create_from_omniauth(@auth, true)
-
+      user = gl_auth.create_from_omniauth(@ldap_auth, true)
       user.should be_valid
       user.extern_uid.should == @info.uid
       user.name.should == 'TestName'
@@ -122,12 +131,29 @@ describe Gitlab::Auth do
       Gitlab.config.stub(omniauth: {}, user_mapping: {})
       Gitlab.config.user_mapping[:username] = ->(auth) { auth.info.email.to_s.downcase.split('@').first }
 
-      @auth = mock(info: @info, provider: 'ldap')
-      user = gl_auth.create_from_omniauth(@auth, true)
-
+      user = gl_auth.create_from_omniauth(@ldap_auth, true)
       user.should be_valid
       user.extern_uid.should == @info.uid
       user.username.should == 'john'
+    end
+
+    it "should be able to use raw ldap information through simple ldap mapping" do
+      Gitlab.config.stub(omniauth: {}, ldap_mapping: {})
+      Gitlab.config.ldap_mapping[:name] = 'cn'
+
+      user = gl_auth.create_from_omniauth(@ldap_auth, true)
+      user.should be_valid
+      user.extern_uid.should == @info.uid
+      user.name.should == 'john'
+    end
+
+    it "should raise an error if an invalid field is in ldap mapping" do
+      Gitlab.config.stub(omniauth: {}, ldap_mapping: {})
+      Gitlab.config.ldap_mapping[:name] = 'invalid'
+
+      expect {
+        gl_auth.create_from_omniauth(@ldap_auth, true)
+      }.to raise_error
     end
   end
 end


### PR DESCRIPTION
As per #3022 I'm trying to add procs to the gitlab configuration that adjust how LDAP attributes are mapped to users. There are two implementations and pull requests because I'm unsure which is better and I should go down the route of writing tests for. The other implementation is #3647.

This is the simpler implementation of the two where I was trying to alter the code as little as possible.

/cc @senny
