### PR TITLE
Add minitest to Gemfile. Fix #3826

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,6 +153,9 @@ group :development, :test do
   gem "launchy"
   gem 'factory_girl_rails'
 
+  # Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
+  gem 'minitest'
+  
   # Generate Fake data
   gem "ffaker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.1)
     mime-types (1.23)
+    minitest (4.7.4)
     modernizr (2.6.2)
       sprockets (~> 2.0)
     multi_json (1.7.2)
@@ -538,6 +539,7 @@ DEPENDENCIES
   kaminari (~> 0.14.1)
   launchy
   letter_opener
+  minitest
   modernizr (= 2.6.2)
   mysql2
   omniauth (~> 1.1.3)


### PR DESCRIPTION
There are occasions where minitest is not bundled in packaged
versions of ruby that some OSes distribute (eg Fedora). Adding
minitest to Gemfile ensures that it gets loaded and tests can run.
