### PR TITLE
Optionally send invitations for SparkleShare

### DIFF
--- a/app/controllers/sparkle_share_controller.rb
+++ b/app/controllers/sparkle_share_controller.rb
@@ -1,0 +1,32 @@
+class SparkleShareController < ApplicationController
+  skip_before_filter :authenticate_user!
+  skip_before_filter :verify_authenticity_token
+  before_filter :get_invite
+
+  # SparkleShare application downloads the invite.xml file
+  def invite
+
+  end
+
+  # SparkleShare application posts its public key
+  def accept_invite
+    if @invite.accept!(posted_public_key)
+      render nothing: true, status: :ok
+    else
+      render nothing: true, status: :forbidden
+    end
+  end
+
+  private
+  def get_invite
+    @invite = SparkleInvite.find_by_token(params[:token])
+    raise ActiveRecord::RecordNotFound unless @invite
+  end
+
+  def posted_public_key
+    # Fix incorrect spaces in the public key by replacing them with +'s
+    parts = params[:public_key].split
+    first, last = parts.shift, parts.pop
+    "#{first} #{parts.join('+')} #{last}"
+  end
+end

--- a/app/models/sparkle_invite.rb
+++ b/app/models/sparkle_invite.rb
@@ -1,0 +1,60 @@
+# Sparkle Share invite system:
+# See https://github.com/hbons/SparkleShare/wiki/Invites
+
+class SparkleInvite < ActiveRecord::Base
+  belongs_to :users_project
+
+  has_one :user, through: :users_project
+  has_one :project, through: :users_project
+
+  validates :users_project, presence: true
+
+  before_create :set_expire_at, :token
+
+  DEFAULT_EXPIRE_WINDOW = 2.days
+
+  def set_expire_at
+    self.expire_at ||= DEFAULT_EXPIRE_WINDOW.from_now
+  end
+
+  def token
+    super || (self.token = SecureRandom.hex(10))
+  end
+
+  def accept!(public_key)
+    if acceptable?
+      add_public_key_to_user(public_key)
+      self.accepted_at = Time.now
+      self.expire_at = nil
+      self.save!
+    end
+  end
+
+  # Attributes for the invite.xml file
+  def address
+    gitlab_shell = Gitlab.config.gitlab_shell
+    "ssh://#{gitlab_shell.ssh_user}@#{gitlab_shell.ssh_host}:#{gitlab_shell.ssh_port}/"
+  end
+
+  def remote_path
+    "/#{project.path_with_namespace}"
+  end
+
+  def fingerprint
+    Gitlab.config.sparkle_share['fingerprint']
+  end
+
+  def announcements_url
+    Gitlab.config.sparkle_share['announcements_url']
+  end
+
+  private
+  def acceptable?
+    self.accepted_at.nil? && (Time.now < self.expire_at)
+  end
+
+  def add_public_key_to_user(public_key)
+    key = user.keys.find_by_key(public_key)
+    key ||= user.keys.create!(key: public_key, title: 'SparkleShare')
+  end
+end

--- a/app/views/notify/project_access_granted_email.html.haml
+++ b/app/views/notify/project_access_granted_email.html.haml
@@ -3,3 +3,24 @@
 %p
   = link_to project_url(@project) do
     = @project.name_with_namespace
