### PR TITLE
Missing Configuration in unicorn.rb?

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -70,11 +70,11 @@ module Gitlab
     config.assets.version = '1.0'
 
     # Uncomment and customize the last line to run in a non-root path
-    # WARNING: This feature is no longer supported
+    # WARNING: This feature is known to work, but unsupported
     # Note that three settings need to be changed for this to work.
     # 1) In your application.rb file: config.relative_url_root = "/gitlab"
     # 2) In your gitlab.yml file: relative_url_root: /gitlab
-    # 3) In your unicorn.rb: ENV['RAILS_RELATIVE_URL_ROOT']
+    # 3) In your unicorn.rb: ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
     #
     # config.relative_url_root = "/gitlab"
   end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -20,11 +20,11 @@ production: &base
     https: false
 
     # Uncomment and customize the last line to run in a non-root path
-    # WARNING: This feature is no longer supported
+    # WARNING: This feature is known to work, but unsupported
     # Note that three settings need to be changed for this to work.
     # 1) In your application.rb file: config.relative_url_root = "/gitlab"
     # 2) In your gitlab.yml file: relative_url_root: /gitlab
-    # 3) In your unicorn.rb: ENV['RAILS_RELATIVE_URL_ROOT']
+    # 3) In your unicorn.rb: ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
     #
     # relative_url_root: /gitlab
 

--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -8,7 +8,13 @@
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html for complete
 # documentation.
 
-# Uncomment and customize the next line to run in a non-root path
+# Uncomment and customize the last line to run in a non-root path
+# WARNING: This feature is known to work, but unsupported
+# Note that three settings need to be changed for this to work.
+# 1) In your application.rb file: config.relative_url_root = "/gitlab"
+# 2) In your gitlab.yml file: relative_url_root: /gitlab
+# 3) In your unicorn.rb: ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+#
 # ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
 
 # Use at least one worker per core if you're on a dedicated server,

--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -8,6 +8,9 @@
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html for complete
 # documentation.
 
+# Uncomment and customize the next line to run in a non-root path
+# ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.
 worker_processes 2


### PR DESCRIPTION
According to [gitlab.yml](https://github.com/gitlabhq/gitlabhq/blob/6-0-stable/config/gitlab.yml.example#L22-L27) I should edit `unicorn.rb` with the following setting.

`ENV['RAILS_RELATIVE_URL_ROOT'` however it does not exist anywhere in the [file](https://github.com/gitlabhq/gitlabhq/blob/6-0-stable/config/unicorn.rb.example)

Does this need to be set somewhere, or should it be removed from the directions in gitlab.yml?
