### PR TITLE
Fixed "recipe_content" path of "check.rake" for 5-2-stable

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -144,7 +144,7 @@ namespace :gitlab do
         return
       end
 
-      recipe_content = `curl https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab 2>/dev/null`
+      recipe_content = `curl https://raw.github.com/gitlabhq/gitlabhq/5-2-stable/lib/support/init.d/gitlab 2>/dev/null`
       script_content = File.read(script_path)
 
       if recipe_content == script_content


### PR DESCRIPTION
In Installation Guide

>   sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5-2-stable/lib/support/init.d/gitlab

but in "check.rake"
https://github.com/gitlabhq/gitlabhq/blob/5-2-stable/lib/tasks/gitlab/check.rake#L147

> ```
>   recipe_content = `curl https://raw.github.com/gitlabhq/gitlab-recipes/master/init.d/gitlab 2>/dev/null`
> ```

So "bundle exec rake gitlab:check RAILS_ENV=production" check results:

> Init script up-to-date? ... no
>  Try fixing it:
>   Redownload the init script
>   For more information see:
>   doc/install/installation.md in section "Install Init Script"
>   Please fix the error above and rerun the checks.

"recipe_content" of "5-2-stable" should be

>  https://raw.github.com/gitlabhq/gitlabhq/5-2-stable/lib/support/init.d/gitlab

Fixes https://github.com/gitlabhq/gitlabhq/issues/4020
