### PR TITLE
Database seeding failing

### DIFF
--- a/db/fixtures/development/09_issues.rb
+++ b/db/fixtures/development/09_issues.rb
@@ -11,7 +11,7 @@ Gitlab::Seeder.quiet do
     next unless user
 
     user_id = user.id
-    IssueObserver.current_user = user
+    Thread.current[:current_user] = user
 
     Issue.seed(:id, [{
       id: i,

--- a/db/fixtures/development/10_merge_requests.rb
+++ b/db/fixtures/development/10_merge_requests.rb
@@ -17,7 +17,8 @@ Gitlab::Seeder.quiet do
     next if branches.uniq.size < 2
 
     user_id = user.id
-    MergeRequestObserver.current_user = user
+    Thread.current[:current_user] = user
+
     MergeRequest.seed(:id, [{
       id: i,
       source_branch: branches.first,


### PR DESCRIPTION
`cattr_accessor` for `current_user` removed from IssueObserver & MergeRequestObserver but not updated in the seed files.
