### PR TITLE
Improve performance of network graph

### DIFF
--- a/app/assets/javascripts/branch-graph.js.coffee
+++ b/app/assets/javascripts/branch-graph.js.coffee
@@ -122,22 +122,11 @@ class BranchGraph
   bindEvents: ->
     drag = {}
     element = @element
-    dragger = (event) ->
-      element.scrollLeft drag.sl - (event.clientX - drag.x)
-      element.scrollTop drag.st - (event.clientY - drag.y)
 
-    element.on mousedown: (event) ->
-      drag =
-        x: event.clientX
-        y: event.clientY
-        st: element.scrollTop()
-        sl: element.scrollLeft()
-      $(window).on "mousemove", dragger
+    $(element).scroll (event) =>
+      @renderPartialGraph()
 
     $(window).on
-      mouseup: =>
-        $(window).off "mousemove", dragger
-        @renderPartialGraph()
       keydown: (event) =>
         # left
         element.scrollLeft element.scrollLeft() - 50  if event.keyCode is 37

--- a/app/assets/javascripts/branch-graph.js.coffee
+++ b/app/assets/javascripts/branch-graph.js.coffee
@@ -9,6 +9,7 @@ class BranchGraph
     @offsetY = 20
     @unitTime = 30
     @unitSpace = 10
+    @prev_start = -1
     @load()
 
   load: ->
@@ -24,10 +25,18 @@ class BranchGraph
 
   prepareData: (@days, @commits) ->
     @collectParents()
+    @graphHeight = $(@element).height()
+    @graphWidth = $(@element).width()
+    ch = Math.max(@graphHeight, @offsetY + @unitTime * @mtime + 150)
+    cw = Math.max(@graphWidth, @offsetX + @unitSpace * @mspace + 300)
+    @r = Raphael(@element.get(0), cw, ch)
+    @top = @r.set()
+    @barHeight = Math.max(@graphHeight, @unitTime * @days.length + 320)
 
     for c in @commits
       c.isParent = true  if c.id of @parents
       @preparedCommits[c.id] = c
+      @markCommit(c)
 
     @collectColors()
 
@@ -49,18 +58,12 @@ class BranchGraph
       k++
 
   buildGraph: ->
-    graphHeight = $(@element).height()
-    graphWidth = $(@element).width()
-    ch = Math.max(graphHeight, @offsetY + @unitTime * @mtime + 150)
-    cw = Math.max(graphWidth, @offsetX + @unitSpace * @mspace + 300)
-    @r = r = Raphael(@element.get(0), cw, ch)
-    top = r.set()
+    r = @r
     cuday = 0
     cumonth = ""
-    barHeight = Math.max(graphHeight, @unitTime * @days.length + 320)
 
-    r.rect(0, 0, 26, barHeight).attr fill: "#222"
-    r.rect(26, 0, 20, barHeight).attr fill: "#444"
+    r.rect(0, 0, 26, @barHeight).attr fill: "#222"
+    r.rect(26, 0, 20, @barHeight).attr fill: "#444"
 
     for day, mm in @days
       if cuday isnt day[0]
@@ -81,22 +84,40 @@ class BranchGraph
           )
         cumonth = day[1]
 
-    for commit in @commits
-      x = @offsetX + @unitSpace * (@mspace - commit.space)
-      y = @offsetY + @unitTime * commit.time
+    @renderPartialGraph()
 
-      @drawDot(x, y, commit)
-
-      @drawLines(x, y, commit)
-
-      @appendLabel(x, y, commit.refs)  if commit.refs
-
-      @appendAnchor(top, commit, x, y)
-
-      @markCommit(x, y, commit, graphHeight)
-
-    top.toFront()
     @bindEvents()
