### PR TITLE
Fix issue 4785 - missing gitlab-shell part in 5.3 to 5.4 update guide

### DIFF
--- a/doc/update/5.3-to-5.4.md
+++ b/doc/update/5.3-to-5.4.md
@@ -17,9 +17,14 @@ sudo -u git -H RAILS_ENV=production bundle exec rake gitlab:backup:create
 ### 2. Get latest code
 
 ```bash
+# GitLab
 cd /home/git/gitlab
 sudo -u git -H git fetch
 sudo -u git -H git checkout 5-4-stable
+# GitLab Shell
+cd /home/git/gitlab-shell
+sudo -u git -H git fetch
+sudo -u git -H git checkout v1.5.0
 ```
 
 ### 3. Install libs, migrations, etc.


### PR DESCRIPTION
Fix document issue => #4785
