### PR TITLE
Fixing error 500 on /groups and /teams.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,7 @@ Gitlab::Application.routes.draw do
   #
   # Groups Area
   #
-  resources :groups, constraints: {id: /(?:[^.]|\.(?!atom$))+/, format: /atom/}  do
+  resources :groups, constraints: {id: /(?:[^.]|\.(?!atom$))+/, format: /atom/}, except: [:index] do
     member do
       get :issues
       get :merge_requests
@@ -146,7 +146,7 @@ Gitlab::Application.routes.draw do
   #
   # Teams Area
   #
-  resources :teams, constraints: {id: /(?:[^.]|\.(?!atom$))+/, format: /atom/} do
+  resources :teams, constraints: {id: /(?:[^.]|\.(?!atom$))+/, format: /atom/}, except: [:index] do
     member do
       get :issues
       get :merge_requests


### PR DESCRIPTION
Although these urls do not exist they were being mapped with rails
resources. I've added an exception not to add the index routes. Now they
will yield 404 errors instead of 500 ones when trying to access /groups
or /teams.

I haven't checked if there's an issue on this.
