### PR TITLE
fixes #3115 and adds support for gif bmp & tiff images

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -8,12 +8,12 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def image?
-    img_ext = %w(png jpg jpeg)
+    img_ext = %w(png jpg jpeg gif bmp tiff)
     if file.respond_to?(:extension)
-      img_ext.include?(file.extension)
+      img_ext.include?(file.extension.downcase)
     else
       # Not all CarrierWave storages respond to :extension
-      ext = file.path.split('.').last
+      ext = file.path.split('.').last.downcase
       img_ext.include?(ext)
     end
   rescue


### PR DESCRIPTION
when showing image preview check via lowercased extension and adds support for gif bmp & tiff images
