### PR TITLE
Attempt at #3022 - More complex implementation

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -112,9 +112,9 @@ production: &base
 
   ## User mapping settings
   user_mapping:
-    name_proc: ->(uid, name, email) { name }
-    username_proc: ->(uid, name, email) { email.match(/^[^@]*/)[0] }
-    email_proc: ->(uid, name, email) { email }
+    name: ->(uid, name, email) { name }
+    username: ->(uid, name, email) { email.match(/^[^@]*/)[0] }
+    email: ->(uid, name, email) { email }
 
 
   #

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -110,6 +110,11 @@ production: &base
       # - { name: 'github', app_id: 'YOUR APP ID',
       #     app_secret: 'YOUR APP SECRET' }
 
+  ## User mapping settings
+  user_mapping:
+    name_proc: ->(uid, name, email) { name }
+    username_proc: ->(uid, name, email) { email.match(/^[^@]*/)[0] }
+    email_proc: ->(uid, name, email) { email }
 
 
   #

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -78,15 +78,15 @@ module Gitlab
       end
 
       def name
-        @auth.info.name.to_s.force_encoding("utf-8")
+        Gitlab.config.user_mapping.name_proc.call(uid, raw_name, raw_email)
       end
 
       def username
-        email.match(/^[^@]*/)[0]
+        Gitlab.config.user_mapping.username_proc.call(uid, raw_name, raw_email)
       end
 
       def email
-        auth.info.email.nil? ? email_error : auth.info.email.to_s.downcase
+        Gitlab.config.user_mapping.email_proc.call(uid, raw_name, raw_email)
       end
 
       def password
@@ -99,6 +99,14 @@ module Gitlab
       end
 
       private
+
+      def raw_name
+        @auth.info.name.to_s.force_encoding("utf-8")
+      end
+
+      def raw_email
+        auth.info.email.nil? ? email_error : auth.info.email.to_s.downcase
+      end
 
       def ldap_prefix
         ldap ? '(LDAP) ' : ''

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -86,7 +86,7 @@ module Gitlab
       end
 
       def email
-        auth.info.email.nil? ? auth.info.email.to_s.downcase : email_error
+        auth.info.email.nil? ? email_error : auth.info.email.to_s.downcase
       end
 
       def password


### PR DESCRIPTION
As per #3022 I'm trying to add procs to the gitlab configuration that adjust how LDAP attributes are mapped to users. There are two implementations and pull requests because I'm unsure which is better and I should go down the route of writing tests for. The other pull request is #3646.

In this implementation I thought the create from omniauth function was getting somewhat complex. Tried to pull some of the more complex stuff out into its own helper class as can be seen. Quite a bit of code removed and then a "large" class added to try and simplify code and interface.

Unsure if it is better or not, hence creating the other implementation with less changes.

/cc @senny
