### PR TITLE
Ming Jin: added cas auth strategy support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'omniauth', "~> 1.1.3"
 gem 'omniauth-google-oauth2'
 gem 'omniauth-twitter'
 gem 'omniauth-github'
+gem "omniauth-cas"
 
 # Extracting information from a git repository
 # Provide access to Gitlab::Git library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,10 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
+    omniauth-cas (1.0.2)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.1.0)
     omniauth-github (1.1.0)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
@@ -568,6 +572,7 @@ DEPENDENCIES
   modernizr (= 2.6.2)
   mysql2
   omniauth (~> 1.1.3)
+  omniauth-cas
   omniauth-github
   omniauth-google-oauth2
   omniauth-twitter

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -24,6 +24,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     sign_in_and_redirect @user
   end
 
+  def cas
+    # We only find ourselves here if the authentication to CAS was successful.
+    oauth = request.env['omniauth.auth']
+    provider, uid = oauth['provider'], oauth['uid']
+    @user = User.find_for_cas_auth(request.env["omniauth.auth"], current_user)
+    if @user.persisted?
+      @user.remember_me = true
+    end
+    sign_in_and_redirect @user
+  end
+
   private
 
   def handle_omniauth

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,6 +186,10 @@ class User < ActiveRecord::Base
       gitlab_auth.find_for_ldap_auth(auth, signed_in_resource)
     end
 
+    def find_for_cas_auth(auth, signed_in_resource = nil)
+      gitlab_auth.find_for_cas_auth(auth, signed_in_resource)
+    end
+
     def gitlab_auth
       Gitlab::Auth.new
     end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -97,6 +97,16 @@ production: &base
     bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
     password: '_the_password_of_the_bind_user'
 
+  ## CAS settigns
+  cas:
+    enabled: true
+    host: '_your_cas_server'
+    mail_server: '_your_mail_server, will use _your_cas_server address if this not set'
+    ssl: true
+    login_url: '_cas_login_url'
+    logout_url: '_cas_logout_url'
+    service_validate_url: '_service_validate_url'
+
   ## OmniAuth settings
   omniauth:
     # Allow login via Twitter, Google, etc. using OmniAuth providers

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -216,6 +216,15 @@ Devise.setup do |config|
       password: Gitlab.config.ldap['password']
   end
 
+  if Gitlab.config.cas.enabled
+    config.omniauth :cas,
+      host:                     Gitlab.config.cas['host'],
+      login_url:                Gitlab.config.cas['login_url'],
+      ssl:                      Gitlab.config.cas['ssl'],
+      service_validate_url:     Gitlab.config.cas['service_validate_url'],
+      logout_url:               Gitlab.config.cas['logout_url']
+  end
+
   Gitlab.config.omniauth.providers.each do |provider|
     case provider['args']
     when Array


### PR DESCRIPTION
This patch is to add CAS Auth Support into gitlabhq 5.3-stable. The code is tested against my company's cas server and it works.

As CAS server may not respond with the auth info as required, e.g. uid, name, email, the rules for new user creation is:
1. if the name is not returned, uid will be used
2. if the email is not returned, the value of email will be combined with the value of uid and the value of variable 'mail_server' defined in gitlab.yml
3. if the value of variable 'mail_server' is not defined, the value of variable 'host' in CAS settings will be used

Please let me know if there's any question.
