### PR TITLE
Feature to have world-accessible snippets

### DIFF
--- a/app/controllers/public/projects_controller.rb
+++ b/app/controllers/public/projects_controller.rb
@@ -2,6 +2,7 @@ class Public::ProjectsController < ApplicationController
   skip_before_filter :authenticate_user!,
     :reject_blocked, :set_current_user_for_observers,
     :add_abilities
+  before_filter :set_object_type
 
   layout 'public'
 
@@ -20,5 +21,10 @@ class Public::ProjectsController < ApplicationController
 
     @commit = @repository.commit(params[:ref])
     @tree = Tree.new(@repository, @commit.id)
+  end
+
+  private
+  def set_object_type
+    @public_object_type = "Projects"
   end
 end

--- a/app/controllers/public/snippets_controller.rb
+++ b/app/controllers/public/snippets_controller.rb
@@ -1,0 +1,33 @@
+class Public::SnippetsController < ApplicationController
+  skip_before_filter :authenticate_user!,
+    :reject_blocked, :set_current_user_for_observers,
+    :add_abilities
+  before_filter :set_object_type
+
+  layout 'public'
+
+  def index
+    @snippets = Snippet.world_public.page(params[:page]).per(20)
+  end
+
+  def show
+    @snippet = Snippet.world_public.find(params[:id])
+    render_404 and return unless @snippet
+  end
+
+  def raw
+    @snippet = Snippet.world_public.find(params[:id])
+
+    send_data(
+      @snippet.content,
+      type: "text/plain",
+      disposition: 'inline',
+      filename: @snippet.file_name
+    )
+  end
+
+  private
+  def set_object_type
+    @public_object_type = "Snippets"
+  end
+end

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -14,7 +14,7 @@ class SnippetsController < ApplicationController
   layout 'navless'
 
   def index
-    @snippets = Snippet.public.fresh.non_expired.page(params[:page]).per(20)
+    @snippets = Snippet.all_public.fresh.non_expired.page(params[:page]).per(20)
   end
 
   def user_index
@@ -24,14 +24,14 @@ class SnippetsController < ApplicationController
     if @user == current_user
       @snippets = case params[:scope]
                   when 'public' then
-                    @snippets.public
+                    @snippets.all_public
                   when 'private' then
                     @snippets.private
                   else
                     @snippets
                   end
     else
-      @snippets = @snippets.public
+      @snippets = @snippets.all_public
     end
 
     @snippets = @snippets.page(params[:page]).per(20)
@@ -92,7 +92,7 @@ class SnippetsController < ApplicationController
   protected
 
   def snippet
-    @snippet ||= PersonalSnippet.where('author_id = :user_id or private is false', user_id: current_user.id).find(params[:id])
+    @snippet ||= PersonalSnippet.where('author_id = :user_id or visibility = :visibility', user_id: current_user.id, visibility: :private).find(params[:id])
   end
 
   def authorize_modify_snippet!

--- a/app/helpers/snippets_helper.rb
+++ b/app/helpers/snippets_helper.rb
@@ -9,6 +9,15 @@ module SnippetsHelper
     options_for_select(options)
   end
 
+  def visibility_select_options(opts={})
+    options = [
+      ['Private',       "private"],
+      ['Gitlab Public', "gitlab_public"],
+      ['World Public',  "world_public"]
+    ]
+    options_for_select(options, opts[:selected])
+  end
+
   def reliable_snippet_path(snippet)
     if snippet.project_id?
       project_snippet_path(snippet.project, snippet)

--- a/app/views/layouts/nav/_public.html.haml
+++ b/app/views/layouts/nav/_public.html.haml
@@ -1,0 +1,7 @@
+%ul
+  = nav_link(controller: [:public, :projects]) do
+    = link_to public_projects_path do
+      Projects
+  = nav_link(controller: [:snippets]) do
+    = link_to public_snippets_path do
+      Snippets

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -1,9 +1,9 @@
 !!! 5
 %html{ lang: "en"}
