### PR TITLE
Make the site title configurable via Gitlab.config.site_title.

### DIFF
--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -64,7 +64,7 @@ class Notify < ActionMailer::Base
   #   >> subject('Lorem ipsum', 'Dolor sit amet')
   #   => "GitLab | Lorem ipsum | Dolor sit amet"
   def subject(*extra)
-    subject = "GitLab"
+    subject = Gitlab.config.gitlab.site_title
     subject << (@project ? " | #{@project.name_with_namespace}" : "")
     subject << " | " + extra.join(' | ') if extra.present?
     subject

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -2,7 +2,7 @@
   %meta{charset: "utf-8"}
   %title
     = "#{title} | " if defined?(title)
-    GitLab
+    = gitlab_config.site_title
   = favicon_link_tag 'favicon.ico'
   = stylesheet_link_tag    "application"
   = javascript_include_tag "application"

--- a/app/views/layouts/notify.html.haml
+++ b/app/views/layouts/notify.html.haml
@@ -2,11 +2,11 @@
   %head
     %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}
       %title
-        GitLab
+        = gitlab_config.site_title
 
   %body
     %h1{style: "background: #EEE; border-bottom: 1px solid #DDD; color: #474D57; font: normal 20px Helvetica, Arial, sans-serif; margin: 0; padding: 5px 10px; line-height: 32px; font-size: 16px;"}
-      GitLab
+      = gitlab_config.site_title
       - if @project
         \|
         = link_to @project.name_with_namespace, project_url(@project), style: 'color: #29B; text-decoration: none'

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -28,6 +28,9 @@ production: &base
     #
     # relative_url_root: /gitlab
 
+    # Title of the site used in HTML titles and Email subjects (default: 'GitLab')
+    # site_title: GitLab@MyCompany
+
     # Uncomment and customize if you can't use the default user to run GitLab (default: 'git')
     # user: git
 

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -57,6 +57,7 @@ Settings.gitlab['https']        = false if Settings.gitlab['https'].nil?
 Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80
 Settings.gitlab['relative_url_root'] ||= ENV['RAILS_RELATIVE_URL_ROOT'] || ''
 Settings.gitlab['protocol']   ||= Settings.gitlab.https ? "https" : "http"
+Settings.gitlab['site_title'] ||= 'GitLab'
 Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
 Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)


### PR DESCRIPTION
GitLab is becoming very popular, and you could easily become a member of many GitLab sites.

So, I think it would be nice if each GitLab site could set its own site title so user can see which GitLab site he is currently looking at.
