### PR TITLE
Add appropriate article to new user email.

### DIFF
--- a/app/views/notify/new_user_email.html.haml
+++ b/app/views/notify/new_user_email.html.haml
@@ -4,7 +4,7 @@
   - if Gitlab.config.gitlab.signup_enabled
     Your account has been created successfully.
   - else
-    The Administrator created an account for you. Now you are a member of company GitLab application.
+    The Administrator created an account for you. Now you are a member of the company GitLab application.
 %p
   login..........................................
   %code= @user['email']

--- a/app/views/notify/new_user_email.text.erb
+++ b/app/views/notify/new_user_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.name %>!
 
-The Administrator created an account for you. Now you are a member of company GitLab application.
+The Administrator created an account for you. Now you are a member of the company GitLab application.
 
 login.................. <%= @user.email %>
 <% if @user.created_by_id %>


### PR DESCRIPTION
Overall the wording is debatable, but missing that "the" left a poor taste in my mouth when adding users.
