### PR TITLE
Changed the issues link to point to the Jira Project page.

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -72,7 +72,7 @@ production: &base
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
     # 
     # jira:
-    #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
+    #   project_url: "http://jira.sample/browse/:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
     #   new_issue_url: "http://jira.sample/secure/CreateIssue.jspa"
 


### PR DESCRIPTION
The browse/:id url is present in more versions of Jira, and links the projects main page in Jira.

Issues /?jql= is not in Jira 4 / 5 at the least, I don't have access to a Jira 6 box to test it.
