### PR TITLE
Rename unspecified to make it clearer and in line with scrum terminology

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -15,7 +15,7 @@ module IssuesHelper
   # to allow filtering issues by an unassigned User or Milestone
   def unassigned_filter
     # Milestone uses :title, Issue uses :name
-    OpenStruct.new(id: 0, title: 'Unspecified', name: 'Unassigned')
+    OpenStruct.new(id: 0, title: 'None (backlog)', name: 'Unassigned')
   end
 
   def issues_filter

--- a/app/views/issues/_issues.html.haml
+++ b/app/views/issues/_issues.html.haml
@@ -63,7 +63,7 @@
             - if @milestone.present?
               %strong= @milestone.title
             - elsif params[:milestone_id] == "0"
-              Unspecified
+              None (backlog)
             - else
               Any
             %b.caret
@@ -72,7 +72,7 @@
               = link_to project_issues_with_filter_path(@project, milestone_id: nil) do
                 Any
               = link_to project_issues_with_filter_path(@project, milestone_id: 0) do
-                Unspecified
+                None (backlog)
             - issues_active_milestones.each do |milestone|
               %li
                 = link_to project_issues_with_filter_path(@project, milestone_id: milestone.id) do


### PR DESCRIPTION
'Milestone: None' is very clear, unspecified may mean it has a milestone but it is not clear which one.
This also makes it obvious how to show the backlog from where you can pick issues for the next sprint.

http://feedback.gitlab.com/forums/176466-general/suggestions/3812741-scrum-planning-view-for-issues
http://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_Backlog
