### PR TITLE
Instructions update: install postfix separately, new privilege to mysql users, sockets dir. Fixes #3639

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -42,7 +42,7 @@ edited by hand. But, you can use any editor you like instead.
 
 Install the required packages:
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server postfix checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev
+    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev
 
 Make sure you have the right version of Python installed.
 
@@ -61,6 +61,11 @@ Make sure you have the right version of Python installed.
     # If you get a "command not found" error create a link to the python binary
     sudo ln -s /usr/bin/python /usr/bin/python2
 
+**Note:** In order to receive mail notifications, make sure to install a
+mail server. By default, Debian is shipped with exim4 whereas Ubuntu
+does not ship with one. The recommended mail server is postfix and you can install it with:
+
+	sudo apt-get install postfix 
 
 # 2. Ruby
 
@@ -132,10 +137,10 @@ To setup the MySQL/PostgreSQL database and dependencies please see [`doc/install
     cd /home/git/gitlab
 
     # Checkout to stable release
-    sudo -u git -H git checkout 5-0-stable
+    sudo -u git -H git checkout 5-1-stable
 
 **Note:**
-You can change `5-0-stable` to `master` if you want the *bleeding edge* version, but
+You can change `5-1-stable` to `master` if you want the *bleeding edge* version, but
 do so with caution!
 
 ## Configure it
@@ -158,11 +163,13 @@ do so with caution!
     # Create directory for satellites
     sudo -u git -H mkdir /home/git/gitlab-satellites
 
-    # Create directory for pids and make sure GitLab can write to it
+    # Create directories for sockets/pids and make sure GitLab can write to them
     sudo -u git -H mkdir tmp/pids/
+    sudo -u git -H mkdir tmp/sockets/
     sudo chmod -R u+rwX  tmp/pids/
+    sudo chmod -R u+rwX  tmp/sockets/
 
-    # Copy the example Unicorn config
+    # Copy the example Puma config
     sudo -u git -H cp config/puma.rb.example config/puma.rb
 
 **Important Note:**

--- a/doc/update/5.0-to-5.1.md
+++ b/doc/update/5.0-to-5.1.md
@@ -3,36 +3,39 @@
 * `unicorn` replaced with `puma`
 * merge request cached diff will be truncated
 
-### 1. stop server
+### 1. Stop server
 
     sudo service gitlab stop
 
-### 2. get latest code
+### 2. Get latest code
 
-```
-
+```bash
+cd /home/git/gitlab
 sudo -u git -H git fetch
 sudo -u git -H git checkout 5-1-stable
-
 ```
 
-### 3. Install libs, migrations etc
+### 3. Update gitlab-shell
 
+```bash
+cd /home/git/gitlab-shell
+sudo -u git -H git fetch
+sudo -u git -H git checkout v1.3.0
 ```
+
+### 4. Install libs, migrations etc
+
+```bash
+cd /home/git/gitlab
+sudo rm tmp/sockets/gitlab.socket
 sudo -u git -H cp config/puma.rb.example config/puma.rb
 
-# Mysql users:
 sudo -u git -H bundle install --without development test postgres --deployment
-
-# Postgres users:
-sudo -u git -H bundle install --without development test mysql --deployment
-
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_merge_requests RAILS_ENV=production
-
 ```
 
-### 4. Update init.d script with a new one
+### 5. Update init.d script with a new one
 
 ```bash
 # init.d
@@ -41,6 +44,16 @@ sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-rec
 sudo chmod +x /etc/init.d/gitlab
 ```
 
-### 5. Start application
+### 6. Mysql grant privileges
+
+Only if you are using mysql:
+
+```bash
+mysql -u root -p
+mysql> GRANT LOCK TABLES ON `gitlabhq_production`.* TO 'gitlab'@'localhost';
+mysql> \q
+```
+
+### 7. Start application
 
     sudo service gitlab start


### PR DESCRIPTION
- As noted in #3596, I removed postfix from deps and added a note for the user to add it separately. 
- Updated update instructions and added a step to grant the additional privilege to the mysql user. Without it, backup [fails](https://groups.google.com/forum/?fromgroups=#!topic/gitlabhq/So4mYIRFsX8).
- Also, in a fresh installation the `tmp/sockets` directory must be created otherwise gitlab service fails to start. See #3639.