-  = render "layouts/head", title: "Public Projects"
+  = render "layouts/head", title: "Public #{@public_object_type}"
   %body{class: "#{app_theme} application", :'data-page' => body_data_page}
     - if current_user
-      = render "layouts/head_panel", title: "Public Projects"
+      = render "layouts/head_panel", title: "Public #{@public_object_type}"
     - else
       %header.navbar.navbar-static-top.navbar-gitlab
         .navbar-inner
@@ -13,7 +13,7 @@
               = link_to public_root_path, class: "home" do
                 %h1 GITLAB
               %span.separator
-            %h1.project_name Public Projects
+            %h1.project_name Public Area
             %ul.nav
               %li
                 %a
@@ -22,6 +22,9 @@
                     Loading...
               %li
                 = link_to "Sign in", new_session_path(:user)
+
+    %nav.main-nav
+      .container= render 'layouts/nav/public'
 
     .container.navless-container
       .content

--- a/app/views/public/snippets/index.html.haml
+++ b/app/views/public/snippets/index.html.haml
@@ -1,0 +1,22 @@
+.row
+  .span6
+    %h3.page-title
+      Snippets (#{@snippets.count})
+      %small with read-only access
+
+
+.public-projects
+  %ul.bordered-list
+    - @snippets.each do |snippet|
+      %li
+        .project-title
+          %i.icon-share.cgray
+          = snippet.author.name
+          \/
+          = link_to public_snippet_path(snippet) do
+            = snippet.title
+
+    - unless @snippets.present?
+      %h3.nothing_here_message No public snippets
+
+= paginate @snippets, theme: "gitlab"

--- a/app/views/public/snippets/show.html.haml
+++ b/app/views/public/snippets/show.html.haml
@@ -1,0 +1,4 @@
+%h3.page-title
+  = @snippet.title
+
+%div.clearfix= render 'snippets/blob', locals: { public_show: true }

--- a/app/views/snippets/_blob.html.haml
+++ b/app/views/snippets/_blob.html.haml
@@ -7,7 +7,11 @@
         - if @snippet.author == current_user
           = link_to "Edit", edit_snippet_path(@snippet), class: "btn btn-tiny", title: 'Edit Snippet'
           = link_to "Delete", snippet_path(@snippet), method: :delete, confirm: "Are you sure?", class: "btn btn-tiny", title: 'Delete Snippet'
-        = link_to "Raw", raw_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
+        - if request.original_url =~ /public/
+          = link_to "Raw", raw_public_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
+        - else
+          = link_to "Raw", raw_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
+
   .file-content.code
     - unless @snippet.content.empty?
       %div{class: user_color_scheme_class}

--- a/app/views/snippets/_form.html.haml
+++ b/app/views/snippets/_form.html.haml
@@ -13,8 +13,8 @@
       = f.label :title
       .input= f.text_field :title, placeholder: "Example Snippet", class: 'input-xlarge', required: true
     .clearfix
-      = f.label "Private?"
-      .input= f.check_box :private, {class: ''}
+      = f.label "Visibility"
+      .input= f.select :visibility, visibility_select_options(selected: @snippet.visibility), {}, {class: 'chosen span2'}
     .clearfix
       .file-editor
         = f.label :file_name, "File"

--- a/app/views/snippets/_snippet.html.haml
+++ b/app/views/snippets/_snippet.html.haml
@@ -2,10 +2,7 @@
   %h4.snippet-title
     = link_to reliable_snippet_path(snippet) do
       = truncate(snippet.title, length: 60)
-      - if snippet.private?
-        %span.label.label-success
-          %i.icon-lock
-          private
+      = render partial: 'snippet_visibility', locals: {snippet: snippet}
     %span.cgray.monospace.tiny.pull-right
       = snippet.file_name
 

--- a/app/views/snippets/_snippet_visibility.html.haml
+++ b/app/views/snippets/_snippet_visibility.html.haml
@@ -1,0 +1,12 @@
+- if snippet.private?
+  %span.label.label-important
+    %i.icon-lock
+    private
+- elsif snippet.gitlab_public?
+  %span.label.label-info
+    %i.icon-unlock
+    gitlab public
+- else
+  %span.label.label-success
+    %i.icon-unlock
+    world public

--- a/app/views/snippets/show.html.haml
+++ b/app/views/snippets/show.html.haml
@@ -1,10 +1,7 @@
 %h3.page-title
   = @snippet.title
 
-  - if @snippet.private?
-    %span.label.label-success
-      %i.icon-lock
-      private
+  = render partial: 'snippet_visibility', locals: { snippet: @snippet }
 
   .pull-right
     = link_to new_snippet_path, class: "btn btn-small add_new grouped btn-primary", title: "New Snippet" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,12 @@ Gitlab::Application.routes.draw do
     resources :projects, only: [:index]
     resources :projects, constraints: { id: /[a-zA-Z.\/0-9_\-]+/ }, only: [:show]
 
+    resources :snippets do
+      member do
+        get :raw
+      end
+    end
+
     root to: "projects#index"
   end
 

--- a/db/migrate/20130730164340_add_visiblity_to_snippets.rb
+++ b/db/migrate/20130730164340_add_visiblity_to_snippets.rb
@@ -1,0 +1,5 @@
+class AddVisiblityToSnippets < ActiveRecord::Migration
+  def change
+    add_column :snippets, :visibility, :string, null: false, default :private
+  end
+end

--- a/db/migrate/20130730164558_convert_snippets_public_to_visibility.rb
+++ b/db/migrate/20130730164558_convert_snippets_public_to_visibility.rb
@@ -1,0 +1,15 @@
+class ConvertSnippetsPublicToVisibility < ActiveRecord::Migration
+  def up
+    Snippet.transaction do
+      Snippet.where(private: true).update_all(visibility: :private)
+      Snippet.where(private: false).update_all(visibility: :gitlab_public)
+    end
+  end
+
+  def down
+    Snippet.transaction do
+      Snippet.where(visibility: :private).update_all(private: true)
+      Snippet.where(visibility: :gitlab_public).update_all(private: false)
+    end
+  end
+end

--- a/db/migrate/20130730165148_remove_private_from_snippets.rb
+++ b/db/migrate/20130730165148_remove_private_from_snippets.rb
@@ -1,0 +1,9 @@
+class RemovePrivateFromSnippets < ActiveRecord::Migration
+  def up
+    remove_column :snippets, :private
+  end
+
+  def down
+    add_column :snippets, :private, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130624162710) do
+ActiveRecord::Schema.define(:version => 20130730165148) do
 
   create_table "deploy_keys_projects", :force => true do |t|
     t.integer  "deploy_key_id", :null => false
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
     t.integer  "assignee_id"
     t.integer  "author_id"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
     t.integer  "position",     :default => 0
     t.string   "branch_name"
     t.text     "description"
