### PR TITLE
Prevent empty public projects from throwing exceptions

### DIFF
--- a/app/controllers/public/projects_controller.rb
+++ b/app/controllers/public/projects_controller.rb
@@ -1,7 +1,7 @@
 class Public::ProjectsController < ApplicationController
   skip_before_filter :authenticate_user!,
-    :reject_blocked, :set_current_user_for_observers,
-    :add_abilities
+                     :reject_blocked, :set_current_user_for_observers,
+                     :add_abilities
 
   layout 'public'
 
@@ -16,9 +16,11 @@ class Public::ProjectsController < ApplicationController
     render_404 and return unless @project
 
     @repository = @project.repository
-    @recent_tags = @repository.tags.first(10)
+    unless @project.empty_repo?
+      @recent_tags = @repository.tags.first(10)
 
-    @commit = @repository.commit(params[:ref])
-    @tree = Tree.new(@repository, @commit.id)
+      @commit = @repository.commit(params[:ref])
+      @tree = Tree.new(@repository, @commit.id)
+    end
   end
 end

--- a/app/views/public/projects/show.html.haml
+++ b/app/views/public/projects/show.html.haml
@@ -15,32 +15,35 @@
 
 %br
 .row
-  .span9
-    = render 'tree', tree: @tree
-  .span3
-    %h5 Repository:
-    %div
-      %p
-        %span.light Bare size is
-        #{@project.repository.size} MB
+  - unless @project.empty_repo?
+    .span9
+      = render 'tree', tree: @tree
+    .span3
+      %h5 Repository:
+      %div
+        %p
+          %span.light Bare size is
+          #{@project.repository.size} MB
 
-      %p
-        = pluralize(@repository.round_commit_count, 'commit')
-      %p
-        = pluralize(@repository.branch_names.count, 'branch')
-      %p
-        = pluralize(@repository.tag_names.count, 'tag')
+        %p
+          = pluralize(@repository.round_commit_count, 'commit')
+        %p
+          = pluralize(@repository.branch_names.count, 'branch')
+        %p
+          = pluralize(@repository.tag_names.count, 'tag')
 
-    - if @recent_tags.present?
-      %hr
-      %h5 Most Recent Tags:
-      %ul.unstyled
-        - @recent_tags.each do |tag|
-          %li
-            %p
-              %i.icon-tag
-              %strong= tag.name
-              %small.light.pull-right
-                %i.icon-calendar
-                  = time_ago_in_words(tag.commit.committed_date)
-                ago
+      - if @recent_tags.present?
+        %hr
+        %h5 Most Recent Tags:
+        %ul.unstyled
+          - @recent_tags.each do |tag|
+            %li
+              %p
+                %i.icon-tag
+                %strong= tag.name
+                %small.light.pull-right
+                  %i.icon-calendar
+                    = time_ago_in_words(tag.commit.committed_date)
+                  ago
+  - else
+    = 'Empty Repository'

--- a/features/public/public_projects.feature
+++ b/features/public/public_projects.feature
@@ -12,3 +12,8 @@ Feature: Public Projects Feature
     When I visit public page for "Community" project
     Then I should see public project details
     And I should see project readme
+
+  Scenario: I visit an empty public project page
+    Given public empty project "Empty Public Project"
+    When I visit empty public project page
+    Then I should see empty public project details

--- a/features/steps/public/projects_feature.rb
+++ b/features/steps/public/projects_feature.rb
@@ -9,6 +9,11 @@ class Spinach::Features::PublicProjectsFeature < Spinach::FeatureSteps
     page.should_not have_content "Enterprise"
   end
 
+  step 'I should see project "Empty Public Project"' do
+    page.should have_content "Empty Public Project"
+    puts page.save_page('foo.html')
+  end
+
   step 'I should see public project details' do
     page.should have_content '32 branches'
     page.should have_content '16 tags'
@@ -20,6 +25,19 @@ class Spinach::Features::PublicProjectsFeature < Spinach::FeatureSteps
 
   step 'public project "Community"' do
     create :project_with_code, name: 'Community', public: true
+  end
+
+  step 'public empty project "Empty Public Project"' do
+    create :project, name: 'Empty Public Project', public: true
+  end
+
+  step 'I visit empty public project page' do
+    project = Project.find_by_name('Empty Public Project')
+    visit public_project_path(project)
+  end
+
+  step 'I should see empty public project details' do
+    page.should have_content 'Empty Repository'
   end
 
   step 'private project "Enterprise"' do


### PR DESCRIPTION
To reproduce the bug prior to this patch, create an empty repository, make it public, and visit it from the public projects page, it should take you to the 500 error page.
