### PR TITLE
Add MathJax support in Wiki and Markdown files.

### DIFF
--- a/app/views/layouts/_mathjax.html.haml
+++ b/app/views/layouts/_mathjax.html.haml
@@ -4,6 +4,7 @@
       url: '#{extra_config.mathjax_url}',
       dataType: 'script',
       crossDomain: true,
+      cache: true,
       success: function() {
         $('.wiki').each(function(k, item) {
           MathJax.Hub.Queue(["Typeset",MathJax.Hub,item]);

--- a/app/views/layouts/_mathjax.html.haml
+++ b/app/views/layouts/_mathjax.html.haml
@@ -1,0 +1,8 @@
+:javascript
+  $(document).ready(function() {
+    $.getScript('#{extra_config.mathjax_url}', function() {
+      $('.wiki').each(function(k, item) {
+        MathJax.Hub.Queue(["Typeset",MathJax.Hub,item]);
+      });
+    });
+  });

--- a/app/views/layouts/_mathjax.html.haml
+++ b/app/views/layouts/_mathjax.html.haml
@@ -1,8 +1,13 @@
 :javascript
   $(document).ready(function() {
-    $.getScript('#{extra_config.mathjax_url}', function() {
-      $('.wiki').each(function(k, item) {
-        MathJax.Hub.Queue(["Typeset",MathJax.Hub,item]);
-      });
+    $.ajax({
+      url: '#{extra_config.mathjax_url}',
+      dataType: 'script',
+      crossDomain: true,
+      success: function() {
+        $('.wiki').each(function(k, item) {
+          MathJax.Hub.Queue(["Typeset",MathJax.Hub,item]);
+        });
+      }
     });
   });

--- a/app/views/projects/blob/show.html.haml
+++ b/app/views/projects/blob/show.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/mathjax' if extra_config.has_key?('mathjax_url')
 %div.tree-ref-holder
   = render 'shared/ref_switcher', destination: 'blob', path: @path
 %div#tree-holder.tree-holder

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/mathjax' if extra_config.has_key?('mathjax_url')
 %h3.page-title
   Issue ##{@issue.iid}
 

--- a/app/views/projects/tree/show.html.haml
+++ b/app/views/projects/tree/show.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/mathjax' if extra_config.has_key?('mathjax_url')
 %div.tree-ref-holder
   = render 'shared/ref_switcher', destination: 'tree', path: @path
 %div#tree-holder.tree-holder

--- a/app/views/projects/wikis/show.html.haml
+++ b/app/views/projects/wikis/show.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/mathjax' if extra_config.has_key?('mathjax_url')
 = render 'nav'
 %h3.page-title
   = @wiki.title.titleize


### PR DESCRIPTION
This patch enables [MathJax](http://www.mathjax.org/) rendering in wiki pages and in `.md` files.

MathJax needs to be installed separately. The [MathJax CDN](http://docs.mathjax.org/en/latest/start.html#mathjax-cdn) can be used, for example.

To enable this feature, simply set the MathJax URL (e.g. `http://.../MathJax.js?config=TeX-AMS-MML_HTMLorMML`) as the `mathjax_url` option in the `extra_config` section of `config/gitlab.yml`.

Note that, unlike other Markdown processors, the GitLab Markdown processor already processes `^`, so this symbol has to be escaped if used in a formula: `\^`.

Here are a couple of examples that can be used in wiki or markdown content:

```
Here is a mathematical formula:

$$f(x) = \sum\_{i=1}\^{N}{x\^2}$$

Here is an inline formula: \\( f(x) = \sum\_{i=1}\^{N}{x\^2} \\)
```

The formulae should be turned into mathematical notation after the page is loaded. The first time MathJax is used, this transformation might seem a bit slow, mainly because it needs to download a number of fonts. This improves once MathJax is cached.
