### PR TITLE
Integration of github-services WIP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,12 @@ gem "foreman"
 # Cache
 gem "redis-rails"
 
+# Github Services
+gem 'github-services', github: 'IMnet/github-services', branch: 'gitlab', ref: 'f52cd67'
+gem 'basecamp'
+gem 'rubyforge'
+gem 'yammer4r'
+
 group :assets do
   gem "sass-rails",   "~> 3.2.5"
   gem "coffee-rails", "~> 3.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,32 @@
 GIT
+  remote: git://github.com/IMnet/github-services.git
+  revision: f52cd6780b724b28028709352fffca96eb12b444
+  ref: f52cd67
+  branch: gitlab
+  specs:
+    github-services (1.0.0.f52cd67)
+      activeresource
+      addressable
+      aws-sdk (~> 1.8.0)
+      excon (~> 0.20.1)
+      faraday
+      httparty
+      mail (~> 2.3)
+      mash (~> 0.1.1)
+      mime-types (~> 1.15)
+      mqtt (= 0.0.8)
+      oauth
+      right_aws (= 3.0.3)
+      right_http_connection (= 1.3.0)
+      ruby-hmac (= 0.4.0)
+      softlayer_messaging (~> 1.0.2)
+      tinder
+      twilio-ruby (= 3.4.2)
+      xml-simple (= 1.0.11)
+      xmpp4r-simple-19 (~> 1.0.0)
+      yajl-ruby (= 1.1.0)
+
+GIT
   remote: https://github.com/ctran/annotate_models.git
   revision: be4e26825b521f0b2d86b181e2dff89901aa9b1e
   specs:
@@ -67,7 +95,15 @@ GEM
     addressable (2.3.2)
     arel (3.0.2)
     awesome_print (1.1.0)
+    aws-sdk (1.8.5)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
     backports (2.6.7)
+    basecamp (0.0.9)
+      activeresource (>= 2.3.0)
+      oauth2
+      xml-simple
     bcrypt-ruby (3.0.1)
     better_errors (0.3.2)
       coderay (>= 1.0.0)
@@ -131,6 +167,7 @@ GEM
     erubis (2.7.0)
     escape_utils (0.2.4)
     eventmachine (1.0.0)
+    excon (0.20.1)
     execjs (1.4.0)
       multi_json (~> 1.0)
     facter (1.6.18)
@@ -141,6 +178,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.8.6)
       multipart-post (~> 1.1)
+    faraday_middleware (0.9.0)
+      faraday (>= 0.7.4, < 0.9)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     ffaker (1.15.0)
@@ -231,6 +270,7 @@ GEM
       jquery-rails
       railties (>= 3.1.0)
     json (1.7.7)
+    json_pure (1.7.7)
     jwt (0.1.5)
       multi_json (>= 1.0)
     kaminari (0.14.1)
@@ -247,10 +287,12 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mash (0.1.1)
     method_source (0.8.1)
     mime-types (1.22)
     modernizr (2.6.2)
       sprockets (~> 2.0)
+    mqtt (0.0.8)
     multi_json (1.7.2)
     multi_xml (0.5.3)
     multipart-post (1.1.5)
