### PR TITLE
Remove user directory path assumptions

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -58,7 +58,11 @@ Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'git'
-Settings.gitlab['user_home']  ||= Etc.getpwnam(Settings.gitlab['user']).dir
+Settings.gitlab['user_home']  ||= begin
+  Etc.getpwnam(Settings.gitlab['user']).dir
+rescue ArgumentError # no user configured
+  '/home/' + Settings.gitlab['user']
+end
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['default_projects_features'] ||= {}

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -58,6 +58,7 @@ Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'git'
+Settings.gitlab['user_home']  ||= Etc.getpwnam(Settings.gitlab['user']).dir
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['default_projects_features'] ||= {}
@@ -79,10 +80,10 @@ Settings.gravatar['ssl_url']    ||= 'https://secure.gravatar.com/avatar/%{hash}?
 # GitLab Shell
 #
 Settings['gitlab_shell'] ||= Settingslogic.new({})
-Settings.gitlab_shell['hooks_path']   ||= '/home/git/gitlab-shell/hooks/'
+Settings.gitlab_shell['hooks_path']   ||= Settings.gitlab['user_home'] + '/gitlab-shell/hooks/'
 Settings.gitlab_shell['receive_pack']   = true if Settings.gitlab_shell['receive_pack'].nil?
 Settings.gitlab_shell['upload_pack']    = true if Settings.gitlab_shell['upload_pack'].nil?
-Settings.gitlab_shell['repos_path']   ||= '/home/git/repositories/'
+Settings.gitlab_shell['repos_path']   ||= Settings.gitlab['user_home'] + '/repositories/'
 Settings.gitlab_shell['ssh_host']     ||= (Settings.gitlab.host || 'localhost')
 Settings.gitlab_shell['ssh_port']     ||= 22
 Settings.gitlab_shell['ssh_user']     ||= Settings.gitlab.user


### PR DESCRIPTION
Where I work /home is an automounted nfs directory. Local users are installed in a different local directory.

So instead of assuming that /home/git is the git users home directory, use the Etc module to get the configured home directory for the Settings.gitlab['user'] value (normally git).

The new setting is named user_home, unoriginal but works well enough could be changed to whatever. Users with /home/git as their home directory will not notice a difference.
