### PR TITLE
Open the issue tag list on click

### DIFF
--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -64,6 +64,9 @@
         event.preventDefault();
       }
     })
+    .bind( "click", function( event ) {
+        $( this ).autocomplete("search", "");
+    })
     .autocomplete({
       minLength: 0,
       source: function( request, response ) {


### PR DESCRIPTION
see #4247

Now the list of available tags will open as soon as i click on the label field.
Previously i needed to type chars of existing tag(s) to open the list.

**Old:**
![old_new](https://f.cloud.github.com/assets/327488/629108/c11cadf2-d126-11e2-8bc7-065ae08cfe67.gif)

**New:**
![new_new](https://f.cloud.github.com/assets/327488/629109/c77e179e-d126-11e2-9da1-5945ce643f15.gif)
