### PR TITLE
Linking objects from GFM references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 6.1.0
+  - Link issues, merge requests, and commits when they reference each other with GFM
+  - Close issues automatically when pushing commits with a special message
+
 v 6.0.0
   - Feature: Replace teams with group membership
     We introduce group membership in 6.0 as a replacement for teams.
@@ -54,7 +58,7 @@ v 5.4.0
   - Notify mentioned users with email
 
 v 5.3.0
-  - Refactored services 
+  - Refactored services
   - Campfire service added
   - HipChat service added
   - Fixed bug with LDAP + git over http

--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -3,6 +3,7 @@ require 'gitlab/satellite/satellite'
 class Projects::MergeRequestsController < Projects::ApplicationController
   before_filter :module_enabled
   before_filter :merge_request, only: [:edit, :update, :show, :commits, :diffs, :automerge, :automerge_check, :ci_status]
+  before_filter :closes_issues, only: [:edit, :update, :show, :commits, :diffs]
   before_filter :validates_merge_request, only: [:show, :diffs]
   before_filter :define_show_vars, only: [:show, :diffs]
 
@@ -133,6 +134,10 @@ class Projects::MergeRequestsController < Projects::ApplicationController
 
   def merge_request
     @merge_request ||= @project.merge_requests.find_by_iid!(params[:id])
+  end
+
+  def closes_issues
+    @closes_issues ||= @merge_request.closes_issues
   end
 
   def authorize_modify_merge_request!

--- a/app/models/concerns/mentionable.rb
+++ b/app/models/concerns/mentionable.rb
@@ -1,11 +1,46 @@
 # == Mentionable concern
 #
-# Contains common functionality shared between Issues and Notes
+# Contains functionality related to objects that can mention Users, Issues, MergeRequests, or Commits by
+# GFM references.
 #
-# Used by Issue, Note
+# Used by Issue, Note, MergeRequest, and Commit.
 #
 module Mentionable
   extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Indicate which attributes of the Mentionable to search for GFM references.
+    def attr_mentionable *attrs
+      mentionable_attrs.concat(attrs.map(&:to_s))
+    end
+
+    # Accessor for attributes marked mentionable.
+    def mentionable_attrs
+      @mentionable_attrs ||= []
+    end
+  end
+
+  # Generate a GFM back-reference that will construct a link back to this Mentionable when rendered. Must
+  # be overridden if this model object can be referenced directly by GFM notation.
+  def gfm_reference
+    raise NotImplementedError.new("#{self.class} does not implement #gfm_reference")
+  end
+
+  # Construct a String that contains possible GFM references.
+  def mentionable_text
+    self.class.mentionable_attrs.map { |attr| send(attr) || '' }.join
+  end
+
+  # The GFM reference to this Mentionable, which shouldn't be included in its #references.
+  def local_reference
+    self
+  end
+
+  # Determine whether or not a cross-reference Note has already been created between this Mentionable and
+  # the specified target.
+  def has_mentioned? target
+    Note.cross_reference_exists?(target, local_reference)
+  end
 
   def mentioned_users
     users = []
@@ -24,14 +59,39 @@ module Mentionable
     users.uniq
   end
 
-  def mentionable_text
-    if self.class == Issue
-      description
-    elsif self.class == Note
-      note
-    else
-      nil
+  # Extract GFM references to other Mentionables from this Mentionable. Always excludes its #local_reference.
+  def references p = project, text = mentionable_text
+    return [] if text.blank?
+    ext = Gitlab::ReferenceExtractor.new
+    ext.analyze(text)
+    (ext.issues_for(p) + ext.merge_requests_for(p) + ext.commits_for(p)).uniq - [local_reference]
+  end
+
+  # Create a cross-reference Note for each GFM reference to another Mentionable found in +mentionable_text+.
+  def create_cross_references! p = project, a = author, without = []
+    refs = references(p) - without
+    refs.each do |ref|
+      Note.create_cross_reference_note(ref, local_reference, a, p)
     end
+  end
+
+  # If the mentionable_text field is about to change, locate any *added* references and create cross references for
+  # them. Invoke from an observer's #before_save implementation.
+  def notice_added_references p = project, a = author
+    ch = changed_attributes
+    original, mentionable_changed = "", false
+    self.class.mentionable_attrs.each do |attr|
+      if ch[attr]
+        original << ch[attr]
+        mentionable_changed = true
+      end
+    end
+
+    # Only proceed if the saved changes actually include a chance to an attr_mentionable field.
+    return unless mentionable_changed
+
+    preexisting = references(p, original)
+    create_cross_references!(p, a, preexisting)
   end
 
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -32,6 +32,7 @@ class Issue < ActiveRecord::Base
   attr_accessible :title, :assignee_id, :position, :description,
                   :milestone_id, :label_list, :author_id_of_changes,
                   :state_event
