### PR TITLE
Add support for reStructured Text markup language

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -71,6 +71,9 @@ Make sure you have the right version of Python installed.
     # If you get a "command not found" error create a link to the python binary
     sudo ln -s /usr/bin/python /usr/bin/python2
 
+    # For reStructuredText markup language support install required package:
+    sudo apt-get install python-docutils
+
 **Note:** In order to receive mail notifications, make sure to install a
 mail server. By default, Debian is shipped with exim4 whereas Ubuntu
 does not ship with one. The recommended mail server is postfix and you can install it with:

--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -35,7 +35,14 @@ sudo -u git -H git fetch
 sudo -u git -H git checkout 6-0-dev
 ```
 
-### 3. Install libs, migrations, etc.
+### 3. Install additional packages
+
+```bash
+# For reStructuredText markup language support install required package:
+sudo apt-get install python-docutils
+```
+
+### 4. Install libs, migrations, etc.
 
 ```bash
 cd /home/git/gitlab
@@ -53,12 +60,12 @@ sudo -u git -H bundle exec rake migrate_keys RAILS_ENV=production
 
 ```
 
-### 4. Update config files
+### 5. Update config files
 
 * Make `/home/git/gitlab/config/gitlab.yml` same as https://github.com/gitlabhq/gitlabhq/blob/5-3-stable/config/gitlab.yml.example but with your settings.
 * Make `/home/git/gitlab/config/puma.rb` same as https://github.com/gitlabhq/gitlabhq/blob/5-3-stable/config/puma.rb.example but with your settings.
 
-### 5. Update Init script
+### 6. Update Init script
 
 ```bash
 sudo rm /etc/init.d/gitlab
@@ -66,12 +73,12 @@ sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5
 sudo chmod +x /etc/init.d/gitlab
 ```
 
-### 6. Start application
+### 7. Start application
 
     sudo service gitlab start
     sudo service nginx restart
 
-### 7. Check application status
+### 8. Check application status
 
 Check if GitLab and its environment are configured correctly:
 


### PR DESCRIPTION
Support for reStructured Text only needs the python `docutils` package to be installed.
This PR adds the installation instruction to the install guide and also to the update guide. Because GitLab uses the system python, installation via packet manager is least painful approach to support for `docutils`

With this PR all `*.rst` will be rendered as reStructuredText markup language.
This implements feature request http://feedback.gitlab.com/forums/176466-general/suggestions/3868963-add-support-for-restructured-text

/cc @senny as discussed.
