### PR TITLE
Add "Can create global project" setting.

### DIFF
--- a/app/contexts/projects/create_context.rb
+++ b/app/contexts/projects/create_context.rb
@@ -75,7 +75,7 @@ module Projects
 
     def allowed_namespace?(user, namespace_id)
       if namespace_id == Namespace.global_id
-        return user.admin
+        return user.can_create_global_project?
       else
         namespace = Namespace.find_by_id(namespace_id)
         current_user.can?(:manage_namespace, namespace)

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -14,7 +14,7 @@ module NamespacesHelper
     users_opts = [ "Users", users.sort_by(&:human_name).map {|u| [u.human_name, u.id]} ]
 
     options = []
-    options << global_opts if current_user.admin
+    options << global_opts if current_user.can_create_global_project?
     options << group_opts
     options << users_opts
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,6 +20,7 @@ class Ability
       rules = []
       rules << :create_group if user.can_create_group
       rules << :create_team if user.can_create_team
+      rules << :create_global_project if user.can_create_global_project
       rules
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,38 +2,39 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string(255)      default(""), not null
-#  encrypted_password     :string(255)      default(""), not null
-#  reset_password_token   :string(255)
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0)
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  name                   :string(255)
-#  admin                  :boolean          default(FALSE), not null
-#  projects_limit         :integer          default(10)
-#  skype                  :string(255)      default(""), not null
-#  linkedin               :string(255)      default(""), not null
-#  twitter                :string(255)      default(""), not null
-#  authentication_token   :string(255)
-#  theme_id               :integer          default(1), not null
-#  bio                    :string(255)
-#  failed_attempts        :integer          default(0)
-#  locked_at              :datetime
-#  extern_uid             :string(255)
-#  provider               :string(255)
-#  username               :string(255)
-#  can_create_group       :boolean          default(TRUE), not null
-#  can_create_team        :boolean          default(TRUE), not null
-#  state                  :string(255)
-#  color_scheme_id        :integer          default(1), not null
-#  notification_level     :integer          default(1), not null
+#  id                         :integer          not null, primary key
+#  email                      :string(255)      default(""), not null
+#  encrypted_password         :string(255)      default(""), not null
+#  reset_password_token       :string(255)
+#  reset_password_sent_at     :datetime
+#  remember_created_at        :datetime
+#  sign_in_count              :integer          default(0)
+#  current_sign_in_at         :datetime
+#  last_sign_in_at            :datetime
+#  current_sign_in_ip         :string(255)
+#  last_sign_in_ip            :string(255)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  name                       :string(255)
+#  admin                      :boolean          default(FALSE), not null
+#  projects_limit             :integer          default(10)
+#  skype                      :string(255)      default(""), not null
+#  linkedin                   :string(255)      default(""), not null
+#  twitter                    :string(255)      default(""), not null
+#  authentication_token       :string(255)
+#  theme_id                   :integer          default(1), not null
+#  bio                        :string(255)
+#  failed_attempts            :integer          default(0)
+#  locked_at                  :datetime
+#  extern_uid                 :string(255)
+#  provider                   :string(255)
+#  username                   :string(255)
+#  can_create_group           :boolean          default(TRUE), not null
+#  can_create_team            :boolean          default(TRUE), not null
+#  can_create_global_project  :boolean          default(FALSE), not null
+#  state                      :string(255)
+#  color_scheme_id            :integer          default(1), not null
+#  notification_level         :integer          default(1), not null
 #
 
 class User < ActiveRecord::Base
@@ -43,7 +44,7 @@ class User < ActiveRecord::Base
   attr_accessible :email, :password, :password_confirmation, :remember_me, :bio, :name, :username,
                   :skype, :linkedin, :twitter, :color_scheme_id, :theme_id, :force_random_password,
                   :extern_uid, :provider, as: [:default, :admin]