+
+- if Gitlab.config.sparkle_share.enabled && @users_project.sparkle_invite
+  %h3 SparkleShare (optional)
+  %p
+    If you want to use this repository for SparkleShare,
+    make sure you have installed v1.1 or later from
+    <a href="http://sparkleshare.org/">sparkleshare.org</a>.
+  %p
+    Click
+    = link_to sparkle_share_invite_url(token: @users_project.sparkle_invite.token, format: :xml, protocol: Gitlab.config.sparkle_share.invite_protocol) do
+      this invitation
+    to autoconfigure SparkleShare.
+    %br
+    Or add it manually (you'll need to make sure that gitlab knowns your public ssh key):
+    %ul
+      %li
+        %strong Address:
+        = @users_project.sparkle_invite.address
+      %li
+        %strong Remote Path:
+        = @users_project.sparkle_invite.remote_path

--- a/app/views/notify/project_access_granted_email.text.erb
+++ b/app/views/notify/project_access_granted_email.text.erb
@@ -2,3 +2,14 @@
 You have been granted <%= @users_project.project_access_human %> access to project <%= @project.name_with_namespace %>
 
 <%= url_for(project_url(@project)) %>
+
+<% if Gitlab.config.sparkle_share.enabled && @users_project.sparkle_invite %>
+If you want to use this repository for SparkleShare, make sure you have installed v1.1 or later from www.sparkleshare.org.
+
+Use this invitation link to autoconfigure sparkleshare:
+<%= sparkle_share_invite_url(token: @users_project.sparkle_invite.token, format: :xml, protocol: Gitlab.config.sparkle_share.invite_protocol) %>
+
+Or add it manually (you'll need to make sure that gitlab knowns your public ssh key):
+* Address: <%= @users_project.sparkle_invite.address %>
+* Remote Path: <%= @users_project.sparkle_invite.remote_path %>
+<% end %>

--- a/app/views/sparkle_share/invite.xml.builder
+++ b/app/views/sparkle_share/invite.xml.builder
@@ -1,0 +1,10 @@
+xml.instruct!
+xml.sparkleshare {
+  xml.invite {
+    xml.address @invite.address
+    xml.remote_path @invite.remote_path
+    xml.fingerprint @invite.fingerprint if @invite.fingerprint
+    xml.accept_url(sparkle_share_accept_invite_url(token: @invite.token))
+    xml.announcements_url(@invite.announcements_url) if @invite.announcements_url
+  }
+}

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -164,6 +164,17 @@ production: &base
     # Git timeout to read a commit, in seconds
     timeout: 10
 
+  # SparkleShare is an opensource dropbox clone
+  # http://sparkleshare.org/
+  # When you enable the sparkle share integration, GitLab will include
+  # an SparkleShare invitation link in the project access email send to team members
+  sparkle_share:
+    enabled: false
+    # ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub | cut --bytes=6-52
+    # fingerprint: ''
+    # run your own fanout.c ()
+    # announcements_url: ''
+
   #
   # 4. Extra customization
   # ==========================

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -75,6 +75,15 @@ Settings.gitlab.default_projects_features['wall']           = false if Settings.
 Settings.gitlab.default_projects_features['snippets']       = false if Settings.gitlab.default_projects_features['snippets'].nil?
 
 #
+# SparkleShare
+#
+Settings['sparkle_share'] ||= Settingslogic.new({})
+Settings.sparkle_share['enabled']           ||= false
+Settings.sparkle_share['fingerprint']       ||= false
+Settings.sparkle_share['anouncements_url']  ||= false
+Settings.sparkle_share['invite_protocol']   = Settings.gitlab.https ? "sparkleshare://addProject/https://" : "sparkleshare://addProject/http://"
+
+#
 # Gravatar
 #
 Settings['gravatar'] ||= Settingslogic.new({})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,12 @@ Gitlab::Application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: :omniauth_callbacks, registrations: :registrations }
 
   #
+  # SparkleShare
+  #
+  get  'sparkle_share/invite'         => 'sparkle_share#invite'
+  post 'sparkle_share/accept_invite'  => 'sparkle_share#accept_invite'
+
+  #
   # Project Area
   #
   resources :projects, constraints: { id: /(?:[a-zA-Z.0-9_\-]+\/)?[a-zA-Z.0-9_\-]+/ }, except: [:new, :create, :index], path: "/" do

--- a/db/migrate/20130517151627_create_sparkle_invites.rb
+++ b/db/migrate/20130517151627_create_sparkle_invites.rb
@@ -1,0 +1,15 @@
+class CreateSparkleInvites < ActiveRecord::Migration
+  def change
+    create_table :sparkle_invites do |t|
+      t.belongs_to :users_project
+      t.string :token
+      t.datetime :expire_at
+      t.datetime :accepted_at
+
+      t.timestamps
+    end
+
+    add_index :sparkle_invites, :users_project_id
+    add_index :sparkle_invites, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130326142630) do
+ActiveRecord::Schema.define(:version => 20130614132337) do
 
   create_table "deploy_keys_projects", :force => true do |t|
     t.integer  "deploy_key_id", :null => false