+  attr_mentionable :title, :description
 
   acts_as_taggable_on :labels
 
@@ -56,4 +57,10 @@ class Issue < ActiveRecord::Base
 
   # Both open and reopened issues should be listed as opened
   scope :opened, -> { with_state(:opened, :reopened) }
+
+  # Mentionable overrides.
+
+  def gfm_reference
+    "issue ##{iid}"
+  end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -31,7 +31,7 @@ class MergeRequest < ActiveRecord::Base
   belongs_to :source_project, foreign_key: :source_project_id, class_name: "Project"
 
   attr_accessible :title, :assignee_id, :source_project_id, :source_branch, :target_project_id, :target_branch, :milestone_id, :author_id_of_changes, :state_event
-
+  attr_mentionable :title
 
   attr_accessor :should_remove_source_branch
 
@@ -253,6 +253,20 @@ class MergeRequest < ActiveRecord::Base
 
   def project
     target_project
+  end
+
+  # Return the set of issues that will be closed if this merge request is accepted.
+  def closes_issues
+    if target_branch == project.default_branch
+      unmerged_commits.map { |c| c.closes_issues(project) }.flatten.uniq.sort_by(&:id)
+    else
+      []
+    end
+  end
+
+  # Mentionable override.
+  def gfm_reference
+    "merge request !#{iid}"
   end
 
   private

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -18,6 +18,7 @@ class Repository
   end
 
   def commit(id = nil)
+    return nil unless raw_repository
     commit = Gitlab::Git::Commit.find(raw_repository, id)
     commit = Commit.new(commit) if commit
     commit

--- a/app/observers/activity_observer.rb
+++ b/app/observers/activity_observer.rb
@@ -5,8 +5,8 @@ class ActivityObserver < BaseObserver
     event_author_id = record.author_id
 
     if record.kind_of?(Note)
-      # Skip system status notes like 'status changed to close'
-      return true if record.note.include?("_Status changed to ")
+      # Skip system notes, like status changes and cross-references.
+      return true if record.system?
 
       # Skip wall notes to prevent spamming of dashboard
       return true if record.noteable_type.blank?

--- a/app/observers/base_observer.rb
+++ b/app/observers/base_observer.rb
@@ -10,4 +10,8 @@ class BaseObserver < ActiveRecord::Observer
   def current_user
     Thread.current[:current_user]
   end
+
+  def current_commit
+    Thread.current[:current_commit]
+  end
 end

--- a/app/observers/issue_observer.rb
+++ b/app/observers/issue_observer.rb
@@ -1,6 +1,8 @@
 class IssueObserver < BaseObserver
   def after_create(issue)
     notification.new_issue(issue, current_user)
+
+    issue.create_cross_references!(issue.project, current_user)
   end
 
   def after_close(issue, transition)
@@ -17,12 +19,14 @@ class IssueObserver < BaseObserver
     if issue.is_being_reassigned?
       notification.reassigned_issue(issue, current_user)
     end
+
+    issue.notice_added_references(issue.project, current_user)
   end
 
   protected
 
   # Create issue note with service comment like 'Status changed to closed'
   def create_note(issue)
-    Note.create_status_change_note(issue, issue.project, current_user, issue.state)
+    Note.create_status_change_note(issue, issue.project, current_user, issue.state, current_commit)
   end
 end

--- a/app/observers/merge_request_observer.rb
+++ b/app/observers/merge_request_observer.rb
@@ -7,11 +7,13 @@ class MergeRequestObserver < ActivityObserver
     end
 
     notification.new_merge_request(merge_request, current_user)
+
+    merge_request.create_cross_references!(merge_request.project, current_user)
   end
 
   def after_close(merge_request, transition)
     create_event(merge_request, Event::CLOSED)
-    Note.create_status_change_note(merge_request, merge_request.target_project, current_user, merge_request.state)
+    Note.create_status_change_note(merge_request, merge_request.target_project, current_user, merge_request.state, nil)
 
     notification.close_mr(merge_request, current_user)
   end
@@ -33,11 +35,13 @@ class MergeRequestObserver < ActivityObserver
 
   def after_reopen(merge_request, transition)
     create_event(merge_request, Event::REOPENED)
-    Note.create_status_change_note(merge_request, merge_request.target_project, current_user, merge_request.state)
+    Note.create_status_change_note(merge_request, merge_request.target_project, current_user, merge_request.state, nil)
   end
 
   def after_update(merge_request)
     notification.reassigned_merge_request(merge_request, current_user) if merge_request.is_being_reassigned?
+
+    merge_request.notice_added_references(merge_request.project, current_user)
   end
 
   def create_event(record, status)

