### PR TITLE
use git user in check script

### DIFF
--- a/script/check
+++ b/script/check
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo -u gitlab -H bundle exec rake gitlab:check RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production


### PR DESCRIPTION
No more separate gitlab user since 5.0.

Should also be merged into 5-0-stable, 5-1-stable, and 5-2-stable.
