### PR TITLE
Issue page redesign

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -51,6 +51,10 @@ table a code {
   text-align: center;
   color: #fff;
   font-size: 14px;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  opacity: 0.8;
 
   .flash-notice {
     background: #49C;
@@ -142,8 +146,7 @@ p.time {
   text-align: center;
   float: right;
   position: relative;
-  top: -5px;
-  @include border-radius(4px);
+  @include border-radius(3px);
 
   &.success {
     background: #4A4;

--- a/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/blocks.scss
@@ -70,8 +70,8 @@
   .ui-box-head {
     .box-title {
       color: $style_color;
-      font-size: 18px;
-      font-weight: normal;
+      font-size: 22px;
+      font-weight: bold;
       line-height: 28px;
       margin: 0;
     }

--- a/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/buttons.scss
@@ -139,3 +139,18 @@
     float: left;
   }
 }
+
+.btn-group {
+  .btn-tiny {
+    margin: 0 !important;
+    border-right: 0;
+
+    i {
+      font-size: inherit !important;
+    }
+
+    &:last-child {
+      border-right: 1px solid #BBB;
+    }
+  }
+}

--- a/app/assets/stylesheets/gitlab_bootstrap/nav.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/nav.scss
@@ -30,10 +30,24 @@
         padding: 16px;
 
         &.success {
-          border-color: #4A4;
+          border-color: rgba(68, 170, 68, 0.5);
+          background: rgba(68, 170, 68, 0.06);
+          color: rgba(68, 170, 68, 0.5);
+
+          &:hover {
+            background: rgba(68, 170, 68, 0.5);
+            color: #fff;
+          }
         }
         &.error {
-          border-color: #DA4E49;
+          border-color: rgba(218, 78, 73, 0.5);
+          background: rgba(218, 78, 73, 0.06);
+          color: rgba(218,78,73,0.5);
+
+          &:hover {
+            background: rgba(218, 78, 73, 0.5);
+            color: #fff;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/gitlab_bootstrap/nav.scss
+++ b/app/assets/stylesheets/gitlab_bootstrap/nav.scss
@@ -28,6 +28,13 @@
       background: #FAFAFA;
       li > a {
         padding: 16px;
+
+        &.success {
+          border-color: #4A4;
+        }
+        &.error {
+          border-color: #DA4E49;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -101,12 +101,14 @@ input.check_all_issues {
 }
 
 .participants {
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 }
 
 .media-body {
   .ui-box:first-child {
     margin-top: 0;
+    border-color: #ddd;
+    @include border-radius(3px);
   }
 }
 

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -104,6 +104,12 @@ input.check_all_issues {
   margin-bottom: 20px;
 }
 
+.issue-milestone {
+  .progress {
+    width: 200px;
+  }
+}
+
 .media-body {
   .ui-box:first-child {
     margin-top: 0;

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -103,3 +103,21 @@ input.check_all_issues {
 .participants {
   margin-bottom: 10px;
 }
+
+.media-body {
+  .ui-box:first-child {
+    margin-top: 0;
+  }
+}
+
+.issue-sidebar {
+  .status_info {
+    float: none;
+    background: #eee;
+    color: #bbb;
+    font-weight: bold;
+    border-radius: 3px;
+    font-size: 16px;
+    padding: 9px;
+  }
+}

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -17,8 +17,7 @@ ul.notes {
   .discussion-header,
   .note-header {
     @extend .cgray;
-    padding-top: 5px;
-    padding-bottom: 15px;
+    padding: 10px 10px 10px 15px;
 
     .avatar {
       float: left;
@@ -28,6 +27,7 @@ ul.notes {
     .discussion-last-update,
     .note-last-update {
       font-style: italic;
+      color: #999;
     }
     .author {
       color: $style_color;
@@ -76,10 +76,10 @@ ul.notes {
   }
 
   .note {
-    padding: 8px 0;
     overflow: hidden;
     display: block;
     position:relative;
+    margin-top: 0;
     p { color: $style_color; }
 
     .avatar {
@@ -91,30 +91,41 @@ ul.notes {
     }
     .note-body {
       @include md-typography;
-      margin-left: 45px;
+      padding-bottom: 3px;
 
       .highlight {
         @include border-radius(4px);
       }
+
+      p:first-child {
+        margin-top: -5px;
+      }
     }
-    .note-header {
-      padding-bottom: 5px;
+
+    .media-body {
+      .ui-box {
+        @include border-radius(3px);
+        overflow: hidden;
+        border-color: #ddd;
+      }
     }
   }
 
   .note:target {
-    -webkit-animation:target-note 2s linear;
-    background: #fffff0;
+    .note-body {
+      -webkit-animation:target-note 2s linear;
+      background: #fffff0;      
+    }
   }
 
   // paint top or bottom borders depending on notes direction
   &:not(.reversed) .note,
   &:not(.reversed) .discussion {
-    border-bottom: 1px solid #eee;
+    //border-bottom: 1px solid #eee;
   }
   &.reversed .note,
   &.reversed .discussion {
-    border-top: 1px solid #eee;
+    //border-top: 1px solid #eee;
   }
 }
 
@@ -160,6 +171,7 @@ ul.notes {
   .note-actions {
     display: none;
     float: right;
+    margin-top: -3px;
 
     [class^="icon-"],
     [class*="icon-"] {
@@ -247,15 +259,19 @@ ul.notes {
 .file,
 .discussion {
   .new_note {
-    margin: 8px 5px 8px 0;
+    margin: 0 5px 8px 0;
   }
 }
 .new_note {
   display: none;
 
+  .author {
+    font-weight: bold;
+    color: #474d57;
+  }
+
   .buttons {
     float: left;
-    margin-top: 8px;
   }
   .clearfix {
     margin-bottom: 0;
@@ -300,23 +316,13 @@ ul.notes {
 }
 
 
-.common-note-form {
-  margin: 0;
-  height: 140px;
-  background: #F9F9F9;
-  padding: 3px;
-  padding-bottom: 25px;
-  border: 1px solid #DDD;
-}
-
-
 .note-form-actions {
-  background: #F9F9F9;
-  height: 45px;
-  padding: 0 5px;
+  background: #f5f5f5;
+  border-top: 1px solid #e5e5e5;
+  padding: 16px;
 
   .note-form-option {
-    margin-top: 10px;
+    margin-top: 3px;
     margin-left: 30px;
     @extend .pull-left;
   }
@@ -338,7 +344,8 @@ ul.notes {
   }
 
   .form-actions {
-    padding-left: 20px;
+    padding: 16px;
+    margin: 18px -15px -21px;
 
     .btn-save {
       float: left;

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -48,7 +48,7 @@
           - @issue.participants.each do |participant|
             = link_to_member(@project, participant, name: false, size: 24)
 
-    .voting_notes#notes= render "projects/notes/notes_with_form"
+        .voting_notes#notes= render "projects/notes/notes_with_form"
 
   .span2.issue-sidebar
     .status_info

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -61,9 +61,9 @@
       - if can?(current_user, :modify_issue, @issue)
         %li
           - if @issue.closed?
-            = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put, class: 'red'
+            = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put, class: 'success'
           - else
-            = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, title: "Close Issue", class: 'green'
+            = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, title: "Close Issue", class: 'error'
         %li
           = link_to edit_project_issue_path(@project, @issue) do
             Edit

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -28,19 +28,19 @@
               - else
                 \ No one assigned.
 
-            - if @issue.milestone
-              - milestone = @issue.milestone
-              .pull-right.issue-milestone
-                .media
-                  .progress.pull-right
-                    .bar{style: "width: #{milestone.percent_complete}%"}
+            .pull-right.issue-milestone
+              - if @issue.milestone
+                - milestone = @issue.milestone
+                  .media
+                    .progress.pull-right
+                      .bar{style: "width: #{milestone.percent_complete}%"}
 
-                  .media-body
-                    %cite.cgray Milestone:
-                    %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
+                    .media-body
+                      %cite.cgray Milestone:
+                      %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
 
-            - else
-              %cite.cgray No milestone set.
+              - else
+                %cite.cgray No milestone set.
 
           - if @issue.description.present?
             .ui-box-bottom

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -61,9 +61,9 @@
       - if can?(current_user, :modify_issue, @issue)
         %li
           - if @issue.closed?
-            = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put
+            = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put, class: 'red'
           - else
-            = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, title: "Close Issue"
+            = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, title: "Close Issue", class: 'green'
         %li
           = link_to edit_project_issue_path(@project, @issue) do
             Edit

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -31,14 +31,13 @@
             .pull-right.issue-milestone
               - if @issue.milestone
                 - milestone = @issue.milestone
-                  .media
-                    .progress.pull-right
-                      .bar{style: "width: #{milestone.percent_complete}%"}
+                .media
+                  .progress.pull-right
+                    .bar{style: "width: #{milestone.percent_complete}%"}
 
-                    .media-body
-                      %cite.cgray Milestone:
-                      %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
-
+                  .media-body
+                    %cite.cgray Milestone:
+                    %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
               - else
                 %cite.cgray No milestone set.
 

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -25,12 +25,22 @@
             %cite.cgray
               - if @issue.assignee
                 \ Assigned to #{link_to_member(@project, @issue.assignee, avatar: false)}
+              - else
+                \ No one assigned.
 
             - if @issue.milestone
-              .pull-right
-                - milestone = @issue.milestone
-                %cite.cgray Milestone:
-                %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
+              - milestone = @issue.milestone
+              .pull-right.issue-milestone
+                .media
+                  .progress.pull-right
+                    .bar{style: "width: #{milestone.percent_complete}%"}
+
+                  .media-body
+                    %cite.cgray Milestone:
+                    %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
+
+            - else
+              %cite.cgray No milestone set.
 
           - if @issue.description.present?
             .ui-box-bottom

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -11,6 +11,8 @@
               .pull-right
                 - if @issue.closed?
                   .error.status_info Closed
+                - else
+                  .success.status_info Opened
 
               .media-body
                 %span.muted

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -16,7 +16,7 @@
 
               .media-body
                 %span.muted
-                  Created by #{link_to_member(@project, @issue.assignee, avatar: false)} 
+                  Created by #{link_to_member(@project, @issue.author, avatar: false)} 
                   %span{title: @issue.created_at.stamp("Aug 21, 2011")} #{time_ago_in_words(@issue.created_at)} ago
                 %h4.box-title
                   = gfm escape_once(@issue.title)

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -1,73 +1,85 @@
-%h3.page-title
-  Issue ##{@issue.id}
+.row
+  .span10
+    .media
+      .pull-left
+        = link_to_member(@project, @issue.author, name: false, size: 50)
 
-  %small
-    created at
-    = @issue.created_at.stamp("Aug 21, 2011")
+      .media-body
+        .ui-box.ui-box-show
+          .ui-box-head
+            .media
+              .pull-right
+                - if @issue.closed?
+                  .error.status_info Closed
 
-  %span.pull-right
-    = link_to new_project_issue_path(@project), class: "btn grouped", title: "New Issue", id: "new_issue_link" do
-      %i.icon-plus
-      New Issue
-    - if can?(current_user, :modify_issue, @issue)
-      - if @issue.closed?
-        = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put,  class: "btn grouped reopen_issue"
-      - else
-        = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn grouped close_issue", title: "Close Issue"
+              .media-body
+                %span.muted
+                  Created by #{link_to_member(@project, @issue.assignee, avatar: false)} 
+                  %span{title: @issue.created_at.stamp("Aug 21, 2011")} #{time_ago_in_words(@issue.created_at)} ago
+                %h4.box-title
+                  = gfm escape_once(@issue.title)
 
-      = link_to edit_project_issue_path(@project, @issue), class: "btn grouped" do
-        %i.icon-edit
-        Edit
+          .ui-box-body
+            %cite.cgray
+              - if @issue.assignee
+                \ Assigned to #{link_to_member(@project, @issue.assignee, avatar: false)}
 
-.pull-right
-  .span3#votes= render 'votes/votes_block', votable: @issue
+            - if @issue.milestone
+              .pull-right
+                - milestone = @issue.milestone
+                %cite.cgray Milestone:
+                %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
 
-.back-link
-  = link_to project_issues_path(@project) do
-    &larr; To issues list
+          - if @issue.description.present?
+            .ui-box-bottom
+              .wiki
+                = preserve do
+                  = markdown @issue.description
 
+        - content_for :note_actions do
+          - if can?(current_user, :modify_issue, @issue)
+            - if @issue.closed?
+              = link_to 'Reopen Issue', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put,  class: "btn grouped reopen_issue"
+            - else
+              = link_to 'Close Issue', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn grouped close_issue", title: "Close Issue"
 
-.ui-box.ui-box-show
-  .ui-box-head
-    %h4.box-title
-      - if @issue.closed?
-        .error.status_info Closed
-      = gfm escape_once(@issue.title)
+        .participants
+          %cite.cgray #{@issue.participants.count} participants
+          - @issue.participants.each do |participant|
+            = link_to_member(@project, participant, name: false, size: 24)
 
-  .ui-box-body
-    %cite.cgray
-      Created by #{link_to_member(@project, @issue.author)}
-      - if @issue.assignee
-        \ and currently assigned to #{link_to_member(@project, @issue.assignee)}
+    .voting_notes#notes= render "projects/notes/notes_with_form"
 
-    - if @issue.milestone
-      - milestone = @issue.milestone
-      %cite.cgray and attached to milestone
-      %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
+  .span2.issue-sidebar
+    .status_info
+      Issue ##{@issue.id}
+    .clearfix
 
-    .pull-right
+    %ul.nav.nav-pills.nav-stacked.nav-stacked-menu
+      - if can?(current_user, :modify_issue, @issue)
+        %li
+          - if @issue.closed?
+            = link_to 'Reopen', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put
+          - else
+            = link_to 'Close', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, title: "Close Issue"
+        %li
+          = link_to edit_project_issue_path(@project, @issue) do
+            Edit
+
+      %li
+        = link_to new_project_issue_path(@project), title: "New Issue", id: "new_issue_link" do
+          New Issue
+
+    %hr
+
+    %h6 Labels
+    %p
       - @issue.labels.each do |label|
         %span{class: "label #{label_css_class(label.name)}"}
           %i.icon-tag
           = label.name
-        &nbsp;
 
-  - if @issue.description.present?
-    .ui-box-bottom
-      .wiki
-        = preserve do
-          = markdown @issue.description
+    %hr
 
-- content_for :note_actions do
-  - if can?(current_user, :modify_issue, @issue)
-    - if @issue.closed?
-      = link_to 'Reopen Issue', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put,  class: "btn grouped reopen_issue"
-    - else
-      = link_to 'Close Issue', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn grouped close_issue", title: "Close Issue"
-
-.participants
-  %cite.cgray #{@issue.participants.count} participants
-  - @issue.participants.each do |participant|
-    = link_to_member(@project, participant, name: false, size: 24)
-
-.voting_notes#notes= render "projects/notes/notes_with_form"
+    %h6 Votes
+    #votes= render 'votes/votes_block', votable: @issue

--- a/app/views/projects/notes/_form.html.haml
+++ b/app/views/projects/notes/_form.html.haml
@@ -1,37 +1,46 @@
 = form_for [@project, @note], remote: true, html: { multipart: true, id: nil, class: "new_note js-new-note-form common-note-form" } do |f|
 
-  = note_target_fields
-  = f.hidden_field :commit_id
-  = f.hidden_field :line_code
-  = f.hidden_field :noteable_id
-  = f.hidden_field :noteable_type
+  .media
+    .pull-left
+      = link_to_member(@project, current_user, name: false, size: 50)
 
-  .note_text_and_preview.js-toggler-container
-    %a.js-note-preview-button.js-toggler-target.turn-off{ href: "javascript:;", title: "Preview", data: {url: preview_project_notes_path(@project)} }
-      %i.icon-eye-open
-    %a.js-note-edit-button.js-toggler-target.turn-off{ href: "javascript:;", title: "Edit" }
-      %i.icon-edit
+    .media-body
+      .ui-box.ui-box-show
+        .note-header.ui-box-body
+          = link_to_member(@project, current_user, avatar: false)
 
-    = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on'
-    .note_preview.js-note-preview.turn-off
+          .pull-right.muted Comments are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
+        
+        .ui-box-bottom.note-body
+          = note_target_fields
+          = f.hidden_field :commit_id
+          = f.hidden_field :line_code
+          = f.hidden_field :noteable_id
+          = f.hidden_field :noteable_type
 
-  .hint
-    .pull-right Comments are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
-  .clearfix
+          .note_text_and_preview.js-toggler-container
+            %a.js-note-preview-button.js-toggler-target.turn-off{ href: "javascript:;", title: "Preview", data: {url: preview_project_notes_path(@project)} }
+              %i.icon-eye-open
+            %a.js-note-edit-button.js-toggler-target.turn-off{ href: "javascript:;", title: "Edit" }
+              %i.icon-edit
 
-  .note-form-actions
-    .buttons
-      = f.submit 'Add Comment', class: "btn comment-btn grouped js-comment-button"
-      = yield(:note_actions)
+            = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on'
+            .note_preview.js-note-preview.turn-off
+          .clearfix
 
-      %a.btn.grouped.js-close-discussion-note-form Cancel
+        .note-form-actions
+          .buttons
+            = f.submit 'Add Comment', class: "btn comment-btn grouped js-comment-button"
+            = yield(:note_actions)
 
-    .note-form-option
-      %a.choose-btn.btn.btn-small.js-choose-note-attachment-button
-        %i.icon-paper-clip
-        %span Choose File ...
-      &nbsp;
-      %span.file_name.js-attachment-filename File name...
-      = f.file_field :attachment, class: "js-note-attachment-input hide"
+            %a.btn.grouped.js-close-discussion-note-form Cancel
 
-    .clearfix
+          .note-form-option
+            %a.choose-btn.btn.btn-small.js-choose-note-attachment-button
+              %i.icon-paper-clip
+              %span Choose File ...
+            &nbsp;
+            %span.file_name.js-attachment-filename File name...
+            = f.file_field :attachment, class: "js-note-attachment-input hide"
+
+          .clearfix

--- a/app/views/projects/notes/_note.html.haml
+++ b/app/views/projects/notes/_note.html.haml
@@ -1,66 +1,65 @@
-%li{ id: dom_id(note), class: dom_class(note), data: { discussion: note.discussion_id } }
-  .note-header
-    .note-actions
-      = link_to "##{dom_id(note)}", name: dom_id(note) do
-        %i.icon-link
-        Link here
-      &nbsp;
-      - if(note.author_id == current_user.id) || can?(current_user, :admin_note, @project)
-        = link_to "#", title: "Edit comment", class: "js-note-edit" do
-          %i.icon-edit
-          Edit
-        &nbsp;
-        = link_to project_note_path(@project, note), title: "Remove comment", method: :delete, confirm: 'Are you sure you want to remove this comment?', remote: true, class: "danger js-note-delete" do
-          %i.icon-trash.cred
-          Remove
-    = image_tag gravatar_icon(note.author_email), class: "avatar s32"
-    = link_to_member(@project, note.author, avatar: false)
-    %span.note-last-update
-      = note_timestamp(note)
+%li{ id: dom_id(note), class: dom_class(note) + ' media', data: { discussion: note.discussion_id } }
+  .pull-left
+    = link_to_member(@project, note.author, name: false, size: 50)
 
-    - if note.upvote?
-      %span.vote.upvote.label.label-success
-        %i.icon-thumbs-up
-        \+1
-    - if note.downvote?
-      %span.vote.downvote.label.label-error
-        %i.icon-thumbs-down
-        \-1
+  .media-body
+    .ui-box.ui-box-show
+      .note-header.ui-box-body
+        .note-actions.btn-group
+          = link_to "##{dom_id(note)}", name: dom_id(note), class: 'btn btn-tiny', title: 'Link here' do
+            %i.icon-link
+          - if(note.author_id == current_user.id) || can?(current_user, :admin_note, @project)
+            = link_to "#", title: "Edit comment", class: "js-note-edit btn btn-tiny", title: 'Edit note' do
+              %i.icon-edit
+            = link_to project_note_path(@project, note), title: "Remove comment", method: :delete, confirm: 'Are you sure you want to remove this comment?', remote: true, class: "btn btn-tiny danger js-note-delete" do
+              %i.icon-trash.cred
+
+        = link_to_member(@project, note.author, avatar: false)
+        %span.note-last-update
+          = note_timestamp(note)
+
+        - if note.upvote?
+          %span.vote.upvote.label.label-success
+            %i.icon-thumbs-up
+            \+1
+        - if note.downvote?
+          %span.vote.downvote.label.label-error
+            %i.icon-thumbs-down
+            \-1
+
+      .ui-box-bottom.note-body
+        .note-text.wiki
+          = preserve do
+            = markdown(note.note)
+
+        .note-edit-form
+          = form_for note, url: project_note_path(@project, note), method: :put, remote: true do |f|
+            = f.text_area :note, class: 'note_text js-note-text js-gfm-input turn-on'
+
+            .form-actions
+              = f.submit 'Save changes', class: "btn btn-primary btn-save"
+
+              .note-form-option
+                %a.choose-btn.btn.btn-small.js-choose-note-attachment-button
+                  %i.icon-paper-clip
+                  %span Choose File ...
+                &nbsp;
+                %span.file_name.js-attachment-filename File name...
+                = f.file_field :attachment, class: "js-note-attachment-input hide"
+
+              = link_to  'Cancel', "#", class: "btn btn-cancel note-edit-cancel"
 
 
-  .note-body
-    .note-text
-      = preserve do
-        = markdown(note.note)
-
-    .note-edit-form
-      = form_for note, url: project_note_path(@project, note), method: :put, remote: true do |f|
-        = f.text_area :note, class: 'note_text js-note-text js-gfm-input turn-on'
-
-        .form-actions
-          = f.submit 'Save changes', class: "btn btn-primary btn-save"
-
-          .note-form-option
-            %a.choose-btn.btn.btn-small.js-choose-note-attachment-button
+      - if note.attachment.url
+        .note-attachment
+          - if note.attachment.image?
+            = link_to note.attachment.url, target: '_blank' do
+              = image_tag note.attachment.url, class: 'note-image-attach'
+          .attachment.pull-right
+            = link_to note.attachment.secure_url, target: "_blank" do
               %i.icon-paper-clip
-              %span Choose File ...
-            &nbsp;
-            %span.file_name.js-attachment-filename File name...
-            = f.file_field :attachment, class: "js-note-attachment-input hide"
-
-          = link_to  'Cancel', "#", class: "btn btn-cancel note-edit-cancel"
-
-
-  - if note.attachment.url
-    .note-attachment
-      - if note.attachment.image?
-        = link_to note.attachment.url, target: '_blank' do
-          = image_tag note.attachment.url, class: 'note-image-attach'
-      .attachment.pull-right
-        = link_to note.attachment.secure_url, target: "_blank" do
-          %i.icon-paper-clip
-          = note.attachment_identifier
-          = link_to delete_attachment_project_note_path(@project, note),
-            title: "Delete this attachment", method: :delete, remote: true, confirm: 'Are you sure you want to remove the attachment?', class: "danger js-note-attachment-delete" do
-            %i.icon-trash.cred
-  .clear
+              = note.attachment_identifier
+              = link_to delete_attachment_project_note_path(@project, note),
+                title: "Delete this attachment", method: :delete, remote: true, confirm: 'Are you sure you want to remove the attachment?', class: "danger js-note-attachment-delete" do
+                %i.icon-trash.cred
+      .clear


### PR DESCRIPTION
Hello!
I'd like to help with gitlab project and that's my first bigger commit. 

IMO GitLab stuggles a bit in cause of big width of it's layout. On one hand it's a good thing cause a lot of information can be displayed and everything is big and readable but on the other hand, some pages looks really bad. Like issue page for instance. Websites are terrible to read when line has about 50 words in it and current issue page is a great example of that.

I want to dedicate a series of PR focused around this 'big width' thing , trying to fix that my way. I hope you'll like my attempt. If not, no worries.

Just for the start - here is a small redesign of Issue page i've made. It was focused on reducing a text section width by inserting a sidebar. I have also reduced a white-unused-space and moved some things from the top to sidebar. I've also tried to style the notes to make them look more organized. I've tried to make that all as much flexible as possible.

![zrzut ekranu 2013-08-17 o 20 17 44](https://f.cloud.github.com/assets/581569/981523/fe6e4a74-076a-11e3-8594-e46af3c477c2.png)

![zrzut ekranu 2013-08-17 o 20 32 02](https://f.cloud.github.com/assets/581569/981530/5b4f6a20-076b-11e3-88aa-c68124ad4bcd.png)

![zrzut ekranu 2013-08-17 o 20 32 30](https://f.cloud.github.com/assets/581569/981531/6b512dfa-076b-11e3-9a47-524b8afaee4e.png)

Some things are heavily inspired by github, others not. I hope you'll like them. There is still much work to be done (with issue page and not only) but i'll try to send some more push request regularly.
