### PR TITLE
Fixed puma.rb environment setting

### DIFF
--- a/config/puma.rb.example
+++ b/config/puma.rb.example
@@ -1,7 +1,7 @@
 #!/usr/bin/env puma
 
 # Start Puma with next command:
-# RAILS_ENV=production bundle exec puma -e production -C ./config/puma.rb
+# RAILS_ENV=production bundle exec puma -C ./config/puma.rb
 
 # uncomment and customize to run in non-root path
 # note that config/gitlab.yml web path should also be changed
@@ -19,7 +19,7 @@ directory application_path
 #
 # The default is “development”.
 #
-environment = :production
+environment 'production'
 
 # Daemonize the server into the background. Highly suggest that
 # this be combined with “pidfile” and “stdout_redirect”.

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -17,7 +17,7 @@
 
 APP_ROOT="/home/git/gitlab"
 APP_USER="git"
-DAEMON_OPTS="-C $APP_ROOT/config/puma.rb -e production"
+DAEMON_OPTS="-C $APP_ROOT/config/puma.rb"
 PID_PATH="$APP_ROOT/tmp/pids"
 WEB_SERVER_PID="$PID_PATH/puma.pid"
 SIDEKIQ_PID="$PID_PATH/sidekiq.pid"


### PR DESCRIPTION
No need to specify 'production' in the daemon options now.

If I'm understanding correctly, the old setting wasn't being used anywhere and wasn't being passed into puma.

Cheers.
