### PR TITLE
Fixed abandoned projects page for PostgreSQL

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -103,7 +103,7 @@ class Project < ActiveRecord::Base
     def abandoned
       project_ids = Event.select('max(created_at) as latest_date, project_id').
         group('project_id').
-        having('latest_date < ?', 6.months.ago).map(&:project_id)
+        having('max(created_at) < ?', 6.months.ago).map(&:project_id)
 
       where(id: project_ids)
     end


### PR DESCRIPTION
The syntax previously used is a MySQL extension (see ONLY_FULL_GROUP_BY notes
at http://dev.mysql.com/doc/refman/5.0/en/group-by-extensions.html).

Fixes #2748.
