### PR TITLE
Style target notes for easy visual identification

### DIFF
--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -1,6 +1,13 @@
 /**
  * Notes
  */
+
+@-webkit-keyframes target-note {
+  from { background:#fffff0; }
+  50% { background:#ffffd3; }
+  to { background:#fffff0; }
+}
+
 ul.notes {
   display: block;
   list-style: none;
@@ -89,6 +96,11 @@ ul.notes {
     .note-header {
       padding-bottom: 5px;
     }
+  }
+
+  .note:target {
+    -webkit-animation:target-note 2s linear;
+    background: #fffff0;
   }
 
   // paint top or bottom borders depending on notes direction


### PR DESCRIPTION
When linking to a previous note in a issue discussion, can be hard to identify the linked comment, specially when the browser doesnt even scroll to it (cause it is already showed).

This adds a little CSS to visually aid the user clicking those internal links.

![notes-highlight](https://f.cloud.github.com/assets/517228/513711/41061f5c-be45-11e2-900a-b77ab2b750cb.png)

@randx Can u put this on the 5.2 final release?
