### PR TITLE
Added show user name as a tooltip on issue participants list

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -32,7 +32,11 @@ module ProjectsHelper
 
     author_html = author_html.html_safe
 
-    link_to(author_html, user_path(author), class: "author_link").html_safe
+    if opts[:name]
+      link_to(author_html, user_path(author), class: "author_link").html_safe
+    else
+      link_to(author_html, user_path(author), class: "author_link has_tooltip", data: { :'original-title' => sanitize(author.name) } ).html_safe
+    end
   end
 
   def project_title project


### PR DESCRIPTION
When avatars are all the same (the default gray one), it is hard to use the participants list (u must click on each one to identify who is it)

This adds a tooltip with the user name when hovering each link avatar.
![captura de pantalla de 2013-07-24 18 12 26](https://f.cloud.github.com/assets/517228/851966/7828fbc0-f4a6-11e2-9c33-23e6b5c86f85.png)
