### PR TITLE
Introduce allow_single_sign_on_email_regexp to limit automatic account creation

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -117,6 +117,8 @@ production: &base
     # This allows users to login without having a user account first (default: false).
     # User accounts will be created automatically when authentication was successful.
     allow_single_sign_on: false
+    # Limit account creation by email address
+    # allow_single_sign_on_email_regexp: '@yourcompany\.com\z'
     # Locks down those users until they have been cleared by the admin (default: true).
     block_auto_created_users: true
 

--- a/lib/gitlab/auth.rb
+++ b/lib/gitlab/auth.rb
@@ -41,6 +41,10 @@ module Gitlab
       raise OmniAuth::Error, "#{ldap_prefix}#{provider} does not provide an email"\
         " address" if auth.info.email.blank?
 
+      if email_regexp = Gitlab.config.omniauth['allow_single_sign_on_email_regexp']
+        Regexp.new(email_regexp, 'i') === email or return nil
+      end
+
       log.info "#{ldap_prefix}Creating user from #{provider} login"\
         " {uid => #{uid}, name => #{name}, email => #{email}}"
       password = Devise.friendly_token[0, 8].downcase

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -67,9 +67,27 @@ describe Gitlab::Auth do
 
     it "should create user if single_sing_on"do
       Gitlab.config.omniauth['allow_single_sign_on'] = true
+      Gitlab.config.omniauth['allow_single_sign_on_email_regexp'] = nil
       User.stub find_by_provider_and_extern_uid: nil
       gl_auth.should_receive :create_from_omniauth
       gl_auth.find_or_new_for_omniauth(@auth)
+    end
+
+    it "should create user if single_sign_on and email matches email_regexp"do
+      Gitlab.config.omniauth['allow_single_sign_on'] = true
+      Gitlab.config.omniauth['allow_single_sign_on_email_regexp'] = "@mail\\.com\\z"
+      User.stub find_by_provider_and_extern_uid: nil
+      gl_auth.should_receive :create_from_omniauth
+      gl_auth.find_or_new_for_omniauth(@auth)
+    end
+
+    it "should not create user if single_sign_on and email does not match email_regexp"do
+      Gitlab.config.omniauth['allow_single_sign_on'] = true
+      Gitlab.config.omniauth['allow_single_sign_on_email_regexp'] = "@mail\\.net\\z"
+      User.stub find_by_provider_and_extern_uid: nil
+      gl_auth.should_receive :create_from_omniauth
+      user = gl_auth.find_or_new_for_omniauth(@auth)
+      user.should be_nil
     end
   end
 


### PR DESCRIPTION
This is especially useful when you want to limit access to the members of a specific organization.