@@ -368,6 +410,9 @@ GEM
     ref (1.0.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    right_aws (3.0.3)
+      right_http_connection (>= 1.2.5)
+    right_http_connection (1.3.0)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -383,7 +428,10 @@ GEM
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
+    ruby-hmac (0.4.0)
     ruby-progressbar (1.0.2)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
     rubyntlm (0.1.1)
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
@@ -411,6 +459,7 @@ GEM
       multi_json (~> 1)
       redis (~> 3)
       redis-namespace
+    simple_oauth (0.1.9)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -424,6 +473,8 @@ GEM
       temple (~> 0.5.5)
       tilt (~> 1.3.3)
     slop (3.4.4)
+    softlayer_messaging (1.0.2)
+      rest-client
     spinach (0.8.1)
       colorize (= 0.5.8)
       gherkin-ruby (~> 0.2.1)
@@ -453,13 +504,31 @@ GEM
     thor (0.18.1)
     tilt (1.3.7)
     timers (1.1.0)
+    tinder (1.9.2)
+      eventmachine (~> 1.0)
+      faraday (~> 0.8)
+      faraday_middleware (~> 0.9)
+      hashie (~> 1.0)
+      json (~> 1.7.5)
+      mime-types (~> 1.19)
+      multi_json (~> 1.5)
+      twitter-stream (~> 0.1)
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
+    twilio-ruby (3.4.2)
+      builder (>= 2.1.2)
+      jwt (>= 0.1.2)
+      multi_json (>= 1.0.3)
+    twitter-stream (0.1.16)
+      eventmachine (>= 0.12.8)
+      http_parser.rb (~> 0.5.1)
+      simple_oauth (~> 0.1.4)
     tzinfo (0.3.37)
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    uuidtools (2.1.3)
     virtus (0.5.4)
       backports (~> 2.6.1)
       descendants_tracker (~> 0.0.1)
@@ -468,9 +537,17 @@ GEM
     webmock (1.9.0)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
+    xml-simple (1.0.11)
+    xmpp4r (0.5)
+    xmpp4r-simple-19 (1.0.0)
+      xmpp4r (>= 0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.1.0)
+    yammer4r (0.1.5)
+      json (>= 1.1.7)
+      mash (>= 0.0.3)
+      oauth (>= 0.3.5)
 
 PLATFORMS
   ruby
@@ -479,6 +556,7 @@ DEPENDENCIES
   acts-as-taggable-on (= 2.3.3)
   annotate!
   awesome_print
+  basecamp
   better_errors
   binding_of_caller
   bootstrap-sass (= 2.2.1.1)
@@ -499,6 +577,7 @@ DEPENDENCIES
   gemoji (~> 1.2.1)
   github-linguist (~> 2.3.4)
   github-markup (~> 0.7.4)
+  github-services!
   gitlab-grack (~> 1.0.0)
   gitlab-pygments.rb (~> 0.3.2)
   gitlab_meta (= 5.0)
@@ -541,6 +620,7 @@ DEPENDENCIES
   redcarpet (~> 2.2.2)
   redis-rails
   rspec-rails
+  rubyforge
   sass-rails (~> 3.2.5)
   sdoc
   seed-fu
@@ -561,3 +641,4 @@ DEPENDENCIES
   thin
   uglifier (~> 1.3.0)
   webmock
+  yammer4r

--- a/app/models/project_service.rb
+++ b/app/models/project_service.rb
@@ -1,0 +1,36 @@
+class ProjectService < ActiveRecord::Base
+  attr_accessible :active, :data, :project_id, :service_hook_name
+
+  validates :project_id, presence: true
+  validates :service_hook_name, presence: true
+
+  serialize :data, Hash
+
+  after_initialize :define_methods
+
+  def define_methods
+    self.service.schema.each do |type, name|
+      define_singleton_method(name) { self.data[name.to_sym] }
+      define_singleton_method("#{name}=") do |value|
+        self.data[name.to_sym] = value
+      end
+      self.class.attr_accessible name.to_sym
+    end
+  end
+
+  def service
+    @service ||= Service.services.select { |service| service.hook_name == self.service_hook_name }.first
+  end
+
+  def data_fields(&block)
+    self.service.schema.each do |type, name|
+      if type == :boolean
+        type = :check_box
+      else
+        type = :text_field
+      end
+      yield name.to_sym, type
+    end
+  end
+
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,7 +12,7 @@
 #  active      :boolean          default(FALSE), not null
 #  project_url :string(255)
 #
-
+=begin
 class Service < ActiveRecord::Base
   attr_accessible :title, :token, :type, :active
 
@@ -25,3 +25,4 @@ class Service < ActiveRecord::Base
     active
   end
 end
+=end

--- a/app/views/services/_form.html.haml
+++ b/app/views/services/_form.html.haml
@@ -1,0 +1,43 @@
+%h3.page_title
+  = @service.title
+  //%small Continuous integration server from GitLab
+  .pull-right
+    - if @project_service.active
+      %small.cgreen Enabled
+    - else
+      %small.cgray Disabled
+
+
+
+.back_link
+  = link_to project_services_path(@project) do
+    &larr; to services
+
+%hr
+= form_for(@project_service, :as => :service, :url => project_service_path(@project, @service.hook_name), :method => :put) do |f|
+  - if @project_service.errors.any?
+    .alert.alert-error
+      %ul
+        - @project_service.errors.full_messages.each do |msg|
+          %li= msg
+  - @project_service.data_fields do |field, type|
+    .control-group
+      = f.label field, class: "control-label"
+      .controls
+        = f.send type, field, class: "input-xlarge"
+
+  .control-group
+    = f.label :active, "Active", class: "control-label"
+    .controls
+      = f.check_box :active
+
+  - if @service.documentation
+    .control-group
+      .controls
+        = markdown @service.documentation
+
+  .form-actions
+    = f.submit 'Save', class: 'btn btn-save'
+    &nbsp;
+    - if @project_service.valid? && @project_service.active
+      = link_to 'Test settings', test_project_service_path(@project), class: 'btn btn-small'

--- a/app/views/services/edit.html.haml
+++ b/app/views/services/edit.html.haml
@@ -1,3 +1,3 @@
 = render "projects/settings_nav"
 
-= render 'gitlab_ci'
+= render 'form'

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -4,6 +4,25 @@
 %br
 
 %ul.ui-box.well-list
+  - @active_project_services.each do |service|
+    %li
+      %h4.cgreen
+        = link_to edit_project_service_path(@project, service.hook_name) do
+          = service.title
+        .pull-right
+          %small.cgreen
+            %i.icon-ok
+            Enabled
+  - @inactive_project_services.each do |service|
+    %li
+      %h4.cgreen
+        = link_to edit_project_service_path(@project, service.hook_name) do
+          = service.title
+        .pull-right
+          %small.cgray
+            %i.icon-off
+            Disabled
+/
   %li
     %h4.cgreen
       = link_to edit_project_service_path(@project, :gitlab_ci) do

--- a/config/initializers/github_services.rb
+++ b/config/initializers/github_services.rb
@@ -1,0 +1,1 @@
+Service.load_services

--- a/db/migrate/20130423150509_create_project_services.rb
+++ b/db/migrate/20130423150509_create_project_services.rb
@@ -1,0 +1,13 @@
+class CreateProjectServices < ActiveRecord::Migration
+  def change
+    create_table :project_services do |t|
+      t.string :service_hook_name
+      t.integer :project_id
+      t.boolean :active
+      t.text :data
+
+      t.timestamps
+    end
+    add_index :project_services, :project_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130410175022) do
+ActiveRecord::Schema.define(:version => 20130423150509) do
 
   create_table "events", :force => true do |t|
     t.string   "target_type"
