### PR TITLE
Fix header text for setting greatest team access to a project

### DIFF
--- a/app/views/admin/teams/projects/new.html.haml
+++ b/app/views/admin/teams/projects/new.html.haml
@@ -8,7 +8,7 @@
     .input
       = select_tag :project_ids, options_from_collection_for_select(@projects , :id, :name_with_namespace), multiple: true, data: {placeholder: 'Select projects'}, class: 'chosen span5'
 
-  %h6 Choose greatest user acces for your team in this projects:
+  %h6 Choose greatest user access for your team in these projects:
   .clearfix
     = label_tag :greatest_project_access, "Greatest Access"
     .input

--- a/app/views/projects/teams/available.html.haml
+++ b/app/views/projects/teams/available.html.haml
@@ -10,7 +10,7 @@
   .padded
     = label_tag :team_id, "Team"
     .input= select_tag(:team_id, options_from_collection_for_select(@teams, :id, :name), prompt: "Select team", class: "chosen xxlarge", required: true)
-  %p.slead Choose greatest user acces in team you want to assign:
+  %p.slead Choose greatest user access for your team in this project:
   .padded
     = label_tag :team_ids, "Permission"
     .input= select_tag :greatest_project_access, options_for_select(UserTeam.access_roles), {class: "project-access-select chosen span3" }


### PR DESCRIPTION
Adjusted the text so that it matches between both pages where greatest user access is chosen.
