### PR TITLE
Fix rendering of README.txt on tree page. See #1676

### DIFF
--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -48,7 +48,7 @@ module TreeHelper
   end
 
   def plain_text_readme? filename
-    filename == 'README'
+    filename =~ /^README(.txt)?$/i
   end
 
   # Simple shortcut to File.join


### PR DESCRIPTION
_I posted an incorrect Pull Request a few minutes ago. Ignore that one. This is the correct one when merging into master_

Previously, only files that where named exactly "README" were rendered as plaintext. Files named "Readme", "README.txt" or something similar were incorrectly handled as Markdown which resulted in a missing `<pre>` tag

Consider this to be a quick and dirty fix. A cleaner version would be to share a partial between `app/views/tree/_tree.html.haml` and `app/views/blob/_text.html.haml` instead of having `app/views/tree/_readme.html.haml`. This woukd ensure that file rendering is consistent between those two pages but I'm not that fluent in HAML and your testing workflow.
