### PR TITLE
user_color_scheme_class with no current_user

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,13 @@ require 'digest/md5'
 require 'uri'
 
 module ApplicationHelper
+  COLOR_SCHEMES = {
+    1 => 'white',
+    2 => 'black',
+    3 => 'solarized-dark',
+    4 => 'monokai',
+  }
+  COLOR_SCHEMES.default = 'white'
 
   # Check if a particular controller is the current one
   #
@@ -124,17 +131,7 @@ module ApplicationHelper
   end
 
   def user_color_scheme_class
-    # in case we dont have current_user (ex. in mailer)
-    return 1 unless defined?(current_user)
-
-    case current_user.color_scheme_id
-    when 1 then 'white'
-    when 2 then 'black'
-    when 3 then 'solarized-dark'
-    when 4 then 'monokai'
-    else
-      'white'
-    end
+    COLOR_SCHEMES[current_user.try(:color_scheme_id)]
   end
 
   # Define whenever show last push event

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -83,4 +83,26 @@ describe ApplicationHelper do
     end
 
   end
+
+  describe "user_color_scheme_class" do
+    context "with current_user is nil" do
+      it "should return a string" do
+        stub!(:current_user).and_return(nil)
+        user_color_scheme_class.should be_kind_of(String)
+      end
+    end
+
+    context "with a current_user" do
+      (1..5).each do |color_scheme_id|
+        context "with color_scheme_id == #{color_scheme_id}" do
+          it "should return a string" do
+            current_user = double(:color_scheme_id => color_scheme_id)
+            stub!(:current_user).and_return(current_user)
+            user_color_scheme_class.should be_kind_of(String)
+          end
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This refactors the `user_color_scheme_class` to use a hash with a default.
This prevents problems with workers that don't have access to the
current_user.

Fixes issue #2758

The previous solution (commit 84e4cfc6bbfa7251dc8e2b88ca4c507b98cadc61) returned
a number, not a string.  I also added unit tests for it.
