### PR TITLE
Make flash messages fixed and sticked to bottom

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -89,7 +89,7 @@ $ ->
   if (flash = $(".flash-container")).length > 0
     flash.click -> $(@).fadeOut()
     flash.show()
-    setTimeout (-> flash.fadeOut()), 3000
+    setTimeout (-> flash.fadeOut()), 5000
 
   # Disable form buttons while a form is submitting
   $('body').on 'ajax:complete, ajax:beforeSend, submit', 'form', (e) ->

--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -89,7 +89,7 @@ $ ->
   if (flash = $(".flash-container")).length > 0
     flash.click -> $(@).fadeOut()
     flash.show()
-    setTimeout (-> flash.fadeOut()), 9000
+    setTimeout (-> flash.fadeOut()), 3000
 
   # Disable form buttons while a form is submitting
   $('body').on 'ajax:complete, ajax:beforeSend, submit', 'form', (e) ->

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -51,6 +51,10 @@ table a code {
   text-align: center;
   color: #fff;
   font-size: 14px;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  opacity: 0.8;
 
   .flash-notice {
     background: #49C;


### PR DESCRIPTION
According to #4653 i've remade flash messages in a more user friendly way. They are different than in a screenshot attached to the issue cause they looked ugly that way. Idecided to make them exactly as they were but for now, they are semi transparent (80%) and sticked to bottom of the screen. 

I've also reduced fadeOut timeout to 3000 ms cause they don't need to last so long.

Here is how it looks right now:
![zrzut ekranu 2013-08-17 o 12 43 27](https://f.cloud.github.com/assets/581569/980890/ead285ca-0729-11e3-8eb9-cc6e64820b5d.png)
