### PR TITLE
additional instruction regarding build dependencies

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -97,6 +97,10 @@ Download Ruby and compile it:
     make
     sudo make install
 
+Install tools required for build process
+
+    sudo apt-get install build-essential g++
+
 Install the Bundler Gem:
 
     sudo gem install bundler --no-ri --no-rdoc


### PR DESCRIPTION
without build-essetials i were getting an error when trying to execute sudo gem install charlock_holmes --version '0.6.9.4'
