### PR TITLE
[gitlab:check] Fix detecting the status of sidekiq

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -663,7 +663,6 @@ namespace :gitlab do
       else
         puts "#{sidekiq_match.length}".red
         try_fixing_it(
-          'Unless you are running another Rails application on this server there should only be one Sidekiq process.',
           'sudo service gitlab stop',
           'sudo pkill -f sidekiq',
           'sleep 10 && sudo pkill -9 -f sidekiq',
@@ -674,7 +673,7 @@ namespace :gitlab do
     end
 
     def sidekiq_process_match
-      run_and_match("ps aux | grep -i sidekiq", /(sidekiq \d+\.\d+\.\d+.+$)/)
+      run_and_match("ps ux | grep -i sidekiq", /(sidekiq \d+\.\d+\.\d+.+$)/)
     end
   end
 


### PR DESCRIPTION
If you are running another sidekiq instance on your server, e.g. GitLab CI, the check script would parse the output of `ps aux` searching for `sidekiq` and returning success, although the GitLab sidekiq may not be running.

Now the `ps` call will only print the processes run by the GitLab user.

---
### Old behavior:

_(uid 1004 = gitlab_ci)_

```
git@server2-2:~/gitlab|master ⇒  ps aux | grep -i sidekiq                         
1004     16523  1.6  1.5 406668 78680 pts/0    Sl   16:06   0:07 sidekiq 2.14.0 gitlab-ci [0 of 25 busy]                                                                                                                     
git      16823  2.6  2.7 571488 141880 pts/0   Sl   16:06   0:11 sidekiq 2.14.0 gitlab [0 of 25 busy]                                                                                                                                                             
```

**Output of check:**

```
[SNIP]
Checking Sidekiq ...

Running? ... yes

Checking Sidekiq ... Finished
[SNIP]
```

Now if for some reason the GitLab sidekiq would crash, the ps would look like this:

```
git@server2-2:~/gitlab|master ⇒  ps aux | grep -i sidekiq     
1004     16523  1.3  1.5 406668 78684 pts/0    Sl   16:06   0:08 sidekiq 2.14.0 gitlab-ci [0 of 25 busy]                                                                                                                     
```

**Output of check:** (since `grep -i sidekiq` would still return a result)

```
[SNIP]
Checking Sidekiq ...

Running? ... yes

Checking Sidekiq ... Finished
[SNIP]
```

---
### New behavior:

---

**Output of check:**

```
[SNIP]
Checking Sidekiq ...

Running? ... no
  Try fixing it:
  sudo -u git -H bundle exec rake sidekiq:start RAILS_ENV=production
  For more information see:
  doc/install/installation.md in section "Install Init Script"
  see log/sidekiq.log for possible errors
  Please fix the error above and rerun the checks.

Checking Sidekiq ... Finished
[SNIP]
```
