### PR TITLE
Sort active milestones by due date (upcoming first)

### DIFF
--- a/app/controllers/projects/milestones_controller.rb
+++ b/app/controllers/projects/milestones_controller.rb
@@ -14,7 +14,7 @@ class Projects::MilestonesController < Projects::ApplicationController
     @milestones = case params[:f]
                   when 'all'; @project.milestones.order("state, due_date DESC")
                   when 'closed'; @project.milestones.closed.order("due_date DESC")
-                  else @project.milestones.active.order("due_date DESC")
+                  else @project.milestones.active.order("due_date ASC")
                   end
 
     @milestones = @milestones.includes(:project)


### PR DESCRIPTION
Currently the active milestones are sorted in reverse, meaning that the nearest due date is at the bottom of the page.

This PR reverses the order for the active milestones, so that the milestones which are due soon come up first on the milestone overview page.
