### PR TITLE
Remove old assets before compiling new ones

### DIFF
--- a/doc/update/6.0-to-6.1.md
+++ b/doc/update/6.0-to-6.1.md
@@ -53,6 +53,7 @@ sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
 sudo -u git -H bundle exec rake migrate_iids RAILS_ENV=production
+sudo -u git -H bundle exec rake assets:clean RAILS_ENV=production
 sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
 ```


### PR DESCRIPTION
When following the update guide from 6.0 to 6.1, all icons in the web interface were broken afterwards. Explicitly removing the old assets before precompiling the new ones resolved the issue. This pull request adds this step to the update guide.
