### PR TITLE
Removes erroneous exit statement in init script

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -35,7 +35,7 @@ sidekiq_pid_path="$pid_path/sidekiq.pid"
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then
-  sudo -u "$app_user" -H -i $0 "$@"; exit;
+  sudo -u "$app_user" -H -i $0 "$@";
 fi
 
 # Switch to the gitlab path, if it fails exit with an error.


### PR DESCRIPTION
This resolves issue Issue #5217

If you call the init script as root, the script would exit without performing any action. 

See stackexchange question here: http://unix.stackexchange.com/questions/92783/how-to-update-an-init-script
