### PR TITLE
Swapped out placeholder text on teams admin page

### DIFF
--- a/app/views/admin/teams/index.html.haml
+++ b/app/views/admin/teams/index.html.haml
@@ -1,7 +1,7 @@
 %h3.page_title
   Teams
   %small
-    simple Teams description
+    allow you to organize groups of people that have a common focus. Use teams to simplify the process of assigning roles to groups of people.
 
   = link_to 'New Team', new_admin_team_path, class: "btn btn-small pull-right"
   %br


### PR DESCRIPTION
Changed "simple Teams description" placeholder subtitle to "allow you
to organize groups of people that have a common focus. Use teams to
simplify the process of assigning roles to groups of people."

Before: 
![image](https://f.cloud.github.com/assets/2149341/451435/e95973de-b2ab-11e2-9897-0f2bbe6d44d7.png)

After: 
![image](https://f.cloud.github.com/assets/2149341/451436/ed37e968-b2ab-11e2-87b4-a34477c55a6f.png)
