### PR TITLE
Create public/uploads directory if missing when backup is executed

### DIFF
--- a/lib/backup/uploads.rb
+++ b/lib/backup/uploads.rb
@@ -10,6 +10,7 @@ module Backup
 
     # Copy uploads from public/uploads to backup/uploads
     def dump
+      FileUtils.mkdir_p(app_uploads_dir)
       FileUtils.mkdir_p(backup_uploads_dir)
       FileUtils.cp_r(app_uploads_dir, backup_dir)
     end


### PR DESCRIPTION
By default there is no gitlab/public/uploads folder when no attachments are uploaded in any project. This breaks the backup, which supposes that the public/uploads directory exists:

```
sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
...
Dumping uploads ... 
rake aborted!
No such file or directory - /home/git/gitlab/public/uploads
```

This fix creates the public/uploads folder in  Backup::Uploads.dump if non-existant.