@@ -217,6 +217,18 @@ ActiveRecord::Schema.define(:version => 20130326142630) do
   add_index "snippets", ["created_at"], :name => "index_snippets_on_created_at"
   add_index "snippets", ["expires_at"], :name => "index_snippets_on_expires_at"
   add_index "snippets", ["project_id"], :name => "index_snippets_on_project_id"
+
+  create_table "sparkle_invites", :force => true do |t|
+    t.integer  "users_project_id"
+    t.string   "token"
+    t.datetime "expire_at"
+    t.datetime "accepted_at"
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
+  end
+
+  add_index "sparkle_invites", ["token"], :name => "index_sparkle_invites_on_token"
+  add_index "sparkle_invites", ["users_project_id"], :name => "index_sparkle_invites_on_users_project_id"
 
   create_table "taggings", :force => true do |t|
     t.integer  "tag_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -236,6 +236,10 @@ FactoryGirl.define do
     service
   end
 
+  factory :sparkle_invite do
+    users_project
+  end
+
   factory :deploy_keys_project do
     deploy_key
     project

--- a/spec/features/sparkle_invite_spec.rb
+++ b/spec/features/sparkle_invite_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe "SparkleInvite" do
+  let!(:new_member) { create(:user) }
+
+  before do
+    Gitlab.config.sparkle_share['enable'] = true
+    login_as :user
+    project = create(:project)
+    project.team << [@user, :master]
+    visit new_project_team_member_path(project)
+
+    find('#user_ids').set(new_member.id.to_s)
+    select "Developer", from: "project_access"
+  end
+
+  it "the last email should contain a link to sparkle share" do
+    UsersProject.observers.enable :users_project_observer do
+      click_button "Add users"
+      email = ActionMailer::Base.deliveries.last
+      email.text_part.body.should have_content('sparkleshare://addProject')
+    end
+  end
+end

--- a/spec/models/sparkle_invite_spec.rb
+++ b/spec/models/sparkle_invite_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe SparkleInvite do
+  describe "Associations" do
+    it { should belong_to(:users_project) }
+  end
+
+  describe "Validation" do
+    let!(:sparkle_invite) { create(:sparkle_invite) }
+
+    it { should validate_presence_of(:users_project) }
+  end
+
+  it "should generate a token" do
+    SecureRandom.stub(:hex).and_return('123456789')
+    sparkle_invite = create :sparkle_invite
+    sparkle_invite.token.should == '123456789'
+  end
+
+  it "should be acceptable?" do
+    sparkle_invite = create(:sparkle_invite)
+    sparkle_invite.should be_acceptable
+  end
+
+  describe "#accept!" do
+    let(:sparkle_invite) { create(:sparkle_invite) }
+    let(:public_key) { "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0= host" }
+
+    before do
+      sparkle_invite.accept!(public_key)
+    end
+
+    it "should no longer be acceptable" do
+      sparkle_invite.should_not be_acceptable
+    end
+
+    it "should have set the public key" do
+      key = sparkle_invite.user.keys.last
+      key.key.should == public_key
+    end
+  end
+end


### PR DESCRIPTION
[SparkleShare](http://sparkleshare.org) is an open source dropbox like file synchroniser. It uses git as a distribution and version control system.

This pull request adds a configuration option to gitlab.yml to enable sending [sparkle share invites](https://github.com/hbons/SparkleShare/wiki/Invites) when a user is added to a project (with developer or master level). This invite adds the project's repository to the user's Sparkle Share application. It also triggers Sparkle Share to post its public ssh key to Gitlab, which links it to the user.
