### PR TITLE
Standardize recently added commit diff api url

### DIFF
--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -239,12 +239,37 @@ Parameters:
 ]
 ```
 
+## Get a single commit
+
+Get a specific commit identified by the commit hash or name of a branch or tag.
+
+```
+GET /projects/:id/repository/commits/:sha
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
++ `sha` (required) - The commit hash or name of a repository branch or tag
+
+```json
+{
+  "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+  "short_id": "6104942438c",
+  "title": "Sanitize for network graph",
+  "author_name": "randx",
+  "author_email": "dmitriy.zaporozhets@gmail.com",
+  "created_at": "2012-09-20T09:06:12+03:00"
+}
+```
+
+
 ## Get the diff of a commit
 
 Get the diff of a commit in a project.
 
 ```
-GET /projects/:id/repository/commit/:sha
+GET /projects/:id/repository/commits/:sha/diff
 ```
 
 Parameters:
@@ -323,7 +348,7 @@ Parameters:
 Get the raw file contents for a file.
 
 ```
-GET /projects/:id/repository/commits/:sha/blob
+GET /projects/:id/repository/blobs/:sha
 ```
 
 Parameters:

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -106,13 +106,29 @@ module API
       #
       # Parameters:
       #   id (required) - The ID of a project
+      #   sha (required) - The commit hash or name of a repository branch or tag
+      # Example Request:
+      #   GET /projects/:id/repository/commits/:sha
+      get ":id/repository/commits/:sha" do
+        authorize! :download_code, user_project
+        sha = params[:sha]
+        commit = user_project.repository.commit(sha)
+        not_found! "Commit" unless commit
+        present commit, with: Entities::RepoCommit
+      end
+
+      # Get the diff for a specific commit of a project
+      #
+      # Parameters:
+      #   id (required) - The ID of a project
       #   sha (required) - The commit or branch name
       # Example Request:
-      #   GET /projects/:id/repository/commit/:sha
-      get ":id/repository/commit/:sha" do
+      #   GET /projects/:id/repository/commits/:sha/diff
+      get ":id/repository/commits/:sha/diff" do
         authorize! :download_code, user_project
         sha = params[:sha]
         result = CommitLoadContext.new(user_project, current_user, {id: sha}).execute
+        not_found! "Commit" unless result[:commit]
         result[:commit].diffs
       end
 
@@ -148,8 +164,8 @@ module API
       #   sha (required) - The commit or branch name
       #   filepath (required) - The path to the file to display
       # Example Request:
-      #   GET /projects/:id/repository/commits/:sha/blob
-      get ":id/repository/commits/:sha/blob" do
+      #   GET /projects/:id/repository/blobs/:sha
+      get [ ":id/repository/blobs/:sha", ":id/repository/commits/:sha/blob" ] do
         authorize! :download_code, user_project
         required_attributes! [:filepath]
 

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -112,23 +112,51 @@ describe API::API do
     end
   end
 
-  describe "GET /projects:id/repository/commit/:sha" do
+  describe "GET /projects:id/repository/commits/:sha" do
+    context "authorized user" do
+      it "should return a commit by sha" do
+        get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}", user)
+        response.status.should == 200
+        json_response['id'].should == project.repository.commit.id
+        json_response['title'].should == project.repository.commit.title
+      end
+
+      it "should return a 404 error if not found" do
+        get api("/projects/#{project.id}/repository/commits/invalid_sha", user)
+        response.status.should == 404
+      end
+    end
+
+    context "unauthorized user" do
+      it "should not return the selected commit" do
+        get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}")
+        response.status.should == 401
+      end
+    end
+  end
+
+  describe "GET /projects:id/repository/commits/:sha/diff" do
     context "authorized user" do
       before { project.team << [user2, :reporter] }
 
       it "should return the diff of the selected commit" do
-        get api("/projects/#{project.id}/repository/commit/#{project.repository.commit.id}", user)
+        get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}/diff", user)
         response.status.should == 200
 
         json_response.should be_an Array
         json_response.length.should >= 1
         json_response.first.keys.should include "diff"
       end
+
+      it "should return a 404 error if invalid commit" do
+        get api("/projects/#{project.id}/repository/commits/invalid_sha/diff", user)
+        response.status.should == 404
+      end
     end
 
     context "unauthorized user" do
       it "should not return the diff of the selected commit" do
-        get api("/projects/#{project.id}/repository/commit/#{project.repository.commit.id}")
+        get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}/diff")
         response.status.should == 401
       end
     end
@@ -157,25 +185,33 @@ describe API::API do
     end
   end
 
+  describe "GET /projects/:id/repository/blobs/:sha" do
+    it "should get the raw file contents" do
+      get api("/projects/#{project.id}/repository/blobs/master?filepath=README.md", user)
+      response.status.should == 200
+    end
+
+    it "should return 404 for invalid branch_name" do
+      get api("/projects/#{project.id}/repository/blobs/invalid_branch_name?filepath=README.md", user)
+      response.status.should == 404
+    end
+
+    it "should return 404 for invalid file" do
+      get api("/projects/#{project.id}/repository/blobs/master?filepath=README.invalid", user)
+      response.status.should == 404
+    end
+
+    it "should return a 400 error if filepath is missing" do
+      get api("/projects/#{project.id}/repository/blobs/master", user)
+      response.status.should == 400
+    end
+  end
+
   describe "GET /projects/:id/repository/commits/:sha/blob" do
     it "should get the raw file contents" do
       get api("/projects/#{project.id}/repository/commits/master/blob?filepath=README.md", user)
       response.status.should == 200
     end
-
-    it "should return 404 for invalid branch_name" do
-      get api("/projects/#{project.id}/repository/commits/invalid_branch_name/blob?filepath=README.md", user)
-      response.status.should == 404
-    end
-
-    it "should return 404 for invalid file" do
-      get api("/projects/#{project.id}/repository/commits/master/blob?filepath=README.invalid", user)
-      response.status.should == 404
-    end
-
-    it "should return a 400 error if filepath is missing" do
-      get api("/projects/#{project.id}/repository/commits/master/blob", user)
-      response.status.should == 400
-    end
   end
+
 end


### PR DESCRIPTION
Use "/commits/:sha/diff" as opposed to "/commit/:sha", keeping in line with existing api urls (e.g. "/commits/:sha/blob", "/projects/:id", etc.)