-  attr_accessible :projects_limit, :can_create_team, :can_create_group, as: :admin
+  attr_accessible :projects_limit, :can_create_team, :can_create_group, :can_create_global_project, as: :admin
 
   attr_accessor :force_random_password
 
@@ -204,6 +205,7 @@ class User < ActiveRecord::Base
       u.projects_limit = Gitlab.config.gitlab.default_projects_limit
       u.can_create_group = Gitlab.config.gitlab.default_can_create_group
       u.can_create_team = Gitlab.config.gitlab.default_can_create_team
+      u.can_create_global_project = Gitlab.config.gitlab.default_can_create_global_project
     end
   end
 
@@ -289,7 +291,7 @@ class User < ActiveRecord::Base
   end
 
   def can_select_namespace?
-    several_namespaces? || admin
+    several_namespaces? || admin || can_create_global_project
   end
 
   def can? action, subject

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -55,6 +55,10 @@
             .input= f.check_box :can_create_team
 
           .clearfix
+            = f.label :can_create_global_project
+            .input= f.check_box :can_create_global_project
+
+          .clearfix
             = f.label :admin do
               %strong.cred Administrator
             .input= f.check_box :admin

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -34,8 +34,9 @@ production: &base
 
     ## User settings
     default_projects_limit: 10
-    # default_can_create_group: false  # default: true
-    # default_can_create_team: false   # default: true
+    # default_can_create_group: false         # default: true
+    # default_can_create_team: false          # default: true
+    # default_can_create_global_project: true # default: false
     # username_changing_enabled: false # default: true - User can change her username/namespace
     
     ## Users management

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -51,6 +51,7 @@ Settings['gitlab'] ||= Settingslogic.new({})
 Settings.gitlab['default_projects_limit'] ||= 10
 Settings.gitlab['default_can_create_group'] = true if Settings.gitlab['default_can_create_group'].nil?
 Settings.gitlab['default_can_create_team']  = true if Settings.gitlab['default_can_create_team'].nil?
+Settings.gitlab['default_can_create_global_project']  = false if Settings.gitlab['default_can_create_global_project'].nil?
 Settings.gitlab['host']       ||= 'localhost'
 Settings.gitlab['https']        = false if Settings.gitlab['https'].nil?
 Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80
@@ -126,4 +127,5 @@ if Rails.env.test?
   Settings.gitlab['default_projects_limit']   = 42
   Settings.gitlab['default_can_create_group'] = false
   Settings.gitlab['default_can_create_team']  = false
+  Settings.gitlab['default_can_create_global_project']  = true
 end

--- a/db/migrate/20130609131213_add_create_global_project_permission.rb
+++ b/db/migrate/20130609131213_add_create_global_project_permission.rb
@@ -1,0 +1,10 @@
+class AddCreateGlobalProjectPermission < ActiveRecord::Migration
+  def up
+    add_column :users, :can_create_global_project, :boolean, default: false, null: false
+    User.admins.update_all(can_create_global_project: true)
+  end
+
+  def down
+    remove_column :users, :can_create_global_project
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130522141856) do
+ActiveRecord::Schema.define(:version => 20130609131213) do
 
   create_table "deploy_keys_projects", :force => true do |t|
     t.integer  "deploy_key_id", :null => false
@@ -261,37 +261,38 @@ ActiveRecord::Schema.define(:version => 20130522141856) do
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                  :default => "",    :null => false
-    t.string   "encrypted_password",     :default => "",    :null => false
+    t.string   "email",                     :default => "",    :null => false
+    t.string   "encrypted_password",        :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default => 0
+    t.integer  "sign_in_count",             :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                :null => false
-    t.datetime "updated_at",                                :null => false
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
     t.string   "name"
