### PR TITLE
Typo fix in  app/views/commit/huge_commit.html.haml 

### DIFF
--- a/app/views/commit/huge_commit.html.haml
+++ b/app/views/commit/huge_commit.html.haml
@@ -1,3 +1,3 @@
-= render "commits/commit_box"
+= render "commit/commit_box"
 .alert.alert-error
   %h4 Commit diffs are too big to be displayed


### PR DESCRIPTION
There is no _commit_box.html.haml in app/views/commits it's in app/views/commit
