### PR TITLE
Fixed check_sidekiq_running to allow two digit version numbers

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -588,7 +588,7 @@ namespace :gitlab do
     def check_sidekiq_running
       print "Running? ... "
 
-      if run_and_match("ps aux | grep -i sidekiq", /sidekiq \d\.\d\.\d.+$/)
+      if run_and_match("ps aux | grep -i sidekiq", /sidekiq \d+\.\d+\.\d+.+$/)
         puts "yes".green
       else
         puts "no".red


### PR DESCRIPTION
Test failed for sidekiq version 2.11.1 as the regular expression was only checking for one digit major/minor/patch versions. New regular expressions checks for at least one digit.
