### PR TITLE
Fixed the link to the init script

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -90,7 +90,7 @@ Note: We switched from Puma in GitLab 5.4 to unicorn in GitLab 6.0.
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/master/lib/support/init.d/gitlab
+sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/6-0-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 


### PR DESCRIPTION
The init script was pointing to the master branch rather than the 6-0-stable causing the rake gitlab:check to think it is out of date.
