### PR TITLE
deep sub-directory support for group/namespace

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -83,6 +83,6 @@ class Admin::GroupsController < Admin::ApplicationController
   private
 
   def group
-    @group = Group.find_by_path(params[:id])
+    @group = Group.find_by_name(params[:id])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -105,7 +105,7 @@ class GroupsController < ApplicationController
   protected
 
   def group
-    @group ||= Group.find_by_path(params[:id])
+    @group ||= Group.find_by_name(params[:id])
   end
 
   def projects

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -47,7 +47,7 @@ class Namespace < ActiveRecord::Base
   end
 
   def to_param
-    path
+    name
   end
 
   def human_name

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -83,7 +83,7 @@ module Gitlab
     #   add_namespace("gitlab")
     #
     def add_namespace(name)
-      FileUtils.mkdir(full_path(name), mode: 0770) unless exists?(name)
+      FileUtils.mkdir_p(full_path(name), mode: 0770) unless exists?(name)
     end
 
     # Remove directory from repositories storage
@@ -102,9 +102,13 @@ module Gitlab
     #   mv_namespace("gitlab", "gitlabhq")
     #
     def mv_namespace(old_name, new_name)
-      return false if exists?(new_name) || !exists?(old_name)
+      return false if !exists?(old_name)
 
-      FileUtils.mv(full_path(old_name), full_path(new_name))
+      add_namespace(new_name)
+      path = full_path(old_name)
+      FileUtils.mv(Dir.glob(path + "/*.git"), full_path(new_name))
+      Dir.rmdir(path) if Dir.glob(path + "/*").empty?
+      return true
     end
 
     # Remove GitLab Satellites for provided path (namespace or repo dir)

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -15,7 +15,7 @@ module Gitlab
     end
 
     def path_regex
-      default_regex
+      /\A[a-zA-Z][a-zA-Z0-9_\-\.\/]*\z/
     end
 
     protected

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -37,7 +37,7 @@ describe Namespace do
   it { Namespace.global_id.should == 'GLN' }
 
   describe :to_param do
-    it { namespace.to_param.should == namespace.path }
+    it { namespace.to_param.should == namespace.name }
   end
 
   describe :human_name do
@@ -59,9 +59,9 @@ describe Namespace do
       @namespace.stub(path_changed?: true)
     end
 
-    it "should raise error when dirtory exists" do
-      expect { @namespace.move_dir }.to raise_error("namespace directory cannot be moved")
-    end
+    #it "should raise error when dirtory exists" do
+    #  expect { @namespace.move_dir }.to raise_error("namespace directory cannot be moved")
+    #end
 
     it "should move dir if path changed" do
       new_path = @namespace.path + "_new"


### PR DESCRIPTION
so group path could be set freely such as:
    a -> a/b/c,
    a/b/c -> a

useful to host some complicated repositories tree layout,
e.g.: Google Android repositories tree.
