### PR TITLE
Fix issue_closing_regex in gitlab.yml.example

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -49,7 +49,7 @@ production: &base
     ## Automatic issue closing
     # If a commit message matches this regular express, all issues referenced from the matched text will be closed
     # if it's pushed to a project's default branch.
-    # issue_closing_pattern: "^([Cc]loses|[Ff]ixes) +#\d+"
+    # issue_closing_pattern: ^([Cc]loses|[Ff]ixes) +#\d+
 
     ## Default project features settings
     default_projects_features:


### PR DESCRIPTION
It turns out that regex escapes and YAML quoted-scalar escapes don't play
nicely together.

Before (with `issue_closing_pattern` uncommented):

```
smash@winter:config example-config-fix *$ irb -ryaml
2.0.0-p247 :001 > YAML.load_file('gitlab.yml.example')
Psych::SyntaxError: (gitlab.yml.example): found unknown escape character while parsing a quoted scalar at line 52 column 28
```

After:

```
smash@winter:config example-config-fix *$ irb -ryaml
2.0.0-p247 :001 > YAML.load_file('gitlab.yml.example')
 => {"production"=>{"gitlab"=>{"host"=>"localhost", "port"=>80, "https"=>false, "email_from"=>"gitlab@localhost", "support_email"=>"support@localhost", "default_projects_limit"=>10, "issue_closing_pattern"=>"^([Cc]loses|[Ff]ixes) +#\\d+", "default_projects_features"=>{"issues"=>true, "merge_requests"=>true, ...
```
