### PR TITLE
Add a clone button for GitHub client

### DIFF
--- a/app/views/projects/_clone_panel.html.haml
+++ b/app/views/projects/_clone_panel.html.haml
@@ -1,6 +1,10 @@
 .project_clone_panel
   .row
     .span8
+      = link_to "javascript:void((function(){var ua=navigator.userAgent.toLowerCase();var s=/windows|win32/.test(ua)?'windows':(/macintosh|mac os x/.test(ua)?'mac':'');if(s){document.location='github-'+s+'://openRepo/"+@project.http_url_to_repo+"';}})())", class: 'btn grouped' do
+        %i.icon-hdd
+        Clone
+
       .form-horizontal= render "shared/clone_panel"
     .span3.pull-right
       .pull-right

--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -22,7 +22,7 @@
           - if current_user
             = link_to_project project
           - else
-		    = link_to project.name_with_namespace, "javascript:void((function(){var ua=navigator.userAgent.toLowerCase();var s=/windows|win32/.test(ua)?'windows':(/macintosh|mac os x/.test(ua)?'mac':'');if(s){document.location='github-'+s+'://openRepo/"+project.http_url_to_repo+"';}})())"
+            = link_to project.name_with_namespace, "javascript:void((function(){var ua=navigator.userAgent.toLowerCase();var s=/windows|win32/.test(ua)?'windows':(/macintosh|mac os x/.test(ua)?'mac':'');if(s){document.location='github-'+s+'://openRepo/"+project.http_url_to_repo+"';}})())"
           .pull-right
             %pre.dark.tiny git clone #{project.http_url_to_repo}
         %p.description

--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -22,7 +22,7 @@
           - if current_user
             = link_to_project project
           - else
-            = project.name_with_namespace
+		    = link_to project.name_with_namespace, "javascript:void((function(){var ua=navigator.userAgent.toLowerCase();var s=/windows|win32/.test(ua)?'windows':(/macintosh|mac os x/.test(ua)?'mac':'');if(s){document.location='github-'+s+'://openRepo/"+project.http_url_to_repo+"';}})())"
           .pull-right
             %pre.dark.tiny git clone #{project.http_url_to_repo}
         %p.description

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,7 +1,7 @@
 .input-prepend.input-append.project_clone_holder
-  %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
-  %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= gitlab_config.protocol.upcase
-  = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select span7", readonly: true
+  %button{class: "btn", :"data-clone" => @project.ssh_url_to_repo} SSH
+  %button{class: "btn active", :"data-clone" => @project.http_url_to_repo}= gitlab_config.protocol.upcase
+  = text_field_tag :project_clone, @project.http_url_to_repo, class: "one_click_select span7", readonly: true
   %span.add-on
     - if @project.public
       .cblue


### PR DESCRIPTION
The clone button support GitHub client to clone gitlab projects, can work correctly under both Mac and Windows.
