### PR TITLE
Join owner when fetching root scope on Namespace

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -36,7 +36,7 @@ class Namespace < ActiveRecord::Base
   after_update :move_dir, if: :path_changed?
   after_destroy :rm_dir
 
-  scope :root, -> { where('type IS NULL') }
+  scope :root, joins(:owner).includes(:owner).where(:type => nil)
 
   def self.search query
     where("name LIKE :query OR path LIKE :query", query: "%#{query}%")


### PR DESCRIPTION
To prevent a new query for each user in namespace helper: This was the debug output of the sql query created by the root scope on Namespace.

```
 Namespace Load (0.2ms)  SELECT `namespaces`.* FROM `namespaces` WHERE (type IS NULL)
  CACHE (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 2 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 3 LIMIT 1
  User Load (0.2ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 4 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 5 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 6 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 7 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 9 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 10 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 11 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 12 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 13 LIMIT 1
  User Load (0.2ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 14 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 15 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 16 LIMIT 1
  User Load (0.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 17 LIMIT 1

  ..for every single user
```

Now it's a single query that joins users and namespaces.
