### PR TITLE
Fix the link to the project branches

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -36,7 +36,7 @@
       %p
         = link_to pluralize(@repository.round_commit_count, 'commit'), project_commits_path(@project, @ref || @repository.root_ref)
       %p
-        = link_to pluralize(@repository.branch_names.count, 'branch'), project_repository_path(@project)
+        = link_to pluralize(@repository.branch_names.count, 'branch'), project_branches_path(@project)
       %p
         = link_to pluralize(@repository.tag_names.count, 'tag'), project_tags_path(@project)
 


### PR DESCRIPTION
Was linking to the non existent action `projects/repositories#show`. (88c741dde062e320ad007a2c5ccb4e7bdc6cdacf)
