### PR TITLE
Fix default_opts merging when creating new Project

### DIFF
--- a/app/contexts/projects/create_context.rb
+++ b/app/contexts/projects/create_context.rb
@@ -18,7 +18,7 @@ module Projects
         snippets_enabled: default_features.snippets,
         merge_requests_enabled: default_features.merge_requests,
         public: default_features.public
-      }
+      }.stringify_keys
 
       @project = Project.new(default_opts.merge(params))
 


### PR DESCRIPTION
Merging of default_opts with params actually didn't work correctly. Without this fix the merged params
have mixed string and symbol keys:

Merged params {:issues_enabled=>true, :wiki_enabled=>true, :wall_enabled=>false, :snippets_enabled=>false, :merge_requests_enabled=>true, :public=>false, "name"=>"test1", "path"=>"", "import_url"=>"", "description"=>""}

(this was actually cut-n-pastet from the debug log after adding 
     ::Rails.logger.debug "Merged params #{default_opts.merge(params)})
in create_context.rb:22
