### PR TITLE
Update 5.1-to-5.2.md

### DIFF
--- a/doc/update/5.1-to-5.2.md
+++ b/doc/update/5.1-to-5.2.md
@@ -7,6 +7,7 @@ It's useful to make a backup just in case things go south:
 
 ```bash
 cd /home/git/gitlab
+sudo -u git -H mkdir /home/git/gitlab/public/uploads
 sudo -u git -H RAILS_ENV=production bundle exec rake gitlab:backup:create
 ```
 


### PR DESCRIPTION
/home/git/gitlab/public/uploads is missing if going from 5.1 to 5.2
