### PR TITLE
Allow SSH keys to be of type ecdsa rather than only rsa and dsa (which are slower, older, and weaker)

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -22,7 +22,7 @@ class Key < ActiveRecord::Base
   before_validation :strip_white_space
 
   validates :title, presence: true, length: { within: 0..255 }
-  validates :key, presence: true, length: { within: 0..5000 }, format: { with: /\Assh-.*\Z/ }, uniqueness: true
+  validates :key, presence: true, length: { within: 0..5000 }, format: { with: /\A(ssh|ecdsa)-.*\Z/ }, uniqueness: true
   validate :fingerprintable_key
 
   delegate :name, :email, to: :user, prefix: true


### PR DESCRIPTION
Update app/models/key.rb to permit SSH keys of type ecdsa rather than forcing dsa and rsa algorithms.
