### PR TITLE
project: allow import via git:// url

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,7 +90,7 @@ class Project < ActiveRecord::Base
   validates_uniqueness_of :path, scope: :namespace_id
 
   validates :import_url,
-    format: { with: URI::regexp(%w(http https)), message: "should be a valid url" },
+    format: { with: URI::regexp(%w(git http https)), message: "should be a valid url" },
     if: :import?
 
   validate :check_limit


### PR DESCRIPTION
Besides specifying http and https url's as the import-url when creating
a new project, you can now use git://... url's to import via the git
protocol.
