### PR TITLE
fixed broken gitlab version determination during backup

### DIFF
--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -11,14 +11,14 @@ namespace :gitlab do
       Rake::Task["gitlab:backup:repo:create"].invoke
       Rake::Task["gitlab:backup:uploads:create"].invoke
 
-      Dir.chdir(Gitlab.config.backup.path)
-
       # saving additional informations
       s = {}
       s[:db_version]         = "#{ActiveRecord::Migrator.current_version}"
       s[:backup_created_at]  = "#{Time.now}"
       s[:gitlab_version]     = %x{git rev-parse HEAD}.gsub(/\n/,"")
       s[:tar_version]        = %x{tar --version | head -1}.gsub(/\n/,"")
+
+      Dir.chdir(Gitlab.config.backup.path)
 
       File.open("#{Gitlab.config.backup.path}/backup_information.yml", "w+") do |file|
         file << s.to_yaml.gsub(/^---\n/,'')


### PR DESCRIPTION
If the backup directory is not sub the gitlab install directory,
then the git rev-parse call will fail.
