### PR TITLE
Allows username only updates to ldap properties

### DIFF
--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -44,11 +44,15 @@ module Gitlab
         end
 
         def find_user(email)
-          if user = model.find_by_email(email)
-          elsif ldap_conf['allow_username_or_email_login']
-            uname = (email.partition('@').first) unless email.nil?
+          user = model.find_by_email(email)
+
+          # If no user found and allow_username_or_email_login is true
+          # we look for user by extracting part of his email
+          if !user && email && ldap_conf['allow_username_or_email_login']
+            uname = email.partition('@').first
             user = model.find_by_username(uname)
           end
+
           user
         end
 

--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -26,7 +26,7 @@ module Gitlab
             # * When user already has account and need to link his LDAP account.
             # * LDAP uid changed for user with same email and we need to update his uid
             #
-            user = model.find_by_email(email)
+            user = find_user(email)
 
             if user
               user.update_attributes(extern_uid: uid, provider: provider)
@@ -40,6 +40,15 @@ module Gitlab
             end
           end
 
+          user
+        end
+
+        def find_user(email)
+          if user = model.find_by_email(email)
+          elsif ldap_conf['allow_username_or_email_login']
+            uname = (email.partition('@').first) unless email.nil?
+            user = model.find_by_username(uname)
+          end
           user
         end
 

--- a/spec/lib/auth_oauth_spec.rb
+++ b/spec/lib/auth_oauth_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe Gitlab::Auth do
+  let(:gl_auth) { Gitlab::Auth.new }
+
+  before do
+    Gitlab.config.stub(omniauth: {})
+
+    @info = mock(
+      uid: '12djsak321',
+      name: 'John',
+      email: 'john@mail.com'
+    )
+  end
+
+  describe :find_for_ldap_auth do
+    before do
+      @auth = mock(
+        uid: '12djsak321',
+        info: @info,
+        provider: 'ldap'
+      )
+    end
+
+    it "should find by uid & provider" do
+      User.should_receive :find_by_extern_uid_and_provider
+      gl_auth.find_for_ldap_auth(@auth)
+    end
+
+    it "should update credentials by email if missing uid" do
+      user = double('User')
+      User.stub find_by_extern_uid_and_provider: nil
+      User.stub find_by_email: user
+      user.should_receive :update_attributes
+      gl_auth.find_for_ldap_auth(@auth)
+    end
+
+    it "should update credentials by username if missing uid and Gitlab.config.ldap.allow_username_or_email_login is true" do
+      user = double('User')
+      value = Gitlab.config.ldap.allow_username_or_email_login
+      Gitlab.config.ldap['allow_username_or_email_login'] = true
+      User.stub find_by_extern_uid_and_provider: nil
+      User.stub find_by_email: nil
+      User.stub find_by_username: user
+      user.should_receive :update_attributes
+      gl_auth.find_for_ldap_auth(@auth)
+      Gitlab.config.ldap['allow_username_or_email_login'] = value
+    end
+
+    it "should not update credentials by username if missing uid and Gitlab.config.ldap.allow_username_or_email_login is false" do
+      user = double('User')
+      value = Gitlab.config.ldap.allow_username_or_email_login
+      Gitlab.config.ldap['allow_username_or_email_login'] = false
+      User.stub find_by_extern_uid_and_provider: nil
+      User.stub find_by_email: nil
+      User.stub find_by_username: user
+      user.should_not_receive :update_attributes
+      gl_auth.find_for_ldap_auth(@auth)
+      Gitlab.config.ldap['allow_username_or_email_login'] = value
+    end
+
+    it "should create from auth if user does not exist"do
+      User.stub find_by_extern_uid_and_provider: nil
+      User.stub find_by_email: nil
+      gl_auth.should_receive :create_from_omniauth
+      gl_auth.find_for_ldap_auth(@auth)
+    end
+  end
+
+  describe :find_or_new_for_omniauth do
+    before do
+      @auth = mock(
+        info: @info,
+        provider: 'twitter',
+        uid: '12djsak321',
+      )
+    end
+
+    it "should find user"do
+      User.should_receive :find_by_provider_and_extern_uid
+      gl_auth.should_not_receive :create_from_omniauth
+      gl_auth.find_or_new_for_omniauth(@auth)
+    end
+
+    it "should not create user"do
+      User.stub find_by_provider_and_extern_uid: nil
+      gl_auth.should_not_receive :create_from_omniauth
+      gl_auth.find_or_new_for_omniauth(@auth)
+    end
+
+    it "should create user if single_sing_on"do
+      Gitlab.config.omniauth['allow_single_sign_on'] = true
+      User.stub find_by_provider_and_extern_uid: nil
+      gl_auth.should_receive :create_from_omniauth
+      gl_auth.find_or_new_for_omniauth(@auth)
+    end
+  end
+end

