### PR TITLE
Reenable the create project button after errors

### DIFF
--- a/app/views/projects/create.js.haml
+++ b/app/views/projects/create.js.haml
@@ -4,5 +4,6 @@
 - else
   :plain
     $(".project-edit-errors").html("#{escape_javascript(render('errors'))}");
+    $('.project-submit').enable();
     $('.save-project-loader').hide();
     $('.project-edit-container').show();


### PR DESCRIPTION
Currently if you try to create a project from an existing repo but give it a bad
URL, you see the "Import url should be a valid url" error and the form, but the
submit button is disabled meaning you can't fix the URL and resubmit the form.
This fix just enables the button when the project has an error.
