### PR TITLE
Rewrote init script.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v 6.1.0
+  - Rewrite: Init script now less prone to errors and keeps better track of the service.
   - Link issues, merge requests, and commits when they reference each other with GFM
   - Close issues automatically when pushing commits with a special message
 

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -1,7 +1,8 @@
-#! /bin/bash
+#! /bin/sh
 
 # GITLAB
 # Maintainer: @randx
+# Authors: rovanion.luckey@gmail.com, @randx
 # App Version: 6.0
 
 ### BEGIN INIT INFO
@@ -14,102 +15,198 @@
 # Description:       GitLab git repository management
 ### END INIT INFO
 
+### Environment variables
+RAILS_ENV="production"
 
-APP_ROOT="/home/git/gitlab"
-APP_USER="git"
-DAEMON_OPTS="-c $APP_ROOT/config/unicorn.rb -E production"
-PID_PATH="$APP_ROOT/tmp/pids"
-SOCKET_PATH="$APP_ROOT/tmp/sockets"
-WEB_SERVER_PID="$PID_PATH/unicorn.pid"
-SIDEKIQ_PID="$PID_PATH/sidekiq.pid"
-STOP_SIDEKIQ="RAILS_ENV=production bundle exec rake sidekiq:stop"
-START_SIDEKIQ="RAILS_ENV=production bundle exec rake sidekiq:start"
-NAME="gitlab"
-DESC="GitLab service"
+# Script variable names should be lower-case not to conflict with internal
+# /bin/sh variables such as PATH, EDITOR or SHELL.
+app_root="/home/gitlab/gitlab"
+app_user="gitlab"
+unicorn_conf="$app_root/config/unicorn.rb"
+pid_path="$app_root/tmp/pids"
+socket_path="$app_root/tmp/sockets"
+web_server_pid_path="$pid_path/unicorn.pid"
+sidekiq_pid_path="$pid_path/sidekiq.pid"
 
-check_pid(){
-  if [ -f $WEB_SERVER_PID ]; then
-    PID=`cat $WEB_SERVER_PID`
-    SPID=`cat $SIDEKIQ_PID`
-    STATUS=`ps aux | grep $PID | grep -v grep | wc -l`
-  else
-    STATUS=0
-    PID=0
-  fi
-}
 
-execute() {
-  sudo -u $APP_USER -H bash -l -c "$1"
-}
 
-start() {
-  cd $APP_ROOT
-  check_pid
-  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
-    # Program is running, exit with error code 1.
-    echo "Error! $DESC $NAME is currently running!"
-    exit 1
-  else
-    if [ `whoami` = root ]; then
-      execute "rm -f $SOCKET_PATH/gitlab.socket"
-      execute "RAILS_ENV=production bundle exec unicorn_rails $DAEMON_OPTS  > /dev/null  2>&1 &"
-      execute "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
-      echo "$DESC started"
-    fi
-  fi
-}
+### Here ends user configuration ###
 
-stop() {
-  cd $APP_ROOT
-  check_pid
-  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
-    ## Program is running, stop it.
-    kill -QUIT `cat $WEB_SERVER_PID`
-    execute "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
-    rm "$WEB_SERVER_PID" >> /dev/null
-    echo "$DESC stopped"
-  else
-    ## Program is not running, exit with error.
-    echo "Error! $DESC not started!"
-    exit 1
-  fi
-}
 
-restart() {
-  cd $APP_ROOT
-  check_pid
-  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
-    echo "Restarting $DESC..."
-    kill -USR2 `cat $WEB_SERVER_PID`
-    execute "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1"
-    if [ `whoami` = root ]; then
-      execute "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
-    fi
-    echo "$DESC restarted."
-  else
-    echo "Error, $NAME not running!"
-    exit 1
-  fi
-}
-
-status() {
-  cd $APP_ROOT
-  check_pid
-  if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
-    echo "$DESC / Unicorn with PID $PID is running."
-    echo "$DESC / Sidekiq with PID $SPID is running."
-  else
-    echo "$DESC is not running."
-    exit 1
-  fi
-}
-
-## Check to see if we are running as root first.
-## Found at http://www.cyberciti.biz/tips/shell-root-user-check-script.html
-if [ "$(id -u)" != "0" ]; then
-    echo "This script must be run as root"
-    exit 1
+# Switch to the app_user if it is not he/she who is running the script.
+if [ "$USER" != "$app_user" ]; then
+  sudo -u "$app_user" -H /etc/init.d/gitlab "$@"; exit;
 fi