-    t.boolean  "admin",                  :default => false, :null => false
-    t.integer  "projects_limit",         :default => 10
-    t.string   "skype",                  :default => "",    :null => false
-    t.string   "linkedin",               :default => "",    :null => false
-    t.string   "twitter",                :default => "",    :null => false
+    t.boolean  "admin",                     :default => false, :null => false
+    t.integer  "projects_limit",            :default => 10
+    t.string   "skype",                     :default => "",    :null => false
+    t.string   "linkedin",                  :default => "",    :null => false
+    t.string   "twitter",                   :default => "",    :null => false
     t.string   "authentication_token"
-    t.integer  "theme_id",               :default => 1,     :null => false
+    t.integer  "theme_id",                  :default => 1,     :null => false
     t.string   "bio"
-    t.integer  "failed_attempts",        :default => 0
+    t.integer  "failed_attempts",           :default => 0
     t.datetime "locked_at"
     t.string   "extern_uid"
     t.string   "provider"
     t.string   "username"
-    t.boolean  "can_create_group",       :default => true,  :null => false
-    t.boolean  "can_create_team",        :default => true,  :null => false
+    t.boolean  "can_create_group",          :default => true,  :null => false
+    t.boolean  "can_create_team",           :default => true,  :null => false
     t.string   "state"
-    t.integer  "color_scheme_id",        :default => 1,     :null => false
-    t.integer  "notification_level",     :default => 1,     :null => false
+    t.integer  "color_scheme_id",           :default => 1,     :null => false
+    t.integer  "notification_level",        :default => 1,     :null => false
+    t.boolean  "can_create_global_project", :default => false, :null => false
   end
 
   add_index "users", ["admin"], :name => "index_users_on_admin"

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -19,6 +19,7 @@ module API
       expose :can_create_group?, as: :can_create_group
       expose :can_create_project?, as: :can_create_project
       expose :can_create_team?, as: :can_create_team
+      expose :can_create_global_project?, as: :can_create_global_project
     end
 
     class Hook < Grape::Entity

--- a/spec/features/admin/admin_users_spec.rb
+++ b/spec/features/admin/admin_users_spec.rb
@@ -39,6 +39,7 @@ describe "Admin::Users" do
       user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
       user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
       user.can_create_team.should == Gitlab.config.gitlab.default_can_create_team
+      user.can_create_global_project.should == Gitlab.config.gitlab.default_can_create_global_project
     end
 
     it "should create user with valid data" do

--- a/spec/helpers/namespaces_helper_spec.rb
+++ b/spec/helpers/namespaces_helper_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe NamespacesHelper do
+  describe "normal user" do
+    let(:current_user) { create :user }
+
+    it { namespaces_options.should match /Users/ }
+    it { namespaces_options.should match /Groups/ }
+    it { namespaces_options.should_not match /Global/ }
+  end
+
+  describe "global project creatable user" do
+    let(:current_user) { create :user, can_create_global_project: true }
+
+    it { namespaces_options.should match /Users/ }
+    it { namespaces_options.should match /Groups/ }
+    it { namespaces_options.should match /Global/ }
+  end
+end
+

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -100,6 +100,7 @@ describe Gitlab::Auth do
       user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
       user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
       user.can_create_team.should == Gitlab.config.gitlab.default_can_create_team
