### PR TITLE
Add a safe migration mode to the wiki migrator.

### DIFF
--- a/lib/tasks/gitlab/migrate_wiki.rake
+++ b/lib/tasks/gitlab/migrate_wiki.rake
@@ -11,7 +11,13 @@ namespace :gitlab do
     # Notes:
     #  * The existing Wiki content will remain in your
     #    database in-tact.
-    desc "GITLAB | Migrate Wiki content from database to Gollum repositories."
+    #  * If the migration does not work the first time,
+    #    run the `RAILS_ENV=production rake gitlab:wiki:rollback`
+    #    command and then execute the migration again with
+    #    the safe_migrate=true environment variable:
+    #
+    #    `RAILS_ENV=production rake gitlab:wiki:migrate safe_migrate=true`
+    desc "GITLAB | Migrate Wiki content from database to Gollum repositories. Use the safe_migrate=true argument if initial migration fails."
     task :migrate => :environment do
       wiki_migrator = WikiToGollumMigrator.new
       wiki_migrator.migrate!

--- a/lib/wiki_to_gollum_migrator.rb
+++ b/lib/wiki_to_gollum_migrator.rb
@@ -55,7 +55,7 @@ class WikiToGollumMigrator
 
   def create_page_and_revisions(project, page)
     # Grab all revisions of the page
-    revisions = project.wikis.where(slug: page.slug).ordered.all
+    revisions = project.wikis.where(slug: page.slug).order('id desc').all
 
     # Remove the first revision created from the array
     # and use it to create the Gollum page. Each successive revision

--- a/lib/wiki_to_gollum_migrator.rb
+++ b/lib/wiki_to_gollum_migrator.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class WikiToGollumMigrator
 
   attr_reader :projects
@@ -84,7 +86,7 @@ class WikiToGollumMigrator
       # and revision created so the correct User is shown in
       # the commit message.
       wiki = GollumWiki.new(project, revision.user)
-      wiki_page = wiki.find_page(page.slug)
+      wiki_page = wiki.find_page(page.title)
 
       attributes = extract_attributes_from_page(revision, project)
 
@@ -103,6 +105,10 @@ class WikiToGollumMigrator
                      .with_indifferent_access
                      .slice(:title, :content)
 
+    if ENV["safe_migrate"] == "true"
+      attributes[:title] = gollum_safe_title(attributes[:title])
+    end
+
     slug = page.slug
 
     # Change 'index' pages to 'home' pages to match Gollum standards
@@ -111,6 +117,10 @@ class WikiToGollumMigrator
     end
 
     attributes
+  end
+
+  def gollum_safe_title(title)
+    title.parameterize.titleize
   end
 
   def home_already_exists?(project)

--- a/spec/lib/wiki_to_gollum_migrator_spec.rb
+++ b/spec/lib/wiki_to_gollum_migrator_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require "spec_helper"
 
 describe WikiToGollumMigrator do
@@ -134,6 +136,98 @@ describe WikiToGollumMigrator do
             page.versions.count.should == 2
           end
         end
+      end
+    end
+
+    context "when migrating wiki's with extra whitespace in the title" do
+      before do
+        subject.rollback!
+        ENV['safe_migrate'] = 'true'
+        @project = @projects.last
+        @page = @project.wikis.new(title: "2012-06-16 ", content: "Page with funky title")
+        @page.slug = @page.title.parameterize
+        @page.user = @project.owner
+        @page.save!
+
+        create_revision(@page)
+
+        subject.migrate!
+      end
+
+      it "creates the wiki page correctly" do
+        wiki = GollumWiki.new(@project, nil)
+        page = wiki.find_page("2012 06 16")
+        page.should be_present
+        page.versions.count.should == 2
+      end
+    end
+
+    context "when migrating wiki's with slashes in the title" do
+      before do
+        subject.rollback!
+        ENV['safe_migrate'] = 'true'
+        @project = @projects.last
+        @page = @project.wikis.new(title: "Awesome 1337 /bin/badass ", content: "Page with funky title")
+        @page.slug = @page.title.parameterize
+        @page.user = @project.owner
+        @page.save!
+
+        create_revision(@page)
+
+        subject.migrate!
+      end
+
+      it "creates the wiki page correctly" do
+        wiki = GollumWiki.new(@project, nil)
+        page = wiki.find_page("Awesome 1337 Bin Badass")
+        page.should be_present
+        page.versions.count.should == 2
+      end
+    end
+
+    context "when migrating wiki's with non alphanumeric characters in the title" do
+      before do
+        subject.rollback!
+        ENV['safe_migrate'] = 'true'
+        @project = @projects.last
+        @page = @project.wikis.new(title: "Awes@me-1337 #!/bin/badass? ", content: "Page with funky title")
+        @page.slug = @page.title.parameterize
+        @page.user = @project.owner
+        @page.save!
+
+        create_revision(@page)
+
+        subject.migrate!
+      end
+
+      it "creates the wiki page correctly" do
+        wiki = GollumWiki.new(@project, nil)
+        page = wiki.find_page("Awes Me 1337 Bin Badass")
+        page.should be_present
+        page.versions.count.should == 2
+      end
+    end
+
+    context "when migrating wiki's with non-english characters in the title" do
+      before do
+        subject.rollback!
+        ENV['safe_migrate'] = 'true'
+        @project = @projects.last
+        @page = @project.wikis.new(title: "Mögliche Aufteilung", content: "Page with funky title")
+        @page.slug = @page.title.parameterize
+        @page.user = @project.owner
+        @page.save!
+
+        create_revision(@page)
+
+        subject.migrate!
+      end
+
+      it "creates the wiki page correctly" do
+        wiki = GollumWiki.new(@project, nil)
+        page = wiki.find_page("Mogliche Aufteilung")
+        page.should be_present
+        page.versions.count.should == 2
       end
     end
 

--- a/spec/lib/wiki_to_gollum_migrator_spec.rb
+++ b/spec/lib/wiki_to_gollum_migrator_spec.rb
@@ -149,7 +149,7 @@ describe WikiToGollumMigrator do
         @page.user = @project.owner
         @page.save!
 
-        create_revision(@page)
+        3.times { create_revision(@page) }
 
         subject.migrate!
       end
@@ -158,6 +158,7 @@ describe WikiToGollumMigrator do
         wiki = GollumWiki.new(@project, nil)
         page = wiki.find_page("2012 06 16")
         page.should be_present
+        page.content.should == "Updated Content"
         page.versions.count.should == 2
       end
     end


### PR DESCRIPTION
The safe migrate mode can be invoked by setting the
safe_migrate environment variable to 'true' on the command
line when running the task.

`RAILS_ENV=production rake gitlab:wiki:migrate safe_migrate=true`

This branch was created off of the 5-0-stable branch. I am targeting that branch in this pull request as well.

This should fix issue #3312 
