### PR TITLE
Increased flash timeout to 15 seconds

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -86,7 +86,7 @@ $ ->
   if (flash = $(".flash-container")).length > 0
     flash.click -> $(@).fadeOut()
     flash.show()
-    setTimeout (-> flash.fadeOut()), 3000
+    setTimeout (-> flash.fadeOut()), 15000
 
   # Disable form buttons while a form is submitting
   $('body').on 'ajax:complete, ajax:beforeSend, submit', 'form', (e) ->


### PR DESCRIPTION
Hi,

The current timeout of 3 seconds for the flash notification is way to short. Sometimes it's quite hard to read the message, especially if it is a little longer. 

I increased it to 15 seconds, which also should be enough for longer messages. 
