### PR TITLE
A little change on wording for new-user email

### DIFF
--- a/app/views/notify/new_user_email.html.haml
+++ b/app/views/notify/new_user_email.html.haml
@@ -2,9 +2,9 @@
   Hi #{@user['name']}!
 %p
   - if Gitlab.config.gitlab.signup_enabled
-    Account has been created successfully.
+    Your account has been created successfully.
   - else
-    Administrator created account for you. Now you are a member of company GitLab application.
+    The Administrator created an account for you. Now you are a member of company GitLab application.
 %p
   login..........................................
   %code= @user['email']


### PR DESCRIPTION
adds missing wording missed in https://github.com/gitlabhq/gitlabhq/pull/3902
