### PR TITLE
Hipchat service implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,9 @@ gem "redis-rails"
 # Campfire integration
 gem 'tinder', '~> 1.9.2'
 
+# HipChat integration
+gem "hipchat", "~> 0.9.0"
+
 group :assets do
   gem "sass-rails"
   gem "coffee-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
       railties (>= 3.1, < 4.1)
     hashie (1.2.0)
     hike (1.2.2)
+    hipchat (0.9.0)
+      httparty
     http_parser.rb (0.5.3)
     httparty (0.11.0)
       multi_json (~> 1.0)
@@ -532,6 +534,7 @@ DEPENDENCIES
   guard-rspec
   guard-spinach
   haml-rails
+  hipchat (~> 0.9.0)
   httparty
   jquery-atwho-rails (= 0.3.0)
   jquery-rails (= 2.1.3)

--- a/app/models/hipchat_service.rb
+++ b/app/models/hipchat_service.rb
@@ -1,0 +1,73 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id          :integer          not null, primary key
+#  type        :string(255)
+#  title       :string(255)
+#  token       :string(255)
+#  project_id  :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  active      :boolean          default(FALSE), not null
+#  project_url :string(255)
+#
+
+class HipchatService < Service
+  attr_accessible :room
+
+  validates :token, presence: true, if: :activated?
+
+  def title
+    'Hipchat'
+  end
+
+  def description
+    'Simple web-based real-time group chat'
+  end
+
+  def to_param
+    'hipchat'
+  end
+
+  def fields
+    [
+      { type: 'text', name: 'token',     placeholder: '' },
+      { type: 'text', name: 'room',      placeholder: '' }
+    ]
+  end
+
+  def execute(push_data)
+    gate[room].send('Gitlab', create_message(push_data))
+  end
+
+  private
+
+  def gate
+    @gate ||= HipChat::Client.new(token)
+  end
+
+  def create_message(push)
+    ref = push[:ref].gsub("refs/heads/", "")
+    before = push[:before]
+    after = push[:after]
+
+    message = ""
+    message << "#{push[:user_name]} "
+    if before =~ /000000/
+      message << "pushed new branch <a href=\"#{project.web_url}/commits/#{ref}\">#{ref}</a> to <a href=\"#{project.web_url}\">#{project.name_with_namespace.gsub!(/\s/,'')}</a>\n"
+    elsif after =~ /000000/
+      message << "removed branch #{ref} from <a href=\"#{project.web_url}\">#{project.name_with_namespace.gsub!(/\s/,'')}</a> \n"
+    else
+      message << "#pushed to branch <a href=\"#{project.web_url}/commits/#{ref}\">#{ref}</a> "
+      message << "of <a href=\"#{project.web_url}\">#{project.name_with_namespace.gsub!(/\s/,'')}</a> "
+      message << "(<a href=\"#{project.web_url}/compare/#{before}...#{after}\">Compare changes</a>)"
+      for commit in push[:commits] do
+        message << "<br /> - #{commit[:message]} (<a href=\"#{commit[:url]}\">#{commit[:id][0..5]}</a>)"
+      end
+    end
+
+    message
+  end
+
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,6 +46,7 @@ class Project < ActiveRecord::Base
   has_one :last_event, class_name: 'Event', order: 'events.created_at DESC', foreign_key: 'project_id'
   has_one :gitlab_ci_service, dependent: :destroy
   has_one :campfire_service, dependent: :destroy
+  has_one :hipchat_service, dependent: :destroy
   has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
   has_one :forked_from_project, through: :forked_project_link
 
@@ -236,7 +237,7 @@ class Project < ActiveRecord::Base
   end
 
   def available_services_names
-    %w(gitlab_ci campfire)
+    %w(gitlab_ci campfire hipchat)
   end
 
   def gitlab_ci?

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -12,3 +12,9 @@ Feature: Project Services
     And I click gitlab-ci service link
     And I fill gitlab-ci settings
     Then I should see service settings saved
+
+  Scenario: Activate hipchat service
+    When I visit project "Shop" services page
+    And I click hipchat service link
+    And I fill hipchat settings
+    Then I should see hipchat service settings saved

--- a/features/steps/project/project_services.rb
+++ b/features/steps/project/project_services.rb
@@ -10,6 +10,7 @@ class ProjectServices < Spinach::FeatureSteps
   Then 'I should see list of available services' do
     page.should have_content 'Services'
     page.should have_content 'Campfire'
+    page.should have_content 'Hipchat'
     page.should have_content 'GitLab CI'
   end
 
@@ -27,4 +28,20 @@ class ProjectServices < Spinach::FeatureSteps
   Then 'I should see service settings saved' do
     find_field('Project url').value.should == 'http://ci.gitlab.org/projects/3'
   end
+
+  And 'I click hipchat service link' do
+    click_link 'Hipchat'
+  end
+
+  And 'I fill hipchat settings' do
+    check 'Active'
+    fill_in 'Room', with: 'gitlab'
+    fill_in 'Token', with: 'verySecret'
+    click_button 'Save'
+  end
+
+  Then 'I should see hipchat service settings saved' do
+    find_field('Room').value.should == 'gitlab'
+  end
+
 end


### PR DESCRIPTION
This allows you to send push notifications to a Hipchat room.
The implementation is based on the existing Campfire service.
