### PR TITLE
Add namespace_id to project creation for a user in API

### DIFF
--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -77,6 +77,7 @@ module Gitlab
       #   wall_enabled (optional) - enabled by default
       #   merge_requests_enabled (optional) - enabled by default
       #   wiki_enabled (optional) - enabled by default
+      #   namespace_id (optional) - defaults to user namespace
       # Example Request
       #   POST /projects/user/:user_id
       post "user/:user_id" do
@@ -88,7 +89,8 @@ module Gitlab
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled]
+                                    :wiki_enabled,
+                                    :namespace_id]
         @project = ::Projects::CreateContext.new(user, attrs).execute
         if @project.saved?
           present @project, with: Entities::Project


### PR DESCRIPTION
This patch just adds the possibility to change the namespace of a
project created for a user via the API.

It behaves like https://github.com/gitlabhq/gitlabhq/pull/3119.

It might be interesting, for an administrator, to create projects in
the global namespace for specific users. This is possible when we create a
project without specifying the owner so why not here.
