### PR TITLE
admin flag accessible to admins

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
                   :extern_uid, :provider, :password_expires_at,
                   as: [:default, :admin]
 
-  attr_accessible :projects_limit, :can_create_group,
+  attr_accessible :projects_limit, :can_create_group, :admin,
                   as: :admin
 
   attr_accessor :force_random_password


### PR DESCRIPTION
Setting the api flag in the /users POST / PUT api is already possible. This PR adds the is_admin flag to the attributes accessible to admins so it can also be fetched via the /users GET api.

Feedback post: http://feedback.gitlab.com/forums/176466-general/suggestions/4529842-allow-admin-to-view-and-set-admin-flag-on-users-by
