### PR TITLE
fix bad constant reference in `project_routing_spec.rb`.

### DIFF
--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -262,7 +262,7 @@ end
 #      project_snippet GET    /:project_id/snippets/:id(.:format)      snippets#show
 #                      PUT    /:project_id/snippets/:id(.:format)      snippets#update
 #                      DELETE /:project_id/snippets/:id(.:format)      snippets#destroy
-describe Project::SnippetsController, "routing" do
+describe Projects::SnippetsController, "routing" do
   it "to #raw" do
     get("/gitlabhq/snippets/1/raw").should route_to('projects/snippets#raw', project_id: 'gitlabhq', id: '1')
   end


### PR DESCRIPTION
this typo resulted in an error that the top-level constant was referenced.
