### PR TITLE
Fixed N+1 problem while fetching all owner names of namespaces

### DIFF
--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -2,7 +2,7 @@ module NamespacesHelper
   def namespaces_options(selected = :current_user, scope = :default)
     if current_user.admin
       groups = Group.all
-      users = Namespace.root
+      users = Namespace.root.includes(:owner)
     else
       groups = current_user.owned_groups.select {|n| n.type == 'Group'}
       users = current_user.namespaces.reject {|n| n.type == 'Group'}


### PR DESCRIPTION
If you enter the new project page there will be N+1 queries where N is all the users.
