### PR TITLE
Fix user.several_namespaces? to work with multiple ownership of groups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,7 +322,7 @@ class User < ActiveRecord::Base
   end
 
   def several_namespaces?
-    namespaces.many?
+    namespaces.many? || owned_groups.any?
   end
 
   def namespace_id

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,6 +139,19 @@ describe User do
     it { @user.owned_groups.should == [@group] }
   end
 
+  describe 'group multiple owners' do
+    before do
+      ActiveRecord::Base.observers.enable(:user_observer)
+      @user = create :user
+      @user2 = create :user
+      @group = create :group, owner: @user
+
+      @group.add_users([@user2.id], UsersGroup::OWNER)
+    end
+
+    it { @user2.several_namespaces?.should be_true }
+  end
+
   describe 'namespaced' do
     before do
       ActiveRecord::Base.observers.enable(:user_observer)


### PR DESCRIPTION
Group membership as an owner is not considered on the project creation page in the logic for displaying the namespace selector. This means the namespace selector is hidden for a user who is a group member as an owner but does not own any namespaces themselves.

Resolves #4900
