### PR TITLE
Usability: Show time stamp in commit view

### DIFF
--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -26,15 +26,15 @@
         .author
           = commit_author_link(@commit, avatar: true, size: 32)
           authored
-          %time{title: @commit.authored_date.stamp("Aug 21, 2011 9:23pm")}
-            #{time_ago_in_words(@commit.authored_date)} ago
+          %time
+            #{@commit.authored_date.stamp("Aug 21, 2011 9:23pm")} (#{time_ago_in_words(@commit.authored_date)} ago)
         - if @commit.different_committer?
           .committer
             &rarr;
             = commit_committer_link(@commit)
             committed
-            %time{title: @commit.committed_date.stamp("Aug 21, 2011 9:23pm")}
-              #{time_ago_in_words(@commit.committed_date)} ago
+            %time
+              #{@commit.committed_date.stamp("Aug 21, 2011 9:23pm")} (#{time_ago_in_words(@commit.committed_date)} ago)
       .span6.pull-right
         .pull-right
           .sha-block


### PR DESCRIPTION
The correct time stamp for commits should not be hidden in mouse over. It seems some (most?) users don't get that it's there but need the information.

What do you think?
