### PR TITLE
Fixed mixins to support values with comma

### DIFF
--- a/app/assets/stylesheets/gitlab_bootstrap/mixins.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/mixins.scss
@@ -1,7 +1,7 @@
 /**
  * Generic mixins
  */
- @mixin box-shadow($shadow) {
+ @mixin box-shadow($shadow...) {
   -webkit-box-shadow: $shadow;
   -moz-box-shadow: $shadow;
   -ms-box-shadow: $shadow;
@@ -24,7 +24,7 @@
   background-image: -o-linear-gradient($from, $to);
 }
 
-@mixin transition($transition) {
+@mixin transition($transition...) {
   -webkit-transition: $transition;
   -moz-transition: $transition;
   -ms-transition: $transition;


### PR DESCRIPTION
Support for  box-shadow and transition values with comma:

``` scss
@include box-shadow(inset 0 1px 2px rgba(0,0,0,0.075),0 0 5px rgba(81,167,232,0.5));
@include transition(border linear .2s, box-shadow linear .2s);
```
