### PR TITLE
 Add check if the signup setting is enabled. fixes #4832

### DIFF
--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -2,7 +2,7 @@
   <%= link_to "Sign in", new_session_path(resource_name), class: "btn" %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if devise_mapping.registerable? && controller_name != 'registrations' && Gitlab.config.gitlab.signup_enabled %>
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end -%>
 

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -52,7 +52,8 @@ production: &base
 
 
     ## Users management
-    # signup_enabled: true          # default: false - Account passwords are not sent via the email if signup is enabled.
+    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # signup_enabled: true
 
     ## Automatic issue closing
     # If a commit message matches this regular express, all issues referenced from the matched text will be closed


### PR DESCRIPTION
This pull request will fix issue #4832

The sign up link was shown on the reset password page even when this setting was disabled.

This is also my first pull request, if I did something wrong please let me know.