@@ -73,8 +73,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
 
   create_table "keys", :force => true do |t|
     t.integer  "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
     t.text     "key"
     t.string   "title"
     t.string   "type"
@@ -90,8 +90,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
     t.integer  "author_id"
     t.integer  "assignee_id"
     t.string   "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                          :null => false
+    t.datetime "updated_at",                          :null => false
     t.text     "st_commits",    :limit => 2147483647
     t.text     "st_diffs",      :limit => 2147483647
     t.integer  "milestone_id"
@@ -140,8 +140,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
     t.text     "note"
     t.string   "noteable_type"
     t.integer  "author_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.integer  "project_id"
     t.string   "attachment"
     t.string   "line_code"
@@ -161,8 +161,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
     t.string   "name"
     t.string   "path"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
     t.integer  "creator_id"
     t.string   "default_branch"
     t.boolean  "issues_enabled",         :default => true,     :null => false
@@ -209,14 +209,14 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
   create_table "snippets", :force => true do |t|
     t.string   "title"
     t.text     "content",    :limit => 2147483647
-    t.integer  "author_id",                                          :null => false
+    t.integer  "author_id",                        :null => false
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                       :null => false
+    t.datetime "updated_at",                       :null => false
     t.string   "file_name"
     t.datetime "expires_at"
