### PR TITLE
allow all git-upload-* commands for deploy keys

### DIFF
--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -26,7 +26,7 @@ module API
 
 
         if key.is_a? DeployKey
-          key.projects.include?(project) && git_cmd == 'git-upload-pack'
+          key.projects.include?(project) && git_cmd.starts_with?('git-upload-')
         else
           user = key.user
 

--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -1,6 +1,10 @@
 module API
   # Internal access API
   class Internal < Grape::API
+
+    DOWNLOAD_COMMANDS = %w{ git-upload-pack git-upload-archive }
+    PUSH_COMMANDS = %w{ git-receive-pack }
+
     namespace 'internal' do
       #
       # Check if ssh key has access to project code
@@ -26,16 +30,16 @@ module API
 
 
         if key.is_a? DeployKey
-          key.projects.include?(project) && git_cmd.starts_with?('git-upload-')
+          key.projects.include?(project) && DOWNLOAD_COMMANDS.include?(git_cmd)
         else
           user = key.user
 
           return false if user.blocked?
 
           action = case git_cmd
-                   when 'git-upload-pack', 'git-upload-archive'
+                   when *DOWNLOAD_COMMANDS
                      then :download_code
-                   when 'git-receive-pack'
+                   when *PUSH_COMMANDS
                      then
                      if project.protected_branch?(params[:ref])
                        :push_code_to_protected_branches

--- a/spec/requests/api/internal_spec.rb
+++ b/spec/requests/api/internal_spec.rb
@@ -100,6 +100,32 @@ describe API::API do
         end
       end
     end
+
+    context "deploy key" do
+      let(:key) { create(:deploy_key) }
+
+      context "added to project" do
+        before do
+          key.projects << project
+        end
+
+        it do
+          archive(key, project)
+
+          response.status.should == 200
+          response.body.should == 'true'
+        end
+      end
+
+      context "not added to project" do
+        it do
+          archive(key, project)
+
+          response.status.should == 200
+          response.body.should == 'false'
+        end
+      end
+    end
   end
 
   def pull(key, project)
@@ -119,6 +145,16 @@ describe API::API do
       key_id: key.id,
       project: project.path_with_namespace,
       action: 'git-receive-pack'
+    )
+  end
+
+  def archive(key, project)
+    get(
+      api("/internal/allowed"),
+      ref: 'master',
+      key_id: key.id,
+      project: project.path_with_namespace,
+      action: 'git-upload-archive'
     )
   end
 end


### PR DESCRIPTION
This allows performing a `git archive` command using a deploy key (see http://feedback.gitlab.com/forums/176466-general/suggestions/3712377-easier-deploy-with-deploy-key). Tests included.
