### PR TITLE
Custom gitlab-shell home path and authorized_keys file path

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -71,7 +71,7 @@ production: &base
     #   ##  :project_id        - GitLab project identifier
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
-    # 
+    #
     # jira:
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
@@ -143,9 +143,14 @@ production: &base
 
   ## GitLab Shell settings
   gitlab_shell:
+    # GitLab Shell deployment directory path
+    home_path: /home/git/gitlab-shell/
     # REPOS_PATH MUST NOT BE A SYMLINK!!!
     repos_path: /home/git/repositories/
-    hooks_path: /home/git/gitlab-shell/hooks/
+    # hooks_path: /home/git/gitlab-shell/hooks/    # default: 'hooks/' relative to home_path
+
+    # File used as authorized_keys for gitlab user
+    # auth_file: "/home/git/.ssh/authorized_keys"  # must be the same as the one in gitlab-shell's config.yml
 
     # Git over HTTP
     upload_pack: true

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -86,7 +86,8 @@ Settings.gravatar['ssl_url']    ||= 'https://secure.gravatar.com/avatar/%{hash}?
 # GitLab Shell
 #
 Settings['gitlab_shell'] ||= Settingslogic.new({})
-Settings.gitlab_shell['hooks_path']   ||= Settings.gitlab['user_home'] + '/gitlab-shell/hooks/'
+Settings.gitlab_shell['home_path']    ||= Settings.gitlab['user_home'] + '/gitlab-shell/'
+Settings.gitlab_shell['hooks_path']   ||= File.expand_path('hooks/', Settings.gitlab_shell.home_path)
 Settings.gitlab_shell['receive_pack']   = true if Settings.gitlab_shell['receive_pack'].nil?
 Settings.gitlab_shell['upload_pack']    = true if Settings.gitlab_shell['upload_pack'].nil?
 Settings.gitlab_shell['repos_path']   ||= Settings.gitlab['user_home'] + '/repositories/'
@@ -95,6 +96,7 @@ Settings.gitlab_shell['ssh_port']     ||= 22
 Settings.gitlab_shell['ssh_user']     ||= Settings.gitlab.user
 Settings.gitlab_shell['owner_group']  ||= Settings.gitlab.user
 Settings.gitlab_shell['ssh_path_prefix'] ||= Settings.send(:build_gitlab_shell_ssh_path_prefix)
+Settings.gitlab_shell['auth_file']    ||= Settings.gitlab['user_home'] + '/.ssh/authorized_keys'
 
 #
 # Backup

--- a/lib/backup/repository.rb
+++ b/lib/backup/repository.rb
@@ -70,8 +70,8 @@ module Backup
       end
 
       print 'Put GitLab hooks in repositories dirs'.yellow
-      gitlab_shell_user_home = File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
-      if system("#{gitlab_shell_user_home}/gitlab-shell/support/rewrite-hooks.sh #{Gitlab.config.gitlab_shell.repos_path}")
+      rewrite_hooks_sh_path = File.expand_path("support/rewrite-hooks.sh", Gitlab.config.gitlab_shell.home_path)
+      if system("#{rewrite_hooks_sh_path} #{Gitlab.config.gitlab_shell.repos_path}")
         puts " [DONE]".green
       else
         puts " [FAILED]".red

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -10,7 +10,7 @@ module Gitlab
     #   add_repository("gitlab/gitlab-ci")
     #
     def add_repository(name)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "add-project", "#{name}.git"
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "add-project", "#{name}.git"
     end
 
     # Import repository
@@ -21,7 +21,7 @@ module Gitlab
     #   import_repository("gitlab/gitlab-ci", "https://github.com/randx/six.git")
     #
     def import_repository(name, url)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "import-project", "#{name}.git", url
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "import-project", "#{name}.git", url
     end
 
     # Move repository
@@ -33,7 +33,7 @@ module Gitlab
     #   mv_repository("gitlab/gitlab-ci", "randx/gitlab-ci-new.git")
     #
     def mv_repository(path, new_path)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "mv-project", "#{path}.git", "#{new_path}.git"
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "mv-project", "#{path}.git", "#{new_path}.git"
     end
 
     # Update HEAD for repository
@@ -45,7 +45,7 @@ module Gitlab
     #  update_repository_head("gitlab/gitlab-ci", "3-1-stable")
     #
     def update_repository_head(path, branch)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "update-head", "#{path}.git", branch
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "update-head", "#{path}.git", branch
     end
 
     # Fork repository to new namespace
@@ -57,7 +57,7 @@ module Gitlab
     #  fork_repository("gitlab/gitlab-ci", "randx")
     #
     def fork_repository(path, fork_namespace)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "fork-project", "#{path}.git", fork_namespace
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "fork-project", "#{path}.git", fork_namespace
     end
 
     # Remove repository from file system
@@ -68,7 +68,7 @@ module Gitlab
     #   remove_repository("gitlab/gitlab-ci")
     #
     def remove_repository(name)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "rm-project", "#{name}.git"
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "rm-project", "#{name}.git"
     end
 
     # Add repository branch from passed ref
@@ -81,7 +81,7 @@ module Gitlab
     #   add_branch("gitlab/gitlab-ci", "4-0-stable", "master")
     #
     def add_branch(path, branch_name, ref)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "create-branch", "#{path}.git", branch_name, ref
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "create-branch", "#{path}.git", branch_name, ref
     end
 
     # Remove repository branch
