### PR TITLE
UI : navbar tooltip position fix when "loading" appears.

### DIFF
--- a/app/assets/stylesheets/gitlab_bootstrap/nav.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/nav.scss
@@ -64,3 +64,14 @@
 
   &.nav-small-tabs > li > a { padding: 6px 9px; }
 }
+
+
+
+/**
+ * fix to keep tooltips position in top navigation bar
+ *
+ */
+.navbar .nav > li {
+  position: relative;
+  white-space: nowrap;
+}


### PR DESCRIPTION
When the loading list item appears, the tooltip change its position:
##### Before clicking :

![before-click](https://f.cloud.github.com/assets/801718/758342/1781d91e-e72b-11e2-8d60-b08da78e40e0.png)
##### After clicking :

![after-click](https://f.cloud.github.com/assets/801718/758343/1fea6530-e72b-11e2-8b3e-e0b156277ec2.png)

This pull request fixes the issue.
