### PR TITLE
Import Bare Repositories instructions/description are incorrect

### DIFF
--- a/doc/raketasks/maintenance.md
+++ b/doc/raketasks/maintenance.md
@@ -122,7 +122,7 @@ Notes:
 
 How to use:
 
-1. copy your bare repos under git base_path (see `config/gitlab.yml` git_host -> base_path)
+1. copy your bare repos under git repos_path (see `config/gitlab.yml` gitlab_shell -> repos_path)
 2. run the command below
 
 ```

--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -2,7 +2,7 @@ namespace :gitlab do
   namespace :import do
     # How to use:
     #
-    #  1. copy your bare repos under git base_path
+    #  1. copy your bare repos under git repos_path
     #  2. run bundle exec rake gitlab:import:repos RAILS_ENV=production
     #
     # Notes:

--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -9,7 +9,7 @@ namespace :gitlab do
     #  * project owner will be a first admin
     #  * existing projects will be skipped
     #
-    desc "GITLAB | Import bare repositories from git_host -> base_path into GitLab project instance"
+    desc "GITLAB | Import bare repositories from gitlab_shell -> repos_path into GitLab project instance"
     task repos: :environment do
 
       git_base_path = Gitlab.config.gitlab_shell.repos_path


### PR DESCRIPTION
I believe the instructions for importing bare repositories are incorrect.
Looking at the latest `import.rake` it seems the new configuration variable is `gitlab_shell -> repos_path`.
I've updated the rakefile and maintenance documentation accordingly.

Cheers and thanks for such an awesome product :beers:!