--- a/app/observers/note_observer.rb
+++ b/app/observers/note_observer.rb
@@ -1,5 +1,17 @@
 class NoteObserver < BaseObserver
   def after_create(note)
     notification.new_note(note)
+
+    unless note.system?
+      # Create a cross-reference note if this Note contains GFM that names an
+      # issue, merge request, or commit.
+      note.references.each do |mentioned|
+        Note.create_cross_reference_note(mentioned, note.noteable, note.author, note.project)
+      end
+    end
+  end
+
+  def after_update(note)
+    note.notice_added_references(note.project, current_user)
   end
 end

--- a/app/views/projects/merge_requests/show/_mr_box.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_box.html.haml
@@ -33,4 +33,10 @@
         %i.icon-ok
         Merged by #{link_to_member(@project, @merge_request.merge_event.author)}
         #{time_ago_in_words(@merge_request.merge_event.created_at)} ago.
-
+  - if !@closes_issues.empty? && @merge_request.opened?
+    .ui-box-bottom.alert-info
+      %span
+        %i.icon-ok
+        Accepting this merge request will close #{@closes_issues.size == 1 ? 'issue' : 'issues'}
+        = succeed '.' do
+          != gfm(@closes_issues.map { |i| "##{i.iid}" }.to_sentence)

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -46,6 +46,11 @@ production: &base
     ## Users management
     # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
 
+    ## Automatic issue closing
+    # If a commit message matches this regular express, all issues referenced from the matched text will be closed
+    # if it's pushed to a project's default branch.
+    # issue_closing_pattern: "^([Cc]loses|[Ff]ixes) +#\d+"
+
     ## Default project features settings
     default_projects_features:
       issues: true

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -68,6 +68,7 @@ rescue ArgumentError # no user configured
 end
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
+Settings.gitlab['issue_closing_pattern'] = '^([Cc]loses|[Ff]ixes) #(\d+)' if Settings.gitlab['issue_closing_pattern'].nil?
 Settings.gitlab['default_projects_features'] ||= {}
 Settings.gitlab.default_projects_features['issues']         = true if Settings.gitlab.default_projects_features['issues'].nil?
 Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.gitlab.default_projects_features['merge_requests'].nil?

--- a/db/migrate/20130528184641_add_system_to_notes.rb
+++ b/db/migrate/20130528184641_add_system_to_notes.rb
@@ -1,0 +1,16 @@
+class AddSystemToNotes < ActiveRecord::Migration
+  class Note < ActiveRecord::Base
+  end
+
+  def up
+    add_column :notes, :system, :boolean, default: false, null: false
+
+    Note.reset_column_information
+    Note.update_all(system: false)
+    Note.where("note like '_status changed to%'").update_all(system: true)
+  end
+
+  def down
+    remove_column :notes, :system
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(:version => 20130821090531) do
     t.string   "commit_id"
     t.integer  "noteable_id"
     t.text     "st_diff"
+    t.boolean  "system",        :default => false, :null => false
   end
 
   add_index "notes", ["author_id"], :name => "index_notes_on_author_id"

--- a/lib/gitlab/reference_extractor.rb
+++ b/lib/gitlab/reference_extractor.rb
@@ -1,0 +1,59 @@
+module Gitlab
+  # Extract possible GFM references from an arbitrary String for further processing.
+  class ReferenceExtractor
+    attr_accessor :users, :issues, :merge_requests, :snippets, :commits
+
+    include Markdown
+
+    def initialize
+      @users, @issues, @merge_requests, @snippets, @commits = [], [], [], [], []
+    end
+
+    def analyze string
+      parse_references(string.dup)
+    end
+
+    # Given a valid project, resolve the extracted identifiers of the requested type to
+    # model objects.
+
+    def users_for project
+      users.map do |identifier|
+        project.users.where(username: identifier).first
+      end.reject(&:nil?)
+    end
+
+    def issues_for project
+      issues.map do |identifier|
+        project.issues.where(iid: identifier).first
+      end.reject(&:nil?)
+    end
+
+    def merge_requests_for project
+      merge_requests.map do |identifier|
+        project.merge_requests.where(iid: identifier).first
+      end.reject(&:nil?)
+    end
+
+    def snippets_for project
+      snippets.map do |identifier|
+        project.snippets.where(id: identifier).first
+      end.reject(&:nil?)
+    end
+
+    def commits_for project
+      repo = project.repository
+      return [] if repo.nil?
+
+      commits.map do |identifier|
+        repo.commit(identifier)
+      end.reject(&:nil?)
+    end
+
+    private
+
+    def reference_link type, identifier
+      # Append identifier to the appropriate collection.
+      send("#{type}s") << identifier
+    end
+  end
+end