+      user.can_create_global_project.should == Gitlab.config.gitlab.default_can_create_global_project
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,38 +2,39 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string(255)      default(""), not null
-#  encrypted_password     :string(255)      default(""), not null
-#  reset_password_token   :string(255)
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0)
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  name                   :string(255)
-#  admin                  :boolean          default(FALSE), not null
-#  projects_limit         :integer          default(10)
-#  skype                  :string(255)      default(""), not null
-#  linkedin               :string(255)      default(""), not null
-#  twitter                :string(255)      default(""), not null
-#  authentication_token   :string(255)
-#  theme_id               :integer          default(1), not null
-#  bio                    :string(255)
-#  failed_attempts        :integer          default(0)
-#  locked_at              :datetime
-#  extern_uid             :string(255)
-#  provider               :string(255)
-#  username               :string(255)
-#  can_create_group       :boolean          default(TRUE), not null
-#  can_create_team        :boolean          default(TRUE), not null
-#  state                  :string(255)
-#  color_scheme_id        :integer          default(1), not null
-#  notification_level     :integer          default(1), not null
+#  id                         :integer          not null, primary key
+#  email                      :string(255)      default(""), not null
+#  encrypted_password         :string(255)      default(""), not null
+#  reset_password_token       :string(255)
+#  reset_password_sent_at     :datetime
+#  remember_created_at        :datetime
+#  sign_in_count              :integer          default(0)
+#  current_sign_in_at         :datetime
+#  last_sign_in_at            :datetime
+#  current_sign_in_ip         :string(255)
+#  last_sign_in_ip            :string(255)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  name                       :string(255)
+#  admin                      :boolean          default(FALSE), not null
+#  projects_limit             :integer          default(10)
+#  skype                      :string(255)      default(""), not null
+#  linkedin                   :string(255)      default(""), not null
+#  twitter                    :string(255)      default(""), not null
+#  authentication_token       :string(255)
+#  theme_id                   :integer          default(1), not null
+#  bio                        :string(255)
+#  failed_attempts            :integer          default(0)
+#  locked_at                  :datetime
+#  extern_uid                 :string(255)
+#  provider                   :string(255)
+#  username                   :string(255)
+#  can_create_group           :boolean          default(TRUE), not null
+#  can_create_team            :boolean          default(TRUE), not null
+#  can_create_global_project  :boolean          default(FALSE), not null
+#  state                      :string(255)
+#  color_scheme_id            :integer          default(1), not null
+#  notification_level         :integer          default(1), not null
 #
 
 require 'spec_helper'
@@ -176,6 +177,18 @@ describe User do
     it { @user.namespaces.should == [@user.namespace] }
   end
 
+  describe :can_select_namespace do
+    before do
+      @user1 = create :user
+      @user2 = create :user, can_create_global_project: true
+      @admin = create :user, admin: true
+    end
+
+    it { @user1.can_select_namespace?.should be_false }
+    it { @user2.can_select_namespace?.should be_true }
+    it { @admin.can_select_namespace?.should be_true }
+  end
+
   describe 'blocking user' do
     let(:user) { create(:user, name: 'John Smith') }
 
@@ -216,6 +229,7 @@ describe User do
     it { user.require_ssh_key?.should be_true }
     it { user.can_create_group?.should be_true }
     it { user.can_create_project?.should be_true }
+    it { user.can_create_global_project?.should be_false }
     it { user.first_name.should == 'John' }
   end
 
@@ -225,6 +239,7 @@ describe User do
       user.projects_limit.should == 10
       user.can_create_group.should == true
       user.can_create_team.should == true
+      user.can_create_global_project.should == false
     end
   end
 
@@ -234,6 +249,7 @@ describe User do
       user.projects_limit.should == 42
       user.can_create_group.should == false
       user.can_create_team.should == false
+      user.can_create_global_project.should == true
     end
   end
 end

--- a/spec/requests/api/session_spec.rb
+++ b/spec/requests/api/session_spec.rb
@@ -17,6 +17,7 @@ describe API::API do
         json_response['can_create_team'].should == user.can_create_team?
         json_response['can_create_project'].should == user.can_create_project?
         json_response['can_create_group'].should == user.can_create_group?
+        json_response['can_create_global_project'].should == user.can_create_global_project?
       end
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -218,6 +218,7 @@ describe API::API do
       json_response['can_create_team'].should == user.can_create_team?
       json_response['can_create_project'].should == user.can_create_project?
       json_response['can_create_group'].should == user.can_create_group?
+      json_response['can_create_global_project'].should == user.can_create_global_project?
     end
 
     it "should return 401 error if user is unauthenticated" do


### PR DESCRIPTION
Global namespace projects had been able to create
by only administrators.

Add "Can create global project" setting to each user.
(The default value is false.)
