### PR TITLE
Added description for Redis connection via unix socket

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -337,6 +337,12 @@ a different host, you can configure its connection string via the
     # example
     production: redis://redis.example.tld:6379
 
+If you want to connect the Redis server via socket, then use the "unix:" URL scheme 
+and the path to the Redis socket file in the `config/resque.yml` file.
+
+    # example
+    production: unix:/path/to/redis/socket
+
 ## Custom SSH Connection
 
 If you are running SSH on a non-standard port, you must change the gitlab user's SSH config.


### PR DESCRIPTION
The communication between Rails and Redis via socket is faster than a TCP connection. I added a short example of this option in the install documentation.
