### PR TITLE
Fix native extension compilation error with mysql2

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -232,6 +232,7 @@ Make sure to edit both `gitlab.yml` and `unicorn.rb` to match your setup.
     sudo gem install charlock_holmes --version '0.6.9.4'
 
     # For MySQL (note, the option says "without ... postgres")
+    sudo apt-get install mysql-client libmysqlclient-dev
     sudo -u git -H bundle install --deployment --without development test postgres aws
 
     # Or for PostgreSQL (note, the option says "without ... mysql")


### PR DESCRIPTION
Solution found here: http://stackoverflow.com/questions/10051448/error-failed-to-build-gem-native-extension-mysql2-on-rails-3-2-3
