### PR TITLE
Fix errors during backup task. Fix #3785

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -169,6 +169,10 @@ do so with caution!
     sudo chmod -R u+rwX  tmp/pids/
     sudo chmod -R u+rwX  tmp/sockets/
 
+		# Create 'uploads' directory otherwise backup will fail
+    sudo -u git -H mkdir public/uploads
+    sudo chmod -R u+rwX  public/uploads
+
     # Copy the example Puma config
     sudo -u git -H cp config/puma.rb.example config/puma.rb
 

--- a/lib/backup/database.rb
+++ b/lib/backup/database.rb
@@ -45,7 +45,7 @@ module Backup
         'encoding'  => '--default-character-set',
         'password'  => '--password'
       }
-      args.map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }.compact.join(' ')
+      args.map { |opt, arg| "#{arg}='#{config[opt]}'" if config[opt] }.compact.join(' ')
     end
 
     def pg_env


### PR DESCRIPTION
By default there is no `public/uploads` directory when no attachments are uploaded. Prompt users to create the uploads directory during install otherwise the backup task will fail.

Place mysqldump args in single quotes to avoid error if password contains special characters.
