### PR TITLE
[Doc] Update from 5.1 to 5.2 

### DIFF
--- a/doc/update/5.1-to-5.2.md
+++ b/doc/update/5.1-to-5.2.md
@@ -7,6 +7,7 @@ It's useful to make a backup just in case things go south:
 
 ```bash
 cd /home/git/gitlab
+mkdir public/uploads
 sudo -u git -H RAILS_ENV=production bundle exec rake gitlab:backup:create
 ```
 


### PR DESCRIPTION
I don't know if I missed something, but `./public/uploads` doesn't exists on my gitlab instance.
