### PR TITLE
Fixes error when creating a backup and public/uploads doesn't exist.

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -169,6 +169,10 @@ do so with caution!
     sudo chmod -R u+rwX  tmp/pids/
     sudo chmod -R u+rwX  tmp/sockets/
 
+		# Create 'uploads' directory otherwise backup will fail
+    sudo -u git -H mkdir public/uploads
+    sudo chmod -R u+rwX  public/uploads
+
     # Copy the example Puma config
     sudo -u git -H cp config/puma.rb.example config/puma.rb
 

--- a/lib/backup/database.rb
+++ b/lib/backup/database.rb
@@ -45,7 +45,7 @@ module Backup
         'encoding'  => '--default-character-set',
         'password'  => '--password'
       }
-      args.map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }.compact.join(' ')
+      args.map { |opt, arg| "#{arg}='#{config[opt]}'" if config[opt] }.compact.join(' ')
     end
 
     def pg_env


### PR DESCRIPTION
If there is not a `public/uploads` directory, backup fails with:

```
Dumping uploads ...
rake aborted!
No such file or directory - /home/git/gitlab/public/uploads
```

Reported in the [forum](https://groups.google.com/forum/?fromgroups=#!topic/gitlabhq/So4mYIRFsX8).

This PR checks if there is a public/uploads directory during backup.

Note: The `uploads` dir is created during backup even if there is nothing into it. We could get the dir creation inside the if loop, but then we should add another if loop in `backup.rake` and change the [tar command](https://github.com/gitlabhq/gitlabhq/blob/master/lib/tasks/gitlab/backup.rake#L29) to exclude the `uploads` dir. Since the dir is empty there is no harm creating it in the first place.
