### PR TITLE
Setting the working directory before git operations

### DIFF
--- a/doc/update/4.0-to-4.1.md
+++ b/doc/update/4.0-to-4.1.md
@@ -16,6 +16,8 @@
 ### 2. Update GitLab
 
 ```bash
+# Set the working directory
+cd /home/gitlab/gitlab/
 
 # Get latest code
 sudo -u gitlab -H git fetch

--- a/doc/update/4.1-to-4.2.md
+++ b/doc/update/4.1-to-4.2.md
@@ -7,6 +7,10 @@
 ### 2. Update code & db
 
 ```bash
+
+#Set the working directory
+cd /home/gitlab/gitlab/
+
 # Get latest code
 sudo -u gitlab git fetch
 

--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -19,6 +19,7 @@ sudo chsh -s /bin/bash git
 __2. git clone gitlab-shell__
 
 ```
+cd /home/git/
 sudo -u git -H git clone https://github.com/gitlabhq/gitlab-shell.git /home/git/gitlab-shell
 ```
 


### PR DESCRIPTION
Set the initial working directory. An issue can arise if the user is logged in as root and the current working directory is /root/. The console will return an error:

fatal: Could not change back to '/root': Permission denied

Changing the working directory prior to the clone operation seems to fix this.
