### PR TITLE
Update api docs and remove old attribute from User entity.

### DIFF
--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -14,32 +14,32 @@ GET /users
     "username": "john_smith",
     "email": "john@example.com",
     "name": "John Smith",
-    "blocked": false,
+    "state": "active",
     "created_at": "2012-05-23T08:00:58Z",
     "bio": null,
     "skype": "",
     "linkedin": "",
     "twitter": "",
-    "dark_scheme": false,
     "extern_uid": "john.smith",
     "provider": "provider_name",
     "theme_id": 1
+    "color_scheme_id": 2
   },
   {
     "id": 2,
     "username": "jack_smith",
     "email": "jack@example.com",
     "name": "Jack Smith",
-    "blocked": false,
+    "state": "blocked",
     "created_at": "2012-05-23T08:01:01Z",
     "bio": null,
     "skype": "",
     "linkedin": "",
     "twitter": "",
-    "dark_scheme": true,
     "extern_uid": "jack.smith",
     "provider": "provider_name",
     "theme_id": 1
+    "color_scheme_id": 3
   }
 ]
 ```
@@ -63,16 +63,16 @@ Parameters:
   "username": "john_smith",
   "email": "john@example.com",
   "name": "John Smith",
-  "blocked": false,
+  "state": "active",
   "created_at": "2012-05-23T08:00:58Z",
   "bio": null,
   "skype": "",
   "linkedin": "",
   "twitter": "",
-  "dark_scheme": false,
   "extern_uid": "john.smith",
   "provider": "provider_name",
   "theme_id": 1
+  "color_scheme_id": 2
 }
 ```
 
@@ -156,14 +156,14 @@ GET /user
   "email": "john@example.com",
   "name": "John Smith",
   "private_token": "dd34asd13as",
-  "blocked": false,
+  "state": "active",
   "created_at": "2012-05-23T08:00:58Z",
   "bio": null,
   "skype": "",
   "linkedin": "",
   "twitter": "",
-  "dark_scheme": false,
   "theme_id": 1
+  "color_scheme_id": 2
   "is_admin": false,
   "can_create_group" : true,
   "can_create_team" : true,

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -2,7 +2,7 @@ module API
   module Entities
     class User < Grape::Entity
       expose :id, :username, :email, :name, :bio, :skype, :linkedin, :twitter,
-             :dark_scheme, :theme_id, :state, :created_at, :extern_uid, :provider
+             :theme_id, :color_scheme_id, :state, :created_at, :extern_uid, :provider
     end
 
     class UserSafe < Grape::Entity


### PR DESCRIPTION
The API docs incorrectly referenced a few attributes associated with users. The 'blocked' attribute has been replaced with 'state'. Also, 'dark_scheme' seems to no longer be available in the User model so it should be removed from the exposed attributes in the API User entity.

The screenshot shows the available attributes prior to this update.  You can see that dark_scheme is not present, although it was exposed via User entity.  Also, you can see that blocked is not present and is instead replaced with state.

![user_api](https://f.cloud.github.com/assets/2394772/576066/f1cdc75e-c7f0-11e2-8d84-dc4a534f8887.png)
