### PR TITLE
Correct path to view for huge commits. Fix #3996

### DIFF
--- a/app/views/projects/commit/huge_commit.html.haml
+++ b/app/views/projects/commit/huge_commit.html.haml
@@ -1,3 +1,3 @@
-= render "commit/commit_box"
+= render "projects/commit/commit_box"
 .alert.alert-error
   %h4 Commit diffs are too big to be displayed


### PR DESCRIPTION
When the view path was incorrect, the haml parser fails and get error wich shown in #3996. This work only on huge commit. I tested and checked this on gitlab-vagrant-vm and found this error on internal repo brightbox/brightbox-cli on the commit url: http://192.168.3.14:3000/brightbox/brightbox-cli/commit/442244140535c7f617d6112b7f6cd10f68ac8cc1
