### PR TITLE
Projects/Gitlab-shell: Make the default branch the real default.

### DIFF
--- a/app/contexts/projects/update_context.rb
+++ b/app/contexts/projects/update_context.rb
@@ -3,6 +3,10 @@ module Projects
     def execute(role = :default)
       params[:project].delete(:namespace_id)
       params[:project].delete(:public) unless can?(current_user, :change_public_mode, project)
+
+      new_default = params[:project]['default_branch']
+      project.update_head(new_default) unless new_default == project.default_branch
+
       project.update_attributes(params[:project], as: role)
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -328,6 +328,10 @@ class Project < ActiveRecord::Base
     true
   end
 
+  def update_head(branch)
+    gitlab_shell.update_head(path_with_namespace, branch)
+  end
+
   def valid_repo?
     repository.exists?
   rescue

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -14,6 +14,7 @@
 
       %hr
       %p
+      %p Default Branch: #{link_to @project.default_branch, project_commits_path(@project, @repository.root_ref)}
       %p Repo Size: #{@project.repository.size} MB
       %p Created at: #{@project.created_at.stamp('Aug 22, 2013')}
       %p Owner: #{link_to @project.owner_name, @project.owner}

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -109,6 +109,14 @@ module Gitlab
       FileUtils.rm_r(satellites_path, force: true)
     end
 
+    # Update the branch that HEAD points to within the repo.
+    #
+    # Ex.
+    #   update_head("gitlab/gitlab-ci", 'master-devel')
+    def update_head(path, branch)
+      system("#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects update-head #{path}.git #{branch}")
+    end
+
     def url_to_repo path
       Gitlab.config.gitlab_shell.ssh_path_prefix + "#{path}.git"
     end


### PR DESCRIPTION
Gitlab will now tell gitlab-shell to update the HEAD pointer using the
update-head command - this ensures that when performing a git clone, the
branch you receive if none is specified will actually be the one you
configured as default.

This also resolves breakage when your repo lacks any branch named
"master.

Depends on commit Olipro/gitlab-shell@0cb0f8c

Fixes #3314
