### PR TITLE
fix bug when project named: mediawiki

### DIFF
--- a/lib/gitlab/backend/grack_helpers.rb
+++ b/lib/gitlab/backend/grack_helpers.rb
@@ -3,7 +3,7 @@ module Grack
     def project_by_path(path)
       if m = /^\/([\w\.\/-]+)\.git/.match(path).to_a
         path_with_namespace = m.last
-        path_with_namespace.gsub!(/.wiki$/, '')
+        path_with_namespace.gsub!(/\.wiki$/, '')
 
         Project.find_with_namespace(path_with_namespace)
       end


### PR DESCRIPTION
mediawiki.wiki.git
mediawiki.git

/.wiki$/ match awiki, when your project named mediawiki
it will be find project named: "medi"

use /.wiki$/ fix this bug
