### PR TITLE
Re-enable notifying commit authors of new commit notes

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -107,17 +107,18 @@ class NotificationService
 
     opts = { noteable_type: note.noteable_type, project_id: note.project_id }
 
-    if note.commit_id.present?
-      opts.merge!(commit_id: note.commit_id)
-    else
-      opts.merge!(noteable_id: note.noteable_id)
-    end
-
     target = note.noteable
     if target.respond_to?(:participants)
       recipients = target.participants
     else
       recipients = note.mentioned_users
+    end
+
+    if note.commit_id.present?
+      opts.merge!(commit_id: note.commit_id)
+      recipients << note.commit_author
+    else
+      opts.merge!(noteable_id: note.noteable_id)
     end
 
     # Get users who left comment in thread


### PR DESCRIPTION
After upgrading to 6.0 we noticed that commit authors stopped receiving e-mail notifications about new notes to their commits. https://github.com/gitlabhq/gitlabhq/commit/cb877b7e6f6b036a2811aec7313dab94473774de#L0L109 seems to be the culprit - this probably slipped through because of missing specs. This PR fixes the issue and the specs as well.
