### PR TITLE
Show emoji popup if colon preceding by space or is new line.

### DIFF
--- a/app/assets/javascripts/gfm_auto_complete.js.coffee
+++ b/app/assets/javascripts/gfm_auto_complete.js.coffee
@@ -20,7 +20,7 @@ GitLab.GfmAutoComplete =
     input = $('.js-gfm-input')
 
     # Emoji
-    input.atWho ':',
+    input.atWho '(?:^|\\s):',
       data: @Emoji.data
       tpl: @Emoji.template
 


### PR DESCRIPTION
While typing colon in GitLab, emoji pops up right away. This makes this popup only if colon is preceded by space or is new line.  Kind of fix for #2730
