### PR TITLE
Fix broken API links, fixes #4463

### DIFF
--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -69,18 +69,18 @@ When listing resources you can pass the following parameters:
 
 ## Contents
 
-+ [Users](users.md)
-+ [Session](session.md)
-+ [Projects](projects.md)
-+ [Project Snippets](project_snippets.md)
-+ [Repositories](repositories.md)
-+ [Issues](issues.md)
-+ [Milestones](milestones.md)
-+ [Notes](notes.md)
-+ [Deploy Keys](deploy_keys.md)
-+ [System Hooks](system_hooks.md)
-+ [Groups](groups.md)
-+ [User Teams](user_teams.md)
++ [Users](api/users.md)
++ [Session](api/session.md)
++ [Projects](api/projects.md)
++ [Project Snippets](api/project_snippets.md)
++ [Repositories](api/repositories.md)
++ [Issues](api/issues.md)
++ [Milestones](api/milestones.md)
++ [Notes](api/notes.md)
++ [Deploy Keys](api/deploy_keys.md)
++ [System Hooks](api/system_hooks.md)
++ [Groups](api/groups.md)
++ [User Teams](api/user_teams.md)
 
 ## Clients
 


### PR DESCRIPTION
This PR reverts the changes from ad0f1276dbfffadb18fa28980fb4bca91dbc19b9.
Although the links won't work on Github anymore this fixes the wrong links for a GitLab instance.

I think it's better to have a working GitLab instead of being able to browse the links on Github's project browser.
