### PR TITLE
Issue-4769 - Unable to update case of label

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -21,6 +21,8 @@ class Issue < ActiveRecord::Base
   include Issuable
   include InternalId
 
+  ActsAsTaggableOn.strict_case_match = true
+
   belongs_to :project
   validates :project, presence: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,6 +27,8 @@
 class Project < ActiveRecord::Base
   include Gitlab::ShellAdapter
   extend Enumerize
+   
+  ActsAsTaggableOn.strict_case_match = true
 
   attr_accessible :name, :path, :description, :default_branch, :issues_tracker, :label_list,
     :issues_enabled, :wall_enabled, :merge_requests_enabled, :snippets_enabled, :issues_tracker_id,


### PR DESCRIPTION
Labels are saved in the database with the case they were originally created with.
Before this change if a user created a label with the same text but different case
the label would use the original case and no new label would be created in the
database. With this change, labels are now case-sensitive.

Steps to test:
1. Before this change, create a new issue with a new label "FIxMe"
2. Edit the issue and change the label to "FixMe"
3. Note that the label reverted to "FIxMe"
4. Apply this change
5. Edit the issue again and change the label to "FixMe"
6. Note that the new case was preserved.
   If you also look in the database in the "tags" table you will see that
   both labels are present - "FIxMe" and "FixMe".
