### PR TITLE
Swap placeholders of project compare view input fileds

### DIFF
--- a/app/views/projects/compare/_form.html.haml
+++ b/app/views/projects/compare/_form.html.haml
@@ -14,9 +14,9 @@
       .pull-left
         - if params[:to] && params[:from]
           = link_to 'switch', {from: params[:to], to: params[:from]}, {class: 'commits-compare-switch has_tooltip', title: 'Switch base of comparison'}
-        = text_field_tag :from, params[:from], placeholder: "master", class: "xlarge input-xpadding"
+        = text_field_tag :from, params[:from], placeholder: "aa8b4ef", class: "xlarge input-xpadding"
         = "..."
-        = text_field_tag :to, params[:to], placeholder: "aa8b4ef", class: "xlarge input-xpadding"
+        = text_field_tag :to, params[:to], placeholder: "master", class: "xlarge input-xpadding"
       .pull-left
         &nbsp;
         = submit_tag "Compare", class: "btn btn-create commits-compare-btn"


### PR DESCRIPTION
Now, placeholders of compare index view like /my_project/compare are shown as from 'master' to 'aa8b4ef'. Because of that user thinks that the order of these input fields are expected TO and FROM.
But these fields are expected FROM and TO.

This commit fixes the misleading placeholder.
