### PR TITLE
Minitest Is Always Required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,9 @@ gem "d3_rails", "~> 3.1.4"
 # underscore-rails
 gem "underscore-rails", "~> 1.4.4"
 
+# Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
+gem 'minitest'
+
 group :assets do
   gem "sass-rails"
   gem "coffee-rails"
@@ -166,9 +169,6 @@ group :development, :test do
   gem "database_cleaner"
   gem "launchy"
   gem 'factory_girl_rails'
-
-  # Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
-  gem 'minitest'
 
   # Generate Fake data
   gem "ffaker"


### PR DESCRIPTION
In GitLab 5.3, minitest is required even when running in production mode. The previous GemFile only included it for test and development modes. 

This is generally not a problem when the Ruby install contains Minitest, but some systems do not. (Noticed on Fedora 18 that had a previously working 5.2 GemFile.)
