### PR TITLE
Use default cursor on network graph.

### DIFF
--- a/app/assets/stylesheets/sections/graph.scss
+++ b/app/assets/stylesheets/sections/graph.scss
@@ -11,7 +11,6 @@
 
   .graph { 
     background: #f1f1f1;
-    cursor: move;
     height: 500px;
     overflow-y: scroll;
     overflow-x: hidden;


### PR DESCRIPTION
The cross 'move' cursor doesen't work if you can't it around.
refs #3741
