### PR TITLE
Allow snippets to be publically accessible in a secure way

### DIFF
--- a/app/controllers/public/snippets_controller.rb
+++ b/app/controllers/public/snippets_controller.rb
@@ -1,0 +1,34 @@
+class Public::SnippetsController < ApplicationController
+  skip_before_filter :authenticate_user!,
+    :reject_blocked, :set_current_user_for_observers,
+    :add_abilities
+
+  layout 'public'
+
+  def index
+    @snippets = Snippet.public_only
+  end
+
+  def show
+
+    @snippet = Snippet.where(:public_hashkey => params[:id]).first
+  
+    not_found if @snippet.nil?
+
+    send_data(
+      @snippet.content,
+      type: "text/plain",
+      disposition: 'inline',
+      filename: @snippet.file_name
+    )
+
+  end
+
+  protected
+
+  def not_found
+    # render :status => 404
+    raise ActionController::RoutingError.new("Not Found")
+  end
+
+end

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -27,6 +27,7 @@ class SnippetsController < ProjectResourceController
   def create
     @snippet = @project.snippets.new(params[:snippet])
     @snippet.author = current_user
+    @snippet.public_hashkey = Digest::MD5.hexdigest("#{Time.now}/#{@snippet.id}/#{@snippet.content}")
     @snippet.save
 
     if @snippet.valid?
@@ -40,7 +41,9 @@ class SnippetsController < ProjectResourceController
   end
 
   def update
-    @snippet.update_attributes(params[:snippet])
+    @snippet.assign_attributes(params[:snippet])
+    @snippet.assign_attributes({:public_hashkey => Digest::MD5.hexdigest("#{@snippet.created_at}/#{@snippet.id}/#{@snippet.content}") }) if @snippet.public_hashkey.nil? || @snippet.public_hashkey.blank?
+    @snippet.save 
 
     if @snippet.valid?
       redirect_to [@project, @snippet]

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -11,12 +11,13 @@
 #  updated_at :datetime         not null
 #  file_name  :string(255)
 #  expires_at :datetime
+#  public_hashkey :string(255)
 #
 
 class Snippet < ActiveRecord::Base
   include Linguist::BlobHelper
 
-  attr_accessible :title, :content, :file_name, :expires_at
+  attr_accessible :title, :content, :file_name, :expires_at, :public_hashkey
 
   belongs_to :project
   belongs_to :author, class_name: "User"
@@ -34,6 +35,7 @@ class Snippet < ActiveRecord::Base
   scope :fresh, -> { order("created_at DESC") }
   scope :non_expired, -> { where(["expires_at IS NULL OR expires_at > ?", Time.current]) }
   scope :expired, -> { where(["expires_at IS NOT NULL AND expires_at < ?", Time.current]) }
+  scope :public_only, -> { where(public: true) }
 
   def self.content_types
     [

--- a/app/views/snippets/show.html.haml
+++ b/app/views/snippets/show.html.haml
@@ -1,6 +1,6 @@
 %h3.page_title
   = @snippet.title
-  %small= @snippet.file_name
+  %small= link_to "/public/snippets/#{@snippet.public_hashkey}", "/public/snippets/#{@snippet.public_hashkey}"
   - if can?(current_user, :admin_snippet, @project) || @snippet.author == current_user
     = link_to "Edit", edit_project_snippet_path(@project, @snippet), class: "btn btn-small pull-right", title: 'Edit Snippet'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Gitlab::Application.routes.draw do
   namespace :public do
     resources :projects, only: [:index]
     root to: "projects#index"
+    resources :snippets, only: [:show]
   end
 
   #

--- a/db/migrate/20130526204024_add_snippets_hashkey.rb
+++ b/db/migrate/20130526204024_add_snippets_hashkey.rb
@@ -1,0 +1,16 @@
+require 'digest/md5'
+
+class AddSnippetsHashkey < ActiveRecord::Migration
+  def up
+    add_column :snippets, :public_hashkey, :string
+    Snippet.all.each { |snippet| 
+      content = "#{snippet.created_at}/#{snippet.id}/#{snippet.content}"
+      snippet.public_hashkey = Digest::MD5.hexdigest(content)
+      snippet.save
+    }
+  end
+
+  def down
+    remove_column :snippets, :public_hashkey
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130506095501) do
+ActiveRecord::Schema.define(:version => 20130526204024) do
 
   create_table "deploy_keys_projects", :force => true do |t|
     t.integer  "deploy_key_id", :null => false
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(:version => 20130506095501) do
     t.datetime "updated_at", :null => false
     t.string   "file_name"
     t.datetime "expires_at"
+    t.string   "public_hashkey"
   end
 
   add_index "snippets", ["created_at"], :name => "index_snippets_on_created_at"


### PR DESCRIPTION
Even though snippets have a "raw" button/function, they do not function quite as well as gists, because requesting a snippet via the raw URL, still requires authentication. 

To solve this, and add gist-like access functionality to snippets, on creation (and rake:migrate) a unique md5 hashcode is assigned to a snippet, which lasts throughout its lifetime. Any user who happens to know the md5 hashcode can view the snippet at any time _without authentication_ through the URL /public/snippets/HASHCODE. This is the mechanism that gists implement, whereby any public user by knowing the hashcode may access an otherwise private gist. This is very useful to keep something basically secure and private, but allow external mechanisms to interface with the snippet.

EXAMPLE OF USE:

Using this new functionality, it is now possible to have scripts in snippets, which update overtime and can be referenced by external mechanisms. For example:

curl http://gitlabserver/public/snippets/HASHCODE | bash -s arg1 arg2 arg3 

as part of an install process. 
