### PR TITLE
Fix project_id field in MergeRequest API

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -107,7 +107,8 @@ module API
     end
 
     class MergeRequest < Grape::Entity
-      expose :id, :target_branch, :source_branch, :project_id, :title, :state
+      expose :id, :target_branch, :source_branch, :title, :state
+      expose :target_project_id, as: :project_id
       expose :author, :assignee, using: Entities::UserBasic
     end
 


### PR DESCRIPTION
With the change to target and source project IDs for Merge Requests, the API was missing the project_id field. This patch adds target_project_id as project_id to the Merge Request API for backwards compatibility. 

Perhaps target and source project IDs should be added as well?
