### PR TITLE
Upgrade guide cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to contribute, please first read our [Contributing Guidelines](https
 
 Each month on the 22th a new version is released together with an upgrade guide.
 
-* [Upgrade guides](https://github.com/gitlabhq/gitlabhq/wiki)
+* [Upgrade guides](https://github.com/gitlabhq/gitlabhq/tree/master/doc/update)
 
 * [Changelog](https://github.com/gitlabhq/gitlabhq/blob/master/CHANGELOG)
 

--- a/doc/update/5.0-to-5.1.md
+++ b/doc/update/5.0-to-5.1.md
@@ -1,3 +1,5 @@
+# From 5.0 to 5.1
+
 ## Release notes:
 
 * `unicorn` replaced with `puma`


### PR DESCRIPTION
I linked the "Upgrade guides" directly into the repository so that we don't have to maintain the list.
