### PR TITLE
we should not use `console.log` in production code...

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -1,6 +1,6 @@
 $ ->
   new Dispatcher()
-  
+
 class Dispatcher
   constructor: () ->
     @initSearch()
@@ -10,8 +10,6 @@ class Dispatcher
     page = $('body').attr('data-page')
     project_id = $('body').attr('data-project-id')
 
-    console.log(page)
- 
     unless page
       return false
 


### PR DESCRIPTION
This also disturbes the tests...

```
dashboard:show
issues:index
issues:index
.undefined
dashboard:show
issues:index
.....undefined
dashboard:show
merge_requests:show
.undefined
dashboard:show
merge_requests:show
.undefined
dashboard:show
merge_requests:show
.undefined
dashboard:show
merge_requests:show
.undefined
```