-    t.boolean  "private",                          :default => true, :null => false
     t.string   "type"
+    t.string   "visibility", :default => "private", :null => false
   end
 
   add_index "snippets", ["author_id"], :name => "index_snippets_on_author_id"
@@ -233,6 +233,9 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
     t.string   "context"
     t.datetime "created_at"
   end
+
+  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
 
   create_table "tags", :force => true do |t|
     t.string "name"
@@ -265,37 +268,37 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                                 :default => "",    :null => false
-    t.string   "encrypted_password",     :limit => 128, :default => "",    :null => false
+    t.string   "email",                  :default => "",    :null => false
+    t.string   "encrypted_password",     :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                         :default => 0
+    t.integer  "sign_in_count",          :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.string   "name"
-    t.boolean  "admin",                                 :default => false, :null => false
-    t.integer  "projects_limit",                        :default => 10
-    t.string   "skype",                                 :default => "",    :null => false
-    t.string   "linkedin",                              :default => "",    :null => false
-    t.string   "twitter",                               :default => "",    :null => false
+    t.boolean  "admin",                  :default => false, :null => false
+    t.integer  "projects_limit",         :default => 10
+    t.string   "skype",                  :default => "",    :null => false
+    t.string   "linkedin",               :default => "",    :null => false
+    t.string   "twitter",                :default => "",    :null => false
     t.string   "authentication_token"
-    t.integer  "theme_id",                              :default => 1,     :null => false
+    t.integer  "theme_id",               :default => 1,     :null => false
     t.string   "bio"
-    t.integer  "failed_attempts",                       :default => 0
+    t.integer  "failed_attempts",        :default => 0
     t.datetime "locked_at"
     t.string   "extern_uid"
     t.string   "provider"
     t.string   "username"
-    t.boolean  "can_create_group",                      :default => true,  :null => false
-    t.boolean  "can_create_team",                       :default => true,  :null => false
+    t.boolean  "can_create_group",       :default => true,  :null => false
+    t.boolean  "can_create_team",        :default => true,  :null => false
     t.string   "state"
-    t.integer  "color_scheme_id",                       :default => 1,     :null => false
-    t.integer  "notification_level",                    :default => 1,     :null => false
+    t.integer  "color_scheme_id",        :default => 1,     :null => false
+    t.integer  "notification_level",     :default => 1,     :null => false
     t.datetime "password_expires_at"
     t.integer  "created_by_id"
   end
@@ -303,6 +306,7 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
   add_index "users", ["admin"], :name => "index_users_on_admin"
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
+  add_index "users", ["extern_uid", "provider"], :name => "index_users_on_extern_uid_and_provider", :unique => true
   add_index "users", ["name"], :name => "index_users_on_name"
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
   add_index "users", ["username"], :name => "index_users_on_username"
@@ -321,8 +325,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
   create_table "users_projects", :force => true do |t|
     t.integer  "user_id",                           :null => false
     t.integer  "project_id",                        :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                        :null => false
+    t.datetime "updated_at",                        :null => false
     t.integer  "project_access",     :default => 0, :null => false
     t.integer  "notification_level", :default => 3, :null => false
   end
@@ -334,8 +338,8 @@ ActiveRecord::Schema.define(:version => 20130624162710) do
   create_table "web_hooks", :force => true do |t|
     t.string   "url"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            :null => false
+    t.datetime "updated_at",                            :null => false
     t.string   "type",       :default => "ProjectHook"
     t.integer  "service_id"
   end

--- a/features/project/public_projects.feature
+++ b/features/project/public_projects.feature
@@ -5,4 +5,5 @@ Feature: Public Projects
   Scenario: I should see the list of public projects
     When I visit the public projects area
     Then I should see the list of public projects
+    And I should see a link to public snippets
 

