### PR TITLE
WIP: Respond with 409 when resources conflict

### DIFF
--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -60,6 +60,11 @@ module API
       attrs
     end
 
+    def handle_activerecord_errors(errors)
+      attribute, message = errors.first
+      conflict!(attribute) if message == 'has already been taken'
+    end
+
     # error helpers
 
     def forbidden!
@@ -85,6 +90,11 @@ module API
 
     def not_allowed!
       render_api_error!('Method Not Allowed', 405)
+    end
+
+    def conflict!(attribute)
+      message = "409 " + attribute.to_s.camelize + " has already been taken"
+      render_api_error!(message, 409)
     end
 
     def render_api_error!(message, status)

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -85,6 +85,7 @@ module API
           if @project.errors[:limit_reached].present?
             error!(@project.errors[:limit_reached], 403)
           end
+          handle_activerecord_errors(@project.errors)
           not_found!
         end
       end
@@ -116,6 +117,7 @@ module API
         if @project.saved?
           present @project, with: Entities::Project
         else
+          handle_activerecord_errors(@project.errors)
           not_found!
         end
       end


### PR DESCRIPTION
*\* Work in progress *\* Seeking feedback

Per the API docs, a 409 response should be sent when resources conflict.  Right now only one part of the API actually implements this functionality (teams I believe). I believe we should make this work across the API where applicable.  This is my first crack at a solution. I am seeking feedback on whether you feel this is a viable solution. If so, I will implement across the API.

Steps to reproduce: Using the API, attempt to create a project with a name or path that already exists. 

Expected behavior: This should result in a 409 conflict response.

Observed behavior: A 404 not found response is received.

Errors that arise from conflicting resources are actually sent by ActiveRecord.  It sends a hash that looks something like { 'name' => 'has already been taken' } or { 'path' => 'has already been taken' }.  So if we check the value for 'has already been taken' we know there's a resource conflict.  Then, the key of the has (like 'name') represents what attribute the error is for.  Documentation for ActiveRecord validations is at http://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html

Thanks for your feedback.
