### PR TITLE
Add git commit mail notifications to GitLab 6.0 (stable)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,10 @@ gem "sanitize"
 
 # Git commit notifier
 gem "git-commit-notifier", "0.12.0"
+gem "nntp", "~> 1.0"
+gem "premailer", "~> 1.7", ">= 1.7.1", "!= 1.7.2"
+gem "nokogiri", "~> 1.4"
+gem "yajl-ruby", "~> 1.0"
 
 group :assets do
   gem "sass-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,7 @@ group :assets do
   gem "raphael-rails",    git: "https://github.com/gitlabhq/raphael-rails.git"
   gem 'bootstrap-sass'
   gem "font-awesome-rails"
-  gem "gemoji", "~> 1.2.1", require: 'emoji/railtie'
+  gem "gemoji", "~> 1.3.1", require: 'emoji/railtie'
   gem "gon"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,9 @@ gem "underscore-rails", "~> 1.4.4"
 # Sanitize user input
 gem "sanitize"
 
+# Git commit notifier
+gem "git-commit-notifier", "0.12.0"
+
 group :assets do
   gem "sass-rails"
   gem "coffee-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,7 @@ group :assets do
   gem "raphael-rails",    git: "https://github.com/gitlabhq/raphael-rails.git"
   gem 'bootstrap-sass'
   gem "font-awesome-rails"
-  gem "gemoji", "~> 1.3.1", require: 'emoji/railtie'
+  gem "gemoji", "~> 1.2.1", require: 'emoji/railtie'
   gem "gon"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     fssm (0.2.10)
     gemoji (1.2.1)
     gherkin-ruby (0.3.0)
+    git-commit-notifier (0.12.0)
     github-linguist (2.3.4)
       charlock_holmes (~> 0.6.6)
       escape_utils (~> 0.2.3)

--- a/app/mailers/emails/commits.rb
+++ b/app/mailers/emails/commits.rb
@@ -1,0 +1,12 @@
+module Emails
+  module Commits
+    def receive_commit_email(project, author_id, data)
+      repo_dir = Gitlab.config.gitlab_shell.repos_path.to_s
+      project_repo_dir = File.join(repo_dir,"#{project.path_with_namespace}.git")
+      repo_notify_config_file = File.join(project_repo_dir,"notify.yml")
+      
+      result = `cd #{project_repo_dir} && echo #{data[:before]} #{data[:after]} #{data[:ref]} | git-commit-notifier #{repo_notify_config_file}`
+      #Gitlab::AppLogger.info result
+    end
+  end
+end

--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -3,6 +3,7 @@ class Notify < ActionMailer::Base
   include Emails::MergeRequests
   include Emails::Notes
   include Emails::Projects
+  include Emails::Commits
 
   add_template_helper ApplicationHelper
   add_template_helper GitlabMarkdownHelper

--- a/app/observers/project_activity_cache_observer.rb
+++ b/app/observers/project_activity_cache_observer.rb
@@ -3,6 +3,10 @@ class ProjectActivityCacheObserver < BaseObserver
 
   def after_create(event)
     event.project.update_column(:last_activity_at, event.created_at) if event.project
+    
+    if event.project && event.action == Event::PUSHED
+        notification.receive_commit(event)
+    end
   end
 end
 

--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -25,6 +25,15 @@ class ProjectObserver < BaseObserver
       project.path_with_namespace,
       project.default_branch
     ) if project.default_branch_changed?
+    
+    repo_dir = Gitlab.config.gitlab_shell.repos_path.to_s
+    default_notify_file = File.join(repo_dir,"notify.yml")
+    project_repo_dir = File.join(repo_dir,"#{project.path_with_namespace}.git")
+    repo_notify_config_file = File.join(project_repo_dir,"notify.yml")
+    user_emails = project.users.map(&:email).join(',')
+    File.open(repo_notify_config_file,'w') do |out|
+       out<<File.open(default_notify_file).read.gsub(/^mailinglist:/,"mailinglist: #{user_emails}")
+    end
   end
 
   def before_destroy(project)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -147,6 +147,10 @@ class NotificationService
   def update_team_member(users_project)
     mailer.project_access_granted_email(users_project.id)
   end
+  
+  def receive_commit(event)
+    mailer.receive_commit_email(event.project, event.author_id, event.data)
+  end
 
   protected
 

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -224,6 +224,11 @@ Make sure to edit both `gitlab.yml` and `unicorn.rb` to match your setup.
     
     # Make config/database.yml readable to git only
     sudo -u git -H chmod o-rwx config/database.yml
+    
+## Install default git-commit-notifier config file
+
+    cd /home/git/repositories
+    sudo -u git wget -O notify.yml https://raw.github.com/git-commit-notifier/git-commit-notifier/v0.12.0/config/git-notifier-config.example.yml
 
 ## Install Gems
 


### PR DESCRIPTION
This pull request add git commit mail notifications to GitLab 6.0 (stable). It uses the gem 'git-commit-notifier' at https://github.com/git-commit-notifier/git-commit-notifier. All members of the project repository receive automatically an commit mail notification.
