### PR TITLE
Updated docs in 5-1-stable. Fixes #3757 and #3639.

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -158,11 +158,13 @@ do so with caution!
     # Create directory for satellites
     sudo -u git -H mkdir /home/git/gitlab-satellites
 
-    # Create directory for pids and make sure GitLab can write to it
+    # Create directories for sockets/pids and make sure GitLab can write to them
     sudo -u git -H mkdir tmp/pids/
+    sudo -u git -H mkdir tmp/sockets/
     sudo chmod -R u+rwX  tmp/pids/
+    sudo chmod -R u+rwX  tmp/sockets/
 
-    # Copy the example Of Puma config
+    # Copy the example of Puma config
     sudo -u git -H cp config/puma.rb.example config/puma.rb
 
 **Important Note:**

--- a/doc/update/5.0-to-5.1.md
+++ b/doc/update/5.0-to-5.1.md
@@ -3,22 +3,21 @@
 * `unicorn` replaced with `puma`
 * merge request cached diff will be truncated
 
-### 1. stop server
+### 1. Stop server
 
     sudo service gitlab stop
 
-### 2. get latest code
+### 2. Get latest code
 
-```
+```bash
 cd /home/git/gitlab
 sudo -u git -H git fetch
 sudo -u git -H git checkout 5-1-stable
-
 ```
 
 ### 3. Update gitlab-shell
 
-```
+```bash
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
 sudo -u git -H git checkout v1.3.0
@@ -26,16 +25,14 @@ sudo -u git -H git checkout v1.3.0
 
 ### 4. Install libs, migrations etc
 
-```
+```bash
 cd /home/git/gitlab
 sudo rm tmp/sockets/gitlab.socket
 sudo -u git -H cp config/puma.rb.example config/puma.rb
 
-
 sudo -u git -H bundle install --without development test postgres --deployment
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_merge_requests RAILS_ENV=production
-
 ```
 
 ### 5. Update init.d script with a new one
@@ -47,6 +44,16 @@ sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-rec
 sudo chmod +x /etc/init.d/gitlab
 ```
 
-### 6. Start application
+### 6. Mysql grant privileges
+
+Only if you are using mysql:
+
+```bash
+mysql -u root -p
+mysql> GRANT LOCK TABLES ON `gitlabhq_production`.* TO 'gitlab'@'localhost';
+mysql> \q
+```
+
+### 7. Start application
 
     sudo service gitlab start

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -143,7 +143,7 @@ namespace :gitlab do
         return
       end
 
-      recipe_content = `curl https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab 2>/dev/null`
+      recipe_content = `curl https://raw.github.com/gitlabhq/gitlab-recipes/5-1-stable/init.d/gitlab 2>/dev/null`
       script_content = File.read(script_path)
 
       if recipe_content == script_content


### PR DESCRIPTION
- New mysql privilege:
  There has been added a new permission in 5.1 that isn't included on update.md. Without that, backup fails. See [this](https://groups.google.com/forum/?fromgroups=#!topic/gitlabhq/So4mYIRFsX8) forum post.
- Fixed path for `init.d/gitlab` in rake check. Fixes #3757.
- On a new installation create `tmp/sockets` directory. Fixes #3639.
