### PR TITLE
Add ability assign Team to group of projects

### DIFF
--- a/app/contexts/projects/create_context.rb
+++ b/app/contexts/projects/create_context.rb
@@ -60,6 +60,14 @@ module Projects
 
       if @project.save
         @project.users_projects.create(project_access: UsersProject::MASTER, user: current_user)
+
+        group = Group.find_by_id(@project.namespace_id)
+        if group
+          group.user_teams.each do |team|
+            access = team.max_project_access_in_group(group)
+            Gitlab::UserTeamManager.assign(team, project, access)
+          end
+        end
       end
 
       @project

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -8,6 +8,11 @@ class Admin::GroupsController < Admin::ApplicationController
   end
 
   def show
+    @group_projects = @group.projects
+    @members = @group.users
+    @teams = @group.user_teams
+
+    @available_teams = group.user_teams.any? ? UserTeam.where("id not in (?)", group.user_teams) : UserTeam.scoped
   end
 
   def new

--- a/app/controllers/groups/application_controller.rb
+++ b/app/controllers/groups/application_controller.rb
@@ -1,0 +1,35 @@
+class Groups::ApplicationController < ApplicationController
+  respond_to :html
+  layout 'group'
+
+  # Authorize
+  before_filter :authorize_read_group!
+
+  protected
+
+  def group
+    @group ||= Group.find_by_path(params[:group_id])
+  end
+
+  def projects
+    @projects ||= current_user.authorized_projects.where(namespace_id: group.id).sorted_by_activity
+  end
+
+  def project_ids
+    projects.map(&:id)
+  end
+
+  # Dont allow unauthorized access to group
+  def authorize_read_group!
+    unless projects.present? or can?(current_user, :manage_group, @group)
+      return render_404
+    end
+  end
+
+  def authorize_admin_group!
+    unless can?(current_user, :manage_group, group)
+      return render_404
+    end
+  end
+
+end

--- a/app/controllers/groups/teams_controller.rb
+++ b/app/controllers/groups/teams_controller.rb
@@ -1,0 +1,46 @@
+class Groups::TeamsController < Groups::ApplicationController
+
+  before_filter :authorize_admin_group!, only: [:new, :edit, :create, :update, :destroy]
+
+  def index
+    @teams = group.user_teams
+  end
+
+  def new
+    @available_teams = current_user.admin? ? UserTeam.scoped : current_user.authorized_teams
+    @available_teams = group.user_teams.any? ? @available_teams.where("id not in (?)", group.user_teams) : @available_teams
+
+    if @available_teams.blank?
+      flash[:notice] = "No available teams for adding to group"
+      redirect_to :back
+    end
+  end
+
+  def create
+    Gitlab::UserTeamManager.assign_to_group(team, group, params[:greatest_project_access])
+    flash[:notice] = "Team successful added to group"
+    redirect_to :back
+  end
+
+  def update
+    Gitlab::UserTeamManager.update_team_user_access_in_group(team, group, params[:greatest_project_access], params[:rebuild_permissions])
+    redirect_to :back
+  end
+
+  def destroy
+    Gitlab::UserTeamManager.resign_from_group(team, group)
+    flash[:notice] = "Team successful removed from group"
+    redirect_to :back
+  end
+
+  def edit
+    group
+    team
+  end
+
+  protected
+
+  def team
+    @team ||= (params[:id].present? ? UserTeam.find_by_path(params[:id]) : UserTeam.find(params[:team_id]))
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -120,7 +120,7 @@ class GroupsController < ApplicationController
 
   # Dont allow unauthorized access to group
   def authorize_read_group!
-    unless projects.present? or can?(current_user, :manage_group, @group)
+    unless projects.present? || can?(current_user, :manage_group, group)
       return render_404
     end
   end

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -1,7 +1,12 @@
 module NamespacesHelper
   def namespaces_options(selected = :current_user, scope = :default)
