### PR TITLE
Add 'services' to path blacklist

### DIFF
--- a/lib/gitlab/blacklist.rb
+++ b/lib/gitlab/blacklist.rb
@@ -3,7 +3,7 @@ module Gitlab
     extend self
 
     def path
-      %w(admin dashboard groups help profile projects search public assets u s teams merge_requests issues users snippets )
+      %w(admin dashboard groups help profile projects search public assets u s teams merge_requests issues users snippets services)
     end
   end
 end


### PR DESCRIPTION
`services` is a reserved system path and it should not be possible to create a new project. 
Otherwise this will throw a 404
