### PR TITLE
Update references to non-existing "unicorn.rb" -> "puma.rb"

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -186,11 +186,11 @@ You can change `5-3-stable` to `master` if you want the *bleeding edge* version,
     sudo chmod -R u+rwX  public/uploads
 
     # Copy the example Puma config
-    sudo -u git -H cp config/unicorn.rb.example config/unicorn.rb
+    sudo -u git -H cp config/puma.rb.example config/puma.rb
 
     # Enable cluster mode if you expect to have a high load instance
     # Ex. change amount of workers to 3 for 2GB RAM server
-    sudo -u git -H vim config/unicorn.rb
+    sudo -u git -H vim config/puma.rb
 
     # Configure Git global settings for git user, useful when editing via web
     # Edit user.email according to what is set in gitlab.yml


### PR DESCRIPTION
The commands and comments had a presumably old reference to a "unicorn.rb" file which no longer exists in the codebase.
