### PR TITLE
500 error on showing not existed commit fixed

### DIFF
--- a/app/controllers/commit_controller.rb
+++ b/app/controllers/commit_controller.rb
@@ -11,7 +11,11 @@ class CommitController < ProjectResourceController
     result = CommitLoadContext.new(project, current_user, params).execute
 
     @commit = result[:commit]
-    git_not_found! unless @commit
+    
+    if @commit.nil?
+      git_not_found!
+      return
+    end
 
     @suppress_diff = result[:suppress_diff]
 


### PR DESCRIPTION
From [Rails Guides](http://guides.rubyonrails.org/v2.3.11/layouts_and_rendering.html)

```
Rails will start the rendering process to dump the @book variable into 
the special_show view. But this will not stop the rest of the code in the 
show action from running, and when Rails hits the end of the action, it 
will start to render the show view – and throw an error.
```

In this case we need to place `return` dirrectly or use exceptions here.
