### PR TITLE
Fix bug in ace-src-noconflict with Relative url.

### DIFF
--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -31,7 +31,7 @@
       = link_to "Cancel", project_blob_path(@project, @id), class: "btn btn-cancel", confirm: leave_edit_message
 
 :javascript
-  ace.config.set("modePath", "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")
+  ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")
   var ace_mode = "#{@blob.language.try(:ace_mode)}";
   var editor = ace.edit("editor");
   if (ace_mode) {


### PR DESCRIPTION
If we doesn't use a relative url we have this:

<pre>gon.relative_url_root=""</pre>

Else <pre>gon.relative_url_root="/gitlab"</pre>

Gitlab::Application.config.assets.prefix contains:

<pre>/assets</pre>
