### PR TITLE
Adding links to the merge requests and group documentation.

### DIFF
--- a/app/views/help/_api_layout.html.haml
+++ b/app/views/help/_api_layout.html.haml
@@ -5,7 +5,7 @@
       Back to help
     %br
     %ul.nav.nav-pills.nav-stacked
-      - %w(README projects project_snippets repositories deploy_keys users session issues milestones notes system_hooks).each do |file|
+      - %w(README projects project_snippets repositories deploy_keys users groups session issues milestones merge_requests notes system_hooks).each do |file|
         %li{class: file == @category ? 'active' : nil}
           = link_to file.titleize, help_api_file_path(file)
 

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -74,6 +74,7 @@ When listing resources you can pass the following parameters:
 + [Projects](projects.md)
 + [Project Snippets](project_snippets.md)
 + [Repositories](repositories.md)
++ [Merge Requests](merge_requests.md)
 + [Issues](issues.md)
 + [Milestones](milestones.md)
 + [Notes](notes.md)


### PR DESCRIPTION
Almost didn't realize there was an api for merge requests - Was about to add support for it when I saw it, so just needed to add links to the documentation :-)

As a heads up - I didn't run this on my local (Running into some issue with the haml parsing - Just errors out - Does that before my change as well though). If someone would be so kind as to run this on their local to test, then it should be good to go.
