### PR TITLE
Add 'notes' to path blacklist, fixes #4967

### DIFF
--- a/lib/gitlab/blacklist.rb
+++ b/lib/gitlab/blacklist.rb
@@ -3,7 +3,7 @@ module Gitlab
     extend self
 
     def path
-      %w(admin dashboard groups help profile projects search public assets u s teams merge_requests issues users snippets services repository hooks)
+      %w(admin dashboard groups help profile projects search public assets u s teams merge_requests issues users snippets services repository hooks notes)
     end
   end
 end


### PR DESCRIPTION
`notes` is a reserved keyword by GitLab. It's not allowed to create such a project.
