### PR TITLE
add missing comma(s) in api examples

### DIFF
--- a/doc/api/deploy_keys.md
+++ b/doc/api/deploy_keys.md
@@ -16,14 +16,14 @@ Parameters:
 [
   {
     "id": 1,
-    "title" : "Public key"
+    "title" : "Public key",
     "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
   },
   {
     "id": 3,
-    "title" : "Another Public key"
+    "title" : "Another Public key",
     "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="
@@ -48,7 +48,7 @@ Parameters:
 ```json
 {
   "id": 1,
-  "title" : "Public key"
+  "title" : "Public key",
   "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="

--- a/doc/api/session.md
+++ b/doc/api/session.md
@@ -27,7 +27,7 @@ __You can login with both GitLab and LDAP credentials now__
   "linkedin": "",
   "twitter": "",
   "dark_scheme": false,
-  "theme_id": 1
+  "theme_id": 1,
   "is_admin": false,
   "can_create_group" : true,
   "can_create_team" : true,

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -22,7 +22,7 @@ GET /users
     "twitter": "",
     "extern_uid": "john.smith",
     "provider": "provider_name",
-    "theme_id": 1
+    "theme_id": 1,
     "color_scheme_id": 2
   },
   {
@@ -38,7 +38,7 @@ GET /users
     "twitter": "",
     "extern_uid": "jack.smith",
     "provider": "provider_name",
-    "theme_id": 1
+    "theme_id": 1,
     "color_scheme_id": 3
   }
 ]
@@ -71,7 +71,7 @@ Parameters:
   "twitter": "",
   "extern_uid": "john.smith",
   "provider": "provider_name",
-  "theme_id": 1
+  "theme_id": 1,
   "color_scheme_id": 2
 }
 ```
@@ -162,8 +162,8 @@ GET /user
   "skype": "",
   "linkedin": "",
   "twitter": "",
-  "theme_id": 1
-  "color_scheme_id": 2
+  "theme_id": 1,
+  "color_scheme_id": 2,
   "is_admin": false,
   "can_create_group" : true,
   "can_create_team" : true,
@@ -184,14 +184,14 @@ GET /user/keys
 [
   {
     "id": 1,
-    "title" : "Public key"
+    "title" : "Public key",
     "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
   },
   {
     "id": 3,
-    "title" : "Another Public key"
+    "title" : "Another Public key",
     "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="
@@ -219,7 +219,7 @@ Parameters:
 ```json
 {
   "id": 1,
-  "title" : "Public key"
+  "title" : "Public key",
   "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4
       596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4
       soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="


### PR DESCRIPTION
Added some missing commas in the api examples.

**before / after:**
![bildschirmfoto von 2013-08-30 21 11 29](https://f.cloud.github.com/assets/327488/1060073/2e8f0b0c-11a8-11e3-9a9d-1a834278b177.png) / ![bildschirmfoto von 2013-08-30 21 11 35](https://f.cloud.github.com/assets/327488/1060075/3105c24a-11a8-11e3-8aeb-de640b1d0260.png)
