### PR TITLE
Fix pygment lexer 500 errors when an alias is used instead of a name.

### DIFF
--- a/lib/redcarpet/render/gitlab_html.rb
+++ b/lib/redcarpet/render/gitlab_html.rb
@@ -11,7 +11,8 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
 
   def block_code(code, language)
     options = { options: {encoding: 'utf-8'} }
-    options.merge!(lexer: language.downcase) if Pygments::Lexer.find(language)
+    lexer = Pygments::Lexer.find(language) # language can be an alias
+    options.merge!(lexer: lexer.name.downcase) if lexer # downcase is required
 
     # New lines are placed to fix an rendering issue
     # with code wrapped inside <h1> tag for next case:


### PR DESCRIPTION
Fixes the following errors:
https://github.com/gitlabhq/gitlabhq/issues/4074
https://github.com/gitlabhq/gitlabhq/issues/3257
https://github.com/gitlabhq/gitlabhq/issues/4015

and problem on GitLab Cloud
