### PR TITLE
Couple of UI additions

### DIFF
--- a/app/views/snippets/_blob.html.haml
+++ b/app/views/snippets/_blob.html.haml
@@ -6,6 +6,7 @@
       .btn-group.tree-btn-group.pull-right
         - if @snippet.author == current_user
           = link_to "Edit", edit_snippet_path(@snippet), class: "btn btn-tiny", title: 'Edit Snippet'
+          = link_to "Delete", snippet_path(@snippet), method: :delete, confirm: "Are you sure?", class: "btn btn-tiny", title: 'Delete Snippet'
         = link_to "Raw", raw_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
   .file_content.code
     - unless @snippet.content.empty?

--- a/app/views/snippets/show.html.haml
+++ b/app/views/snippets/show.html.haml
@@ -1,8 +1,8 @@
 %h3.page_title
   - if @snippet.private?
-    %i.icon-lock.cgreen
+    %i{:class => "icon-lock cgreen has_bottom_tooltip", "data-original-title" => "Private snippet"}
   - else
-    %i.icon-globe.cblue
+    %i{:class => "icon-globe cblue has_bottom_tooltip", "data-original-title" => "Public snippet"}
 
   = @snippet.title
 


### PR DESCRIPTION
There's currently no way (outside of the API) to delete a snippet. Added a tooltip to the snippet icon to make it obvious what public/private state it is.
