### PR TITLE
Create satellites during update to 6.0. Fix #4938

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -70,6 +70,7 @@ sudo -u git -H bundle exec rake migrate_groups RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_global_projects RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_keys RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_inline_notes RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:satellites:create RAILS_ENV=production
 
 # Clear redis cache
 sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production


### PR DESCRIPTION
Satellites for projects that were located in the root namespace needs to be recreated once they've been migrated to the creator’s namespace during the upgrade process.

This can be achieved by running the sudo -u git -H bundle exec rake gitlab:satellites:create RAILS_ENV=production during the update process.

The command has been added to the 5.4 to 6.0 update doc.
