### PR TITLE
Updated command to perform backup...

### DIFF
--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -4,7 +4,7 @@ Creates a backup archive of the database and all repositories. This archive will
 The filename will be `[TIMESTAMP]_gitlab_backup.tar`. This timestamp can be used to restore an specific backup.
 
 ```
-bundle exec rake gitlab:backup:create RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```
 
 Example output:


### PR DESCRIPTION
When you run the backup raketask, the rake suggests that you shouldn't be running the job as root, but only after it creates a file structure owned by root that then later has to be fixed before running the task as the git user. Adding the sudo prefix to the command saves the hassle.
