### PR TITLE
Do not try to send a new ssh key email when the key is not found.

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -27,7 +27,12 @@ class Notify < ActionMailer::Base
   end
 
   def new_ssh_key_email(key_id)
-    @key = Key.find(key_id)
+    begin
+      @key = Key.find(key_id)
+    rescue ActiveRecord::RecordNotFound
+      logger.warn "key-#{key_id} not found; probably removed immediately"
+      return
+    end
     @user = @key.user
     mail(to: @user.email, subject: subject("SSH key was added to your account"))
   end


### PR DESCRIPTION
When a user adds a key and then removes it immediately, a background job for the "SSH key was added" notification fails in retrieving the key record and the job will get stuck in the queue.
