### PR TITLE
Fix typo in Project API documentation for deleting hooks

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -313,7 +313,7 @@ Removes a hook from project. This is an idempotent method and can be called mult
 Either the hook is available or not.
 
 ```
-DELETE /projects/:id/hooks/
+DELETE /projects/:id/hooks/:hook_id
 ```
 
 Parameters:


### PR DESCRIPTION
In the docs, the hook_id was missing from the sample URL.

This patch fixes the URL.
