### PR TITLE
Gravatar image fixes when gravatar unavailable

### DIFF
--- a/app/assets/stylesheets/gitlab_bootstrap/avatar.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/avatar.scss
@@ -15,6 +15,7 @@
 
   &.s16 { width: 16px; height: 16px; margin-right: 6px; }
   &.s24 { width: 24px; height: 24px; margin-right: 8px; }
+  &.s26 { width: 26px; height: 26px; margin-right: 8px; }
   &.s32 { width: 32px; height: 32px; margin-right: 10px; }
   &.s90 { width: 90px; height: 90px; margin-right: 15px; }
 }

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -25,7 +25,7 @@ module ProjectsHelper
     author_html =  ""
 
     # Build avatar image tag
-    author_html << image_tag(gravatar_icon(author.try(:email), opts[:size]), width: opts[:size], class: "avatar avatar-inline #{"s#{opts[:size]}" if opts[:size]}") if opts[:avatar]
+    author_html << image_tag(gravatar_icon(author.try(:email), opts[:size]), width: opts[:size], class: "avatar avatar-inline #{"s#{opts[:size]}" if opts[:size]}", alt:'') if opts[:avatar]
 
     # Build name span tag
     author_html << content_tag(:span, sanitize(author.name), class: 'author') if opts[:name]

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -20,12 +20,11 @@
 
 .row
   .span6
-<<<<<<< HEAD
     .ui-box
       %h5.title
         Account:
         .pull-right
-          = image_tag gravatar_icon(@admin_user.email, 32), class: "avatar s32", alt: ''
+          = image_tag gravatar_icon(@admin_user.email, 32), class:"avatar s32", alt:""
       %ul.well-list
         %li
           %span.light Name:

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -20,11 +20,12 @@
 
 .row
   .span6
+<<<<<<< HEAD
     .ui-box
       %h5.title
         Account:
         .pull-right
-          = image_tag gravatar_icon(@admin_user.email, 32), class: "avatar s32"
+          = image_tag gravatar_icon(@admin_user.email, 32), class: "avatar s32", alt: ''
       %ul.well-list
         %li
           %span.light Name:
@@ -62,7 +63,6 @@
             %span.light Created by:
             %strong
               = link_to @admin_user.created_by.name, [:admin, @admin_user.created_by]
-
     %hr
     %h5
       Add User to Projects

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -1,6 +1,6 @@
 %li.commit
   %p
-    = link_to commit[:id][0..8], project_commit_path(project, commit[:id]), class: "commit_short_id"
+    = link_to commit[:id][0..8], project_commit_path(project, commit[:id]), class: "commit_short_id", alt: ''
     %span= commit[:author][:name]
     &ndash;
     = image_tag gravatar_icon(commit[:author][:email]), class: "avatar", width: 16

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -4,7 +4,7 @@
       #{time_ago_in_words(event.created_at)} ago.
 
     = cache event do
-      = image_tag gravatar_icon(event.author_email), class: "avatar s24"
+      = image_tag gravatar_icon(event.author_email), class: "avatar s24", alt:''
 
       - if event.push?
         = render "events/event/push", event: event

--- a/app/views/groups/people.html.haml
+++ b/app/views/groups/people.html.haml
@@ -12,7 +12,7 @@
       %ul.well-list
         - @users.each do |user|
           %li
-            = image_tag gravatar_icon(user.email, 16), class: "avatar s16"
+            = image_tag gravatar_icon(user.email, 16), class: "avatar s16" , alt: ''
             %strong= user.name
             %span.cgray= user.email
             - if @group.owner == user

--- a/app/views/issues/_issues.html.haml
+++ b/app/views/issues/_issues.html.haml
@@ -53,7 +53,7 @@
             - @project.users.sort_by(&:name).each do |user|
               %li
                 = link_to project_issues_with_filter_path(@project, assignee_id: user.id) do
-                  = image_tag gravatar_icon(user.email), class: "avatar s16"
+                  = image_tag gravatar_icon(user.email), class: "avatar s16", alt: ''
                   = user.name
 
         .dropdown.inline.prepend-left-10

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -37,5 +37,4 @@
             %i.icon-signout
         %li
           = link_to current_user, class: "profile-pic" do
-            = image_tag gravatar_icon(current_user.email, 26)
-
+            = image_tag(gravatar_icon(current_user.email, 26),alt: '',class: "avatar s26")

--- a/app/views/notes/_discussion.html.haml
+++ b/app/views/notes/_discussion.html.haml
@@ -8,7 +8,7 @@
       = link_to "javascript:;", class: "js-details-target turn-off js-toggler-target" do
         %i.icon-eye-open
         Show discussion
-    = image_tag gravatar_icon(note.author.email), class: "avatar s32"
+    = image_tag gravatar_icon(note.author.email), class: "avatar s32", alt: ''
     %div
       = link_to_member(@project, note.author, avatar: false)
       - if note.for_merge_request?

--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -8,7 +8,7 @@
       - if(note.author_id == current_user.id) || can?(current_user, :admin_note, @project)
         = link_to project_note_path(@project, note), title: "Remove comment", method: :delete, confirm: 'Are you sure you want to remove comment?', remote: true, class: "danger js-note-delete" do
           %i.icon-trash.cred
-    = image_tag gravatar_icon(note.author.email), class: "avatar s32"
+    = image_tag gravatar_icon(note.author.email), class: "avatar s32", alt: ''
     = link_to_member(@project, note.author, avatar: false)
     %span.note-last-update
       = time_ago_in_words(note.updated_at)

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,5 +1,5 @@
 .profile_avatar_holder
-  = image_tag gravatar_icon(@user.email, 90)
+  = image_tag gravatar_icon(@user.email, 90), alt: ''
 %h3.page_title
   = @user.name
   %br

--- a/app/views/repositories/_branch.html.haml
+++ b/app/views/repositories/_branch.html.haml
@@ -12,7 +12,7 @@
   %td
     = link_to project_commit_path(@project, commit.id), class: 'commit_short_id' do
       = commit.short_id
-    = image_tag gravatar_icon(commit.author_email), class: "avatar s16"
+    = image_tag gravatar_icon(commit.author_email), class: "avatar s16", alt: ''
     %span.light
       = gfm escape_once(truncate(commit.title, length: 40))
     %span

--- a/app/views/repositories/_feed.html.haml
+++ b/app/views/repositories/_feed.html.haml
@@ -11,7 +11,7 @@
     %div
       = link_to project_commits_path(@project, commit.id) do
         %code= commit.short_id
-      = image_tag gravatar_icon(commit.author_email), class: "", width: 16
+      = image_tag gravatar_icon(commit.author_email), class: "", width: 16, alt: ''
       = gfm escape_once(truncate(commit.title, length: 40))
   %td
     %span.pull-right.cgray

--- a/app/views/repositories/stats.html.haml
+++ b/app/views/repositories/stats.html.haml
@@ -19,7 +19,7 @@
     %ol.styled
       - @stats.authors[0...50].each do |author|
         %li
-          = image_tag gravatar_icon(author.email, 16), class: 'avatar s16'
+          = image_tag gravatar_icon(author.email, 16), class: 'avatar s16', alt: ''
           = author.name
           %small.light= author.email
           .pull-right

--- a/app/views/snippets/_snippet.html.haml
+++ b/app/views/snippets/_snippet.html.haml
@@ -25,6 +25,6 @@
     = "##{snippet.id}"
     %span.light
       by
-      = image_tag gravatar_icon(snippet.author_email), class: "avatar avatar-inline s16"
+      = image_tag gravatar_icon(snippet.author_email), class: "avatar avatar-inline s16", alt: ''
       = snippet.author_name
 

--- a/app/views/team_members/_team_member.html.haml
+++ b/app/views/team_members/_team_member.html.haml
@@ -4,7 +4,7 @@
   .row
     .span4
       = link_to user, title: user.name, class: "dark" do
-        = image_tag gravatar_icon(user.email, 32), class: "avatar s32"
+        = image_tag gravatar_icon(user.email, 32), class: "avatar s32", alt: ''
         %strong= truncate(user.name, lenght: 40)
         %br
         %small.cgray= user.username

--- a/app/views/teams/members/_member.html.haml
+++ b/app/views/teams/members/_member.html.haml
@@ -4,7 +4,7 @@
   .row
     .span3
       = link_to user_path(user.username), title: user.name, class: "dark" do
-        = image_tag gravatar_icon(user.email, 40), class: "avatar s32"
+        = image_tag gravatar_icon(user.email, 40), class: "avatar s32", alt: ''
       = link_to user_path(user.username), title: user.name, class: "dark" do
         %strong= truncate(user.name, lenght: 40)
         %br

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,7 @@
 .row
   .span8
     %h3.page_title
-      = image_tag gravatar_icon(@user.email, 90), class: "avatar s90"
+      = image_tag gravatar_icon(@user.email, 90), class: "avatar s90", alt: ''
       = @user.name
       - if @user == current_user
         .pull-right


### PR DESCRIPTION
-Alt text to image was set to hash, which would make the page display hashes if the image/gravatar  wasn't available, set the alt text to '', and made the main tool bar image follow the same or similar constraints as the other images (.avatar, .s26)

Conflicts:
    app/assets/stylesheets/themes/ui_bb.scss
    app/views/snippets/_snippet.html.haml
