### PR TITLE
fix ace editor Syntax Highlighter mode load 404

### DIFF
--- a/app/views/edit_tree/show.html.haml
+++ b/app/views/edit_tree/show.html.haml
@@ -30,6 +30,7 @@
       = link_to "Cancel", project_tree_path(@project, @id), class: "btn btn-cancel", confirm: "Are you sure?"
 
 :javascript
+  ace.config.set("modePath", "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")
   var ace_mode = "#{@blob.language.try(:ace_mode)}";
   var editor = ace.edit("editor");
   if (ace_mode) {


### PR DESCRIPTION
This error happens on `production mode` only, when you edit a markdown file, the content can't be correctly highlighted cause of a `404` error of ajax loading `mode-markdown.js`.

Ace load js use a relative path to itself and our `ace.js` is packed to `application.js`, so the final url ace used to load js is error.

I use nginx `gzip_static` module, so it's better to precompile all ace related js: 

``` ruby
config.assets.precompile += %w( ace-src-noconflict/* )
```
