### PR TITLE
Authenticate LDAP users in the grack module - fixed problems - tested code

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -1,4 +1,5 @@
 require_relative 'shell_env'
+require 'omniauth-ldap'
 
 module Grack
   class Auth < Rack::Auth::Basic
@@ -32,8 +33,14 @@ module Grack
         # Authentication with username and password
         login, password = @auth.credentials
         self.user = User.find_by_email(login) || User.find_by_username(login)
-        return false unless user.try(:valid_password?, password)
 
+        if user.nil?
+          ldap_auth(login,password)
+          return false unless !user.nil?
+        else
+          return false unless user.valid_password?(password);
+        end
+           
         Gitlab::ShellEnv.set_env(user)
       end
 
@@ -44,6 +51,23 @@ module Grack
         validate_post_request
       else
         false
+      end
+    end
+
+    def ldap_auth(login, password)
+      # Check user against LDAP backend if user is not authenticated
+      # Only check with valid login and password to prevent anonymous bind results
+      gl = Gitlab.config
+      if gl.ldap.enabled && !login.blank? && !password.blank?
+        ldap = OmniAuth::LDAP::Adaptor.new(gl.ldap)
+        ldap_user = ldap.bind_as(
+          filter: Net::LDAP::Filter.eq(ldap.uid, login),
+          size: 1,
+          password: password
+        )
+        if ldap_user
+          self.user = User.find_by_extern_uid_and_provider(ldap_user.dn, 'ldap')
+        end
       end
     end
 

--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -34,11 +34,15 @@ module Grack
         login, password = @auth.credentials
         self.user = User.find_by_email(login) || User.find_by_username(login)
 
-        if user.nil?
+        # If the provided login was not a known email or username
+        # then user is nil
+        if user.nil? 
+          # Second chance - try LDAP authentication
+          return false unless Gitlab.config.ldap.enabled         
           ldap_auth(login,password)
           return false unless !user.nil?
         else
-          return false unless user.valid_password?(password);
+          return false unless user.valid_password?(password)
         end
            
         Gitlab::ShellEnv.set_env(user)


### PR DESCRIPTION
This is based on the Pull Request #3141 from @jasl8r and Pull Request #3470 from @drahamim. I added the ideas from @randx 
- I added the require to the top of the file (taken from #3470)
- I moved the ldap authorization check in a separate method
- I fixed the password check problem in #3470 
- I tested the code with ldap and email users with correct and wrong passwords and non-existing users. I think this works.

So this will add LDAP Authentification in the grack module. With this I can push via https for users which have LDAP or Email authentification. Discussion about this topic was in #2012 and #2557. 
