### PR TITLE
Fixed up wording on the new SSH key page.

### DIFF
--- a/app/views/profiles/keys/_form.html.haml
+++ b/app/views/profiles/keys/_form.html.haml
@@ -13,7 +13,7 @@
       = f.label :key
       .controls
         %p.light
-          Paste your public key here. Read more about how generate it #{link_to "here", help_ssh_path}
+          Paste your public key here. Read more about how to generate a key on #{link_to "the SSH help page", help_ssh_path}.
         = f.text_area :key, class: "input-xxlarge thin_area"
 
 


### PR DESCRIPTION
Minor rewording for the SSH key addition page to direct users to the help page. At a minimum, the word "to" should be added.
