### PR TITLE
Include groups in import with import repos rake task

### DIFF
--- a/doc/raketasks/maintenance.md
+++ b/doc/raketasks/maintenance.md
@@ -116,6 +116,8 @@ bundle exec rake gitlab:satellites:create RAILS_ENV=production
 Notes:
 
 * project owner will be a first admin
+* groups will be created as needed
+* group owner will be the first admin
 * existing projects will be skipped
 
 How to use:
@@ -132,5 +134,8 @@ Example output:
 ```
 Processing abcd.git
  * Created abcd (abcd.git)
+Processing group/xyz.git
+ * Created Group group (2)
+ * Created xyz (group/xyz.git)
 [...]
 ```


### PR DESCRIPTION
The current behavior for the import repos task is to only find top-level repos, e.g. `{repo_dir}/*.git`.  Projects already in groups (sub-directories), are not imported.  This patch extends the existing import to create groups (as needed), and import projects into groups.  Top-level projects are still imported with the same behavior as previously implemented.

Expand the import glob to include `**/*.git` to find projects in groups as well as top level projects.  Check for existing group, and create group if needed.  Set namespace_id for imported projects.

This has been tested (on v5.2) with a set of projects including top-level and grouped projects (one level deep only).
