### PR TITLE
Messing with Travis: Avoid sleep by increasing default_wait_time to 20s

### DIFF
--- a/features/steps/project/project_merge_requests.rb
+++ b/features/steps/project/project_merge_requests.rb
@@ -111,7 +111,6 @@ class ProjectMergeRequests < Spinach::FeatureSteps
     within(".js-temp-notes-holder") do
       fill_in "note_note", with: "Line is wrong"
       click_button "Add Comment"
-      sleep 0.05
     end
   end
 

--- a/features/steps/project/project_network_graph.rb
+++ b/features/steps/project/project_network_graph.rb
@@ -30,22 +30,18 @@ class ProjectNetworkGraph < Spinach::FeatureSteps
 
   When 'I switch ref to "stable"' do
     page.select 'stable', from: 'ref'
-    sleep 2
   end
 
   When 'I switch ref to "v2.1.0"' do
     page.select 'v2.1.0', from: 'ref'
-    sleep 2
   end
 
   When 'I switch ref to "v2.1.0"' do
     page.select 'v2.1.0', from: 'ref'
-    sleep 2
   end
 
   When 'click "Show only selected branch" checkbox' do
     find('#filter_ref').click
-    sleep 2
   end
 
   Then 'page should have content not cotaining "v2.1.0"' do

--- a/features/steps/shared/diff_note.rb
+++ b/features/steps/shared/diff_note.rb
@@ -23,7 +23,6 @@ module SharedDiffNote
     within(".file form[rel$='586fb7c4e1add2d4d24e27566ed7064680098646_29_14']") do
       fill_in "note[note]", with: "Typo, please fix"
       find(".js-comment-button").trigger("click")
-      sleep 0.05
     end
   end
 

--- a/features/steps/shared/note.rb
+++ b/features/steps/shared/note.rb
@@ -16,7 +16,6 @@ module SharedNote
     within(".js-main-target-form") do
       fill_in "note[note]", with: "XML attached"
       click_button "Add Comment"
-      sleep 0.05
     end
   end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,7 +29,7 @@ Capybara.javascript_driver = :poltergeist
 Spinach.hooks.on_tag("javascript") do
   ::Capybara.current_driver = ::Capybara.javascript_driver
 end
-Capybara.default_wait_time = 10
+Capybara.default_wait_time = 20
 Capybara.ignore_hidden_elements = false
 
 DatabaseCleaner.strategy = :truncation

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,7 +29,7 @@ Capybara.javascript_driver = :poltergeist
 Spinach.hooks.on_tag("javascript") do
   ::Capybara.current_driver = ::Capybara.javascript_driver
 end
-Capybara.default_wait_time = 20
+Capybara.default_wait_time = 30
 Capybara.ignore_hidden_elements = false
 
 DatabaseCleaner.strategy = :truncation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ Spork.prefork do
   # if you change any configuration or code from libraries loaded here, you'll
   # need to restart spork for it take effect.
   Capybara.javascript_driver = :poltergeist
-  Capybara.default_wait_time = 20
+  Capybara.default_wait_time = 30
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ Spork.prefork do
   # if you change any configuration or code from libraries loaded here, you'll
   # need to restart spork for it take effect.
   Capybara.javascript_driver = :poltergeist
-  Capybara.default_wait_time = 10
+  Capybara.default_wait_time = 20
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.


### PR DESCRIPTION
I am testing to see how the Travis build behaves when we try to solve timing issues using `Capybara.default_wait_time` instead of by adding `sleep` statements.
