### PR TITLE
Adds files per commit, created/deleted/compare to hook data.

### DIFF
--- a/app/services/git_push_service.rb
+++ b/app/services/git_push_service.rb
@@ -150,16 +150,25 @@ class GitPushService
     # will be passed as post receive hook data.
     #
     push_commits_limited.each do |commit|
-      data[:commits] << {
+      cdata = {
         id: commit.id,
         message: commit.safe_message,
-        timestamp: commit.committed_date.xmlschema,
+        modified: [],
+        added: [],
+        removed: [],
+        timestamp: commit.date.xmlschema,
         url: "#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}/commit/#{commit.id}",
         author: {
           name: commit.author_name,
           email: commit.author_email
         }
       }
+      commit.quick_diffs.each do |diff|
+        cdata[:added] << diff.new_path if diff.new_file
+        cdata[:removed] << diff.new_path if diff.deleted_file
+        cdata[:modified] << diff.new_path unless (diff.new_file or diff.deleted_file)
+      end
+      data[:commits] << cdata
     end
 
     data

--- a/app/views/projects/hooks/_data_ex.html.erb
+++ b/app/views/projects/hooks/_data_ex.html.erb
@@ -15,6 +15,11 @@
     {
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "message": "Update Catalan translation to e38cb41.",
+      "modified":[
+        "README.md"
+      ],
+      "added":[],
+      "removed":[],
       "timestamp": "2011-12-12T14:27:31+02:00",
       "url": "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
@@ -26,6 +31,13 @@
     {
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
+      "modified":[
+        "README.md"
+      ],
+      "added":[
+        "lib/cool-new-file.rb"
+      ],
+      "removed":[],
       "timestamp": "2012-01-03T23:36:29+02:00",
       "url": "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {


### PR DESCRIPTION
Uses quick_diffs to include files affected by each commit in hook data.

This PR depends on the following PRs:
https://github.com/gitlabhq/grit/pull/30
https://github.com/gitlabhq/gitlab_git/pull/6
