### PR TITLE
Fix not using git.bin_path in config.

### DIFF
--- a/config/initializers/3_grit_ext.rb
+++ b/config/initializers/3_grit_ext.rb
@@ -1,6 +1,7 @@
 require 'grit'
 require 'pygments'
 
+Grit::Git.git_binary = Gitlab.config.git.bin_path
 Grit::Git.git_timeout = Gitlab.config.git.timeout
 Grit::Git.git_max_size = Gitlab.config.git.max_size
 


### PR DESCRIPTION
There is the setting of git.bin_path in config, but not used practically.
