### PR TITLE
Fix GitLab Shell version check

### DIFF
--- a/lib/tasks/gitlab/info.rake
+++ b/lib/tasks/gitlab/info.rake
@@ -54,7 +54,7 @@ namespace :gitlab do
 
 
       # check Gitolite version
-      gitlab_shell_version_file = "#{Gitlab.config.gitlab_shell.repos_path}/../gitlab-shell/VERSION"
+      gitlab_shell_version_file = "#{Gitlab.config.gitlab_shell.hooks_path}/../VERSION"
       if File.readable?(gitlab_shell_version_file)
         gitlab_shell_version = File.read(gitlab_shell_version_file)
       end


### PR DESCRIPTION
Currently, the `gitlab_shell_version_file` uses `repos_path` to find the VERSION file. I have moved my repositories path to a custom directory outside of `gitlab-shell`. This causes the check to fail and return Unknown. The hooks directory is more likely to be inside the gitlab-shell base directory. Using the hooks path to find the VERSION file would be more reliable. 
