### PR TITLE
Jira - Fixed Jira Issue tracker support

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -70,6 +70,11 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
+    # 
+    # jira:
+    #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
+    #   issues_url: "http://jira.sample/browse/:id"
+    #   new_issue_url: "http://jira.sample/secure/CreateIssue.jspa"
 
   ## Gravatar
   gravatar:

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -7,6 +7,7 @@ module Gitlab
   # Supported reference formats are:
   #   * @foo for team members
   #   * #123 for issues
+  #   * #JIRA-123 for Jira issues
   #   * !123 for merge requests
   #   * $123 for snippets
   #   * 123456 for commits
@@ -97,7 +98,7 @@ module Gitlab
       (?<prefix>\W)?                         # Prefix
       (                                      # Reference
          @(?<user>[a-zA-Z][a-zA-Z0-9_\-\.]*) # User name
-        |\#(?<issue>\d+)                     # Issue ID
+        |\#(?<issue>([a-zA-Z]+-)?\d+)        # Issue ID
         |!(?<merge_request>\d+)              # MR ID
         |\$(?<snippet>\d+)                   # Snippet ID
         |(?<commit>[\h]{6,40})               # Commit ID


### PR DESCRIPTION
Integration with Jira issue tracker was not working out of the box, because Jira uses issues ids as: PROJECT-1234.  Changed the Issues regular expression to support this format as well.
Also added configuration example for a Jira server.
