### PR TITLE
Show commit message and issue title in references

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -76,7 +76,7 @@ class Note < ActiveRecord::Base
       commit_id: (noteable.sha if noteable.respond_to? :sha),
       project: project,
       author: author,
-      note: "_mentioned in #{mentioner.gfm_reference}_",
+      note: "_mentioned in #{mentioner.gfm_reference}_" + ((mentioner.kind_of? Commit) ? ":  #{mentioner.message}" : "") + ((mentioner.kind_of? Issue) ? ": #{mentioner.title}" : ""),
       system: true
     }, without_protection: true)
   end

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -60,7 +60,7 @@ describe Commit do
   it_behaves_like 'a mentionable' do
     let(:subject) { commit }
     let(:mauthor) { create :user, email: commit.author_email }
-    let(:backref_text) { "commit #{subject.sha[0..5]}" }
+    let(:backref_text) { "commit #{subject.sha[0..5]}_: #{subject.message}" }
     let(:set_mentionable_text) { ->(txt){ subject.stub(safe_message: txt) } }
 
     # Include the subject in the repository stub.

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -195,7 +195,7 @@ describe Note do
 
       it { should be_valid }
       its(:noteable) { should == issue }
-      its(:note) { should == "_mentioned in commit #{commit.sha[0..5]}_" }
+      its(:note) { should == "_mentioned in commit #{commit.sha[0..5]}_: #{commit.message}" }
     end
 
     context 'merge request from an issue' do
@@ -204,7 +204,7 @@ describe Note do
       it { should be_valid }
       its(:noteable) { should == mergereq }
       its(:project) { should == mergereq.project }
-      its(:note) { should == "_mentioned in issue ##{issue.iid}_" }
+      its(:note) { should == "_mentioned in issue ##{issue.iid}_: #{issue.title}" }
     end
 
     context 'commit from a merge request' do


### PR DESCRIPTION
This will add the commit message after the "referenced in commit XXXX" note ,which is inserted into issues when a commit message refereces it. It will also add the issue title in the "referenced in issue #XX" message, which is shown in a commit when its referenced from an issue.

Mentioned in #4507
