### PR TITLE
Show autocomplete list when editing notes.

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -227,9 +227,10 @@ var NoteList = {
     // Show the attachment delete link
     note.find(".js-note-attachment-delete").show();
 
+    GitLab.GfmAutoComplete.setup();
+
     var form = note.find(".note-edit-form");
     form.show();
-
 
     var textarea = form.find("textarea");
     var p = $("<p></p>").text(textarea.val());


### PR DESCRIPTION
When editing a note, the autocomplete for users/issues/milestones doesn't show up - see #4579.  This fixes that.
