### PR TITLE
Fix abort gitlab:app:check

### DIFF
--- a/lib/gitlab/version_info.rb
+++ b/lib/gitlab/version_info.rb
@@ -5,7 +5,7 @@ module Gitlab
     attr_reader :major, :minor, :patch
 
     def self.parse(str)
-      if m = str.match(/(\d+)\.(\d+)\.(\d+)/)
+      if str && m = str.match(/(\d+)\.(\d+)\.(\d+)/)
         VersionInfo.new(m[1].to_i, m[2].to_i, m[3].to_i)
       else
         VersionInfo.new

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -659,7 +659,7 @@ namespace :gitlab do
     current_version = Gitlab::VersionInfo.parse(gitlab_shell_version)
 
     print "GitLab Shell version >= #{required_version} ? ... "
-    if required_version <= current_version
+    if current_version.valid? && required_version <= current_version
       puts "OK (#{current_version})".green
     else
       puts "FAIL. Please update gitlab-shell to #{required_version} from #{current_version}".red
@@ -673,7 +673,7 @@ namespace :gitlab do
     puts "Your git bin path is \"#{Gitlab.config.git.bin_path}\""
     print "Git version >= #{required_version} ? ... "
 
-    if required_version <= current_version
+    if current_version.valid? && required_version <= current_version
         puts "yes (#{current_version})".green
     else
       puts "no".red


### PR DESCRIPTION
When the file that pointed git bin_path in gitlab.yml dose'nt exist,
bundle rake gitlab:app:check would be aborted.

refs #4205

Newer output is like following

```
Your git bin path is "/usr/local/bin/git/a"
Git version >= 1.7.10 ? ... no
  Try fixing it:
  Update your git to a version >= 1.7.10 from Unknown
  Please fix the error above and rerun the checks.
```
