### PR TITLE
Routing fix Commit-List: branch with # and + in name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,11 +251,11 @@ Gitlab::Application.routes.draw do
 
       member do
         # tree viewer logs
-        get "logs_tree", constraints: { id: /[a-zA-Z.\/0-9_\-#%]+/ }
+        get "logs_tree", constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ }
         get "logs_tree/:path" => "refs#logs_tree",
           as: :logs_file,
           constraints: {
-            id:   /[a-zA-Z.0-9\/_\-#%]+/,
+            id:   /[a-zA-Z.0-9\/_\-#%+]+/,
             path: /.*/
           }
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,11 +251,11 @@ Gitlab::Application.routes.draw do
 
       member do
         # tree viewer logs
-        get "logs_tree", constraints: { id: /[a-zA-Z.\/0-9_\-]+/ }
+        get "logs_tree", constraints: { id: /[a-zA-Z.\/0-9_\-#%]+/ }
         get "logs_tree/:path" => "refs#logs_tree",
           as: :logs_file,
           constraints: {
-            id:   /[a-zA-Z.0-9\/_\-]+/,
+            id:   /[a-zA-Z.0-9\/_\-#%]+/,
             path: /.*/
           }
       end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -202,8 +202,10 @@ describe RefsController, "routing" do
   it "to #logs_tree" do
     get("/gitlabhq/refs/stable/logs_tree").should             route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'stable')
     get("/gitlabhq/refs/feature%2345/logs_tree").should             route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature#45')
+    get("/gitlabhq/refs/feature%2B45/logs_tree").should             route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature+45')
     get("/gitlabhq/refs/stable/logs_tree/foo/bar/baz").should route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'stable', path: 'foo/bar/baz')
     get("/gitlabhq/refs/feature%2345/logs_tree/foo/bar/baz").should route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature#45', path: 'foo/bar/baz')
+    get("/gitlabhq/refs/feature%2B45/logs_tree/foo/bar/baz").should route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature+45', path: 'foo/bar/baz')
     get("/gitlab/gitlabhq/refs/stable/logs_tree/files.scss").should route_to('refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'files.scss')
   end
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -201,7 +201,9 @@ describe RefsController, "routing" do
 
   it "to #logs_tree" do
     get("/gitlabhq/refs/stable/logs_tree").should             route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'stable')
+    get("/gitlabhq/refs/feature%2345/logs_tree").should             route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature#45')
     get("/gitlabhq/refs/stable/logs_tree/foo/bar/baz").should route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'stable', path: 'foo/bar/baz')
+    get("/gitlabhq/refs/feature%2345/logs_tree/foo/bar/baz").should route_to('refs#logs_tree', project_id: 'gitlabhq', id: 'feature#45', path: 'foo/bar/baz')
     get("/gitlab/gitlabhq/refs/stable/logs_tree/files.scss").should route_to('refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'files.scss')
   end
 end


### PR DESCRIPTION
This fixes issue #4105 and #3739.

Now the branch name can contain a `#` at any position (#4105).

![bildschirmfoto von 2013-06-09 15 36 20](https://f.cloud.github.com/assets/327488/628906/eb6877a2-d109-11e2-98a9-910eb1d6bfc5.png)

Also a `+` in branch name is possible (#3739):

![bildschirmfoto von 2013-06-09 23 52 59](https://f.cloud.github.com/assets/327488/629466/fe0645e8-d14e-11e2-85b5-a8640d7c4c6d.png)

---

Should any other special chars be allowed in the branch name?