+
+# Switch to the gitlab path, if it fails exit with an error.
+if ! cd "$app_root" ; then
+ echo "Failed to cd into $app_root, exiting!";  exit 1
+fi
+
+### Init Script functions
+
+check_pids(){
+  if ! mkdir -p "$pid_path"; then
+    echo "Could not create the path $pid_path needed to store the pids."
+    exit 1
+  fi
+  # If there exists a file which should hold the value of the Unicorn pid: read it.
+  if [ -f "$web_server_pid_path" ]; then
+    wpid=$(cat "$web_server_pid_path")
+  else
+    wpid=0
+  fi
+  if [ -f "$sidekiq_pid_path" ]; then
+    spid=$(cat "$sidekiq_pid_path")
+  else
+    spid=0
+  fi
+}
+
+# We use the pids in so many parts of the script it makes sense to always check them.
+# Only after start() is run should the pids change. Sidekiq sets it's own pid.
+check_pids
+
+
+# Checks wether the different parts of the server is already running or not.
+check_status(){
+  check_pids
+  # If the web server is running kill -0 $wpid returns true, or rather 0.
+  # Checks of *_status should only check for == 0 or != 0, never anything else.
+  if [ $wpid -ne 0 ]; then
+    kill -0 "$wpid" 2>/dev/null
+    web_status="$?"
+  fi
+  if [ $spid -ne 0 ]; then
+    kill -0 "$spid" 2>/dev/null
+    sidekiq_status="$?"
+  fi
+}
+
+# Check for stale pids and remove them if necessary
+check_stale_pids(){
+  check_status
+  # If there is a pid it is something else than 0, the service is running if
+  # *_status is == 0.
+  if [ "$wpid" != "0" -a "$web_status" != "0" ]; then
+    echo "Found stale Unicorn web server pid, removing. This is most likely caused by the web server crashing the last time it ran."
+    rm "$web_server_pid_path"
+  fi
+  if [ "$spid" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "Found stale Sidekiq web server pid, removing. This is most likely caused by the Sidekiq crashing the last time it ran."
+    rm "$sidekiq_pid_path"
+  fi
+}
+
+# If no parts of the service is running, bail out.
+check_not_running(){
+  check_stale_pids
+  if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "GitLab is not running."
+    exit
+  fi
+}
+
+# Starts Unicorn and Sidekiq.
+start() {
+  check_stale_pids
+
+  # Then check if the service is running. If it is: don't start again.
+  if [ "$web_status" = "0" ]; then
+    echo "The Unicorn web server already running with pid $wpid, not restarting."
+  else
+    echo "Starting the GitLab Unicorn web server..."
+    # Remove old socket if it exists
+    rm -f "$socket_path"/gitlab.socket
+    # Start the webserver
+    bundle exec unicorn_rails -D -c "$unicorn_conf" -E "$RAILS_ENV"
+  fi
+
+  # If sidekiq is already running, don't start it again.
+  if [ "$sidekiq_status" = "0" ]; then
+    echo "The Sidekiq job dispatcher is already running with pid $spid, not restarting"
+  else
+    echo "Starting the GitLab Sidekiq event dispatcher..."
+    RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:start
+    # We are sleeping a bit here because sidekiq is slow at writing it's pid
+    sleep 2
+  fi
+
+  # Finally check the status to tell wether or not GitLab is running
+  status
+}
+
+# Asks the Unicorn and the Sidekiq if they would be so kind as to stop, if not kills them.
+stop() {
+  check_not_running
+  # If the Unicorn web server is running, tell it to stop;
+  if [ "$web_status" = "0" ]; then
+    kill -QUIT "$wpid" &
+    echo "Stopping the GitLab Unicorn web server..."
+    stopping=true
+  else
+    echo "The Unicorn web was not running, doing nothing."
+  fi
+  # And do the same thing for the Sidekiq.
+  if [ "$sidekiq_status" = "0" ]; then
+    printf "Stopping Sidekiq job dispatcher."
+    RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:stop &
+    stopping=true
+  else
+    echo "The Sidekiq was not running, must have run out of breath."
+  fi
+
+
+  # If something needs to be stopped, lets wait for it to stop. Never use SIGKILL in a script.
+  while [ "$stopping" = "true" ]; do
+    sleep 1
+    check_status
+    if [ "$web_status" = "0" -o "$sidekiq_status" = "0" ]; then
+      printf "."
+    else
+      printf "\n"
+      break
+    fi
+  done
+  sleep 1
+  # Cleaning up unused pids
+  rm "$web_server_pid_path" 2>/dev/null
+  # rm "$sidekiq_pid_path" # Sidekiq seems to be cleaning up it's own pid.
+
+  status
+}
+
+# Returns the status of GitLab and it's components
+status() {
+  check_not_running
+  if [ "$web_status" = "0" ]; then
+      echo "The GitLab Unicorn webserver with pid $wpid is running."
+  else
+      printf "The GitLab Unicorn webserver is \033[31mnot running\033[0m.\n"
+  fi
+  if [ "$sidekiq_status" = "0" ]; then
+      echo "The GitLab Sidekiq job dispatcher with pid $spid is running."
+  else
+      printf "The GitLab Sidekiq job dispatcher is \033[31mnot running\033[0m.\n"
+  fi
+  if [ "$web_status" = "0" -a "$sidekiq_status" = "0" ]; then
+    printf "GitLab and all it's components are \033[32mup and running\033[0m.\n"
+  fi
+}
+
+reload(){
+  check_not_running
+  if [ "$wpid" = "0" ];then
+    echo "The GitLab Unicorn Web server is not running thus it's configuration can't be reloaded."
+    exit 1
+  fi
+  printf "Reloading GitLab configuration... "
+  kill -HUP "$wpid"
+  echo "Done."
+}
+
+
+## Finally the input handling.
 
 case "$1" in
   start)
