### PR TITLE
Migrate notes.line_code format.

### DIFF
--- a/lib/tasks/migrate/migrate_note_linecode.rake
+++ b/lib/tasks/migrate/migrate_note_linecode.rake
@@ -1,0 +1,13 @@
+desc "GITLAB | Migrate Note LineCode"
+task migrate_note_linecode: :environment do
+  Note.inline.each do |note|
+    index = note.diff_file_index
+    if index =~ /^\d{1,10}$/ # is number. not hash.
+      hash = Digest::SHA1.hexdigest(note.noteable.diffs[index.to_i].new_path)
+      new_line_code = note.line_code.sub(index, hash)
+      note.update_column :line_code, new_line_code
+      print '.'
+    end
+  end
+end
+


### PR DESCRIPTION
Since version 4.1, notes.line_code means:
  {SHA1 hash of file path}_{old line}_{new line}
but the older version means:
  {file index of the commit}_{old line}_{new line}

This rake task migrate the above differences.
