### PR TITLE
Fix for "Diff suppressed. Click to show" links 

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -112,7 +112,7 @@ $ ->
         e.preventDefault()
 
   # Commit show suppressed diff
-  $(".supp_diff_link").bind "click", ->
+  $(".diffs").on "click", ".supp_diff_link", ->
     $(@).next('table').show()
     $(@).remove()
 


### PR DESCRIPTION
Event handler on "Diff suppressed. Click to show" links were broken as the elements that have the correct handler are replaced by ones loaded with an AJAX request. This patch attaches the event handler to elements loaded afterwards as well.
