### PR TITLE
Add link to project page from admin view

### DIFF
--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -12,7 +12,8 @@
       %ul.well-list
         %li
           %span.light Name:
-          %strong= @project.name
+          %strong
+            = link_to @project.name, project_path(@project)
         %li
           %span.light Namespace:
           %strong


### PR DESCRIPTION
Currently, there is no way to link directly to a project page from the admin interface. When you visit `/admin/projects/user.name/project.name` to view the details of the project, there is no link to get directly to the project at `/user.name/project.name`.  This simply adds a link to the project name linking directly to the project path.

The only way to get to a project page from the admin view is by clicking the Edit button and then navigating to the project home. This takes too many clicks.