--- a/spec/lib/gitlab/reference_extractor_spec.rb
+++ b/spec/lib/gitlab/reference_extractor_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Gitlab::ReferenceExtractor do
+  it 'extracts username references' do
+    subject.analyze "this contains a @user reference"
+    subject.users.should == ["user"]
+  end
+
+  it 'extracts issue references' do
+    subject.analyze "this one talks about issue #1234"
+    subject.issues.should == ["1234"]
+  end
+
+  it 'extracts merge request references' do
+    subject.analyze "and here's !43, a merge request"
+    subject.merge_requests.should == ["43"]
+  end
+
+  it 'extracts snippet ids' do
+    subject.analyze "snippets like $12 get extracted as well"
+    subject.snippets.should == ["12"]
+  end
+
+  it 'extracts commit shas' do
+    subject.analyze "commit shas 98cf0ae3 are pulled out as Strings"
+    subject.commits.should == ["98cf0ae3"]
+  end
+
+  it 'extracts multiple references and preserves their order' do
+    subject.analyze "@me and @you both care about this"
+    subject.users.should == ["me", "you"]
+  end
+
+  it 'leaves the original note unmodified' do
+    text = "issue #123 is just the worst, @user"
+    subject.analyze text
+    text.should == "issue #123 is just the worst, @user"
+  end
+
+  it 'handles all possible kinds of references' do
+    accessors = Gitlab::Markdown::TYPES.map { |t| "#{t}s".to_sym }
+    subject.should respond_to(*accessors)
+  end
+
+  context 'with a project' do
+    let(:project) { create(:project_with_code) }
+
+    it 'accesses valid user objects on the project team' do
+      @u_foo = create(:user, username: 'foo')
+      @u_bar = create(:user, username: 'bar')
+      create(:user, username: 'offteam')
+
+      project.team << [@u_foo, :reporter]
+      project.team << [@u_bar, :guest]
+
+      subject.analyze "@foo, @baduser, @bar, and @offteam"
+      subject.users_for(project).should == [@u_foo, @u_bar]
+    end
+
+    it 'accesses valid issue objects' do
+      @i0 = create(:issue, project: project)
+      @i1 = create(:issue, project: project)
+
+      subject.analyze "##{@i0.iid}, ##{@i1.iid}, and #999."
+      subject.issues_for(project).should == [@i0, @i1]
+    end
+
+    it 'accesses valid merge requests' do
+      @m0 = create(:merge_request, source_project: project, target_project: project, source_branch: 'aaa')
+      @m1 = create(:merge_request, source_project: project, target_project: project, source_branch: 'bbb')
+
+      subject.analyze "!999, !#{@m1.iid}, and !#{@m0.iid}."
+      subject.merge_requests_for(project).should == [@m1, @m0]
+    end
+
+    it 'accesses valid snippets' do
+      @s0 = create(:project_snippet, project: project)
+      @s1 = create(:project_snippet, project: project)
+      @s2 = create(:project_snippet)
+
+      subject.analyze "$#{@s0.id}, $999, $#{@s2.id}, $#{@s1.id}"
+      subject.snippets_for(project).should == [@s0, @s1]
+    end
+
+    it 'accesses valid commits' do
+      commit = project.repository.commit("master")
+
+      subject.analyze "this references commits #{commit.sha[0..6]} and 012345"
+      extracted = subject.commits_for(project)
+      extracted.should have(1).item
+      extracted[0].sha.should == commit.sha
+      extracted[0].message.should == commit.message
+    end
+  end
+end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -56,4 +56,10 @@ describe Issue do
       Issue.open_for(user).count.should eq 2
     end
   end
+
+  it_behaves_like 'an editable mentionable' do
+    let(:subject) { create :issue, project: mproject }
+    let(:backref_text) { "issue ##{subject.iid}" }
+    let(:set_mentionable_text) { ->(txt){ subject.description = txt } }
+  end
 end

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -43,7 +43,6 @@ describe MergeRequest do
     it { should include_module(Issuable) }
   end
 
-
   describe "#mr_and_commit_notes" do
     let!(:merge_request) { create(:merge_request) }
 
@@ -104,4 +103,34 @@ describe MergeRequest do
     end
   end
 
