### PR TITLE
Fix wrong file versions in update docs (5.2 to 5.3)

### DIFF
--- a/doc/update/5.2-to-5.3.md
+++ b/doc/update/5.2-to-5.3.md
@@ -38,8 +38,8 @@ sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
 
 ### 4. Update config files
 
-* Make `/home/git/gitlab/config/gitlab.yml` same as https://github.com/gitlabhq/gitlabhq/blob/5-2-stable/config/gitlab.yml.example but with your settings.
-* Make `/home/git/gitlab/config/puma.rb` same as https://github.com/gitlabhq/gitlabhq/blob/5-2-stable/config/puma.rb.example but with your settings.
+* Make `/home/git/gitlab/config/gitlab.yml` same as https://github.com/gitlabhq/gitlabhq/blob/5-3-stable/config/gitlab.yml.example but with your settings.
+* Make `/home/git/gitlab/config/puma.rb` same as https://github.com/gitlabhq/gitlabhq/blob/5-3-stable/config/puma.rb.example but with your settings.
 
 ### 5. Update Init script
 


### PR DESCRIPTION
Fix versions in update docs for updating from 5.2 to 5.3.
Some links still refered to 5.2.
