### PR TITLE
Increase snippet content column size.

### DIFF
--- a/db/migrate/20130611210815_increase_snippet_text_column_size.rb
+++ b/db/migrate/20130611210815_increase_snippet_text_column_size.rb
@@ -1,0 +1,9 @@
+class IncreaseSnippetTextColumnSize < ActiveRecord::Migration
+  def up
+    # MYSQL LARGETEXT for snippet
+    change_column :snippets, :content, :text, :limit => 4294967295
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
This fixes issue #3904

Before:

```
mysql> desc snippets;
+------------+--------------+------+-----+---------+----------------+
| Field      | Type         | Null | Key | Default | Extra          |
+------------+--------------+------+-----+---------+----------------+
| id         | int(11)      | NO   | PRI | NULL    | auto_increment |
| title      | varchar(255) | YES  |     | NULL    |                |
| content    | text         | YES  |     | NULL    |                |
| author_id  | int(11)      | NO   |     | NULL    |                |
| project_id | int(11)      | NO   | MUL | NULL    |                |
| created_at | datetime     | NO   | MUL | NULL    |                |
| updated_at | datetime     | NO   |     | NULL    |                |
| file_name  | varchar(255) | YES  |     | NULL    |                |
| expires_at | datetime     | YES  | MUL | NULL    |                |
+------------+--------------+------+-----+---------+----------------+
9 rows in set (0.00 sec)

mysql> SELECT MAX(LENGTH(content)) FROM snippets;
+----------------------+
| MAX(LENGTH(content)) |
+----------------------+
|                65535 |
+----------------------+
1 row in set (0.02 sec)
```

After:

```
mysql> desc snippets;
+------------+--------------+------+-----+---------+----------------+
| Field      | Type         | Null | Key | Default | Extra          |
+------------+--------------+------+-----+---------+----------------+
| id         | int(11)      | NO   | PRI | NULL    | auto_increment |
| title      | varchar(255) | YES  |     | NULL    |                |
| content    | longtext     | YES  |     | NULL    |                |
| author_id  | int(11)      | NO   |     | NULL    |                |
| project_id | int(11)      | NO   | MUL | NULL    |                |
| created_at | datetime     | YES  | MUL | NULL    |                |
| updated_at | datetime     | YES  |     | NULL    |                |
| file_name  | varchar(255) | YES  |     | NULL    |                |
| expires_at | datetime     | YES  | MUL | NULL    |                |
+------------+--------------+------+-----+---------+----------------+
9 rows in set (0.00 sec)

mysql> SELECT MAX(LENGTH(content)) FROM snippets;
+----------------------+
| MAX(LENGTH(content)) |
+----------------------+
|               279552 |
+----------------------+
1 row in set (0.00 sec)
```

You will see that the 'text' type was changed to 'longtext' now after implementing this change and running a db:migrate task.  The 'SELECT MAX(LENGTH(content)) FROM snippets;' simply shows that I was able to successfully create a snippet with content length > 65,535 which was the previous limit.

I went with longtext (4294967295) because I didn't see a reason why not.  Merge requests also support this limit.
