### PR TITLE
Allow admin to transfer projects to any namespace

### DIFF
--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -1,7 +1,11 @@
 module NamespacesHelper
   def namespaces_options(selected = :current_user, scope = :default)
     groups = current_user.owned_groups.select {|n| n.type == 'Group'}
-    users = current_user.namespaces.reject {|n| n.type == 'Group'}
+    users = if current_user.admin
+              Namespace.root
+            else
+              current_user.namespaces.reject {|n| n.type == 'Group'}
+            end
 
     group_opts = ["Groups", groups.sort_by(&:human_name).map {|g| [g.human_name, g.id]} ]
     users_opts = [ "Users", users.sort_by(&:human_name).map {|u| [u.human_name, u.id]} ]


### PR DESCRIPTION
This fixes bug #4456, it allows the admin user to transfer projects to any namespace, not only to his own.