--- a/features/public/public_snippets.feature
+++ b/features/public/public_snippets.feature
@@ -1,0 +1,15 @@
+Feature: Public Snippets Feature
+  Background:
+    Given world public snippet "World Public Snippet"
+    And gitlab public snippet "Gitlab Public Snippet"
+    And private snippet "Private Snippet"
+
+  Scenario: I visit public snippets area
+    When I visit the public snippets area
+    Then I should see snippet "World Public Snippet"
+    And I should not see snippet "Gitlab Public Snippet"
+    And I should not see snippet "Private Snippet"
+
+  Scenario: I visit public snippet page
+    When I visit public page for "World Public Snippet" snippet
+    Then I should see snippet "World Public Snippet"

--- a/features/snippets/discover_snippets.feature
+++ b/features/snippets/discover_snippets.feature
@@ -1,7 +1,7 @@
 Feature: Discover Snippets
   Background:
     Given I sign in as a user
-    And I have public "Personal snippet one" snippet
+    And I have gitlab public "Personal snippet one" snippet
     And I have private "Personal snippet private" snippet
 
   Scenario: I should see snippets

--- a/features/snippets/snippets.feature
+++ b/features/snippets/snippets.feature
@@ -1,7 +1,7 @@
 Feature: Snippets Feature
   Background:
     Given I sign in as a user
-    And I have public "Personal snippet one" snippet
+    And I have gitlab public "Personal snippet one" snippet
     And I have private "Personal snippet private" snippet
 
   Scenario: I create new snippet
@@ -15,11 +15,11 @@ Feature: Snippets Feature
     And I submit new title "Personal snippet new title"
     Then I should see "Personal snippet new title"
 
-  Scenario: Set "Personal snippet one" public
+  Scenario: Set "Personal snippet one" private
     Given I visit snippet page "Personal snippet one"
     And I click link "Edit"
-    And I uncheck "Private" checkbox
-    Then I should see "Personal snippet one" public
+    And I choose "Private" visibility
+    Then I should see "Personal snippet one" private
 
   Scenario: I destroy "Personal snippet one"
     Given I visit snippet page "Personal snippet one"

--- a/features/snippets/user_snippets.feature
+++ b/features/snippets/user_snippets.feature
@@ -1,7 +1,8 @@
 Feature: User Snippets
   Background:
     Given I sign in as a user
-    And I have public "Personal snippet one" snippet
+    And I have gitlab public "Personal snippet one" snippet
+    And I have world public "Personal snippet world public" snippet
     And I have private "Personal snippet private" snippet
 
   Scenario: I should see all my snippets

--- a/features/steps/project/public_projects.rb
+++ b/features/steps/project/public_projects.rb
@@ -6,4 +6,8 @@ class PublicProjects < Spinach::FeatureSteps
   Then 'I should see the list of public projects' do
     page.should have_content "Public Projects"
   end
+
+  step 'I should see a link to public snippets' do
+    page.should have_content "Snippets"
+  end
 end

--- a/features/steps/public/snippets_feature.rb
+++ b/features/steps/public/snippets_feature.rb
@@ -1,0 +1,32 @@
+class Spinach::Features::PublicSnippetsFeature < Spinach::FeatureSteps
+  include SharedPaths
+
+  step 'world public snippet "World Public Snippet"' do
+    create :snippet, title: "World Public Snippet", visibility: :world_public
+  end
+
+  step 'gitlab public snippet "Gitlab Public Snippet"' do
+    create :snippet, title: "Gitlab Public Snippet", visibility: :gitlab_public
+  end
+
+  step 'private snippet "Private Snippet"' do
+    create :snippet, title: "Private Snippet", visibility: :private
+  end
+
+  step 'I should see snippet "World Public Snippet"' do
+    page.should have_content "World Public Snippet"
+  end
+
+  step 'I should not see snippet "World Public Snippet"' do
+    page.should_not have_content "World Public Snippet"
+  end
+
+  step 'I should not see snippet "Gitlab Public Snippet"' do
+    page.should_not have_content "Gitlab Public Snippet"
+  end
+
+  step 'I should not see snippet "Private Snippet"' do
+    page.should_not have_content "Private Snippet"
+  end
+end
+

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -280,6 +280,18 @@ module SharedPaths
   end
 
   # ----------------------------------------
