### PR TITLE
Removed --disabled-login from adduser command Closes #3650

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -82,7 +82,7 @@ Install the Bundler Gem:
 
 Create a `git` user for Gitlab:
 
-    sudo adduser --disabled-login --gecos 'GitLab' git
+    sudo adduser --gecos 'GitLab' git
 
 
 # 4. GitLab shell


### PR DESCRIPTION
Removed --disabled-login from adduser command to enable login to the git user via ssh for push/pull
