### PR TITLE
Fix PostgreSQL database restoration problem (#4217)

### DIFF
--- a/lib/backup/database.rb
+++ b/lib/backup/database.rb
@@ -26,7 +26,7 @@ module Backup
         system("mysql #{mysql_args} #{config['database']} < #{db_file_name}")
       when "postgresql" then
         pg_env
-        system("pg_restore #{config['database']} #{db_file_name}")
+        system("psql #{config['database']} -f #{db_file_name}")
       end
     end
 


### PR DESCRIPTION
Use psql instead of pg_restore to restore SQL dump file.
