### PR TITLE
bind unicorn listener to 127.0.0.1

### DIFF
--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -26,7 +26,7 @@ working_directory "/home/git/gitlab" # available in 0.94.0+
 # listen on both a Unix domain socket and a TCP port,
 # we use a shorter backlog for quicker failover when busy
 listen "/home/git/gitlab/tmp/sockets/gitlab.socket", :backlog => 64
-listen 8080, :tcp_nopush => true
+listen "127.0.0.1:8080", :tcp_nopush => true
 
 # nuke workers after 30 seconds instead of 60 seconds (the default)
 timeout 30


### PR DESCRIPTION
as far as I understand, otherwise it will listen on 0.0.0.0, what might not be the best idea.
