### PR TITLE
Use proper titles for issues trackers

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -80,6 +80,18 @@ module ProjectsHelper
     @project.milestones.active.order("id desc").all
   end
 
+  def project_issues_trackers
+    values = Project.issues_tracker.values.map do |tracker_key|
+      if tracker_key.to_sym == :gitlab
+        ['GitLab', tracker_key]
+      else
+        [Gitlab.config.issues_tracker[tracker_key]['title'] || tracker_key, tracker_key]
+      end
+    end
+
+    options_for_select(values)
+  end
+
   private
 
   def get_project_nav_tabs(project, current_user)

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -67,7 +67,7 @@
             - if Project.issues_tracker.values.count > 1
               .control-group
                 = f.label :issues_tracker, "Issues tracker", class: 'control-label'
-                .controls= f.select(:issues_tracker, Project.issues_tracker.values, {}, { disabled: !@project.issues_enabled })
+                .controls= f.select(:issues_tracker, project_issues_trackers, {}, { disabled: !@project.issues_enabled })
 
               .control-group
                 = f.label :issues_tracker_id, "Project name or id in issues tracker", class: 'control-label'

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -73,6 +73,7 @@ production: &base
   ## External issues trackers
   issues_tracker:
     # redmine:
+    #   title: "Redmine"
     #   ## If not nil, link 'Issues' on project page will be replaced with this
     #   ## Use placeholders:
     #   ##  :project_id        - GitLab project identifier
@@ -93,6 +94,7 @@ production: &base
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
     # 
     # jira:
+    #   title: "Atlassian Jira"
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
     #   new_issue_url: "http://jira.sample/secure/CreateIssue.jspa"
@@ -206,6 +208,7 @@ test:
   <<: *base
   issues_tracker:
     redmine:
+      title: "Redmine"
       project_url: "http://redmine/projects/:issues_tracker_id"
       issues_url: "http://redmine/:project_id/:issues_tracker_id/:id"
       new_issue_url: "http://redmine/projects/:issues_tracker_id/issues/new"

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe ProjectsHelper do
+  describe '#project_issues_trackers' do
+    it "returns the correct issues trackers available" do
+      project_issues_trackers.should ==
+          "<option value=\"redmine\">Redmine</option>\n" \
+          "<option value=\"gitlab\">GitLab</option>"
+    end
+  end
+end


### PR DESCRIPTION
It's just a visual aspect, but in my opinion it gives a more professional look... :necktie: 

![image](https://f.cloud.github.com/assets/207754/1289732/38a1fea0-3026-11e3-958b-e8d7536d4f26.png)
