### PR TITLE
have email views use iid

### DIFF
--- a/app/views/notify/closed_issue_email.html.haml
+++ b/app/views/notify/closed_issue_email.html.haml
@@ -1,5 +1,5 @@
 %p
   = "Issue was closed by #{@updated_by.name}"
 %p
-  = "Issue ##{@issue.id}"
+  = "Issue ##{@issue.iid}"
   = link_to_gfm truncate(@issue.title, length: 45), project_issue_url(@issue.project, @issue), title: @issue.title

--- a/app/views/notify/closed_issue_email.text.haml
+++ b/app/views/notify/closed_issue_email.text.haml
@@ -1,3 +1,3 @@
 = "Issue was closed by #{@updated_by.name}"
 
-Issue ##{@issue.id}: #{project_issue_url(@issue.project, @issue)}
+Issue ##{@issue.iid}: #{project_issue_url(@issue.project, @issue)}

--- a/app/views/notify/closed_merge_request_email.html.haml
+++ b/app/views/notify/closed_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Merge Request #{@merge_request.id} was closed by #{@updated_by.name}"
+  = "Merge Request #{@merge_request.iid} was closed by #{@updated_by.name}"
 %p
   = link_to_gfm truncate(@merge_request.title, length: 40), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p

--- a/app/views/notify/closed_merge_request_email.text.haml
+++ b/app/views/notify/closed_merge_request_email.text.haml
@@ -1,4 +1,4 @@
-= "Merge Request #{@merge_request.id} was closed by #{@updated_by.name}"
+= "Merge Request #{@merge_request.iid} was closed by #{@updated_by.name}"
 
 Merge Request url: #{project_merge_request_url(@merge_request.target_project, @merge_request)}
 

--- a/app/views/notify/issue_status_changed_email.html.haml
+++ b/app/views/notify/issue_status_changed_email.html.haml
@@ -1,5 +1,5 @@
 %p
   = "Issue was #{@issue_status} by #{@updated_by.name}"
 %p
-  = "Issue ##{@issue.id}"
+  = "Issue ##{@issue.iid}"
   = link_to_gfm truncate(@issue.title, length: 45), project_issue_url(@issue.project, @issue), title: @issue.title

--- a/app/views/notify/issue_status_changed_email.text.erb
+++ b/app/views/notify/issue_status_changed_email.text.erb
@@ -1,4 +1,4 @@
 Issue was <%= @issue_status %> by <%= @updated_by.name %>
 
-Issue <%= @issue.id %>: <%= url_for(project_issue_url(@issue.project, @issue)) %>
+Issue <%= @issue.iid %>: <%= url_for(project_issue_url(@issue.project, @issue)) %>
 

--- a/app/views/notify/merged_merge_request_email.html.haml
+++ b/app/views/notify/merged_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Merge Request #{@merge_request.id} was merged"
+  = "Merge Request #{@merge_request.iid} was merged"
 %p
   = link_to_gfm truncate(@merge_request.title, length: 40), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p

--- a/app/views/notify/merged_merge_request_email.text.haml
+++ b/app/views/notify/merged_merge_request_email.text.haml
@@ -1,4 +1,4 @@
-= "Merge Request #{@merge_request.id} was merged"
+= "Merge Request #{@merge_request.iid} was merged"
 
 Merge Request Url: #{project_merge_request_url(@merge_request.target_project, @merge_request)}
 

--- a/app/views/notify/new_issue_email.html.haml
+++ b/app/views/notify/new_issue_email.html.haml
@@ -1,7 +1,7 @@
 %p
   New Issue was created.
 %p
-  = "Issue ##{@issue.id}"
+  = "Issue ##{@issue.iid}"
   = link_to_gfm truncate(@issue.title, length: 45), project_issue_url(@issue.project, @issue), title: @issue.title
 %p
   Author: #{@issue.author_name}

--- a/app/views/notify/new_issue_email.text.erb
+++ b/app/views/notify/new_issue_email.text.erb
@@ -1,5 +1,5 @@
 New Issue was created.
-          
-Issue <%= @issue.id %>: <%= url_for(project_issue_url(@issue.project, @issue)) %>
+
+Issue <%= @issue.iid %>: <%= url_for(project_issue_url(@issue.project, @issue)) %>
 Author:   <%= @issue.author_name %>
 Asignee:  <%= @issue.assignee_name %>

--- a/app/views/notify/new_merge_request_email.html.haml
+++ b/app/views/notify/new_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "New Merge Request !#{@merge_request.id}"
+  = "New Merge Request !#{@merge_request.iid}"
 %p
   = link_to_gfm truncate(@merge_request.title, length: 40), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p

