### PR TITLE
fix when default_branch is nil in database, gitlab-ci integration doesn't work because the parameter is "ref"=>"refs/heads/"

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,7 +11,7 @@ class ProjectsController < Projects::ApplicationController
   before_filter :set_title, only: [:new, :create]
 
   def new
-    @project = Project.new
+    @project = Project.new(default_branch: "master")
   end
 
   def edit


### PR DESCRIPTION
the gitlab-ci integration api require parameter "ref"=>"refs/heads/master", but for new project the default_branch default to null in database unless user save project settings, then the gitlab-ci api got parameter "ref"=>"refs/heads/" can not receives build from gitlab successful.
