### PR TITLE
Security: keep the Rails secret token out of version control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ db/data.yml
 vendor/bundle/*
 rails_best_practices_output.html
 doc/code/*
+.secret

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,23 @@
 # Be sure to restart your server when you modify this file.
 
+require 'securerandom'
+
 # Your secret key for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Gitlab::Application.config.secret_token = '0a38e9a40ca5d66d7002a6ade0ed0f8b71058c820163f66cf65d91521ab55255ff708b9909b138008a7f13d68fec575def1dc3ff7200cd72b065896315e0bed2'
+
+def find_secure_token
+  token_file = Rails.root.join('.secret')
+  if File.exist? token_file
+    # Use the existing token.
+    File.read(token_file).chomp
+  else
+    # Generate a new token of 64 random hexadecimal characters and store it in token_file.
+    token = SecureRandom.hex(64)
+    File.write(token_file, token)
+    token
+  end
+end
+
+Gitlab::Application.config.secret_token = find_secure_token


### PR DESCRIPTION
This patch stores the secret token in a `.gitignore`d file called ".secret", which is
created by the initializer if it doesn't exist. This keeps the Rails session token out of version control and deals with a security vulnerability.

For reference:

http://blog.phusion.nl/2013/01/04/securing-the-rails-session-secret/

http://blog.codeclimate.com/blog/2013/03/27/rails-insecure-defaults/ (Item 3)
