### PR TITLE
Issue 3599: Add snippets_enabled flag to projects for API

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -53,6 +53,7 @@ GET /projects
     "merge_requests_enabled": true,
     "wall_enabled": true,
     "wiki_enabled": true,
+    "snippets_enabled": true,
     "created_at": "2012-05-30T12:49:20Z",
     "last_activity_at": "2012-05-23T08:05:02Z"
   }
@@ -95,6 +96,7 @@ Parameters:
   "merge_requests_enabled": true,
   "wall_enabled": true,
   "wiki_enabled": true,
+  "snippets_enabled": true,
   "created_at": "2012-05-30T12:49:20Z",
   "last_activity_at": "2012-05-23T08:05:02Z"
 }
@@ -182,10 +184,11 @@ Parameters:
 + `name` (required) - new project name
 + `description` (optional) - short project description
 + `default_branch` (optional) - 'master' by default
-+ `issues_enabled` (optional) - enabled by default
-+ `wall_enabled` (optional) - enabled by default
-+ `merge_requests_enabled` (optional) - enabled by default
-+ `wiki_enabled` (optional) - enabled by default
++ `issues_enabled` (optional)
++ `wall_enabled` (optional)
++ `merge_requests_enabled` (optional)
++ `wiki_enabled` (optional) 
++ `snippets_enabled` (optional)
 
 **Project access levels**
 
@@ -213,10 +216,11 @@ Parameters:
 + `name` (required) - new project name
 + `description` (optional) - short project description
 + `default_branch` (optional) - 'master' by default
-+ `issues_enabled` (optional) - enabled by default
-+ `wall_enabled` (optional) - enabled by default
-+ `merge_requests_enabled` (optional) - enabled by default
-+ `wiki_enabled` (optional) - enabled by default
++ `issues_enabled` (optional)
++ `wall_enabled` (optional)
++ `merge_requests_enabled` (optional)
++ `wiki_enabled` (optional) 
++ `snippets_enabled` (optional)
 
 
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -30,7 +30,7 @@ module API
       expose :owner, using: Entities::UserBasic
       expose :name, :name_with_namespace
       expose :path, :path_with_namespace
-      expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :created_at, :last_activity_at
+      expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :snippets_enabled, :created_at, :last_activity_at
       expose :namespace
     end
 

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -61,10 +61,11 @@ module API
       #   name (required) - name for new project
       #   description (optional) - short project description
       #   default_branch (optional) - 'master' by default
-      #   issues_enabled (optional) - enabled by default
-      #   wall_enabled (optional) - enabled by default
-      #   merge_requests_enabled (optional) - enabled by default
-      #   wiki_enabled (optional) - enabled by default
+      #   issues_enabled (optional) 
+      #   wall_enabled (optional) 
+      #   merge_requests_enabled (optional) 
+      #   wiki_enabled (optional) 
+      #   snippets_enabled (optional)
       #   namespace_id (optional) - defaults to user namespace
       # Example Request
       #   POST /projects
@@ -77,6 +78,7 @@ module API
                                     :wall_enabled,
                                     :merge_requests_enabled,
                                     :wiki_enabled,
+                                    :snippets_enabled,
                                     :namespace_id]
         @project = ::Projects::CreateContext.new(current_user, attrs).execute
         if @project.saved?
@@ -96,10 +98,11 @@ module API
       #   name (required) - name for new project
       #   description (optional) - short project description
       #   default_branch (optional) - 'master' by default
-      #   issues_enabled (optional) - enabled by default
-      #   wall_enabled (optional) - enabled by default
-      #   merge_requests_enabled (optional) - enabled by default
-      #   wiki_enabled (optional) - enabled by default
+      #   issues_enabled (optional) 
+      #   wall_enabled (optional) 
+      #   merge_requests_enabled (optional) 
+      #   wiki_enabled (optional)
+      #   snippets_enabled (optional)
       # Example Request
       #   POST /projects/user/:user_id
       post "user/:user_id" do
@@ -111,7 +114,8 @@ module API
                                     :issues_enabled,
                                     :wall_enabled,
                                     :merge_requests_enabled,
-                                    :wiki_enabled]
+                                    :wiki_enabled,
+                                    :snippets_enabled]
         @project = ::Projects::CreateContext.new(user, attrs).execute
         if @project.saved?
           present @project, with: Entities::Project


### PR DESCRIPTION
Fixes #3599.

I have tested this for both creation and retrieval via API and it all works as described. I applied these changes and tested on a master branch build.

Please see previous pull request at #3989 for discussion regarding the comments.  I had some issues with the squash and ended up having to close that PR in favor of this one.  Thanks.