@@ -119,20 +216,19 @@ case "$1" in
         stop
         ;;
   restart)
-        restart
+        stop
+	start
         ;;
   reload|force-reload)
-        echo -n "Reloading $NAME configuration: "
-        kill -HUP `cat $PID`
-        echo "done."
+	reload
         ;;
   status)
         status
         ;;
   *)
-        echo "Usage: sudo service gitlab {start|stop|restart|reload}" >&2
+        echo "Usage: service gitlab {start|stop|restart|reload|status}"
         exit 1
         ;;
 esac
 
-exit 0
+exit

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -20,8 +20,8 @@ RAILS_ENV="production"
 
 # Script variable names should be lower-case not to conflict with internal
 # /bin/sh variables such as PATH, EDITOR or SHELL.
-app_root="/home/gitlab/gitlab"
-app_user="gitlab"
+app_root="/home/git/gitlab"
+app_user="git"
 unicorn_conf="$app_root/config/unicorn.rb"
 pid_path="$app_root/tmp/pids"
 socket_path="$app_root/tmp/sockets"
@@ -68,7 +68,7 @@ check_pids(){
 check_pids
 
 
-# Checks wether the different parts of the server is already running or not.
+# Checks whether the different parts of the service are already running or not.
 check_status(){
   check_pids
   # If the web server is running kill -0 $wpid returns true, or rather 0.
@@ -117,7 +117,7 @@ start() {
   else
     echo "Starting the GitLab Unicorn web server..."
     # Remove old socket if it exists
-    rm -f "$socket_path"/gitlab.socket
+    rm -f "$socket_path"/gitlab.socket 2>/dev/null
     # Start the webserver
     bundle exec unicorn_rails -D -c "$unicorn_conf" -E "$RAILS_ENV"
   fi

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -20,8 +20,8 @@ RAILS_ENV="production"
 
 # Script variable names should be lower-case not to conflict with internal
 # /bin/sh variables such as PATH, EDITOR or SHELL.
-app_root="/home/gitlab/gitlab"
-app_user="gitlab"
+app_root="/home/git/gitlab"
+app_user="git"
 unicorn_conf="$app_root/config/unicorn.rb"
 pid_path="$app_root/tmp/pids"
 socket_path="$app_root/tmp/sockets"
@@ -76,10 +76,14 @@ check_status(){
   if [ $wpid -ne 0 ]; then
     kill -0 "$wpid" 2>/dev/null
     web_status="$?"
+  else
+    web_status="-1"
   fi
   if [ $spid -ne 0 ]; then
     kill -0 "$spid" 2>/dev/null
     sidekiq_status="$?"
+  else
+    sidekiq_status="-1"
   fi
 }
 
@@ -89,12 +93,18 @@ check_stale_pids(){
   # If there is a pid it is something else than 0, the service is running if
   # *_status is == 0.
   if [ "$wpid" != "0" -a "$web_status" != "0" ]; then
-    echo "Found stale Unicorn web server pid, removing. This is most likely caused by the web server crashing the last time it ran."
-    rm "$web_server_pid_path"
+    echo "Removing stale Unicorn web server pid. This is most likely caused by the web server crashing the last time it ran."
+    if ! rm "$web_server_pid_path"; then
+      echo "Unable to remove stale pid, exiting"
+      exit 1
+    fi
   fi
   if [ "$spid" != "0" -a "$sidekiq_status" != "0" ]; then
-    echo "Found stale Sidekiq web server pid, removing. This is most likely caused by the Sidekiq crashing the last time it ran."
-    rm "$sidekiq_pid_path"
+    echo "Removing stale Sidekiq web server pid. This is most likely caused by the Sidekiq crashing the last time it ran."
+    if ! rm "$sidekiq_pid_path"; then
+      echo "Unable to remove stale pid, exiting"
+      exit 1
+    fi
   fi
 }
 
@@ -205,7 +215,7 @@ reload(){
   echo "Done."
   echo "Restarting GitLab Sidekiq since it isn't capable of reloading it's config..."
   RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:stop
-  echo "Starting Sidekiq..."  
+  echo "Starting Sidekiq..."
   RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:start
   # Waiting 2 seconds for sidekiq to write it.
   sleep 2

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -188,7 +188,11 @@ stop() {
 
 # Returns the status of GitLab and it's components
 status() {
-  exit_if_not_running
+  check_status
+  if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "GitLab is not running."
+    return
+  fi
   if [ "$web_status" = "0" ]; then
       echo "The GitLab Unicorn webserver with pid $wpid is running."
   else
@@ -207,19 +211,27 @@ status() {
 reload(){
   exit_if_not_running
   if [ "$wpid" = "0" ];then
-    echo "The GitLab Unicorn Web server is not running thus it's configuration can't be reloaded."
+    echo "The GitLab Unicorn Web server is not running thus its configuration can't be reloaded."
     exit 1
   fi
   printf "Reloading GitLab Unicorn configuration... "
   kill -USR2 "$wpid"
   echo "Done."
-  echo "Restarting GitLab Sidekiq since it isn't capable of reloading it's config..."
+  echo "Restarting GitLab Sidekiq since it isn't capable of reloading its config..."
   RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:stop
   echo "Starting Sidekiq..."
   RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:start
   # Waiting 2 seconds for sidekiq to write it.
   sleep 2
   status
+}
+
+restart(){
+  check_status
+  if [ "$web_status" = "0" -o "$sidekiq_status" = "0" ]; then
+    stop
+  fi
+  start
 }
 
 
@@ -233,8 +245,7 @@ case "$1" in
         stop
         ;;
   restart)
-        stop
-	start
+        restart
         ;;
   reload|force-reload)
 	reload

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -20,8 +20,8 @@ RAILS_ENV="production"
 
 # Script variable names should be lower-case not to conflict with internal
 # /bin/sh variables such as PATH, EDITOR or SHELL.
-app_root="/home/git/gitlab"
-app_user="git"
+app_root="/home/gitlab/gitlab"
+app_user="gitlab"
 unicorn_conf="$app_root/config/unicorn.rb"
 pid_path="$app_root/tmp/pids"
 socket_path="$app_root/tmp/sockets"
@@ -99,7 +99,7 @@ check_stale_pids(){
 }
 
 # If no parts of the service is running, bail out.
-check_not_running(){
+exit_if_not_running(){
   check_stale_pids
   if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
     echo "GitLab is not running."
@@ -138,7 +138,7 @@ start() {
 
 # Asks the Unicorn and the Sidekiq if they would be so kind as to stop, if not kills them.
 stop() {
-  check_not_running
+  exit_if_not_running
   # If the Unicorn web server is running, tell it to stop;
   if [ "$web_status" = "0" ]; then
     kill -QUIT "$wpid" &
@@ -178,7 +178,7 @@ stop() {
 
 # Returns the status of GitLab and it's components
 status() {
-  check_not_running
+  exit_if_not_running
   if [ "$web_status" = "0" ]; then
       echo "The GitLab Unicorn webserver with pid $wpid is running."
   else
@@ -195,14 +195,21 @@ status() {
 }
 
 reload(){
-  check_not_running
+  exit_if_not_running
   if [ "$wpid" = "0" ];then
     echo "The GitLab Unicorn Web server is not running thus it's configuration can't be reloaded."
     exit 1
   fi
-  printf "Reloading GitLab configuration... "
-  kill -HUP "$wpid"
+  printf "Reloading GitLab Unicorn configuration... "
+  kill -USR2 "$wpid"
   echo "Done."
+  echo "Restarting GitLab Sidekiq since it isn't capable of reloading it's config..."
+  RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:stop
+  echo "Starting Sidekiq..."  
+  RAILS_ENV=$RAILS_ENV bundle exec rake sidekiq:start
+  # Waiting 2 seconds for sidekiq to write it.
+  sleep 2
+  status
 }
 
 

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -35,7 +35,7 @@ sidekiq_pid_path="$pid_path/sidekiq.pid"
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then
-  sudo -u "$app_user" -H /etc/init.d/gitlab "$@"; exit;
+  sudo -u "$app_user" -H $0 "$@"; exit;
 fi
 
 # Switch to the gitlab path, if it fails exit with an error.


### PR DESCRIPTION
Rewrite of the GitLab init-script providing the following features:
- Conforms to the Debian, and inherently Ubuntu, init-script guidelines.
  - Is a valid POSIX or /bin/sh script as demanded by the guidelines.
- Keeps track of the Unicorn and Sidekiq and their state separately.
  - Makes sure that both services start and stop appropriately before telling the user that they are or aren't running.
  - Handles cases where one service started and the other didn't. Highlighting it with a red warning text.
  - Knows the running state of both, not just the pids.
  - No longer uses the error prone "ps aux | grep $pid" method for finding out state.
  - Deals with stale pids caused by application crashes.
- User set variables are properly escaped, ensures that paths with spaces in them work.
- No more commands in variables as that sometimes leads to odd edge-cases.
- The script now always runs as the $app_user, not as root or any other user.
- No longer swallows errors produced.
  - This was my initial reason for rewriting the script: GitLab didn't start after an upgrade and there were nothing in the logs and no errors printed by the init script.
- Has passed the peer review of #bash on irc.freenode.org
