### PR TITLE
fixed a typo (mysql/postgres were switched)

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -201,10 +201,10 @@ Make sure to update username/password in config/database.yml.
     sudo gem install charlock_holmes --version '0.6.9.4'
 
     # For MySQL (note, the option says "without")
-    sudo -u git -H bundle install --deployment --without development test postgres
+    sudo -u git -H bundle install --deployment --without development test mysql
 
     # Or for PostgreSQL
-    sudo -u git -H bundle install --deployment --without development test mysql
+    sudo -u git -H bundle install --deployment --without development test postgres
 
 
 ## Initialise Database and Activate Advanced Features


### PR DESCRIPTION
In section "Install Gems" the mysql/postgres statements at the end of the commands were switched. The mysql one stated 'postgres' and the other way around.
