### PR TITLE
Authorize all teams to admin: fix 500 error on showing team page.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -125,7 +125,7 @@ class Ability
       rules = []
 
       # Only group owner and administrators can manage team
-      if team.owner == user || team.admin?(user) || user.admin?
+      if user.admin? || team.owner == user || team.admin?(user)
         rules << [ :manage_user_team ]
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,8 +245,12 @@ class User < ActiveRecord::Base
   end
 
   def authorized_teams
-    @team_ids ||= (user_teams.pluck(:id) + own_teams.pluck(:id)).uniq
-    UserTeam.where(id: @team_ids)
+    if admin?
+      UserTeam.scoped
+    else
+      @team_ids ||= (user_teams.pluck(:id) + own_teams.pluck(:id)).uniq
+      UserTeam.where(id: @team_ids)
+    end
   end
 
   # Team membership in authorized projects

--- a/app/models/user_team.rb
+++ b/app/models/user_team.rb
@@ -111,6 +111,6 @@ class UserTeam < ActiveRecord::Base
   end
 
   def admin?(member)
-    user_team_user_relationships.with_user(member).first.group_admin?
+    user_team_user_relationships.with_user(member).first.try(:group_admin?)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -126,6 +126,23 @@ describe User do
     it { @user.owned_groups.should == [@group] }
   end
 
+  describe 'teams' do
+    before do
+      ActiveRecord::Base.observers.enable(:user_observer)
+      @admin = create :user, admin: true
+      @user1 = create :user
+      @user2 = create :user
+      @team = create :user_team, owner: @user1
+    end
+
+    it { @admin.authorized_teams.should == [@team] }
+    it { @user1.authorized_teams.should == [@team] }
+    it { @user2.authorized_teams.should be_empty }
+    it { @admin.should be_can(:manage_user_team, @team) }
+    it { @user1.should be_can(:manage_user_team, @team) }
+    it { @user2.should_not be_can(:manage_user_team, @team) }
+  end
+
   describe 'namespaced' do
     before do
       ActiveRecord::Base.observers.enable(:user_observer)


### PR DESCRIPTION
500 error was occured in the following steps:
1. user1 creates new team "team1".
2. Assign team1 to project1.
3. Sign in as admin. This admin is not a member of team1.
4. Open project1 team setting page (/project1/team).
5. Click "team1" link in "Assigned teams" area.
6. 500 error.

Fixed this issue.
