### PR TITLE
Added libmysqld-dev to the requiered packages list

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -52,7 +52,7 @@ If you are not familiar with vim please skip this and keep using the default edi
 
 Install the required packages:
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev
+    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev libmysqld-dev
 
 Make sure you have the right version of Python installed.
 


### PR DESCRIPTION
Because it is needed in order for the mysql2 gem to install.
