### PR TITLE
Add capybara-accessible for accessibility errors in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,6 +189,7 @@ group :development, :test do
 
   # PhantomJS driver for Capybara
   gem 'poltergeist', '~> 1.3.0'
+  gem 'capybara-accessible'
 
   gem 'spork', '~> 1.0rc'
   gem 'jasmine'

--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ group :assets do
   gem 'select2-rails'
   gem 'jquery-atwho-rails', "0.3.0"
   gem "jquery-rails",     "2.1.3"
-  gem "jquery-ui-rails",  "2.0.2"
+  gem "jquery-ui-rails",  "3.0.1"
   gem "modernizr",        "2.6.2"
   gem "raphael-rails",    git: "https://github.com/gitlabhq/raphael-rails.git"
   gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     jquery-turbolinks (1.0.0)
       railties (>= 3.1.0)
       turbolinks
-    jquery-ui-rails (2.0.2)
+    jquery-ui-rails (3.0.1)
       jquery-rails
       railties (>= 3.1.0)
     json (1.7.7)
@@ -588,7 +588,7 @@ DEPENDENCIES
   jquery-atwho-rails (= 0.3.0)
   jquery-rails (= 2.1.3)
   jquery-turbolinks
-  jquery-ui-rails (= 2.0.2)
+  jquery-ui-rails (= 3.0.1)
   kaminari (~> 0.14.1)
   launchy
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-accessible (0.1.8)
+      capybara
+      selenium-webdriver
     carrierwave (0.8.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -547,6 +550,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   capybara
+  capybara-accessible
   carrierwave
   chosen-rails (= 0.9.8)
   coffee-rails

--- a/app/views/projects/walls/show.html.haml
+++ b/app/views/projects/walls/show.html.haml
@@ -6,7 +6,7 @@
       = form_for [@project, @note], remote: true, html: { multipart: true, id: nil, class: "new_note wall-note-form" } do |f|
         = note_target_fields
         .note_text_and_preview
-          = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on'
+          = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on', "aria-label" => "Enter a comment"
         .note-form-actions
           .buttons
             = f.submit 'Add Comment', class: "btn comment-btn grouped js-comment-button"

--- a/features/admin/groups.feature
+++ b/features/admin/groups.feature
@@ -14,7 +14,7 @@ Feature: Admin Groups
     Then I should be redirected to group page
     And I should see newly created group
 
-  @javascript
+  @javascript @inaccessible
   Scenario: Add user into projects in group
     When I visit admin group page
     When I select user "John" from user list as "Reporter"

--- a/features/group/group.feature
+++ b/features/group/group.feature
@@ -19,7 +19,7 @@ Feature: Groups
     When I visit group merge requests page
     Then I should see merge requests from this group assigned to me
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should add user to projects in Group
     Given I have new user "John"
     When I visit group members page

--- a/features/project/commits/commit_comments.feature
+++ b/features/project/commits/commit_comments.feature
@@ -4,44 +4,44 @@ Feature: Comments on commits
     And I own project "Shop"
     And I visit project commit page
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can comment on a commit
     Given I leave a comment like "XML attached"
     Then I should see a comment saying "XML attached"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can't cancel the main form
     Then I should not see the cancel comment button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can't preview without text
     Given I haven't written any comment text
     Then I should not see the comment preview button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can preview with text
     Given I write a comment like "Nice"
     Then I should see the comment preview button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I preview a comment
     Given I preview a comment text like "Bug fixed :smile:"
     Then I should see the comment preview
     And I should not see the comment text field
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can edit after preview
     Given I preview a comment text like "Bug fixed :smile:"
     Then I should see the comment edit button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I have a reset form after posting from preview
     Given I preview a comment text like "Bug fixed :smile:"
     And I submit the comment
     Then I should see an empty comment text field
     And I should not see the comment preview
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can delete a comment
     Given I leave a comment like "XML attached"
     And I delete a comment

--- a/features/project/commits/commit_diff_comments.feature
+++ b/features/project/commits/commit_diff_comments.feature
@@ -4,38 +4,38 @@ Feature: Comments on commit diffs
     And I own project "Shop"
     And I visit project commit page
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can access add diff comment buttons
     Then I should see add a diff comment button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can comment on a commit diff
     Given I leave a diff comment like "Typo, please fix"
     Then I should see a diff comment saying "Typo, please fix"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I get a temporary form for the first comment on a diff line
     Given I open a diff comment form
     Then I should see a temporary diff comment form
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I have a cancel button on the diff form
     Given I open a diff comment form
     Then I should see the cancel comment button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can cancel a diff form
     Given I open a diff comment form
     And I cancel the diff comment
     Then I should not see the diff comment form
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can't open a second form for a diff line
     Given I open a diff comment form
     And I open a diff comment form
     Then I should only see one diff form
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can have multiple forms
     Given I open a diff comment form
     And I write a diff comment like ":-1: I don't like this"
@@ -43,41 +43,41 @@ Feature: Comments on commit diffs
     Then I should see a diff comment form with ":-1: I don't like this"
     And I should see an empty diff comment form
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can preview multiple forms separately
     Given I preview a diff comment text like "Should fix it :smile:"
     And I preview another diff comment text like "DRY this up"
     Then I should see two separate previews
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I have a reply button in discussions
     Given I leave a diff comment like "Typo, please fix"
     Then I should see a discussion reply button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can't preview without text
     Given I open a diff comment form
     And I haven't written any diff comment text
     Then I should not see the diff comment preview button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can preview with text
     Given I open a diff comment form
     And I write a diff comment like ":-1: I don't like this"
     Then I should see the diff comment preview button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I preview a diff comment
     Given I preview a diff comment text like "Should fix it :smile:"
     Then I should see the diff comment preview
     And I should not see the diff comment text field
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can edit after preview
     Given I preview a diff comment text like "Should fix it :smile:"
     Then I should see the diff comment edit button
 
-  @javascript
+  @javascript @inaccessible
   Scenario: The form gets removed after posting
     Given I preview a diff comment text like "Should fix it :smile:"
     And I submit the diff comment

--- a/features/project/issues/issues.feature
+++ b/features/project/issues/issues.feature
@@ -29,26 +29,26 @@ Feature: Project Issues
     And I submit new issue "500 error on profile"
     Then I should see issue "500 error on profile"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I comment issue
     Given I visit issue page "Release 0.4"
     And I leave a comment like "XML attached"
     Then I should see comment "XML attached"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I search issue
     Given I fill in issue search with "Release"
     Then I should see "Release 0.4" in issues
     And I should not see "Release 0.3" in issues
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I search issue that not exist
     Given I fill in issue search with "Bug"
     Then I should not see "Release 0.4" in issues
     And I should not see "Release 0.3" in issues
 
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I search all issues
     Given I click link "All"
     And I fill in issue search with "0.3"

--- a/features/project/merge_requests.feature
+++ b/features/project/merge_requests.feature
@@ -34,13 +34,13 @@ Feature: Project Merge Requests
     And I submit new merge request "Wiki Feature"
     Then I should see merge request "Wiki Feature"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I comment on a merge request
     Given I visit merge request page "Bug NS-04"
     And I leave a comment like "XML attached"
     Then I should see comment "XML attached"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I comment on a merge request diff
     Given project "Shop" have "Bug NS-05" open merge request with diffs inside
     And I visit merge request page "Bug NS-05"
@@ -49,7 +49,7 @@ Feature: Project Merge Requests
     And I switch to the merge request's comments tab
     Then I should see a discussion has started on line 185
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I comment on a line of a commit in merge request
     Given project "Shop" have "Bug NS-05" open merge request with diffs inside
     And I visit merge request page "Bug NS-05"
@@ -58,7 +58,7 @@ Feature: Project Merge Requests
     And I switch to the merge request's comments tab
     Then I should see a discussion has started on commit bcf03b5de6c:L185
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I comment on a commit in merge request
     Given project "Shop" have "Bug NS-05" open merge request with diffs inside
     And I visit merge request page "Bug NS-05"

--- a/features/project/network.feature
+++ b/features/project/network.feature
@@ -4,13 +4,13 @@ Feature: Project Network Graph
     And I own project "Shop"
     And I visit project "Shop" network page
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should see project network
     Then page should have network graph
     And page should select "master" in select box
     And page should have "master" on graph
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should switch "branch" and "tag"
     When I switch ref to "stable"
     Then page should select "stable" in select box
@@ -19,14 +19,14 @@ Feature: Project Network Graph
     Then page should select "v2.1.0" in select box
     And page should have "v2.1.0" on graph
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should looking for a commit by SHA
     When I looking for a commit by SHA of "v2.1.0"
     Then page should have network graph
     And page should select "master" in select box
     And page should have "v2.1.0" on graph
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should filter selected tag
     When I switch ref to "v2.1.0"
     Then page should have content not cotaining "v2.1.0"

--- a/features/project/project.feature
+++ b/features/project/project.feature
@@ -5,7 +5,7 @@ Feature: Project Feature
     And project "Shop" has push event
     And I visit project "Shop" page
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I should see project activity
     When I visit project "Shop" page
     Then I should see project "Shop" activity feed

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -20,7 +20,7 @@ Feature: Project Browse files
     And I click link "raw"
     Then I should see raw file content
 
-  @javascript
+  @javascript @inaccessible
   Scenario: I can edit file
     Given I click on "Gemfile.lock" file in repo
     And I click button "edit"

--- a/features/project/team_management.feature
+++ b/features/project/team_management.feature
@@ -11,13 +11,13 @@ Feature: Project Team management
     Then I should be able to see myself in team
     And I should see "Sam" in team list
 
-  @javascript
+  @javascript @inaccessible
   Scenario: Add user to project
     Given I click link "New Team Member"
     And I select "Mike" as "Reporter"
     Then I should see "Mike" in team list as "Reporter"
 
-  @javascript
+  @javascript @inaccessible
   Scenario: Update user access
     Given I should see "Sam" in team list as "Developer"
     And I change "Sam" role to "Reporter"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,8 +25,13 @@ WebMock.allow_net_connect!
 # JS driver
 #
 require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+require 'capybara/accessible'
 Spinach.hooks.on_tag("javascript") do
+  ::Capybara.javascript_driver = (ENV['WEBDRIVER'] == 'accessible') ? :accessible : :poltergeist
+  ::Capybara.current_driver = ::Capybara.javascript_driver
+end
+Spinach.hooks.on_tag("inaccessible") do
+  ::Capybara.javascript_driver = :poltergeist
   ::Capybara.current_driver = ::Capybara.javascript_driver
 end
 Capybara.default_wait_time = 10


### PR DESCRIPTION
[capybara-accessible](https://github.com/casecommons/capybara-accessible) applies javascript accessibility assertions to pages when they load, using [Google's Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools) tests. That way, accessibility errors in markup will trigger errors in CI.

We've fixed one of the layout errors and marked the other failing tests as inaccessible, until they can be addressed. The inaccessible tags are used to skip the audits on those example groups. The tags are necessary to keep that build green right now. You can try running locally after removing one of the tags, it should blow up.

The goal should be to remove the tags one by one and then fix the underlying accessibility issues that go red. At the very least, it'd be good to try and avoid adding the tags to new features :)

With this pull request you'll be able to set up a build in your CI instance to catch accessibility errors going forward. You can clone an existing build and set an environment variable: WEBDRIVER=accessible.

I had to upgrade jquery-ui from 2.0.2 to 3.0.1 because the older version was adding an invalid aria-activedescendant attribute on the hidden autocomplete placeholder ("ul" element). v3.0.1 fixes that without introducing any significant changes to jquery-ui.