+  describe 'detection of issues to be closed' do
+    let(:issue0) { create :issue, project: subject.project }
+    let(:issue1) { create :issue, project: subject.project }
+    let(:commit0) { mock('commit0', closes_issues: [issue0]) }
+    let(:commit1) { mock('commit1', closes_issues: [issue0]) }
+    let(:commit2) { mock('commit2', closes_issues: [issue1]) }
+
+    before do
+      subject.stub(unmerged_commits: [commit0, commit1, commit2])
+    end
+
+    it 'accesses the set of issues that will be closed on acceptance' do
+      subject.project.default_branch = subject.target_branch
+
+      subject.closes_issues.should == [issue0, issue1].sort_by(&:id)
+    end
+
+    it 'only lists issues as to be closed if it targets the default branch' do
+      subject.project.default_branch = 'master'
+      subject.target_branch = 'something-else'
+
+      subject.closes_issues.should be_empty
+    end
+  end
+
+  it_behaves_like 'an editable mentionable' do
+    let(:subject) { create :merge_request, source_project: mproject, target_project: mproject }
+    let(:backref_text) { "merge request !#{subject.iid}" }
+    let(:set_mentionable_text) { ->(txt){ subject.title = txt } }
+  end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -72,7 +72,6 @@ describe Note do
   end
 
   let(:project) { create(:project) }
-  let(:commit) { project.repository.commit }
 
   describe "Commit notes" do
     let!(:note) { create(:note_on_commit, note: "+1 from me") }
@@ -131,7 +130,7 @@ describe Note do
   describe "Merge request notes" do
     let!(:note) { create(:note_on_merge_request, note: "+1 from me") }
 
-    it "should not be votable" do
+    it "should be votable" do
       note.should be_votable
     end
   end
@@ -150,7 +149,7 @@ describe Note do
     let(:author) { create(:user) }
     let(:status) { 'new_status' }
 
-    subject { Note.create_status_change_note(thing, project, author, status) }
+    subject { Note.create_status_change_note(thing, project, author, status, nil) }
 
     it 'creates and saves a Note' do
       should be_a Note
