### PR TITLE
Fixed init.d script for some configurations

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -40,11 +40,10 @@ check_pid(){
 }
 
 execute() {
-  sudo -u $APP_USER -H bash -l -c "$1"
+  sudo -u $APP_USER -H bash -l -c "cd $APP_ROOT && $1"
 }
 
 start() {
-  cd $APP_ROOT
   check_pid
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     # Program is running, exit with error code 1.
@@ -61,7 +60,6 @@ start() {
 }
 
 stop() {
-  cd $APP_ROOT
   check_pid
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     ## Program is running, stop it.
@@ -78,7 +76,6 @@ stop() {
 }
 
 restart() {
-  cd $APP_ROOT
   check_pid
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "Restarting $DESC..."
@@ -95,7 +92,6 @@ restart() {
 }
 
 status() {
-  cd $APP_ROOT
   check_pid
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "$DESC / Puma with PID $PID is running."


### PR DESCRIPTION
In my environment your version of init.d script fails on 43th line because it tries execute **$1** in **/home/git** directory.
This fix resolves the issue and also removes excess four lines of code :)
