### PR TITLE
Fix regression caused by using newer version of Grape

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,8 @@ gem "gitlab-gollum-lib", "~> 1.0.0", require: 'gollum-lib'
 gem "github-linguist", require: "linguist"
 
 # API
-gem "grape"
-gem "grape-entity"
+gem "grape", "~> 0.3.1"
+gem "grape-entity", "~> 0.2.0"
 
 # Format dates and times
 # based on human-friendly examples

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     gon (4.1.0)
       actionpack (>= 2.3.0)
       json
-    grape (0.4.1)
+    grape (0.3.1)
       activesupport
       builder
       hashie (>= 1.2.0)
@@ -183,7 +183,7 @@ GEM
       rack-accept
       rack-mount
       virtus
-    grape-entity (0.3.0)
+    grape-entity (0.2.0)
       activesupport
       multi_json (>= 1.3.2)
     growl (1.0.3)


### PR DESCRIPTION
This commit fixes the regression caused by using a newer version of Grape and Grape entity.  This solves Issue #4023.

I don't know if there was a particular reason for changing Grape version (commit 083d66563e8275fd13851ec0a1974cb17379f84f). If there is no compelling reason to change the Grape version, I recommend we revert that change with this PR to solve the current regression with raw content in the API.  This regression breaks tools that integrate with the API.

Before:
![before](https://f.cloud.github.com/assets/2394772/564751/7d1e10f2-c59e-11e2-93c4-7711f6db3151.png)

After:
![after](https://f.cloud.github.com/assets/2394772/564744/f8f7ae46-c59d-11e2-933b-4d9deafa360a.png)
