### PR TITLE
Don't deactivate postgres explicit on update process 

### DIFF
--- a/doc/update/5.1-to-5.2.md
+++ b/doc/update/5.1-to-5.2.md
@@ -22,6 +22,16 @@ sudo -u git -H git checkout v1.4.0
 
 ### 4. Install libs, migrations etc
 
+If you running gitlab with a PostgreSQL-backend you have to call:
+
+```bash
+cd /home/git/gitlab
+sudo -u git -H bundle install --without development test mysql --deployment
+sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
+```
+
+While running with a MySQL-backend, the steps you have to do are:
+
 ```bash
 cd /home/git/gitlab
 sudo -u git -H bundle install --without development test postgres --deployment


### PR DESCRIPTION
Without, postgreSQL based installations will not be able to migrated which prevents from being updated.