+
+  renderPartialGraph: ->
+    start = Math.floor((@element.scrollTop() - @offsetY) / @unitTime) - 10
+    start = 0 if start < 0
+    end = start + 40
+    end = @commits.length if @commits.length < end
+
+    if @prev_start == -1 or Math.abs(@prev_start - start) > 10
+      i = start
+
+      @prev_start = start
+
+      while i < end
+        commit = @commits[i]
+        i += 1
+
+        if commit.hasDrawn isnt true
+          x = @offsetX + @unitSpace * (@mspace - commit.space)
+          y = @offsetY + @unitTime * commit.time
+
+          @drawDot(x, y, commit)
+
+          @drawLines(x, y, commit)
+
+          @appendLabel(x, y, commit)
+
+          @appendAnchor(x, y, commit)
+
+          commit.hasDrawn = true
+
+      @top.toFront()
 
   bindEvents: ->
     drag = {}
@@ -114,9 +135,10 @@ class BranchGraph
       $(window).on "mousemove", dragger
 
     $(window).on
-      mouseup: ->
+      mouseup: =>
         $(window).off "mousemove", dragger
-      keydown: (event) ->
+        @renderPartialGraph()
+      keydown: (event) =>
         # left
         element.scrollLeft element.scrollLeft() - 50  if event.keyCode is 37
         # top
@@ -125,17 +147,20 @@ class BranchGraph
         element.scrollLeft element.scrollLeft() + 50  if event.keyCode is 39
         # bottom
         element.scrollTop element.scrollTop() + 50  if event.keyCode is 40
+        @renderPartialGraph()
 
-  appendLabel: (x, y, refs) ->
+  appendLabel: (x, y, commit) ->
+    return unless commit.refs
+
     r = @r
-    shortrefs = refs
+    shortrefs = commit.refs
     # Truncate if longer than 15 chars
     shortrefs = shortrefs.substr(0, 15) + "…"  if shortrefs.length > 17
     text = r.text(x + 4, y, shortrefs).attr(
       "text-anchor": "start"
       font: "10px Monaco, monospace"
       fill: "#FFF"
-      title: refs
+      title: commit.refs
     )
     textbox = text.getBBox()
     # Create rectangle based on the size of the textbox
@@ -156,8 +181,9 @@ class BranchGraph
     # Set text to front
     text.toFront()
 
-  appendAnchor: (top, commit, x, y) ->
+  appendAnchor: (x, y, commit) ->
     r = @r
+    top = @top
     options = @options
     anchor = r.circle(x, y, 10).attr(
       fill: "#000"
@@ -240,16 +266,18 @@ class BranchGraph
           stroke: color
           "stroke-width": 2)
 
-  markCommit: (x, y, commit, graphHeight) ->
+  markCommit: (commit) ->
     if commit.id is @options.commit_id
       r = @r
+      x = @offsetX + @unitSpace * (@mspace - commit.space)
+      y = @offsetY + @unitTime * commit.time
       r.path(["M", x + 5, y, "L", x + 15, y + 4, "L", x + 15, y - 4, "Z"]).attr(
         fill: "#000"
         "fill-opacity": .5
         stroke: "none"
       )
       # Displayed in the center
-      @element.scrollTop(y - graphHeight / 2)
+      @element.scrollTop(y - @graphHeight / 2)
 
 Raphael::commitTooltip = (x, y, commit) ->
   boxWidth = 300

--- a/app/assets/stylesheets/sections/graph.scss
+++ b/app/assets/stylesheets/sections/graph.scss
@@ -13,7 +13,8 @@
     background: #f1f1f1;
     cursor: move;
     height: 500px;
-    overflow: hidden;
+    overflow-y: scroll;
+    overflow-x: hidden;
   }
 }
 

--- a/app/helpers/graph_helper.rb
+++ b/app/helpers/graph_helper.rb
@@ -4,8 +4,7 @@ module GraphHelper
     refs += commit.refs.collect{|r|r.name}.join(" ") if commit.refs
 
     # append note count
-    notes = @project.notes.for_commit_id(commit.id)
-    refs += "[#{notes.count}]" if notes.any?
+    refs += "[#{@graph.notes[commit.id]}]" if @graph.notes[commit.id] > 0
 
     refs
   end

--- a/app/models/network/graph.rb
+++ b/app/models/network/graph.rb
@@ -2,7 +2,7 @@ require "grit"
 
 module Network
   class Graph
-    attr_reader :days, :commits, :map
+    attr_reader :days, :commits, :map, :notes
 
     def self.max_count
       @max_count ||= 650
