### PR TITLE
adding update info regarding gitlab-shell config.yml (re: dashboard update problems)

### DIFF
--- a/doc/update/5.0-to-5.1.md
+++ b/doc/update/5.0-to-5.1.md
@@ -23,7 +23,13 @@ sudo -u git -H git checkout 5-1-stable
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
 sudo -u git -H git checkout v1.3.0
+# replace your old config with the new one
+sudo -u git -H mv config.yml config.yml.old
+sudo -u git -H cp config.yml.example config.yml
+# edit options to match old config
+sudo -u git -H vi config.yml
 ```
+
 
 ### 4. Install libs, migrations etc
 


### PR DESCRIPTION
Commit gitlabhq/gitlab-shell@93bfff7b3fc30fc362b90c4d362528f6e49786e6 from Chris adds remote redis support to gitlab-shell.

Because of the new feature, additional configuration options must be specified in gitlab-shell's [config.yml](https://github.com/gitlabhq/gitlab-shell/blob/master/config.yml.example).

The [documentation](https://github.com/gitlabhq/gitlabhq/blob/master/doc/update/5.0-to-5.1.md) that describes upgrading from GitLab 5.0 to 5.1 mentions updating gitlab-shell to v1.3.0 but does not inform the upgrader that changes have been made to `config.yml` and that the user's existing `config.yml` needs to be updated with the new options.

Without the redis configuration options, I encountered issues similar to: #4027, #3633, #4061, and #3807.

After updating gitlab-shell's `config.yml` with the new redis options, the dashboard updates correctly again.

![gitlab](https://f.cloud.github.com/assets/1251005/581698/f1a00480-c8a5-11e2-99d7-75773af96cdb.png)
