### PR TITLE
Add "public-project?" checkbox to new-project view 

### DIFF
--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -36,6 +36,12 @@
   }
 }
 
+.project-public-holder {
+  .help-inline {
+    padding-top: 7px;
+  }
+}
+
 .save-project-loader {
   img {
     margin-top: 50px;

--- a/app/contexts/projects/create_context.rb
+++ b/app/contexts/projects/create_context.rb
@@ -18,7 +18,7 @@ module Projects
         snippets_enabled: default_features.snippets,
         merge_requests_enabled: default_features.merge_requests,
         public: default_features.public
-      }
+      }.stringify_keys
 
       @project = Project.new(default_opts.merge(params))
 

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -2,13 +2,7 @@
   .project-edit-errors
     = render 'projects/errors'
   .project-edit-content
-    - if Gitlab.config.gitlab.default_projects_features.public
-      %p.slead
-        New projects are public by default. Any signed in user can see your project but cannot commit to it unless granted access.
-    - else
-      %p.slead
-        New projects are private by default. You choose who can see the project and commit to repository.
-    %hr
+
     = form_for @project, remote: true do |f|
       .control-group.project-name-holder
         = f.label :name do
@@ -53,6 +47,12 @@
           %span.light (optional)
         .controls
           = f.text_area :description, placeholder: "awesome project", class: "input-xlarge", rows: 3, maxlength: 250, tabindex: 3
+      .control-group.project-public-holder
+        = f.label :public do
+          %span Public project
+        .controls
+          = f.check_box :public, { :checked => Gitlab.config.gitlab.default_projects_features.public }, true, false
+          %span.help-inline Make project visible to everyone
 
       .form-actions
         = f.submit 'Create project', class: "btn btn-create project-submit", tabindex: 4

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -51,7 +51,7 @@
         = f.label :public do
           %span Public project
         .controls
-          = f.check_box :public, { :checked => Gitlab.config.gitlab.default_projects_features.public }, true, false
+          = f.check_box :public, { checked: Gitlab.config.gitlab.default_projects_features.public }, true, false
           %span.help-inline Make project visible to everyone
 
       .form-actions


### PR DESCRIPTION
My impression is that being public or not is such a important choice, that it should be displayed when creating a 
new project. It does not make the new-project page more cluttered because the warning/explaination at the beginning 
of the page can now be removed.

![new-proj](https://f.cloud.github.com/assets/241247/1138269/6af2f3cc-1c72-11e3-8133-1ad8acf2aa39.png)

The default for that checkbox is determined by the global default setting. If this change is in principle acceptable, I will try to write a proper test; Still need to figure out how to do that though.