@@ -16,9 +16,18 @@ module Network
 
       @commits = collect_commits
       @days = index_commits
+      @notes = collect_notes
     end
 
     protected
+
+    def collect_notes
+      h = Hash.new(0)
+      @project.notes.where('noteable_type = ?' ,"Commit").group('notes.commit_id').select('notes.commit_id, count(notes.id) as note_count').each do |item|
+        h[item["commit_id"]] = item["note_count"]
+      end
+      h
+    end
 
     # Get commits from repository
     #

--- a/app/models/network/graph.rb
+++ b/app/models/network/graph.rb
@@ -190,7 +190,7 @@ module Network
         l.spaces << space
         # Also add space to parent
         l.parents(@map).each do |parent|
-          if parent.space > 0
+          if 0 < parent.space && parent.space < space
             parent.spaces << space
           end
         end

--- a/features/project/network.feature
+++ b/features/project/network.feature
@@ -11,14 +11,16 @@ Feature: Project Network Graph
     And page should have "master" on graph
 
   @javascript
-  Scenario: I should switch ref to "stable"
+  Scenario: I should switch "branch" and "tag"
     When I switch ref to "stable"
-    Then page should have network graph
-    And page should select "stable" in select box
+    Then page should select "stable" in select box
     And page should have "stable" on graph
+    When I switch ref to "v2.1.0"
+    Then page should select "v2.1.0" in select box
+    And page should have "v2.1.0" on graph
 
   @javascript
-  Scenario: I should looking for a commit by SHA of "v2.1.0"
+  Scenario: I should looking for a commit by SHA
     When I looking for a commit by SHA of "v2.1.0"
     Then page should have network graph
     And page should select "master" in select box

--- a/features/steps/project/project_network_graph.rb
+++ b/features/steps/project/project_network_graph.rb
@@ -30,8 +30,17 @@ class ProjectNetworkGraph < Spinach::FeatureSteps
     sleep 2
   end
 
+  When 'I switch ref to "v2.1.0"' do
+    page.select 'v2.1.0', :from => 'ref'
+    sleep 2
+  end
+
   And 'page should select "stable" in select box' do
     page.should have_selector '#ref_chzn span', :text => "stable"
+  end
+
+  And 'page should select "v2.1.0" in select box' do
+    page.should have_selector '#ref_chzn span', :text => "v2.1.0"
   end
 
   And 'page should have "stable" on graph' do

--- a/lib/extracts_path.rb
+++ b/lib/extracts_path.rb
@@ -98,9 +98,7 @@ module ExtractsPath
 
     @ref, @path = extract_ref(@id)
 
-    # It is used "@project.repository.commits(@ref, @path, 1, 0)",
-    # because "@project.repository.commit(@ref)" returns wrong commit when @ref is tag name.
-    @commit = @project.repository.commits(@ref, @path, 1, 0).first
+    @commit = @project.repository.commit(@ref)
 
     @tree = Tree.new(@project.repository, @commit.id, @ref, @path)
 

--- a/lib/gitlab/git/repository.rb
+++ b/lib/gitlab/git/repository.rb
@@ -49,7 +49,16 @@ module Gitlab
 
       def commit(commit_id = nil)
         commit = if commit_id
-                   repo.commit(commit_id)
+                   # Find repo.refs first,
+                   # because if commit_id is "tag name",
+                   # repo.commit(commit_id) returns wrong commit sha
+                   # that is git tag object sha.
+                   ref = repo.refs.find {|r| r.name == commit_id}
+                   if ref
+                     ref.commit
+                   else
+                     repo.commit(commit_id)
+                   end
                  else
                    repo.commits(root_ref).first
                  end


### PR DESCRIPTION
I think that loading network graph is as fast as that of 5.0.
### Overview
1. Rendering graph partially.
2. Reduce database access to get notes.
3. Enable vertical scrolling.Thanks @giggsey.
4. Some minor bugs related to network graph is fixed.

Dragging network graph is disabled, because it conflicts with scroll.
### Screenshot

![vertical-scrolling](https://f.cloud.github.com/assets/72138/428074/aa99b642-adf9-11e2-97c3-87d51dd69c4a.png)

fixes #3684
refs #3711
