### PR TITLE
[BUGFIX] User suggest at team_members/new not working with relative_url_root

### DIFF
--- a/app/assets/javascripts/api.js.coffee
+++ b/app/assets/javascripts/api.js.coffee
@@ -50,4 +50,5 @@
       callback(users)
 
   buildUrl: (url) ->
+    url = gon.relative_url_root + url if gon.relative_url_root.present?
     return url.replace(':version', gon.api_version)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -155,5 +155,6 @@ class ApplicationController < ActionController::Base
     gon.api_version = Gitlab::API.version
     gon.api_token = current_user.private_token if current_user
     gon.gravatar_url = request.ssl? ? Gitlab.config.gravatar.ssl_url : Gitlab.config.gravatar.plain_url
+    gon.relative_url_root = Gitlab.config.gitlab.relative_url_root
   end
 end


### PR DESCRIPTION
This should fix the non working auto-suggestion, when adding a new team member on a relative_url_root setup. This bug exists also in 5.0 and 5.1. 
