### PR TITLE
Fixed a nginx configuration

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -253,9 +253,10 @@ Download an example site config:
 
 Make sure to edit the config file to match your setup:
 
-    # Change **YOUR_SERVER_IP** and **YOUR_SERVER_FQDN**
-    # to the IP address and fully-qualified domain name
-    # of your host serving GitLab
+    # **YOUR_SERVER_FQDN** to the fully-qualified
+    # domain name of your host serving GitLab. Also, replace
+    # the 'listen' line with the following:
+    #   listen 80 default_server;         # e.g., listen 192.168.1.1:80;
     sudo vim /etc/nginx/sites-available/gitlab
 
 ## Restart


### PR DESCRIPTION
For some reason, if the nginx configuration is bound to an IP, it breaks the install, causing all git clone/push/pull operations to die with a 'fatal: The remote end hung up unexpectedly' message. Changing this configuration seems to fix the problem. I reckon that this is just a temporary fix. I don't know the ins and outs of GitLab well enough to vouch for this change, but I do know that these instructions are broken, and that this update will fix them.
