### PR TITLE
 Clear redis cache and precompile assets during update to 6.0. Fix #4874 #4840

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -4,7 +4,7 @@
 
 #### Global projects
 
-We deprecated root(global) namespace for projects. 
+We deprecated root(global) namespace for projects.
 So you need to move all your global projects under group/users manually before update or they will be automatically moved to the owner namespace during the update.
 
 #### Teams
@@ -62,7 +62,7 @@ cd /home/git/gitlab
 # MySQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
@@ -71,6 +71,12 @@ sudo -u git -H bundle exec rake migrate_global_projects RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_keys RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_inline_notes RAILS_ENV=production
 
+# Clear redis cache
+sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
+
+# Clear and precompile assets
+sudo -u git -H bundle exec rake assets:clean RAILS_ENV=production
+sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 ```
 
 ### 6. Update config files


### PR DESCRIPTION
As a consequence on the namespaces change from 5.4 to 6.0, after upgrade lots of links on the dashboard were not working (pointing to projects without the group part on the url).

Also, after upgrading to 6.0-stable, the network (branch history) function does not work. The progress bar rotates forever, but the network graph cannot be generated.

Clearing redis cache reportedly fixed those issues.
