### PR TITLE
Added .ruby-version & .ruby-gemset in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ coverage/*
 backups/*
 *.swp
 public/uploads/
+.ruby-version
+.ruby-gemset
 .rvmrc
 .rbenv-version
 .directory


### PR DESCRIPTION
Added .ruby-version & .ruby-gemset to .gitignore. 
This is used as .rvmrc, hence adding it in .gitignore
