### PR TITLE
Fix bug with rendering changing images in commits

### DIFF
--- a/app/views/projects/commits/_image.html.haml
+++ b/app/views/projects/commits/_image.html.haml
@@ -9,7 +9,7 @@
     %div.two-up.view
       %span.wrap
         .frame.deleted
-          %a{href: project_tree_path(@project, tree_join(@commit.id, diff.old_path))}
+          %a{href: project_blob_path(@project, tree_join(@commit.parent_id, diff.old_path))}
             %img{src: "data:#{old_file.mime_type};base64,#{Base64.encode64(old_file.data)}"}
         %p.image-info.hide
           %span.meta-filesize= "#{number_to_human_size old_file.size}"
@@ -21,7 +21,7 @@
           %span.meta-height
       %span.wrap
         .frame.added
-          %a{href: project_tree_path(@project, tree_join(@commit.id, diff.new_path))}
+          %a{href: project_blob_path(@project, tree_join(@commit.id, diff.new_path))}
             %img{src: "data:#{file.mime_type};base64,#{Base64.encode64(file.data)}"}
         %p.image-info.hide
           %span.meta-filesize= "#{number_to_human_size file.size}"

--- a/features/project/commits/commits.feature
+++ b/features/project/commits/commits.feature
@@ -35,3 +35,7 @@ Feature: Project Browse commits
   Scenario: I browse huge commit
     Given I visit huge commit page
     Then I see huge commit message
+
+  Scenario: I browse a commit with an image
+    Given I visit a commit with an image that changed
+    Then The diff links to both the previous and current image

--- a/features/steps/project/project_browse_commits.rb
+++ b/features/steps/project/project_browse_commits.rb
@@ -78,4 +78,14 @@ class ProjectBrowseCommits < Spinach::FeatureSteps
     page.should have_content "Warning! This is a large diff"
     page.should_not have_content "If you still want to see the diff"
   end
+
+  Given 'I visit a commit with an image that changed' do
+    visit project_commit_path(@project, 'cc1ba255d6c5ffdce87a357ba7ccc397a4f4026b')
+  end
+
+  Then 'The diff links to both the previous and current image' do
+    links = page.all('.two-up span div a')
+    links[0]['href'].should =~ %r{blob/bc3735004cb45cec5e0e4fa92710897a910a5957}
+    links[1]['href'].should =~ %r{blob/cc1ba255d6c5ffdce87a357ba7ccc397a4f4026b}
+  end
 end


### PR DESCRIPTION
When viewing the diff for a changed image file, two bugs occur:
- Both the 'before' and 'after' images link to the 'after' commit
- Visiting the link for either image will cause a error

The first is caused by both image links referencing `@commit.id` rather than `@commit.parent_id`.  The second is caused by the use of `project_tree_path` which is used for creating links to directories in the git file tree. `project_blob_path` (which links to files) should be used instead.

[Live example](http://demo.gitlab.com/gitlab/gitlabhq/commit/cc1ba255d6c5ffdce87a357ba7ccc397a4f4026b) click on the images for `blueprint_add.png` or `blueprint_delete.png`.