@@ -93,7 +93,7 @@ module Gitlab
     #   rm_branch("gitlab/gitlab-ci", "4-0-stable")
     #
     def rm_branch(path, branch_name)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "rm-branch", "#{path}.git", branch_name
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "rm-branch", "#{path}.git", branch_name
     end
 
     # Add repository tag from passed ref
@@ -106,7 +106,7 @@ module Gitlab
     #   add_tag("gitlab/gitlab-ci", "v4.0", "master")
     #
     def add_tag(path, tag_name, ref)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "create-tag", "#{path}.git", tag_name, ref
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "create-tag", "#{path}.git", tag_name, ref
     end
 
     # Remove repository tag
@@ -118,7 +118,7 @@ module Gitlab
     #   rm_tag("gitlab/gitlab-ci", "v4.0")
     #
     def rm_tag(path, tag_name)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "rm-tag", "#{path}.git", tag_name
+      system File.expand_path("bin/gitlab-projects", Gitlab.config.gitlab_shell.home_path), "rm-tag", "#{path}.git", tag_name
     end
 
     # Add new key to gitlab-shell
@@ -127,7 +127,7 @@ module Gitlab
     #   add_key("key-42", "sha-rsa ...")
     #
     def add_key(key_id, key_content)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-keys", "add-key", key_id, key_content
+      system File.expand_path("bin/gitlab-keys", Gitlab.config.gitlab_shell.home_path), "add-key", key_id, key_content
     end
 
     # Remove ssh key from gitlab shell
@@ -136,7 +136,7 @@ module Gitlab
     #   remove_key("key-342", "sha-rsa ...")
     #
     def remove_key(key_id, key_content)
-      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-keys", "rm-key", key_id, key_content
+      system File.expand_path("bin/gitlab-keys", Gitlab.config.gitlab_shell.home_path), "rm-key", key_id, key_content
     end
 
     # Add empty directory for storing repositories
@@ -188,10 +188,6 @@ module Gitlab
     end
 
     protected
-
-    def gitlab_shell_user_home
-      File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
-    end
 
     def repos_path
       Gitlab.config.gitlab_shell.repos_path

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -527,7 +527,7 @@ namespace :gitlab do
               "sudo -u #{gitlab_shell_ssh_user} ln -sf #{gitlab_shell_hook_file} #{project_hook_file}"
             )
             for_more_information(
-              "#{gitlab_shell_user_home}/gitlab-shell/support/rewrite-hooks.sh"
+              File.expand_path("support/rewrite-hooks.sh", Gitlab.config.gitlab_shell.home_path)
             )
             fix_and_rerun
             next
@@ -554,12 +554,8 @@ namespace :gitlab do
     # Helper methods
     ########################
 
-    def gitlab_shell_user_home
-      File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
-    end
-
     def gitlab_shell_version
-      gitlab_shell_version_file = "#{gitlab_shell_user_home}/gitlab-shell/VERSION"
+      gitlab_shell_version_file = File.expand_path("VERSION", Gitlab.config.gitlab_shell.home_path)
       if File.readable?(gitlab_shell_version_file)
         File.read(gitlab_shell_version_file)
       end

--- a/lib/tasks/gitlab/info.rake
+++ b/lib/tasks/gitlab/info.rake
@@ -53,8 +53,8 @@ namespace :gitlab do
 
 
 
-      # check Gitolite version
-      gitlab_shell_version_file = "#{Gitlab.config.gitlab_shell.repos_path}/../gitlab-shell/VERSION"
+      # check GitLab Shell version
+      gitlab_shell_version_file = File.expand_path("VERSION", Gitlab.config.gitlab_shell.home_path)
       if File.readable?(gitlab_shell_version_file)
         gitlab_shell_version = File.read(gitlab_shell_version_file)
       end
@@ -63,6 +63,7 @@ namespace :gitlab do
       puts "GitLab Shell".yellow
       puts "Version:\t#{gitlab_shell_version || "unknown".red}"
       puts "Repositories:\t#{Gitlab.config.gitlab_shell.repos_path}"
+      puts "Home:\t\t#{Gitlab.config.gitlab_shell.home_path}"
       puts "Hooks:\t\t#{Gitlab.config.gitlab_shell.hooks_path}"
       puts "Git:\t\t#{Gitlab.config.git.bin_path}"
 

--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -25,15 +25,14 @@ namespace :gitlab do
   def setup
     warn_user_is_not_gitlab
 
-    gitlab_shell_authorized_keys = File.join(File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}"),'.ssh/authorized_keys')
     unless ENV['force'] == 'yes'
       puts "This will rebuild an authorized_keys file."
-      puts "You will lose any data stored in #{gitlab_shell_authorized_keys}."
+      puts "You will lose any data stored in #{Gitlab.config.gitlab_shell.auth_file}."
       ask_to_continue
       puts ""
     end
 
-    system("echo '# Managed by gitlab-shell' > #{gitlab_shell_authorized_keys}")
+    system("echo '# Managed by gitlab-shell' > #{Gitlab.config.gitlab_shell.auth_file}")
 
     Key.find_each(batch_size: 1000) do |key|
       if Gitlab::Shell.new.add_key(key.shell_id, key.key)


### PR DESCRIPTION
I noticed some small issues.
1. GitLab Shell must be deployed under user home directory, however, the [installation doc](https://github.com/gitlabhq/gitlabhq/blob/master/doc/install/installation.md#4-gitlab-shell) does not specify it with an **Important Note**.
2. `Authorized_keys` file path is customizable in GitLab Shell, but it is hard-coded in GitLab.

So, here comes this pull request, it's convenient especially for development.
