### PR TITLE
Clarification on backup task syntax

### DIFF
--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -4,7 +4,7 @@ Creates a backup archive of the database and all repositories. This archive will
 The filename will be `[TIMESTAMP]_gitlab_backup.tar`. This timestamp can be used to restore an specific backup.
 
 ```
-bundle exec rake gitlab:backup:create
+sudo -u gitlab -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```
 
 Example output:
@@ -40,7 +40,7 @@ Deleting old backups... [SKIPPING]
 ### Restore a previously created backup
 
 ```
-bundle exec rake gitlab:backup:restore
+sudo -u gitlab -H bundle exec rake gitlab:backup:restore RAILS_ENV=production
 ```
 
 Options:


### PR DESCRIPTION
Without the `RAILS_ENV` option specified, the task fails with this error:

```
rake aborted!
cannot load such file -- rb-inotify
```

Additionally, I added the user switch for consistency.