-    groups = current_user.owned_groups.select {|n| n.type == 'Group'}
-    users = current_user.namespaces.reject {|n| n.type == 'Group'}
+    if current_user.admin
+      groups = Group.scoped
+      users = Namespace.root
+    else
+      groups = current_user.owned_groups.select {|n| n.type == 'Group'}
+      users = current_user.namespaces.reject {|n| n.type == 'Group'}
+    end
 
     global_opts = ["Global", [['/', Namespace.global_id]] ]
     group_opts = ["Groups", groups.sort_by(&:human_name).map {|g| [g.human_name, g.id]} ]

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,8 +28,11 @@ class Ability
 
       team = project.team
 
+      user_teams = project.user_teams
+      is_team_admin = user_teams.inject(false) { |a, b| a = a || b.admin?(user)}
+
       # Rules based on role in project
-      if team.masters.include?(user)
+      if team.masters.include?(user) || is_team_admin
         rules << project_master_rules
 
       elsif team.developers.include?(user)
@@ -132,7 +135,7 @@ class Ability
       rules = []
 
       # Only group owner and administrators can manage group
-      if group.owner == user || user.admin?
+      if group.owner == user || user.admin? || group.admins.include?(user)
         rules << [
           :manage_group,
           :manage_namespace

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,6 +13,9 @@
 #
 
 class Group < Namespace
+  has_many :user_team_group_relationships, dependent: :destroy
+  has_many :user_teams, through: :user_team_group_relationships
+  has_many :admins, through: :user_teams, class_name: User, conditions: { user_team_user_relationships: { group_admin: true } }
 
   def add_users_to_project_teams(user_ids, project_access)
     UsersProject.add_users_into_projects(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,10 @@ class User < ActiveRecord::Base
   has_many :recent_events,                                 foreign_key: :author_id,   class_name: "Event", order: "id DESC"
   has_many :assigned_issues,          dependent: :destroy, foreign_key: :assignee_id, class_name: "Issue"
   has_many :assigned_merge_requests,  dependent: :destroy, foreign_key: :assignee_id, class_name: "MergeRequest"
+  has_many :user_team_group_relationships,   through: :user_teams, conditions: { user_team_user_relationships: { group_admin: true } }
+  has_many :team_groups,                     through: :user_team_group_relationships, source: :group
+  has_many :user_team_group_relationships,   through: :user_teams, conditions: { user_team_user_relationships: { group_admin: true } }
+  has_many :team_groups,                     through: :user_team_group_relationships, source: :group
 
   has_many :personal_projects,        through: :namespace, source: :projects
   has_many :projects,                 through: :users_projects
@@ -230,7 +234,8 @@ class User < ActiveRecord::Base
 
   # Groups where user is an owner
   def owned_groups
-    groups
+   @group_ids = groups.pluck(:id) + team_groups.pluck(:id)
+   Group.where(id: @group_ids)
   end
 
   def owned_teams
@@ -243,6 +248,10 @@ class User < ActiveRecord::Base
     Group.where(id: @group_ids)
   end
 
+  def authorized_namespaces
+    namespace_ids = owned_groups.pluck(:id) + [namespace.id]
+    Namespace.where(id: namespace_ids)
+  end
 
   # Projects user has access to
   def authorized_projects
@@ -331,7 +340,7 @@ class User < ActiveRecord::Base
   end
 
   def several_namespaces?
-    namespaces.many?
+    authorized_namespaces.many?
   end
 
   def namespace_id

--- a/app/models/user_team_group_relationship.rb
+++ b/app/models/user_team_group_relationship.rb
@@ -1,0 +1,28 @@
+class UserTeamGroupRelationship < ActiveRecord::Base
+  attr_accessible :group_id, :user_team_id, :greatest_access
+
+  belongs_to :group
+  belongs_to :user_team
+
+  validate :group, presence: true
+  validate :user_team, presence: true
+  validate :check_greatest_access
+
+  scope :with_group, ->(group) {where(group_id: group)}
+
+  def human_max_access
+    UserTeam.access_roles.key(greatest_access)
+  end
+
+  private
+
+  def check_greatest_access
+    errors.add(:base, :incorrect_access_code) unless correct_access?
+  end
+
+  def correct_access?
+    return false if greatest_access.blank?
+    return true if UsersProject.access_roles.has_value?(greatest_access)
+    false
+  end
+end

--- a/app/views/admin/groups/_members_list.html.haml
+++ b/app/views/admin/groups/_members_list.html.haml
@@ -1,0 +1,29 @@
+.tab-pane#members-list
+  %fieldset
+    .ui-box
+      %h5.title
+        Add user to Group projects:
+      .ui-box-body.form-holder
+        %p.light
+          Read more about project permissions
+          %strong= link_to "here", help_permissions_path, class: "vlink"
+
+        = form_tag project_teams_update_admin_group_path(@group), id: "new_team_member", class: "bulk_import", method: :put  do
+          %div
+            = users_select_tag(:user_ids, multiple: true)
+          %div.prepend-top-10
+            = select_tag :project_access, options_for_select(Project.access_options), {class: "project-access-select chosen span2"}
+          %hr
+          = submit_tag 'Add user to projects in group', class: "btn btn-create"
+    .ui-box
+      %h5.title
+        Users from Group projects
+        %small
+          (#{@group.users.count})
+      %ul.well-list
+        - @group.users.sort_by(&:name).each do |user|
+          %li{class: dom_class(user)}
+            %strong
+              = link_to user.name, admin_user_path(user)
+            %span.pull-right.light
+              = pluralize user.authorized_projects.in_namespace(@group).count, 'project'

--- a/app/views/admin/groups/_teams_list.html.haml
+++ b/app/views/admin/groups/_teams_list.html.haml
@@ -1,0 +1,45 @@
+.tab-pane#teams-list
+  %fieldset
+    %table.zebra-striped
+      %thead
+        %tr
+          %th
+            Name
+            %i.icon-sort-down
+          %th Description
+          %th Permission
+          %th Admins
+          %th Owner
+          %th.cred Danger Zone!
+
+      - @teams.each do |team|
+        %tr
+          %td
+            %strong= link_to team.name, team_path(team)
+          %td= truncate team.description
+          %td= team.human_max_group_access(@group)
+          %td= raw team.admins.any? ? team.admins.map { |a| link_to a.name, user_path(a) }.join(", ") : "-"
+          %td
+            - if team.owner
+              = link_to team.owner.name, user_path(team.owner)
+            - else
+              (deleted)
+          %td.bgred
+            = link_to 'Edit', edit_group_team_path(@group, team), id: "edit_#{dom_id(team)}", class: "btn btn-small"
+            = link_to 'Resign', group_team_path(@group, team), confirm: "REMOVE #{team.name}? Are you sure?", method: :delete, class: "btn btn-small btn-remove"
+
+    - if @available_teams.any?
+      = form_tag group_teams_path(@group), method: 'post' do
+        %fieldset
+          %legend Assign Team to group
+          .padded
+            = label_tag :team_id, "Team"
+            .input= select_tag(:team_id, options_from_collection_for_select(@available_teams, :id, :name), prompt: "Select team", class: "chosen xxlarge", required: true)
+          %p.slead Choose greatest user acces in team you want to assign:
+          .padded
+            = label_tag :team_ids, "Permission"
+            .input= select_tag :greatest_project_access, options_for_select(UserTeam.access_roles), {class: "project-access-select chosen span3" }
+
+          .actions
+            = submit_tag 'Assign', class: "btn btn-create"
+            = link_to "Cancel", group_teams_path(@group), class: "btn btn-cancel"

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -18,12 +18,10 @@
           %span.light Path:
           %strong
             = @group.path
-
         %li
           %span.light Description:
           %strong
             = @group.description
-
         %li
           %span.light Owned by:
           %strong
@@ -49,35 +47,6 @@
           %strong
             = @group.created_at.stamp("March 1, 1999")
 
-
-    .ui-box
-      %h5.title
-        Add user to Group projects:
-      .ui-box-body.form-holder
-        %p.light
-          Read more about project permissions
-          %strong= link_to "here", help_permissions_path, class: "vlink"
-
-        = form_tag project_teams_update_admin_group_path(@group), id: "new_team_member", class: "bulk_import", method: :put  do
-          %div
-            = users_select_tag(:user_ids, multiple: true)
-          %div.prepend-top-10
-            = select_tag :project_access, options_for_select(Project.access_options), {class: "project-access-select chosen span2"}
-          %hr
-          = submit_tag 'Add user to projects in group', class: "btn btn-create"
-    .ui-box
-      %h5.title
-        Users from Group projects
-        %small
-          (#{@group.users.count})
-      %ul.well-list
-        - @group.users.sort_by(&:name).each do |user|
-          %li{class: dom_class(user)}
-            %strong
-              = link_to user.name, admin_user_path(user)
-            %span.pull-right.light
-              = pluralize user.authorized_projects.in_namespace(@group).count, 'project'
-
   .span6
     .ui-box
       %h5.title
@@ -91,3 +60,25 @@
               = link_to project.name_with_namespace, [:admin, project]
             %span.pull-right.light
               %span.monospace= project.path_with_namespace + ".git"
+
+%ul#group-relations.nav.nav-tabs
+  %li= link_to("Members (#{@members.count})", "#members-list", "data-toggle" => "tab")
+  %li= link_to("Teams (#{@teams.count})", "#teams-list", "data-toggle" => "tab")
+.tab-content
+  = render "members_list"
+  = render "teams_list"
+
+:javascript
+  $(function(){
+    var modal = $('.change-owner-holder');
+    $('.change-owner-link').bind("click", function(){
+      $(this).hide();
+      modal.show();
+    });
+    $('.change-owner-cancel-link').bind("click", function(){
+      modal.hide();
+      $('.change-owner-link').show();
+    })
+
+    $('#group-relations a:first').tab('show')
+  })

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,14 +1,11 @@
 .row
   .span3
     %ul.nav.nav-pills.nav-stacked
-      %li.active
-        = link_to 'Projects', '#tab-projects', 'data-toggle' => 'tab'
-      %li
-        = link_to 'Edit Group', '#tab-edit', 'data-toggle' => 'tab'
-      %li
-        = link_to 'Transfer', '#tab-transfer', 'data-toggle' => 'tab'
-      %li
-        = link_to 'Remove', '#tab-remove', 'data-toggle' => 'tab'
+      %li.active= link_to 'Projects', '#tab-projects', 'data-toggle' => 'tab'
+      %li= link_to 'Teams', '#tab-teams', 'data-toggle' => 'tab'
+      %li= link_to 'Edit Group', '#tab-edit', 'data-toggle' => 'tab'
+      %li= link_to 'Transfer', '#tab-transfer', 'data-toggle' => 'tab'
+      %li= link_to 'Remove', '#tab-remove', 'data-toggle' => 'tab'
 
   .span9
     .tab-content
@@ -29,6 +26,28 @@
                   = link_to 'Remove', project, confirm: remove_project_message(project), method: :delete, class: "btn btn-small btn-remove"
             - if @group.projects.blank?
               %p.nothing_here_message This group has no projects yet
+
+      .tab-pane#tab-teams
+        .ui-box
+          %h5.title
+            Teams
+            %small
+              (#{@group.user_teams.count})
+            %span.pull-right
+              = link_to new_group_team_path(@group), class: "btn btn-tiny info" do
+                %i.icon-plus
+                Assign Team
+            -# if @avaliable_teams.any?
+          %ul.well-list
+            - @group.user_teams.each do |team|
+              %li
+                = link_to team.name, team_path(team)
+                .pull-right
+                  = link_to 'Edit', edit_group_team_path(@group, team), id: "edit_#{dom_id(team)}", class: "btn btn-small"
+                  = link_to 'Resign', group_team_path(@group, team), confirm: "RESIGN #{team.name} from #{@group.name} and all group projects? Are you sure?", method: :delete, class: "btn btn-small btn-remove"
+            - if @group.projects.blank?
+              %p.nothing_here_message This group has no teams yet
+
 
       .tab-pane#tab-edit
         .ui-box

--- a/app/views/groups/teams/_team_list.html.haml
+++ b/app/views/groups/teams/_team_list.html.haml
@@ -1,0 +1,23 @@
+%table.zebra-striped
+  %thead
+    %tr
+      %th
+        Name
+        %i.icon-sort-down
+      %th Description
+      %th Permission
+      %th Admins
+      %th Owner
+
+  - @teams.each do |team|
+    %tr
+      %td
+        %strong= link_to team.name, team_path(team)
+      %td= truncate team.description
+      %td= team.human_max_group_access(@group)
+      %td= raw team.admins.any? ? team.admins.map { |a| link_to a.name, user_path(a) }.join(", ") : "-"
+      %td
+        - if team.owner
+          = link_to team.owner.name, user_path(team.owner)
+        - else
+          (deleted)

--- a/app/views/groups/teams/edit.html.haml
+++ b/app/views/groups/teams/edit.html.haml
@@ -1,0 +1,20 @@
+%h3.page_title
+  Edit max access in #{link_to @group.name, @group} for #{link_to(@team.name, team_path(@team))} team
+
+%hr
+
+= form_tag group_team_path(@group, @team), method: :put do
+  .clearfix
+    %label Max access for Team members:
+    .input
+      = select_tag :greatest_project_access, options_for_select(UserTeam.access_roles, @team.max_project_access_in_group(@group)), class: "project-access-select chosen span3"
+
+  .clearfix
+    %label Rebuild current permissions in projects
+    .input
+      = check_box_tag :rebuild_permissions, :yes, false, class: "project-access-select chosen span3"
+
+  %br
+  .actions
+    = submit_tag 'Save', class: "btn btn-save"
+    = link_to 'Cancel', :back, class: "btn btn-cancel"

--- a/app/views/groups/teams/index.html.haml
+++ b/app/views/groups/teams/index.html.haml
@@ -1,0 +1,6 @@
+%h3.page_title
+  Teams
+  %small
+    assigned to all projects in Group
+
+= render "groups/teams/team_list"

--- a/app/views/groups/teams/new.html.haml
+++ b/app/views/groups/teams/new.html.haml
@@ -1,0 +1,18 @@
+%h3.page_title
+  = "Assign #{@group.name} group to team of users"
+%hr
+%p.slead
+  Read more about assign to team of users #{link_to "here", '#', class: 'vlink'}.
+= form_tag group_teams_path(@group), method: 'post' do
+  %p.slead Choose Team of users you want to assign:
+  .padded
+    = label_tag :team_id, "Team"
+    .input= select_tag(:team_id, options_from_collection_for_select(@available_teams, :id, :name), prompt: "Select team", class: "chosen xxlarge", required: true)
+  %p.slead Choose greatest user acces in team you want to assign:
+  .padded
+    = label_tag :team_ids, "Permission"
+    .input= select_tag :greatest_project_access, options_for_select(UserTeam.access_roles), {class: "project-access-select chosen span3" }
+
+  .actions
+    = submit_tag 'Assign', class: "btn btn-create"
+    = link_to "Cancel", group_teams_path(@group), class: "btn btn-cancel"

--- a/app/views/layouts/nav/_group.html.haml
+++ b/app/views/layouts/nav/_group.html.haml
@@ -12,6 +12,8 @@
       %span.count= current_user.cared_merge_requests.opened.of_group(@group).count
   = nav_link(path: 'groups#people') do
     = link_to "People", people_group_path(@group)
+  = nav_link(path: 'groups#teams') do
+    = link_to "Teams", group_teams_path(@group)
 
   - if can?(current_user, :manage_group, @group)
     = nav_link(path: 'groups#edit') do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,9 @@ Gitlab::Application.routes.draw do
       get :people
       post :team_members
     end
+    scope module: :groups do
+      resources :teams
+    end
   end
 
   #

--- a/db/migrate/20130506001109_create_user_team_group_relationships.rb
+++ b/db/migrate/20130506001109_create_user_team_group_relationships.rb
@@ -1,0 +1,11 @@
+class CreateUserTeamGroupRelationships < ActiveRecord::Migration
+  def change
+    create_table :user_team_group_relationships do |t|
+      t.integer :user_team_id
+      t.integer :group_id
+      t.integer :greatest_access
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,6 +235,14 @@ ActiveRecord::Schema.define(:version => 20130614132337) do
     t.string "name"
   end
 
+  create_table "user_team_group_relationships", :force => true do |t|
+    t.integer  "user_team_id"
+    t.integer  "group_id"
+    t.integer  "greatest_access"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+  end
+
   create_table "user_team_project_relationships", :force => true do |t|
     t.integer  "project_id"
     t.integer  "user_team_id"

--- a/lib/gitlab/user_team_manager.rb
+++ b/lib/gitlab/user_team_manager.rb
@@ -19,7 +19,7 @@ module Gitlab
 
         team.user_team_project_relationships.with_project(project).destroy_all
 
-        update_team_users_access_in_project(team, project, :updated)
+        update_team_users_access_in_project(team, project, :deleted)
       end
 
       def update_team_user_membership(team, member, options)
@@ -141,6 +141,50 @@ module Gitlab
           UsersProject.in_projects(team.projects).with_user(user).destroy_all
         end
       end
+
+      def assign_to_group(team, group, access)
+        group = find_entity(group, Group)
+        team = find_entity(team, UserTeam)
+
+        searched_group = team.user_team_group_relationships.find_by_group_id(group.id)
+
+        unless searched_group.present?
+          team.user_team_group_relationships.create(group_id: group.id, greatest_access: access)
+          group.projects.each do |project|
+            assign(team, project, access)
+          end
+        end
+      end
+
+      def resign_from_group(team, group)
+        group = find_entity(group, Group)
+        team = find_entity(team, UserTeam)
+
+        team.user_team_group_relationships.with_group(group).destroy_all
+
+        group.projects.each do |project|
+          resign(team, project)
+        end
+      end
+
+      def update_team_user_access_in_group(team, group, access, rebuild_flag = nil)
+        group = find_entity(group, Group)
+        team = find_entity(team, UserTeam)
+
+        relationship = team.user_team_group_relationships.with_group(group)
+        relationship.update_all(greatest_access: access)
+
+        if rebuild_flag
+          group.projects.each do |project|
+            update_project_greates_access(team, project, permission)
+          end
+        end
+      end
+
+      def find_entity(entity, entity_type)
+        entity.is_a?(entity_type) ? entity : entity_type.find(entity)
+      end
+
     end
   end
 end

--- a/spec/factories/user_team_group_relationships.rb
+++ b/spec/factories/user_team_group_relationships.rb
@@ -1,0 +1,9 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :user_team_group_relationship do
+    user_team
+    group
+    greatest_access 40
+  end
+end

--- a/spec/lib/gitlab/user_team_manager_spec.rb
+++ b/spec/lib/gitlab/user_team_manager_spec.rb
@@ -1,28 +1,97 @@
 require 'spec_helper'
 
 describe Gitlab::UserTeamManager do
-  before do
-    @user = create :user
-    @project = create :project, creator: @user
 
-    @master = create :user
-    @developer = create :user
-    @reporter = create :user
+  describe "Team assign on group" do
+    before do
+      @user = create :user
+      @group = create :group
+      @team = create :user_team
+    end
 
-    @project.team << [@master, :master]
-    @project.team << [@developer, :developer]
-    @project.team << [@reporter, :reporter]
+    it "should assign team to group" do
+      Gitlab::UserTeamManager.assign_to_group(@team, @group, UserTeam.access_roles.first.second)
+      @group.user_teams.should_not be_blank
+    end
 
-    @team = create :user_team, owner: @user
+    it "should resign team from group" do
+      Gitlab::UserTeamManager.assign_to_group(@team, @group, UserTeam.access_roles.first.second)
+      count_team_in_group = @group.user_teams.count
 
-    @team.add_members([@master.id, @developer.id, @reporter.id], UsersProject::DEVELOPER, false)
+      Gitlab::UserTeamManager.resign_from_group(@team, @group)
+      count_team_in_group_after_resign = @group.user_teams.count
+
+      (count_team_in_group - count_team_in_group_after_resign).should == 1
+    end
+
+    it "shoul update team defoult access" do
+      Gitlab::UserTeamManager.assign_to_group(@team, @group, UserTeam.access_roles.first.second)
+      greatest_access = @group.user_team_group_relationships.last.greatest_access
+      Gitlab::UserTeamManager.update_team_user_access_in_group(@team, @group, UserTeam.access_roles.dup.drop(1).last.second)
+      @group.user_team_group_relationships.last.greatest_access.should_not be_equal(greatest_access)
+    end
+
+    it "should resign tema from group with one or more project in group" do
+      project = create :project, creator: @user, namespace: @group
+      second_project = create :project, creator: @user, namespace: @group
+      project.users.count.should == 0
+
+      additional_user = create :user
+      Gitlab::UserTeamManager.add_member_into_team(@team, additional_user, UserTeam.access_roles.first.second, true)
+      project.users.count.should == 0
+
+      Gitlab::UserTeamManager.assign_to_group(@team, @group, UserTeam.access_roles.first.second)
+      project.users.count.should == 1
+      @group.user_teams.count.should == 1
+
+      Gitlab::UserTeamManager.resign_from_group(@team, @group)
+      @group.user_teams.count.should == 0
+      project.users.count.should == 0
+
+      Gitlab::UserTeamManager.assign_to_group(@team, @group, UserTeam.access_roles.first.second)
+      project.users.count.should == 1
+      @group.user_teams.count.should == 1
+
+      second_team = create :user_team, owner: @user
+      second_additional_user = create :user
+      Gitlab::UserTeamManager.add_member_into_team(second_team, additional_user, UserTeam.access_roles.first.second, true)
+      Gitlab::UserTeamManager.add_member_into_team(second_team, second_additional_user, UserTeam.access_roles.first.second, true)
+      Gitlab::UserTeamManager.assign_to_group(second_team, @group, UserTeam.access_roles.first.second)
+
+      project.users.count.should == 2
+      @group.user_teams.count.should == 2
+
+      Gitlab::UserTeamManager.resign_from_group(@team, @group)
+      Gitlab::UserTeamManager.resign_from_group(second_team, @group)
+      @group.user_teams.count.should == 0
+      project.users.count.should == 0
+    end
   end
 
-  it "should assign team to project with correct permissions result" do
-    @team.assign_to_project(@project, UsersProject::MASTER)
+  describe "Team assign on project" do
+    before do
+      @user = create :user
+      @project = create :project, creator: @user
 
-    @project.users_projects.find_by_user_id(@master).project_access.should == UsersProject::MASTER
-    @project.users_projects.find_by_user_id(@developer).project_access.should == UsersProject::DEVELOPER
-    @project.users_projects.find_by_user_id(@reporter).project_access.should == UsersProject::DEVELOPER
+      @master = create :user
+      @developer = create :user
+      @reporter = create :user
+
+      @project.team << [@master, :master]
+      @project.team << [@developer, :developer]
+      @project.team << [@reporter, :reporter]
+
+      @team = create :user_team, owner: @user
+
+      @team.add_members([@master.id, @developer.id, @reporter.id], UsersProject::DEVELOPER, false)
+    end
+
+    it "should assign team to project with correct permissions result" do
+      @team.assign_to_project(@project, UsersProject::MASTER)
+
+      @project.users_projects.find_by_user_id(@master).project_access.should == UsersProject::MASTER
+      @project.users_projects.find_by_user_id(@developer).project_access.should == UsersProject::DEVELOPER
+      @project.users_projects.find_by_user_id(@reporter).project_access.should == UsersProject::DEVELOPER
+    end
   end
 end

--- a/spec/models/user_team_group_relationship_spec.rb
+++ b/spec/models/user_team_group_relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe UserTeamGroupRelationship do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Assign a command to a group of projects.

When you add a new project to the group - the team is automatically assigned to this project.

Administrators have the right team on project management in a group of projects (including projects to add to the group.)

![Teams link in group](http://puu.sh/2UuDj.png)

![Settings page in group](http://puu.sh/2UuE2.png)

![Assign team page](http://puu.sh/2UuEu.png)

![Teams list](http://puu.sh/2UuF7.png)

![Admin groups page](http://puu.sh/2UuGP.png)

![Admin group page](http://puu.sh/2UuHs.png)