@@ -37,8 +37,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
     t.integer  "assignee_id"
     t.integer  "author_id"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
     t.integer  "position",     :default => 0
     t.string   "branch_name"
     t.text     "description"
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
 
   create_table "keys", :force => true do |t|
     t.integer  "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
     t.text     "key"
     t.string   "title"
     t.string   "identifier"
@@ -68,16 +68,16 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
   add_index "keys", ["user_id"], :name => "index_keys_on_user_id"
 
   create_table "merge_requests", :force => true do |t|
-    t.string   "target_branch",                       :null => false
-    t.string   "source_branch",                       :null => false
-    t.integer  "project_id",                          :null => false
+    t.string   "target_branch", :null => false
+    t.string   "source_branch", :null => false
+    t.integer  "project_id",    :null => false
     t.integer  "author_id"
     t.integer  "assignee_id"
     t.string   "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text     "st_commits",    :limit => 2147483647
-    t.text     "st_diffs",      :limit => 2147483647
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+    t.text     "st_commits"
+    t.text     "st_diffs"
     t.integer  "milestone_id"
     t.string   "state"
     t.string   "merge_status"
@@ -124,8 +124,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
     t.text     "note"
     t.string   "noteable_type"
     t.integer  "author_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.integer  "project_id"
     t.string   "attachment"
     t.string   "line_code"
@@ -139,12 +139,23 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
   add_index "notes", ["project_id", "noteable_type"], :name => "index_notes_on_project_id_and_noteable_type"
   add_index "notes", ["project_id"], :name => "index_notes_on_project_id"
 
+  create_table "project_services", :force => true do |t|
+    t.string   "service_hook_name"
+    t.integer  "project_id"
+    t.boolean  "active"
+    t.text     "data"
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
+  end
+
+  add_index "project_services", ["project_id"], :name => "index_project_services_on_project_id"
+
   create_table "projects", :force => true do |t|
     t.string   "name"
     t.string   "path"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
     t.integer  "creator_id"
     t.string   "default_branch"
     t.boolean  "issues_enabled",         :default => true,     :null => false
@@ -188,8 +199,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
     t.text     "content"
     t.integer  "author_id",  :null => false
     t.integer  "project_id", :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
     t.string   "file_name"
     t.datetime "expires_at"
   end
@@ -207,6 +218,9 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
     t.string   "context"
     t.datetime "created_at"
   end
+
+  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
 
   create_table "tags", :force => true do |t|
     t.string "name"
