### PR TITLE
Fixed user removal from team and associated projects.

### DIFF
--- a/lib/gitlab/user_team_manager.rb
+++ b/lib/gitlab/user_team_manager.rb
@@ -136,7 +136,7 @@ module Gitlab
         team.projects.each do |project|
           other_teams << project.user_teams.with_member(user)
         end
-        other_teams.uniq
+        other_teams.flatten!
         unless other_teams.any?
           UsersProject.in_projects(team.projects).with_user(user).destroy_all
         end

--- a/spec/lib/gitlab/user_team_manager_spec.rb
+++ b/spec/lib/gitlab/user_team_manager_spec.rb
@@ -1,28 +1,59 @@
 require 'spec_helper'
 
 describe Gitlab::UserTeamManager do
-  before do
-    @user = create :user
-    @project = create :project, creator: @user
 
-    @master = create :user
-    @developer = create :user
-    @reporter = create :user
+  let(:user) { create(:user) }
+  let!(:project) { create(:project, namespace: user.namespace, creator: user) }
+  let!(:team) { create(:user_team, owner: user) }
 
-    @project.team << [@master, :master]
-    @project.team << [@developer, :developer]
-    @project.team << [@reporter, :reporter]
+  describe "Team Access" do
+    let(:master) { create(:user) }
+    let(:developer) { create(:user) }
+    let(:reporter) { create(:user) }
 
-    @team = create :user_team, owner: @user
+    before do
+      project.team << [master, :master]
+      project.team << [developer, :developer]
+      project.team << [reporter, :reporter]
 
-    @team.add_members([@master.id, @developer.id, @reporter.id], UsersProject::DEVELOPER, false)
+      team.add_members([master.id, developer.id, reporter.id], UsersProject::DEVELOPER, false)
+    end
+
+    it "should assign team to project with correct permissions result" do
+      team.assign_to_project(project, UsersProject::MASTER)
+
+      project.users_projects.find_by_user_id(master).project_access.should == UsersProject::MASTER
+      project.users_projects.find_by_user_id(developer).project_access.should == UsersProject::DEVELOPER
+      project.users_projects.find_by_user_id(reporter).project_access.should == UsersProject::DEVELOPER
+    end
   end
 
-  it "should assign team to project with correct permissions result" do
-    @team.assign_to_project(@project, UsersProject::MASTER)
+  describe "Team Members" do
+    
+    before do
+      team.assign_to_project(project, UserTeam.access_roles["Master"])
+    end
 
-    @project.users_projects.find_by_user_id(@master).project_access.should == UsersProject::MASTER
-    @project.users_projects.find_by_user_id(@developer).project_access.should == UsersProject::DEVELOPER
-    @project.users_projects.find_by_user_id(@reporter).project_access.should == UsersProject::DEVELOPER
+    describe "Add member to team and associated project" do
+      it "should add the user to the associated project" do
+        project.users.map {|u| u.username}.should == []
+        team.add_member(user, UserTeam.access_roles["Developer"], false)
+        project.users.reload
+        project.users.map {|u| u.username}.should == [user.username]
+      end
+    end
+
+    describe "Delete member from team and associated project" do
+      before do
+        team.add_member(user, UserTeam.access_roles["Developer"], false)
+      end
+
+      it "should remove user from team and project" do
+        project.users.map {|u| u.username}.should == [user.username]
+        team.remove_member(user)
+        project.users.reload
+        project.users.map {|u| u.username}.should == []
+      end
+    end
   end
 end


### PR DESCRIPTION
Added tests for adding and removing team members from associated projects.

Previously, when removing a user from a team, the user was not properly removed from associated projects. Reason was that the other_teams array was not flat, so when "empty" it actually looked like this: [[]].
