### PR TITLE
addresses issue #4156

### DIFF
--- a/app/views/team_members/_team.html.haml
+++ b/app/views/team_members/_team.html.haml
@@ -1,3 +1,4 @@
+- can_admin_project = (can? current_user, :admin_project, @project)
 - team.each do |access, members|
   - role = Project.access_options.key(access).pluralize
   .ui-box{class: role.downcase}
@@ -6,4 +7,4 @@
       %span.light (#{members.size})
     %ul.well-list
       - members.sort_by(&:user_name).each do |team_member|
-        = render 'team_members/team_member', member: team_member
+        = render 'team_members/team_member', member: team_member, current_user_can_admin_project: can_admin_project

--- a/app/views/team_members/_team_member.html.haml
+++ b/app/views/team_members/_team_member.html.haml
@@ -1,5 +1,5 @@
 - user = member.user
-- allow_admin = can? current_user, :admin_project, @project
+- allow_admin = current_user_can_admin_project
 %li{id: dom_id(user), class: "team_member_row user_#{user.id}"}
   .row
     .span4


### PR DESCRIPTION
when there are large number of members of in a team, for me 260+

Before:
[2013-06-01 00:55:01]   Rendered team_members/_team_member.html.haml (206.9ms)
[2013-06-01 00:55:01]   Rendered team_members/_team.html.haml (54479.2ms)

After:
[2013-06-02 02:40:36]   Rendered team_members/_team_member.html.haml (2.1ms)
[2013-06-02 02:40:36]   Rendered team_members/_team.html.haml (1412.6ms)

There are no doubt more elegant solutions, but this addressed my immediate problem.
