### PR TITLE
Fix download link to "other files" in blob

### DIFF
--- a/app/views/projects/blob/_download.html.haml
+++ b/app/views/projects/blob/_download.html.haml
@@ -1,6 +1,6 @@
 .file-content.blob_file
   %center
-    = link_to project_blob_path(@project, @id) do
+    = link_to project_raw_path(@project, @id) do
       %div.padded
         %h4
           %i.icon-download-alt


### PR DESCRIPTION
This fix the download link in blob, example:

![gitlab](https://f.cloud.github.com/assets/965653/801276/fa35c164-ed9b-11e2-91dc-57340a71775d.jpg)

Currently this link returns us back to the same page that we find, however with this fix will begin downloading the file.

Sorry for my bad English, my native languaje is Spanish
