### PR TITLE
move the update instructions for 4.2 to 5.0 from the Wiki into the Repo

### DIFF
--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -1,0 +1,163 @@
+# From 4.2 to 5.0
+
+## Important changes
+
+* We dont use `gitlab` user any more. Everything will be moved to `git` user
+* __requires ruby1.9.3__
+
+
+__0. Stop gitlab__
+
+    sudo service gitlab stop
+
+__1. add bash to git user__
+
+```
+sudo chsh -s /bin/bash git
+```
+
+__2. git clone gitlab-shell__
+
+```
+sudo -u git -H git clone https://github.com/gitlabhq/gitlab-shell.git /home/git/gitlab-shell
+```
+
+__3. setup gitlab-shell__
+
+```bash
+# chmod all repos and files under git
+sudo chown git:git -R /home/git/repositories/
+
+# login as git
+sudo su git
+cd /home/git/gitlab-shell
+
+# copy config
+cp config.yml.example config.yml
+
+# change url to gitlab instance
+# ! make sure url end with '/' like 'https://gitlab.example/'
+vim config.yml
+
+# rewrite hooks
+./support/rewrite-hooks.sh
+
+# check ruby version for git user ( 1.9 required!! )
+# gitlab shell requires system ruby 1.9
+ruby -v
+
+# exit from git user
+exit
+```
+
+__4. Copy gitlab instance to git user__
+
+```bash
+sudo cp -R /home/gitlab/gitlab /home/git/gitlab
+sudo chown git:git -R /home/git/gitlab
+sudo rm -rf /home/gitlab/gitlab-satellites
+
+# if exists
+sudo rm /tmp/gitlab.socket
+```
+
+__5. Update gitlab to recent version__
+
+```bash
+cd /home/git/gitlab
+
+# backup current config
+sudo -u git -H cp config/gitlab.yml config/gitlab.yml.old
+
+sudo -u git -H git fetch
+sudo -u git -H git checkout 5-0-stable
+
+# replace config with recent one
+sudo -u git -H cp config/gitlab.yml.example config/gitlab.yml
+
+# edit it
+sudo -u git -H vim config/gitlab.yml
+
+
+sudo -u git -H bundle install --without development test postgres --deployment
+sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:shell:setup RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:shell:build_missing_projects RAILS_ENV=production
+
+sudo -u git -H mkdir /home/git/gitlab-satellites
+sudo -u git -H bundle exec rake gitlab:satellites:create RAILS_ENV=production
+
+# migrate wiki to git
+sudo -u git -H bundle exec rake gitlab:wiki:migrate RAILS_ENV=production
+
+
+# check permissions for /home/git/.ssh/
+sudo -u git -H chmod 700 /home/git/.ssh
+sudo -u git -H chmod 600 /home/git/.ssh/authorized_keys
+
+# check permissions for /home/git/gitlab/
+sudo chown -R git /home/git/gitlab/log/
+sudo chown -R git /home/git/gitlab/tmp/
+sudo chmod -R u+rwX  /home/git/gitlab/log/
+sudo chmod -R u+rwX  /home/git/gitlab/tmp/
+sudo -u git -H mkdir /home/git/gitlab/tmp/pids/
+sudo chmod -R u+rwX  /home/git/gitlab/tmp/pids
+
+```
+
+__6. Update init.d script and nginx config__
+
+```bash
+# init.d
+sudo rm /etc/init.d/gitlab
+sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-0-stable/init.d/gitlab
+sudo chmod +x /etc/init.d/gitlab
+
+# unicorn
+sudo -u git -H cp /home/git/gitlab/config/unicorn.rb /home/git/gitlab/config/unicorn.rb.old
+sudo -u git -H cp /home/git/gitlab/config/unicorn.rb.example /home/git/gitlab/config/unicorn.rb
+
+#nginx
+# Replace path from '/home/gitlab/' to '/home/git/'
+sudo vim /etc/nginx/sites-enabled/gitlab
+sudo service nginx restart
+
+
+```
+
+__7. Start gitlab instace__
+
+```
+
+
+sudo service gitlab start
+
+# check if unicorn and sidekiq started
+# If not try to logout, also check replaced path from '/home/gitlab/' to '/home/git/'
+# in nginx, unicorn, init.d etc
+ps aux | grep unicorn
+ps aux | grep sidekiq
+
+```
+
+__8. Check installation__
+
+
+```bash
+# In 5-10 seconds lets check gitlab-shell
+sudo -u git -H /home/git/gitlab-shell/bin/check
+
+# Example of success output
+# Check GitLab API access: OK
+# Check directories and files:
+#         /home/git/repositories: OK
+#         /home/git/.ssh/authorized_keys: OK
+
+
+# Now check gitlab instance
+sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+
+```
+
+
+__P.S. If everything works as expected you can remove gitlab user from system__


### PR DESCRIPTION
I moved the update instructions from the wiki into the project. This allows contributors to submit PR's regarding those instructions.
