### PR TITLE
puma.rb.example lacks "=" in definitions

### DIFF
--- a/config/puma.rb.example
+++ b/config/puma.rb.example
@@ -13,36 +13,36 @@ application_path = '/home/git/gitlab'
 #
 # The default is the current directory.
 #
-directory application_path
+directory = 'application_path'
 
 # Set the environment in which the rack's app will run.
 #
 # The default is “development”.
 #
-environment 'production'
+environment = 'production'
 
 # Daemonize the server into the background. Highly suggest that
 # this be combined with “pidfile” and “stdout_redirect”.
 #
 # The default is “false”.
 #
-daemonize true
+daemonize = 'true'
 
 # Store the pid of the server in the file at “path”.
 #
-pidfile "#{application_path}/tmp/pids/puma.pid"
+pidfile = "#{application_path}/tmp/pids/puma.pid"
 
 # Use “path” as the file to store the server info state. This is
 # used by “pumactl” to query and control the server.
 #
-state_path "#{application_path}/tmp/pids/puma.state"
+state_path = "#{application_path}/tmp/pids/puma.state"
 
 # Redirect STDOUT and STDERR to files specified. The 3rd parameter
 # (“append”) specifies whether the output is appended, the default is
 # “false”.
 #
-stdout_redirect "#{application_path}/log/puma.stdout.log", "#{application_path}/log/puma.stderr.log"
-# stdout_redirect '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr', true
+stdout_redirect = "#{application_path}/log/puma.stdout.log", "#{application_path}/log/puma.stderr.log"
+# stdout_redirect = '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr', true
 
 # Disable request logging.
 #
@@ -63,7 +63,7 @@ stdout_redirect "#{application_path}/log/puma.stdout.log", "#{application_path}/
 # The default is “tcp://0.0.0.0:9292”.
 #
 # bind 'tcp://0.0.0.0:9292'
-bind "unix://#{application_path}/tmp/sockets/gitlab.socket"
+bind = "unix://#{application_path}/tmp/sockets/gitlab.socket"
 
 # Instead of “bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'” you
 # can also use the “ssl_bind” option.


### PR DESCRIPTION
Starting gitlab on a freshly installed system was impossible because of undefined methods.
That's an easy fix for a blocking issue.