--- a/spec/lib/gitlab/ldap/ldap_user_auth_spec.rb
+++ b/spec/lib/gitlab/ldap/ldap_user_auth_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Gitlab::Auth do
-  let(:gl_auth) { Gitlab::Auth.new }
+describe Gitlab::LDAP do
+  let(:gl_auth) { Gitlab::LDAP::User }
 
   before do
     Gitlab.config.stub(omniauth: {})
@@ -22,17 +22,12 @@ describe Gitlab::Auth do
       )
     end
 
-    it "should find by uid & provider" do
-      User.should_receive :find_by_extern_uid_and_provider
-      gl_auth.find_for_ldap_auth(@auth)
-    end
-
     it "should update credentials by email if missing uid" do
       user = double('User')
       User.stub find_by_extern_uid_and_provider: nil
       User.stub find_by_email: user
       user.should_receive :update_attributes
-      gl_auth.find_for_ldap_auth(@auth)
+      gl_auth.find_or_create(@auth)
     end
 
     it "should update credentials by username if missing uid and Gitlab.config.ldap.allow_username_or_email_login is true" do
@@ -43,7 +38,7 @@ describe Gitlab::Auth do
       User.stub find_by_email: nil
       User.stub find_by_username: user
       user.should_receive :update_attributes
-      gl_auth.find_for_ldap_auth(@auth)
+      gl_auth.find_or_create(@auth)
       Gitlab.config.ldap['allow_username_or_email_login'] = value
     end
 
@@ -55,44 +50,8 @@ describe Gitlab::Auth do
       User.stub find_by_email: nil
       User.stub find_by_username: user
       user.should_not_receive :update_attributes
-      gl_auth.find_for_ldap_auth(@auth)
+      gl_auth.find_or_create(@auth)
       Gitlab.config.ldap['allow_username_or_email_login'] = value
-    end
-
-    it "should create from auth if user does not exist"do
-      User.stub find_by_extern_uid_and_provider: nil
-      User.stub find_by_email: nil
-      gl_auth.should_receive :create_from_omniauth
-      gl_auth.find_for_ldap_auth(@auth)
-    end
-  end
-
-  describe :find_or_new_for_omniauth do
-    before do
-      @auth = mock(
-        info: @info,
-        provider: 'twitter',
-        uid: '12djsak321',
-      )
-    end
-
-    it "should find user"do
-      User.should_receive :find_by_provider_and_extern_uid
-      gl_auth.should_not_receive :create_from_omniauth
-      gl_auth.find_or_new_for_omniauth(@auth)
-    end
-
-    it "should not create user"do
-      User.stub find_by_provider_and_extern_uid: nil
-      gl_auth.should_not_receive :create_from_omniauth
-      gl_auth.find_or_new_for_omniauth(@auth)
-    end
-
-    it "should create user if single_sing_on"do
-      Gitlab.config.omniauth['allow_single_sign_on'] = true
-      User.stub find_by_provider_and_extern_uid: nil
-      gl_auth.should_receive :create_from_omniauth
-      gl_auth.find_or_new_for_omniauth(@auth)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -233,7 +233,7 @@ describe User do
         it "should apply defaults to user" do
           Gitlab.config.gitlab.default_projects_limit.should_not == 123
           Gitlab.config.gitlab.default_can_create_group.should_not be_true
-          Gitlab.config.gitlab.default_theme.should_not == Gitlab::Theme::MARS
+          Gitlab.config.gitlab.default_theme.should_not == Gitlab::Theme::BASIC
           user.projects_limit.should == 123
           user.can_create_group.should be_true
           user.theme_id.should == Gitlab::Theme::BASIC


### PR DESCRIPTION
-when logging in if users are allowed to login with just usernames in ldap we will update uid of the user if their uid is out of date

-I added back some tests under auth_oauth_spec, including tests for my additions

Conflicts:
    spec/lib/auth_spec.rb

Change-Id: Ia171b3d5133da86edc18c0d08ecfaf6a174f2574
