### PR TITLE
Fix typo in installation.md

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -111,7 +111,7 @@ Create a `git` user for Gitlab:
 
 # 4. GitLab shell
 
-GitLab Shell is a ssh access and repository management software developed specially for GitLab.
+GitLab Shell is an ssh access and repository management software developed specially for GitLab.
 
     # Go to home directory
     cd /home/git


### PR DESCRIPTION
SSH is pronounced as /es es aged/, so we need "an" instead of "a".