@@ -239,41 +253,42 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                                 :default => "",    :null => false
-    t.string   "encrypted_password",     :limit => 128, :default => "",    :null => false
+    t.string   "email",                  :default => "",    :null => false
+    t.string   "encrypted_password",     :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                         :default => 0
+    t.integer  "sign_in_count",          :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.string   "name"
-    t.boolean  "admin",                                 :default => false, :null => false
-    t.integer  "projects_limit",                        :default => 10
-    t.string   "skype",                                 :default => "",    :null => false
-    t.string   "linkedin",                              :default => "",    :null => false
-    t.string   "twitter",                               :default => "",    :null => false
+    t.boolean  "admin",                  :default => false, :null => false
+    t.integer  "projects_limit",         :default => 10
+    t.string   "skype",                  :default => "",    :null => false
+    t.string   "linkedin",               :default => "",    :null => false
+    t.string   "twitter",                :default => "",    :null => false
     t.string   "authentication_token"
-    t.integer  "theme_id",                              :default => 1,     :null => false
+    t.integer  "theme_id",               :default => 1,     :null => false
     t.string   "bio"
-    t.integer  "failed_attempts",                       :default => 0
+    t.integer  "failed_attempts",        :default => 0
     t.datetime "locked_at"
     t.string   "extern_uid"
     t.string   "provider"
     t.string   "username"
-    t.boolean  "can_create_group",                      :default => true,  :null => false
-    t.boolean  "can_create_team",                       :default => true,  :null => false
+    t.boolean  "can_create_group",       :default => true,  :null => false
+    t.boolean  "can_create_team",        :default => true,  :null => false
     t.string   "state"
-    t.integer  "color_scheme_id",                       :default => 1,     :null => false
-    t.integer  "notification_level",                    :default => 1,     :null => false
+    t.integer  "color_scheme_id",        :default => 1,     :null => false
+    t.integer  "notification_level",     :default => 1,     :null => false
   end
 
   add_index "users", ["admin"], :name => "index_users_on_admin"
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
+  add_index "users", ["extern_uid", "provider"], :name => "index_users_on_extern_uid_and_provider", :unique => true
   add_index "users", ["name"], :name => "index_users_on_name"
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
   add_index "users", ["username"], :name => "index_users_on_username"
@@ -281,8 +296,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
   create_table "users_projects", :force => true do |t|
     t.integer  "user_id",                           :null => false
     t.integer  "project_id",                        :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                        :null => false
+    t.datetime "updated_at",                        :null => false
     t.integer  "project_access",     :default => 0, :null => false
     t.integer  "notification_level", :default => 3, :null => false
   end
@@ -294,8 +309,8 @@ ActiveRecord::Schema.define(:version => 20130410175022) do
   create_table "web_hooks", :force => true do |t|
     t.string   "url"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            :null => false
+    t.datetime "updated_at",                            :null => false
     t.string   "type",       :default => "ProjectHook"
     t.integer  "service_id"
   end

--- a/spec/factories/project_services.rb
+++ b/spec/factories/project_services.rb
@@ -1,0 +1,10 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :project_service do
+    service_hook_name "MyString"
+    project_id 1
+    active false
+    data "MyText"
+  end
+end

--- a/spec/models/project_service_spec.rb
+++ b/spec/models/project_service_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe ProjectService do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This is not a finished feature,  probably basic functions are not implemented yet.  I created this pull request to check if you guys are OK with my approach of integrating the [github-services](https://github.com/github/github-services) gem.

My goal was to make as few changes as possible to the gem.  [This changes](https://github.com/IMnet/gitlabhq/compare/github-services) are the ones I had to make and which will probably never be merged to the original version as they are pretty specific to our needs.

**List of changes I made and/or are proposing:**
- Removed the `Service` model and rely on the `Service` classes github-services provides
- Created a `ProjectService` which stores the configuration for every Project <-> GitHub Service
- _Todo_: change the payload to match GitHubs version as much as possible. For the current web hook the payload should of course stay the same.
- _Todo_: create a github-service for GitLabCI, because GitHub requires that implemented services send the payload unmodified, so it would probably be good to change the receiving endpoint in GitLabCI or create a new one
- _Todo_: migrate the old GitLabCI service settings to the new one
- _Todo_: validate as many hooks as possible that they are working as expected and blacklist the broken ones
- _Todo_: tests for the code, and make this actually usable :wink:

**What does work?**

At the moment the services can just be used via the 'Test service' button.  I tested the Campfire, Hipchat and IRC hooks and they worked kinda nicely :smile:

Here is a small teaser:
![teaser](https://f.cloud.github.com/assets/20943/420310/27897016-acec-11e2-908d-841978f64c2c.gif)

regards,

Dominik
