### PR TITLE
fork failing when calling initialize_dup

### DIFF
--- a/app/contexts/projects/fork_context.rb
+++ b/app/contexts/projects/fork_context.rb
@@ -7,8 +7,7 @@ module Projects
     end
 
     def execute
-      project = Project.new
-      project.initialize_dup(@from_project)
+      project = @from_project.dup
       project.name = @from_project.name
       project.path = @from_project.path
       project.namespace = current_user.namespace


### PR DESCRIPTION
initialize_dup has been made private as of ruby 2.0.0. I have
corrected it to call the publicly available dup method
