### PR TITLE
Wrong attachment URL with relative URLs

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -21,7 +21,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def secure_url
-    "/files/#{model.class.to_s.underscore}/#{model.id}/#{file.filename}"
+    Gitlab.config.gitlab.relative_url_root + "/files/#{model.class.to_s.underscore}/#{model.id}/#{file.filename}"
   end
 
   def file_storage?


### PR DESCRIPTION
Fixes #3657.

Note:
- I'm not a ruby expert at all. So the fix may not be perfect. But it works for me.
- It's still missing a fix for image previews in notes. This must probably be done by overriding some setting for `CarrierWave::Uploader::Base` in the `AttachmentUploader`. Any help on this is much apreciated.
