### PR TITLE
fixed command to update init script

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -91,7 +91,7 @@ Note: We switched from Puma in GitLab 5.4 to unicorn in GitLab 6.0.
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/master/lib/support/init.d/gitlab
+sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/6-0-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 


### PR DESCRIPTION
The init script was being loaded from the master branch causing the  rake gitlab:check to think that it was out of date. Fixed the link to the proper branch
