### PR TITLE
Additon of apis for fork administration.

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -453,3 +453,28 @@ Parameters:
 + `id` (required) - The ID of the project.
 + `branch` (required) - The name of the branch.
 
+
+## Admin fork relation
+
+Allows modification of the forked relationship between existing projects. . Available only for admins.
+
+### Create a forked from/to relation between existing projects.
+
+```
+POST /projects/:id/fork/:forked_from_id
+```
+
+Parameters:
+
++ `id` (required) - The ID of the project
++ `forked_from_id:` (required) - The ID of the project that was forked from
+
+### Delete an existing forked from relationship
+
+```
+DELETE /projects/:id/fork
+```
+
+Parameter:
+
++ `id` (required) - The ID of the project

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -25,6 +25,12 @@ module API
       expose :id, :url, :created_at
     end
 
+    class ForkedFromProject < Grape::Entity
+      expose :id
+      expose :name, :name_with_namespace
+      expose :path, :path_with_namespace
+    end
+
     class Project < Grape::Entity
       expose :id, :description, :default_branch, :public, :ssh_url_to_repo, :http_url_to_repo, :web_url
       expose :owner, using: Entities::UserBasic
@@ -32,6 +38,7 @@ module API
       expose :path, :path_with_namespace
       expose :issues_enabled, :merge_requests_enabled, :wall_enabled, :wiki_enabled, :created_at, :last_activity_at
       expose :namespace
+      expose :forked_from_project, using: Entities::ForkedFromProject, :if => lambda{ | project, options | project.forked? }
     end
 
     class ProjectMember < UserBasic

--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -5,12 +5,12 @@ module API
     end
 
     def user_project
-      @project ||= find_project
+      @project ||= find_project(params[:id])
       @project || not_found!
     end
 
-    def find_project
-      project = Project.find_by_id(params[:id]) || Project.find_with_namespace(params[:id])
+    def find_project(id)
+      project = Project.find_by_id(id) || Project.find_with_namespace(id)
 
       if project && can?(current_user, :read_project, project)
         project

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -121,6 +121,42 @@ module API
       end
 
 
+      # Mark this project as forked from another
+      #
+      # Parameters:
+      #   id: (required) - The ID of the project being marked as a fork
+      #   forked_from_id: (required) - The ID of the project it was forked from
+      # Example Request:
+      #   POST /projects/:id/fork/:forked_from_id
+      post ":id/fork/:forked_from_id" do
+        authenticated_as_admin!
+        forked_from_project = find_project(params[:forked_from_id])
+        unless forked_from_project.nil?
+          if user_project.forked_from_project.nil?
+            user_project.create_forked_project_link(forked_to_project_id: user_project.id, forked_from_project_id: forked_from_project.id)
+          else
+            render_api_error!("Project already forked", 409)
+          end
+        else
+          not_found!
+        end
+
+      end
+
+      # Remove a forked_from relationship
+      #
+      # Parameters:
+      # id: (required) - The ID of the project being marked as a fork
+      # Example Request:
+      #  DELETE /projects/:id/fork
+      delete ":id/fork" do
+        authenticated_as_admin!
+        unless user_project.forked_project_link.nil?
+          user_project.forked_project_link.destroy
+        end
+      end
+
+
       # Get a project team members
       #
       # Parameters:


### PR DESCRIPTION
Added ability to add and remove the forked from/to relationship
between existing repos.

This is primarily useful when migrating repos from something like github into gitlab, allowing the fork from/to relationship to be maintained.