--- a/app/views/notify/new_merge_request_email.text.erb
+++ b/app/views/notify/new_merge_request_email.text.erb
@@ -1,4 +1,4 @@
-New Merge Request <%= @merge_request.id %>
+New Merge Request <%= @merge_request.iid %>
 
 <%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request)) %>
 

--- a/app/views/notify/new_user_email.text.erb
+++ b/app/views/notify/new_user_email.text.erb
@@ -5,7 +5,7 @@ The Administrator created an account for you. Now you are a member of the compan
 login.................. <%= @user.email %>
 <% if @user.created_by_id %>
   password............... <%= @password %>
-  
+
   You will be forced to change this password immediately after login.
 <% end %>
 

--- a/app/views/notify/note_issue_email.html.haml
+++ b/app/views/notify/note_issue_email.html.haml
@@ -1,4 +1,4 @@
 %p
-  = "New comment for Issue ##{@issue.id}"
+  = "New comment for Issue ##{@issue.iid}"
   = link_to_gfm truncate(@issue.title, length: 35), project_issue_url(@issue.project, @issue, anchor: "note_#{@note.id}")
 = render 'note_message'

--- a/app/views/notify/note_issue_email.text.erb
+++ b/app/views/notify/note_issue_email.text.erb
@@ -1,4 +1,4 @@
-New comment for Issue <%= @issue.id %>
+New comment for Issue <%= @issue.iid %>
 
 <%= url_for(project_issue_url(@issue.project, @issue, anchor: "note_#{@note.id}")) %>
 

--- a/app/views/notify/note_merge_request_email.html.haml
+++ b/app/views/notify/note_merge_request_email.html.haml
@@ -3,6 +3,6 @@
     = link_to "New comment on diff", diffs_project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")
   - else
     = link_to "New comment", project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")
-  for Merge Request ##{@merge_request.id}
+  for Merge Request ##{@merge_request.iid}
   %cite "#{truncate(@merge_request.title, length: 20)}"
 = render 'note_message'

--- a/app/views/notify/note_merge_request_email.text.erb
+++ b/app/views/notify/note_merge_request_email.text.erb
@@ -1,9 +1,9 @@
-New comment for Merge Request <%= @merge_request.id %>
+New comment for Merge Request <%= @merge_request.iid %>
 
 <%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")) %>
-      
+
 
 <%= @note.author_name %>
-                  
+
 <%= @note.note %>
 

--- a/app/views/notify/note_wall_email.text.erb
+++ b/app/views/notify/note_wall_email.text.erb
@@ -1,7 +1,7 @@
 New message on the project wall <%= @note.project %>
 
 <%= url_for(project_wall_url(@note.project, anchor: "note_#{@note.id}")) %>
-          
+
 
 <%= @note.author_name %>
 

--- a/app/views/notify/project_was_moved_email.text.erb
+++ b/app/views/notify/project_was_moved_email.text.erb
@@ -1,8 +1,8 @@
 Project was moved to another location
-          
+
 The project is now located under 
 <%= project_url(@project) %>
-          
+
 
 To update the remote url in your local repository run:
   git remote set-url origin <%= @project.ssh_url_to_repo %>

--- a/app/views/notify/reassigned_issue_email.html.haml
+++ b/app/views/notify/reassigned_issue_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Reassigned Issue ##{@issue.id}"
+  = "Reassigned Issue ##{@issue.iid}"
   = link_to_gfm truncate(@issue.title, length: 30), project_issue_url(@issue.project, @issue)
 %p
   Assignee changed

--- a/app/views/notify/reassigned_issue_email.text.erb
+++ b/app/views/notify/reassigned_issue_email.text.erb
@@ -1,5 +1,5 @@
-Reassigned Issue <%= @issue.id %>
+Reassigned Issue <%= @issue.iid %>
 
 <%= url_for(project_issue_url(@issue.project, @issue)) %>
-          
+
 Assignee changed <%= "from #{@previous_assignee.name}" if @previous_assignee %> to <%= @issue.assignee_name %>

--- a/app/views/notify/reassigned_merge_request_email.html.haml
+++ b/app/views/notify/reassigned_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Reassigned Merge Request !#{@merge_request.id}"
+  = "Reassigned Merge Request !#{@merge_request.iid}"
   = link_to_gfm truncate(@merge_request.title, length: 30), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p
   Assignee changed

--- a/app/views/notify/reassigned_merge_request_email.text.erb
+++ b/app/views/notify/reassigned_merge_request_email.text.erb
@@ -1,7 +1,7 @@
-Reassigned Merge Request <%= @merge_request.id %>
+Reassigned Merge Request <%= @merge_request.iid %>
 
 <%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request)) %>
-          
+
 
 Assignee changed <%= "from #{@previous_assignee.name}" if @previous_assignee %> to <%= @merge_request.assignee_name %>
 


### PR DESCRIPTION
Switch emails for issues / merge requests / milestones to use `iid` rather than `id`.
