### PR TITLE
ssh keys publically available for sysadmins via http, the github way

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v 6.2.0
+  - Retrieving user ssh keys publically(github style): http://__HOST__/__USERNAME__.keys
   - Public projects are visible from the outside
   - Add group access to permissions page
   - Require current password to change one

--- a/app/controllers/profiles/keys_controller.rb
+++ b/app/controllers/profiles/keys_controller.rb
@@ -1,5 +1,6 @@
 class Profiles::KeysController < ApplicationController
   layout "profile"
+  skip_before_filter :authenticate_user!, only: [:get_keys]
 
   def index
     @keys = current_user.keys.order('id DESC').all
@@ -32,4 +33,21 @@ class Profiles::KeysController < ApplicationController
       format.js { render nothing: true }
     end
   end
+
+  #get all keys of a user(params[:username]) in a text format
+  #helpful for sysadmins to put in respective servers
+  def get_keys
+    if params[:username].present?
+      begin
+        user = User.find_by_username(params[:username])
+        user.present? ? (render :text => user.all_ssh_keys) :
+          (render_404 and return)
+      rescue => e
+        render text: e.message
+      end
+    else
+      render_404 and return
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -391,4 +391,8 @@ class User < ActiveRecord::Base
 
     self
   end
+
+  def all_ssh_keys
+    keys.collect{|x| x.key}.join("\n")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Gitlab::Application.routes.draw do
   API::API.logger Rails.logger
   mount API::API => '/api'
 
+  #get all keys of user
+  get ':username.keys' => 'profiles/keys#get_keys' , constraints: { username: /.*/ }
+
   constraint = lambda { |request| request.env["warden"].authenticate? and request.env['warden'].user.admin? }
   constraints constraint do
     mount Sidekiq::Web, at: "/admin/sidekiq", as: :sidekiq


### PR DESCRIPTION
Very helpful feature for sysadmins to get user ssh-keys and append in servers. For example:

http://github.com/devaroop.keys

After this merge, gitlab users will be able to use it the same way: 

```
http://<gitlab_host>/<username>.keys
```

More information about its advantages: http://thechangelog.com/github-exposes-public-ssh-keys-for-its-users/