+  # Public Snippets
+  # ----------------------------------------
+
+  step 'I visit the public snippets area' do
+    visit public_snippets_path
+  end
+
+  step 'I visit public page for "World Public Snippet" snippet' do
+    visit public_snippet_path(Snippet.find_by_title("World Public Snippet"))
+  end
+
+  # ----------------------------------------
   # Snippets
   # ----------------------------------------
 

--- a/features/steps/shared/snippet.rb
+++ b/features/steps/shared/snippet.rb
@@ -1,12 +1,12 @@
 module SharedSnippet
   include Spinach::DSL
 
-  And 'I have public "Personal snippet one" snippet' do
+  And 'I have gitlab public "Personal snippet one" snippet' do
     create(:personal_snippet,
            title: "Personal snippet one",
            content: "Test content",
            file_name: "snippet.rb",
-           private: false,
+           visibility: "gitlab_public",
            author: current_user)
   end
 
@@ -15,7 +15,7 @@ module SharedSnippet
            title: "Personal snippet private",
            content: "Provate content",
            file_name: "private_snippet.rb",
-           private: true,
+           visibility: "private",
            author: current_user)
   end
 end

--- a/features/steps/shared/snippet.rb
+++ b/features/steps/shared/snippet.rb
@@ -10,6 +10,15 @@ module SharedSnippet
            author: current_user)
   end
 
+  And 'I have world public "Personal snippet world public" snippet' do
+    create(:personal_snippet,
+           title: "Personal snippet world public",
+           content: "Test content",
+           file_name: "snippet.rb",
+           visibility: "world_public",
+           author: current_user)
+  end
+
   And 'I have private "Personal snippet private" snippet' do
     create(:personal_snippet,
            title: "Personal snippet private",

--- a/features/steps/snippets/snippets.rb
+++ b/features/steps/snippets/snippets.rb
@@ -45,13 +45,13 @@ class SnippetsFeature < Spinach::FeatureSteps
     page.should have_content "Personal snippet new title"
   end
 
-  And 'I uncheck "Private" checkbox' do
-    find(:xpath, "//input[@id='personal_snippet_private']").set true
+  And 'I choose "Private" visibility' do
+    page.select('Private', :from => 'personal_snippet_visibility')
     click_button "Save"
   end
 
-  Then 'I should see "Personal snippet one" public' do
-    page.should have_no_xpath("//i[@class='public-snippet']")
+  Then 'I should see "Personal snippet one" private' do
+    page.should have_content "private"
   end
 
   And 'I visit snippet page "Personal snippet one"' do

--- a/spec/models/snippet_spec.rb
+++ b/spec/models/snippet_spec.rb
@@ -4,15 +4,15 @@
 #
 #  id         :integer          not null, primary key
 #  title      :string(255)
-#  content    :text
+#  content    :text(2147483647)
 #  author_id  :integer          not null
 #  project_id :integer
-#  created_at :datetime
-#  updated_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #  file_name  :string(255)
 #  expires_at :datetime
-#  private    :boolean          default(TRUE), not null
 #  type       :string(255)
+#  visibility :string(255)      not null
 #
 
 require 'spec_helper'
@@ -37,5 +37,12 @@ describe Snippet do
     it { should ensure_length_of(:title).is_within(0..255) }
 
     it { should validate_presence_of(:content) }
+  end
+
+  describe "visibility" do
+    it "sets the default visibility" do
+      snippet = create(:snippet)
+      snippet.visibility.should eq("private")
+    end
   end
 end


### PR DESCRIPTION
I've added a new feature to snippets to allow them to be world-accessible (like the new "public projects" feature). Before, a snippet could have its `private` attribute as `true`/`false` - a private snippet could only be viewed by the user who created it, whereas a `public` snippet could be viewed by any GitLab user. I've changed the `private` attribute to `visibility` - allowing 3 visibility types: `private`, `gitlab_public` and `world_public`. The first two are the same as described before, but `world_public` lets the snippet be visible on the public page allowing anyone people to view the snippet without being signed in.