@@ -161,6 +160,102 @@ describe Note do
     its(:project) { should == thing.project }
     its(:author) { should == author }
     its(:note) { should =~ /Status changed to #{status}/ }
+
+    it 'appends a back-reference if a closing mentionable is supplied' do
+      commit = double('commit', gfm_reference: 'commit 123456')
+      n = Note.create_status_change_note(thing, project, author, status, commit)
+
+      n.note.should =~ /Status changed to #{status} by commit 123456/
+    end
+  end
+
+  describe '#create_cross_reference_note' do
+    let(:project)    { create(:project_with_code) }
+    let(:author)     { create(:user) }
+    let(:issue)      { create(:issue, project: project) }
+    let(:mergereq)   { create(:merge_request, target_project: project) }
+    let(:commit)     { project.repository.commit }
+
+    # Test all of {issue, merge request, commit} in both the referenced and referencing
+    # roles, to ensure that the correct information can be inferred from any argument.
+
+    context 'issue from a merge request' do
+      subject { Note.create_cross_reference_note(issue, mergereq, author, project) }
+
+      it { should be_valid }
+      its(:noteable) { should == issue }
+      its(:project)  { should == issue.project }
+      its(:author)   { should == author }
+      its(:note) { should == "_mentioned in merge request !#{mergereq.iid}_" }
+    end
+
+    context 'issue from a commit' do
+      subject { Note.create_cross_reference_note(issue, commit, author, project) }
+
+      it { should be_valid }
+      its(:noteable) { should == issue }
+      its(:note) { should == "_mentioned in commit #{commit.sha[0..5]}_" }
+    end
+
+    context 'merge request from an issue' do
+      subject { Note.create_cross_reference_note(mergereq, issue, author, project) }
+
+      it { should be_valid }
+      its(:noteable) { should == mergereq }
+      its(:project) { should == mergereq.project }
+      its(:note) { should == "_mentioned in issue ##{issue.iid}_" }
+    end
+
+    context 'commit from a merge request' do
+      subject { Note.create_cross_reference_note(commit, mergereq, author, project) }
+
+      it { should be_valid }
+      its(:noteable) { should == commit }
+      its(:project) { should == project }
+      its(:note) { should == "_mentioned in merge request !#{mergereq.iid}_" }
+    end
+  end
+
+  describe '#cross_reference_exists?' do
+    let(:project) { create :project }
+    let(:author) { create :user }
+    let(:issue) { create :issue }
+    let(:commit0) { double 'commit0', gfm_reference: 'commit 123456' }
+    let(:commit1) { double 'commit1', gfm_reference: 'commit 654321' }
+
+    before do
+      Note.create_cross_reference_note(issue, commit0, author, project)
+    end
+
+    it 'detects if a mentionable has already been mentioned' do
+      Note.cross_reference_exists?(issue, commit0).should be_true
+    end
+
+    it 'detects if a mentionable has not already been mentioned' do
+      Note.cross_reference_exists?(issue, commit1).should be_false
+    end
+  end
+
+  describe '#system?' do
+    let(:project) { create(:project) }
+    let(:issue)   { create(:issue, project: project) }
+    let(:other)   { create(:issue, project: project) }
+    let(:author)  { create(:user) }
+
+    it 'should recognize user-supplied notes as non-system' do
+      @note = create(:note_on_issue)
+      @note.should_not be_system
+    end
+
+    it 'should identify status-change notes as system notes' do
+      @note = Note.create_status_change_note(issue, project, author, 'closed', nil)
+      @note.should be_system
+    end
+
+    it 'should identify cross-reference notes as system notes' do
+      @note = Note.create_cross_reference_note(issue, other, author, project)
+      @note.should be_system
+    end
   end
 
   describe :authorization do
@@ -207,5 +302,12 @@ describe Note do
       it { @abilities.allowed?(@u2, :admin_note, @p1).should be_true }
       it { @abilities.allowed?(@u3, :admin_note, @p1).should be_false }
     end
+  end
+
+  it_behaves_like 'an editable mentionable' do
+    let(:issue) { create :issue, project: project }
+    let(:subject) { create :note, noteable: issue, project: project }
+    let(:backref_text) { issue.gfm_reference }
+    let(:set_mentionable_text) { ->(txt) { subject.note = txt } }
   end
 end

--- a/spec/observers/activity_observer_spec.rb
+++ b/spec/observers/activity_observer_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe ActivityObserver do
   let(:project)  { create(:project) }
 
+  before { Thread.current[:current_user] = create(:user) }
+
   def self.it_should_be_valid_event
     it { @event.should_not be_nil }
     it { @event.project.should == project }
@@ -33,5 +35,27 @@ describe ActivityObserver do
     it_should_be_valid_event
     it { @event.action.should == Event::COMMENTED }
     it { @event.target.should == @note }
+  end
+
+  describe "Ignore system notes" do
+    let(:author) { create(:user) }
+    let!(:issue) { create(:issue, project: project) }
+    let!(:other) { create(:issue) }
+
+    it "should not create events for status change notes" do
+      expect do
+        Note.observers.enable :activity_observer do
+          Note.create_status_change_note(issue, project, author, 'reopened', nil)
+        end
+      end.to_not change { Event.count }
+    end
+
+    it "should not create events for cross-reference notes" do
+      expect do
+        Note.observers.enable :activity_observer do
+          Note.create_cross_reference_note(issue, other, author, issue.project)
+        end
+      end.to_not change { Event.count }
+    end
   end
 end

--- a/spec/observers/merge_request_observer_spec.rb
+++ b/spec/observers/merge_request_observer_spec.rb
@@ -5,15 +5,20 @@ describe MergeRequestObserver do
   let(:assignee) { create :user }
   let(:author) { create :user }
   let(:mr_mock) { double(:merge_request, id: 42, assignee: assignee, author: author) }
-  let(:assigned_mr) { create(:merge_request, assignee: assignee, author: author) }
-  let(:unassigned_mr) { create(:merge_request, author: author) }
-  let(:closed_assigned_mr) { create(:closed_merge_request, assignee: assignee, author: author) }
-  let(:closed_unassigned_mr) { create(:closed_merge_request, author: author) }
+  let(:assigned_mr) { create(:merge_request, assignee: assignee, author: author, target_project: create(:project)) }
+  let(:unassigned_mr) { create(:merge_request, author: author, target_project: create(:project)) }
+  let(:closed_assigned_mr) { create(:closed_merge_request, assignee: assignee, author: author, target_project: create(:project)) }
+  let(:closed_unassigned_mr) { create(:closed_merge_request, author: author, target_project: create(:project)) }
 
   before { subject.stub(:current_user).and_return(some_user) }
   before { subject.stub(notification: mock('NotificationService').as_null_object) }
   before { mr_mock.stub(:author_id) }
   before { mr_mock.stub(:target_project) }
+  before { mr_mock.stub(:source_project) }
+  before { mr_mock.stub(:project) }
+  before { mr_mock.stub(:create_cross_references!).and_return(true) }
+  before { Repository.any_instance.stub(commit: nil) }
+
   before(:each) { enable_observers }
   after(:each) { disable_observers }
 
@@ -24,11 +29,20 @@ describe MergeRequestObserver do
       subject.should_receive(:notification)
       subject.after_create(mr_mock)
     end
+
+    it 'creates cross-reference notes' do
+       project = create :project
+       mr_mock.stub(title: "this mr references !#{assigned_mr.id}", project: project)
+       mr_mock.should_receive(:create_cross_references!).with(project, some_user)
+
+       subject.after_create(mr_mock)
+    end
   end
 
   context '#after_update' do
     before(:each) do
       mr_mock.stub(:is_being_reassigned?).and_return(false)
+      mr_mock.stub(:notice_added_references)
     end
 
     it 'is called when a merge request is changed' do
@@ -39,6 +53,12 @@ describe MergeRequestObserver do
         changed.title = 'I changed'
         changed.save
       end
+    end
+
+    it 'checks for new references' do
+      mr_mock.should_receive(:notice_added_references)
+
+      subject.after_update(mr_mock)
     end
 
     context 'a notification' do
@@ -61,13 +81,13 @@ describe MergeRequestObserver do
   context '#after_close' do
     context 'a status "closed"' do
       it 'note is created if the merge request is being closed' do
-        Note.should_receive(:create_status_change_note).with(assigned_mr, assigned_mr.target_project, some_user, 'closed')
+        Note.should_receive(:create_status_change_note).with(assigned_mr, assigned_mr.target_project, some_user, 'closed', nil)
 
         assigned_mr.close
       end
 
       it 'notification is delivered only to author if the merge request is being closed' do
-        Note.should_receive(:create_status_change_note).with(unassigned_mr, unassigned_mr.target_project, some_user, 'closed')
+        Note.should_receive(:create_status_change_note).with(unassigned_mr, unassigned_mr.target_project, some_user, 'closed', nil)
 
         unassigned_mr.close
       end
@@ -77,13 +97,13 @@ describe MergeRequestObserver do
   context '#after_reopen' do
     context 'a status "reopened"' do
       it 'note is created if the merge request is being reopened' do
-        Note.should_receive(:create_status_change_note).with(closed_assigned_mr, closed_assigned_mr.target_project, some_user, 'reopened')
+        Note.should_receive(:create_status_change_note).with(closed_assigned_mr, closed_assigned_mr.target_project, some_user, 'reopened', nil)
 
         closed_assigned_mr.reopen
       end
 
       it 'notification is delivered only to author if the merge request is being reopened' do
-        Note.should_receive(:create_status_change_note).with(closed_unassigned_mr, closed_unassigned_mr.target_project, some_user, 'reopened')
+        Note.should_receive(:create_status_change_note).with(closed_unassigned_mr, closed_unassigned_mr.target_project, some_user, 'reopened', nil)
 
         closed_unassigned_mr.reopen
       end

--- a/spec/observers/note_observer_spec.rb
+++ b/spec/observers/note_observer_spec.rb
@@ -5,9 +5,9 @@ describe NoteObserver do
   before { subject.stub(notification: mock('NotificationService').as_null_object) }
 
   let(:team_without_author) { (1..2).map { |n| double :user, id: n } }
+  let(:note) { double(:note).as_null_object }
 
   describe '#after_create' do
-    let(:note) { double :note }
 
     it 'is called after a note is created' do
       subject.should_receive :after_create
@@ -21,6 +21,36 @@ describe NoteObserver do
       subject.should_receive(:notification)
 
       subject.after_create(note)
+    end
+
+    it 'creates cross-reference notes as appropriate' do
+      @p = create(:project)
+      @referenced = create(:issue, project: @p)
+      @referencer = create(:issue, project: @p)
+      @author = create(:user)
+
+      Note.should_receive(:create_cross_reference_note).with(@referenced, @referencer, @author, @p)
+
+      Note.observers.enable :note_observer do
+        create(:note, project: @p, author: @author, noteable: @referencer,
+          note: "Duplicate of ##{@referenced.iid}")
+      end
+    end
+
+    it "doesn't cross-reference system notes" do
+      Note.should_receive(:create_cross_reference_note).once
+
+      Note.observers.enable :note_observer do
+        Note.create_cross_reference_note(create(:issue), create(:issue))
+      end
+    end
+  end
+
+  describe '#after_update' do
+    it 'checks for new cross-references' do
+      note.should_receive(:notice_added_references)
+
+      subject.after_update(note)
     end
   end
 end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -18,6 +18,7 @@ module LoginHelpers
     fill_in "user_login", with: user.email
     fill_in "user_password", with: "123456"
     click_button "Sign in"
+    Thread.current[:current_user] = user
   end
 
   def logout

--- a/spec/support/mentionable_shared_examples.rb
+++ b/spec/support/mentionable_shared_examples.rb
@@ -1,0 +1,94 @@
+# Specifications for behavior common to all Mentionable implementations.
+# Requires a shared context containing:
+# - let(:subject) { "the mentionable implementation" }
+# - let(:backref_text) { "the way that +subject+ should refer to itself in backreferences " }
+# - let(:set_mentionable_text) { lambda { |txt| "block that assigns txt to the subject's mentionable_text" } }
+
+def common_mentionable_setup
+  # Avoid name collisions with let(:project) or let(:author) in the surrounding scope.
+  let(:mproject) { create :project }
+  let(:mauthor) { subject.author }
+
+  let(:mentioned_issue) { create :issue, project: mproject }
+  let(:other_issue) { create :issue, project: mproject }
+  let(:mentioned_mr) { create :merge_request, target_project: mproject, source_branch: 'different' }
+  let(:mentioned_commit) { mock('commit', sha: '1234567890abcdef').as_null_object }
+
+  # Override to add known commits to the repository stub.
+  let(:extra_commits) { [] }
+
+  # A string that mentions each of the +mentioned_.*+ objects above. Mentionables should add a self-reference
+  # to this string and place it in their +mentionable_text+.
+  let(:ref_string) do
+    "mentions ##{mentioned_issue.iid} twice ##{mentioned_issue.iid}, !#{mentioned_mr.iid}, " +
+    "#{mentioned_commit.sha[0..5]} and itself as #{backref_text}"
+  end
+
+  before do
+    # Wire the project's repository to return the mentioned commit, and +nil+ for any
+    # unrecognized commits.
+    commitmap = { '123456' => mentioned_commit }
+    extra_commits.each { |c| commitmap[c.sha[0..5]] = c }
+
+    repo = mock('repository')
+    repo.stub(:commit) { |sha| commitmap[sha] }
+    mproject.stub(repository: repo)
+
+    set_mentionable_text.call(ref_string)
+  end
+end
+
+shared_examples 'a mentionable' do
+  common_mentionable_setup
+
+  it 'generates a descriptive back-reference' do
+    subject.gfm_reference.should == backref_text
+  end
+
+  it "extracts references from its reference property" do
+    # De-duplicate and omit itself
+    refs = subject.references(mproject)
+
+    refs.should have(3).items
+    refs.should include(mentioned_issue)
+    refs.should include(mentioned_mr)
+    refs.should include(mentioned_commit)
+  end
+
+  it 'creates cross-reference notes' do
+    [mentioned_issue, mentioned_mr, mentioned_commit].each do |referenced|
+      Note.should_receive(:create_cross_reference_note).with(referenced, subject.local_reference, mauthor, mproject)
+    end
+
+    subject.create_cross_references!(mproject, mauthor)
+  end
+
+  it 'detects existing cross-references' do
+    Note.create_cross_reference_note(mentioned_issue, subject.local_reference, mauthor, mproject)
+
+    subject.has_mentioned?(mentioned_issue).should be_true
+    subject.has_mentioned?(mentioned_mr).should be_false
+  end
+end
+
+shared_examples 'an editable mentionable' do
+  common_mentionable_setup
+
+  it_behaves_like 'a mentionable'
+
+  it 'creates new cross-reference notes when the mentionable text is edited' do
+    new_text = "this text still mentions ##{mentioned_issue.iid} and #{mentioned_commit.sha[0..5]}, " +
+      "but now it mentions ##{other_issue.iid}, too."
+
+    [mentioned_issue, mentioned_commit].each do |oldref|
+      Note.should_not_receive(:create_cross_reference_note).with(oldref, subject.local_reference,
+        mauthor, mproject)
+    end
+
+    Note.should_receive(:create_cross_reference_note).with(other_issue, subject.local_reference, mauthor, mproject)
+
+    subject.save
+    set_mentionable_text.call(new_text)
+    subject.notice_added_references(mproject, mauthor)
+  end
+end


### PR DESCRIPTION
Hello!

This is an implementation in progress of [linking issues from comments](http://feedback.gitlab.com/forums/176466-general/suggestions/3692754-linking-issue-references), also referenced in #2676, #2714, #1170, #302, and probably others. I'm pushing it out now to get early feedback on what I've already done and to hear any thoughts about edge cases I might not be accounting for.

Any mention of issues, merge requests, or commits via GitLab-flavored markdown references in descriptions, titles or follow-on notes to any of the above attaches a system note to the referenced object containing a backtracking link. Furthermore, pushing commits that match a (configurable) regexp to a project's default branch will close any issues mentioned in the closing phrase.

_Left to do:_
- [x] Only close issues from commits pushed to the project's default branch -- meaning, actually make it do that thing I said it does :wink:
- [x] If any `Mentionable` is edited, create additional cross-references for any references that weren't there to begin with.
- [x] Merge request and issue creation don't create cross-references correctly, only notes and edits. D'oh.
- [x] Accepting a merge request that brings in a commit that "fixes" an issue works fine, but if the "fixes" text is in a line other than the first, it happens without warning. Detect and add an "accepting this request will close issues X, Y, and Z" banner on the merge request page.
- [x] Look into using `ActiveRecord::Dirty` to implement `Mentionable#watch_references`, which would let us push reference updating into the observers where it belongs.
- [x] Duplicate "mentioned in commit..." notes when a commit that mentions a thing is merged into a new branch.
- [x] Link an issue closed notification back to the commit that closed it, when closing from a commit. "Status changed to closed by..."
- [x] Catch references in the commits in the first push to a new branch.
- [x] Do a final rebase and squash on upstream master.
