### PR TITLE
make public/private setting for project creation configurable

### DIFF
--- a/app/contexts/projects/create_context.rb
+++ b/app/contexts/projects/create_context.rb
@@ -16,7 +16,8 @@ module Projects
         wiki_enabled: default_features.wiki,
         wall_enabled: default_features.wall,
         snippets_enabled: default_features.snippets,
-        merge_requests_enabled: default_features.merge_requests
+        merge_requests_enabled: default_features.merge_requests,
+        public: default_features.public
       }
 
       @project = Project.new(default_opts.merge(params))

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -2,8 +2,12 @@
   .project-edit-errors
     = render 'projects/errors'
   .project-edit-content
-    %p.slead
-      New projects are private by default. You choose who can see the project and commit to repository.
+    - if Gitlab.config.gitlab.default_projects_features.public
+      %p.slead
+        New projects are public by default. Any signed in user can see your project but cannot commit to it unless granted access.
+    - else
+      %p.slead
+        New projects are private by default. You choose who can see the project and commit to repository.
     %hr
     = form_for @project, remote: true do |f|
       .control-group.project-name-holder

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -58,6 +58,7 @@ production: &base
       wiki: true
       wall: false
       snippets: false
+      public: false
 
   ## External issues trackers
   issues_tracker:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -75,6 +75,7 @@ Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.g
 Settings.gitlab.default_projects_features['wiki']           = true if Settings.gitlab.default_projects_features['wiki'].nil?
 Settings.gitlab.default_projects_features['wall']           = false if Settings.gitlab.default_projects_features['wall'].nil?
 Settings.gitlab.default_projects_features['snippets']       = false if Settings.gitlab.default_projects_features['snippets'].nil?
+Settings.gitlab.default_projects_features['public']         = false if Settings.gitlab.default_projects_features['public'].nil?
 
 #
 # Gravatar

--- a/spec/contexts/projects_create_context_spec.rb
+++ b/spec/contexts/projects_create_context_spec.rb
@@ -42,21 +42,24 @@ describe Projects::CreateContext do
         stub_const("Settings", Class.new)
         Settings.stub_chain(:gitlab, :default_projects_features).and_return(@settings)
       end
+
       context 'should be public when setting is public' do
         before do
           @settings.stub(:public) { true }
           @project = create_project(@user, @opts)
         end
+
         it { @project.public.should be_true }
       end
+
       context 'should be private when setting is not public' do
         before do
           @settings.stub(:public) { false }
           @project = create_project(@user, @opts)
         end
+
         it { @project.public.should be_false }
       end
-
     end
   end
 

--- a/spec/contexts/projects_create_context_spec.rb
+++ b/spec/contexts/projects_create_context_spec.rb
@@ -30,6 +30,34 @@ describe Projects::CreateContext do
       it { @project.owner.should == @user }
       it { @project.namespace.should == @group }
     end
+
+    context 'respect configured public setting' do
+      before(:each) do
+        @settings = double("settings")
+        @settings.stub(:issues) { true }
+        @settings.stub(:merge_requests) { true }
+        @settings.stub(:wiki) { true }
+        @settings.stub(:wall) { true }
+        @settings.stub(:snippets) { true }
+        stub_const("Settings", Class.new)
+        Settings.stub_chain(:gitlab, :default_projects_features).and_return(@settings)
+      end
+      context 'should be public when setting is public' do
+        before do
+          @settings.stub(:public) { true }
+          @project = create_project(@user, @opts)
+        end
+        it { @project.public.should be_true }
+      end
+      context 'should be private when setting is not public' do
+        before do
+          @settings.stub(:public) { false }
+          @project = create_project(@user, @opts)
+        end
+        it { @project.public.should be_false }
+      end
+
+    end
   end
 
   def create_project(user, opts)


### PR DESCRIPTION
This allows the default public setting on a project be configured in config.yaml
