### PR TITLE
Remove -y option when removing ruby1.8

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -86,7 +86,7 @@ Then select 'Internet Site' and press enter to confirm the hostname.
 
 Remove the old Ruby 1.8 if present
 
-    sudo apt-get remove -y ruby1.8
+    sudo apt-get remove ruby1.8
 
 Download Ruby and compile it:
 


### PR DESCRIPTION
Since it is easily could break installations running on the server. The person who follows this guide should be presented with the information of what other packages that are going to get ripped out if ruby 1.8 goes.
