### PR TITLE
Remove gitolite repo check for import script

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -29,8 +29,6 @@ namespace :gitlab do
         # Skip if group or user
         next if namespaces.include?(name)
 
-        next if name == 'gitolite-admin'
-
         puts "Processing #{repo_path}".yellow
 
         project = Project.find_with_namespace(path)


### PR DESCRIPTION
Old version used a gitolite admin repository. There is no needines anymore to check for this since it doesn't exist.
