### PR TITLE
add mysql to Required-Start

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -7,7 +7,7 @@
 
 ### BEGIN INIT INFO
 # Provides:          gitlab
-# Required-Start:    $local_fs $remote_fs $network $syslog redis-server
+# Required-Start:    $local_fs $remote_fs $network $syslog redis-server mysql
 # Required-Stop:     $local_fs $remote_fs $network $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
allow init to build correct build order
