### PR TITLE
Remove the dependancy of grit from class Network::Graph

### DIFF
--- a/app/helpers/graph_helper.rb
+++ b/app/helpers/graph_helper.rb
@@ -1,7 +1,7 @@
 module GraphHelper
-  def get_refs(commit)
+  def get_refs(repo, commit)
     refs = ""
-    refs += commit.refs.collect{|r|r.name}.join(" ") if commit.refs
+    refs += commit.ref_names(repo).join(" ")
 
     # append note count
     refs += "[#{@graph.notes[commit.id]}]" if @graph.notes[commit.id] > 0

--- a/app/models/network/commit.rb
+++ b/app/models/network/commit.rb
@@ -4,15 +4,13 @@ module Network
   class Commit
     include ActionView::Helpers::TagHelper
 
-    attr_reader :refs
     attr_accessor :time, :spaces, :parent_spaces
 
-    def initialize(raw_commit, refs)
-      @commit = Gitlab::Git::Commit.new(raw_commit)
+    def initialize(raw_commit)
+      @commit = raw_commit
       @time = -1
       @spaces = []
       @parent_spaces = []
-      @refs = refs || []
     end
 
     def method_missing(m, *args, &block)

--- a/app/views/projects/network/show.json.erb
+++ b/app/views/projects/network/show.json.erb
@@ -13,7 +13,7 @@
         },
         time: c.time,
         space: c.spaces.first,
-        refs: get_refs(c),
+        refs: get_refs(@graph.repo, c),
         id: c.sha,
         date: c.date,
         message: c.message,


### PR DESCRIPTION
This PR is dependent on https://github.com/gitlabhq/gitlab_git/pull/9
