### PR TITLE
fixes for gitlab restore with non-standard backup and repo dirs

### DIFF
--- a/lib/backup/repository.rb
+++ b/lib/backup/repository.rb
@@ -71,7 +71,7 @@ module Backup
 
       print 'Put GitLab hooks in repositories dirs'.yellow
       gitlab_shell_user_home = File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
-      if system("#{gitlab_shell_user_home}/gitlab-shell/support/rewrite-hooks.sh")
+      if system("#{gitlab_shell_user_home}/gitlab-shell/support/rewrite-hooks.sh #{Gitlab.config.gitlab_shell.repos_path}")
         puts " [DONE]".green
       else
         puts " [FAILED]".red

--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -91,15 +91,20 @@ namespace :gitlab do
       ENV["VERSION"] = "#{settings[:db_version]}" if settings[:db_version].to_i > 0
 
       # backups directory is not always sub of Rails root and able to execute the git rev-parse below
-      Dir.chdir(Rails.root)
+      begin
+        Dir.chdir(Rails.root)
 
-      # restoring mismatching backups can lead to unexpected problems
-      if settings[:gitlab_version] != %x{git rev-parse HEAD}.gsub(/\n/,"")
-        puts "GitLab version mismatch:".red
-        puts "  Your current HEAD differs from the HEAD in the backup!".red
-        puts "  Please switch to the following revision and try again:".red
-        puts "  revision: #{settings[:gitlab_version]}".red
-        exit 1
+        # restoring mismatching backups can lead to unexpected problems
+        if settings[:gitlab_version] != %x{git rev-parse HEAD}.gsub(/\n/, "")
+          puts "GitLab version mismatch:".red
+          puts "  Your current HEAD differs from the HEAD in the backup!".red
+          puts "  Please switch to the following revision and try again:".red
+          puts "  revision: #{settings[:gitlab_version]}".red
+          exit 1
+        end
+      ensure
+        # chdir back to original intended dir
+        Dir.chdir(Gitlab.config.backup.path)
       end
 
       Rake::Task["gitlab:backup:db:restore"].invoke

--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -90,6 +90,9 @@ namespace :gitlab do
       settings = YAML.load_file("backup_information.yml")
       ENV["VERSION"] = "#{settings[:db_version]}" if settings[:db_version].to_i > 0
 
+      # backups directory is not always sub of Rails root and able to execute the git rev-parse below
+      Dir.chdir(Rails.root)
+
       # restoring mismatching backups can lead to unexpected problems
       if settings[:gitlab_version] != %x{git rev-parse HEAD}.gsub(/\n/,"")
         puts "GitLab version mismatch:".red

--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -26,10 +26,12 @@ namespace :gitlab do
     warn_user_is_not_gitlab
 
     gitlab_shell_authorized_keys = File.join(File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}"),'.ssh/authorized_keys')
-    puts "This will rebuild an authorized_keys file."
-    puts "You will lose any data stored in #{gitlab_shell_authorized_keys}."
-    ask_to_continue
-    puts ""
+    unless ENV['force'] == 'yes'
+      puts "This will rebuild an authorized_keys file."
+      puts "You will lose any data stored in #{gitlab_shell_authorized_keys}."
+      ask_to_continue
+      puts ""
+    end
 
     system("echo '# Managed by gitlab-shell' > #{gitlab_shell_authorized_keys}")
 


### PR DESCRIPTION
**NOTE** These are dependent upon the following pull request on gitlab-shell: https://github.com/gitlabhq/gitlab-shell/pull/60

These fixes will allow a restore of gitlab when the backups and
repositories directories are in non-standard locations (ie sub-dirs
of gitlabhq).  Also allows the restore to be run from script
overriding the need of a user to confirm the rebuild of the
authorized_keys file.
