### PR TITLE
Use BlobHelper#content_type instead of #mime_type.

### DIFF
--- a/app/controllers/projects/raw_controller.rb
+++ b/app/controllers/projects/raw_controller.rb
@@ -13,7 +13,7 @@ class Projects::RawController < Projects::ApplicationController
     if @blob.exists?
       send_data(
         @blob.data,
-        type: @blob.mime_type,
+        type: @blob.content_type,
         disposition: 'inline',
         filename: @blob.name
       )


### PR DESCRIPTION
This provides Content-Type with a proper charset, and plugs a security
hole that a raw HTML file is served with a browser executable MIME
type (text/html) from the same domain where users are authenticated.
