### PR TITLE
Expose merge_request.closed, .merged, merge_request/:id/commits to API

### DIFF
--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -84,6 +84,41 @@ Parameters:
 ```
 
 
+## Get commits for single MR
+
+Shows unmerged commits for a single merge request.
+
+```
+GET /projects/:id/merge_request/:merge_request_id/commits
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
++ `merge_request_id` (required) - The ID of MR
+
+```json
+[
+  {
+    "id": "ed899a2f4b50b4370feeea94676502b42383c746",
+    "short_id": "ed899a2f4b5",
+    "title": "Replace sanitize with escape once",
+    "author_name": "Dmitriy Zaporozhets",
+    "author_email": "dzaporozhets@sphereconsultinginc.com",
+    "created_at": "2012-09-20T11:50:22+03:00"
+  },
+  {
+    "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+    "short_id": "6104942438c",
+    "title": "Sanitize for network graph",
+    "author_name": "randx",
+    "author_email": "dmitriy.zaporozhets@gmail.com",
+    "created_at": "2012-09-20T09:06:12+03:00"
+  }
+]
+```
+
+
 ## Create MR
 
 Creates a new merge request.

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -114,6 +114,8 @@ module API
 
     class MergeRequest < Grape::Entity
       expose :id, :target_branch, :source_branch, :title, :state
+      expose :closed?, as: :closed
+      expose :merged?, as: :merged
       expose :target_project_id, as: :project_id
       expose :author, :assignee, using: Entities::UserBasic
     end

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -55,6 +55,26 @@ module API
         present merge_request, with: Entities::MergeRequest
       end
 
+      # Show MR commits
+      #
+      # Parameters:
+      #   id (required)               - The ID or code name of a project
+      #   merge_request_id (required) - The ID of MR
+      #
+      # Example:
+      #   GET /projects/:id/merge_request/:merge_request_id/commits
+      #
+      get ":id/merge_request/:merge_request_id/commits" do
+        merge_request = user_project.merge_requests.find(params[:merge_request_id])
+
+        authorize! :read_merge_request, merge_request
+        authorize! :download_code, user_project
+
+        commits = merge_request.unmerged_commits
+        present CommitDecorator.decorate(commits), with: Entities::RepoCommit
+
+      end
+
       # Create MR
       #
       # Parameters:

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -30,15 +30,26 @@ describe API::API do
   end
 
   describe "GET /projects/:id/merge_request/:merge_request_id" do
-    it "should return merge_request" do
+    it "should return merge_request with closed and merged values" do
       get api("/projects/#{project.id}/merge_request/#{merge_request.id}", user)
       response.status.should == 200
       json_response['title'].should == merge_request.title
+      json_response['closed'].should == merge_request.closed?
+      json_response['merged'].should == merge_request.merged?
     end
 
     it "should return a 404 error if merge_request_id not found" do
       get api("/projects/#{project.id}/merge_request/999", user)
       response.status.should == 404
+    end
+  end
+
+  describe "GET /projects/:id/merge_request/:merge_request_id/commits" do
+    it "should return commits for the merge_request" do
+      get api("/projects/#{project.id}/merge_request/#{merge_request.id}/commits", user)
+      response.status.should == 200
+      json_response.should be_an Array
+      json_response.first['title'].should == merge_request.unmerged_commits.first['title']
     end
   end
 


### PR DESCRIPTION
Hello,

This is a more complete version of PR #2179 I submitted earlier this year.  It exposes a few attributes of MergeRequest which are needed for "pretty" PR merging, as with [jresig/pulley](https://github.com/jresig/pulley), creating [pulley-gitlab](https://github.com/doublerebel/pulley-gitlab).

I have rebased the PR against master branch and added RSpec tests for the new features.

Although I learned a ton about RoR while adding this feature, I am stumped by the 2nd test.  It fails with:

``` rb
Failure/Error: get api("/projects/#{project.id}/merge_request/#{merge_request.id}/commits", user)
    ActionController::RoutingError:
       No route matches [GET] "/api/v3/projects/785/merge_request/395/commits"
```

I have written a rake task helper to show me the API routes:

_lib/task/gitlab/api_routes.rake_

``` rb
desc "API Routes"
task api_routes: :environment do
  API::API.routes.each do |api|
    method = api.route_method.ljust(10)
    path = api.route_path
    puts "     #{method} #{path}"
  end
end
```

Which shows me that my new route does exist in the test environment:

```
$ sudo -u git -H bundle exec rake api_routes RAILS_ENV=test
...
GET   /:version/projects/:id/merge_request/:merge_request_id/commits(.:format)
...
```

Does GitLab cache routes?  Have I implemented the test incorrectly?  I have pored over the sources and tried other solutions to no avail.

Many thanks for GitLab!  I am happy to continue work on this PR and appreciate any help or hints from the community.

Best,

Charles
