### PR TITLE
Doc api group access

### DIFF
--- a/doc/api/groups.md
+++ b/doc/api/groups.md
@@ -105,6 +105,18 @@ Parameters:
 + `access_level` (required) - Project access level
 
 
+**Group access levels**
+
+The group access levels are defined in the `users_group.rb` class. Currently, these levels are recognized:
+
+```
+  GUEST     = 10
+  REPORTER  = 20
+  DEVELOPER = 30
+  MASTER    = 40
+  OWNER     = 50
+```
+
 ### Remove user team member
 
 Removes user from user team.

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -193,7 +193,7 @@ Parameters:
 
 **Project access levels**
 
-The project access levels are defined in the `user_project.rb` class. Currently, these levels are recognized:
+The project access levels are defined in the `users_project.rb` class. Currently, these levels are recognized:
 
 ```
   GUEST     = 10


### PR DESCRIPTION
Currently working with the API a bit, noticed omission of group access levels in groups.md and a typo in the access level description for projects.
