### PR TITLE
Bump version of gitlab-shell to 1.7.0

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -119,7 +119,7 @@ GitLab Shell is a ssh access and repository management software developed specia
     cd gitlab-shell
 
     # switch to right version
-    sudo -u git -H git checkout v1.4.0
+    sudo -u git -H git checkout v1.7.0
 
     sudo -u git -H cp config.yml.example config.yml
 


### PR DESCRIPTION
Update docs : bump version of gitlab-shell to 1.7.0.
