### PR TITLE
Implement PAM on top of gitlab 6-1-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'omniauth', "~> 1.1.3"
 gem 'omniauth-google-oauth2'
 gem 'omniauth-twitter'
 gem 'omniauth-github'
+#gem "omniauth-pam", "~> 1.1.0"
+# LDAP Auth
+gem 'gitlab_omniauth-ldap', '1.0.3', require: "omniauth-ldap"
 
 # Extracting information from a git repository
 # Provide access to Gitlab::Git library
@@ -27,9 +30,6 @@ gem "gitlab_git", '2.3.1'
 
 # Ruby/Rack Git Smart-HTTP Server Handler
 gem 'gitlab-grack', '~> 1.0.1', require: 'grack'
-
-# LDAP Auth
-gem 'gitlab_omniauth-ldap', '1.0.3', require: "omniauth-ldap"
 
 # Syntax highlighter
 gem "gitlab-pygments.rb", '~> 0.3.2', require: 'pygments.rb'

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -23,6 +23,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     sign_in_and_redirect(@user)
   end
 
+  def pam
+    @user = Gitlab::PAM::User.find_or_create(oauth)
+    @user.remember_me = true if @user.persisted?
+    sign_in_and_redirect(@user)
+  end
+
   private
 
   def handle_omniauth

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -70,7 +70,7 @@ class ProfilesController < ApplicationController
   end
 
   def authorize_change_password!
-    return render_404 if @user.ldap_user?
+    return render_404 if @user.ldap_user? || @user.pam_user?
   end
 
   def authorize_change_username!

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -70,7 +70,7 @@ class ProfilesController < ApplicationController
   end
 
   def authorize_change_password!
-    return render_404 if @user.ldap_user? || @user.pam_user?
+    return render_404 unless @user.can_change_password?
   end
 
   def authorize_change_username!

--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -3,8 +3,12 @@ module OauthHelper
     Devise.omniauth_providers.include?(:ldap)
   end
 
+  def pam_enabled?
+    Devise.omniauth_providers.include?(:pam)
+  end
+
   def default_providers
-    [:twitter, :github, :google_oauth2, :ldap]
+    [:twitter, :github, :google_oauth2, :ldap, :pam]
   end
 
   def enabled_oauth_providers

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -10,10 +10,10 @@ module ProfileHelper
   end
 
   def show_profile_social_tab?
-    Gitlab.config.omniauth.enabled && !current_user.ldap_user?
+    Gitlab.config.omniauth.enabled && !current_user.ldap_user? && !current_user.pam_user?
   end
 
   def show_profile_remove_tab?
-    Gitlab.config.gitlab.signup_enabled && !current_user.ldap_user?
+    Gitlab.config.gitlab.signup_enabled && !current_user.ldap_user? && !current_user.pam_user?
   end
 end

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -5,6 +5,10 @@ module ProfileHelper
     end
   end
 
+  def show_profile_password_tab?
+    current_user.can_change_password?
+  end
+
   def show_profile_username_tab?
     current_user.can_change_username?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,7 @@ class User < ActiveRecord::Base
   scope :not_in_project, ->(project) { project.users.present? ? where("id not in (:ids)", ids: project.users.map(&:id) ) : scoped }
   scope :without_projects, -> { where('id NOT IN (SELECT DISTINCT(user_id) FROM users_projects)') }
   scope :ldap, -> { where(provider:  'ldap') }
+  scope :pam, -> { where(provider:  'pam') }
 
   scope :potential_team_members, ->(team) { team.members.any? ? active.not_in_team(team) : active  }
 
@@ -361,6 +362,10 @@ class User < ActiveRecord::Base
 
   def ldap_user?
     extern_uid && provider == 'ldap'
+  end
+
+  def pam_user?
+    extern_uid && provider == 'pam'
   end
 
   def accessible_deploy_keys

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -272,6 +272,10 @@ class User < ActiveRecord::Base
     keys.count == 0
   end
 
+  def can_change_password?
+    !ldap_user? && !pam_user?
+  end
+
   def can_change_username?
     Gitlab.config.gitlab.username_changing_enabled
   end

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -60,6 +60,12 @@
             %strong
               = @user.extern_uid
 
+        - elsif @user.pam_user?
+          %li
+            %span.light PAM uid:
+            %strong
+              = @user.extern_uid
+
         - if @user.created_by
           %li
             %span.light Created by:

--- a/app/views/devise/sessions/_new_pam.html.haml
+++ b/app/views/devise/sessions/_new_pam.html.haml
@@ -1,0 +1,5 @@
+= form_tag(user_omniauth_callback_path(:pam), id: 'new_pam_user' ) do
+  = text_field_tag :username, nil, {class: "text top", placeholder: "PAM Login", autofocus: "autofocus"}
+  = password_field_tag :password, nil, {class: "text bottom", placeholder: "Password"}
+  %br/
+  = submit_tag "PAM Sign in", class: "btn-create btn"

--- a/app/views/devise/sessions/_oauth_providers.html.haml
+++ b/app/views/devise/sessions/_oauth_providers.html.haml
@@ -1,4 +1,4 @@
-- providers = (enabled_oauth_providers - [:ldap])
+- providers = enabled_social_providers
 - if providers.present?
   %hr
   %div{:'data-no-turbolink' => 'data-no-turbolink'}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,14 +1,22 @@
 .login-box
   %h3.page-title Sign in
-  - if ldap_enabled?
+  - if ldap_enabled? || pam_enabled?
     %ul.nav.nav-tabs
-      %li.active
-        = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
+      - if ldap_enabled?
+        %li.active
+          = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
+      - if pam_enabled?
+        %li.active
+          = link_to 'PAM', '#tab-pam', 'data-toggle' => 'tab'
       %li
         = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
     .tab-content
-      %div#tab-ldap.tab-pane.active
-        = render partial: 'devise/sessions/new_ldap'
+      - if ldap_enabled?
+        %div#tab-ldap.tab-pane.active
+          = render partial: 'devise/sessions/new_ldap'
+      - if pam_enabled?
+        %div#tab-pam.tab-pane.active
+          = render partial: 'devise/sessions/new_pam'
       %div#tab-signin.tab-pane
         = render partial: 'devise/sessions/new_base'
 

--- a/app/views/profiles/account.html.haml
+++ b/app/views/profiles/account.html.haml
@@ -4,6 +4,8 @@
   You can change your password, username and private token here.
   - if current_user.ldap_user?
     Some options are unavailable for LDAP accounts
+  - elsif current_user.pam_user?
+    Some options are unavailable for PAM accounts
 %hr
 
 

--- a/app/views/profiles/account.html.haml
+++ b/app/views/profiles/account.html.haml
@@ -15,9 +15,10 @@
       %li.active
         = link_to '#tab-token', 'data-toggle' => 'tab' do
           Private Token
-      %li
-        = link_to '#tab-password', 'data-toggle' => 'tab' do
-          Password
+      - if show_profile_password_tab?
+        %li
+          = link_to '#tab-password', 'data-toggle' => 'tab' do
+            Password
 
       - if show_profile_social_tab?
         %li
@@ -56,27 +57,28 @@
                     %span You don`t have one yet. Click generate to fix it.
                     = f.submit 'Generate', class: "btn success btn-build-token"
 
-      .tab-pane#tab-password
-        %fieldset.update-password
-          %legend Password
-          = form_for @user, url: update_password_profile_path, method: :put do |f|
-            %div
-              %p.slead After a successful password update you will be redirected to login page where you should login with your new password
-              -if @user.errors.any?
-                .alert.alert-error
-                  %ul
-                    - @user.errors.full_messages.each do |msg|
-                      %li= msg
-              .control-group
-                = f.label :password
-                .controls= f.password_field :password, required: true
-              .control-group
-                = f.label :password_confirmation
-                .controls
-                  = f.password_field :password_confirmation, required: true
-              .control-group
-                .controls
-                  = f.submit 'Save password', class: "btn btn-save"
+      - if show_profile_password_tab?
+        .tab-pane#tab-password
+          %fieldset.update-password
+            %legend Password
+            = form_for @user, url: update_password_profile_path, method: :put do |f|
+              %div
+                %p.slead After a successful password update you will be redirected to login page where you should login with your new password
+                -if @user.errors.any?
+                  .alert.alert-error
+                    %ul
+                      - @user.errors.full_messages.each do |msg|
+                        %li= msg
+                .control-group
+                  = f.label :password
+                  .controls= f.password_field :password, required: true
+                .control-group
+                  = f.label :password_confirmation
+                  .controls
+                    = f.password_field :password_confirmation, required: true
+                .control-group
+                  .controls
+                    = f.submit 'Save password', class: "btn btn-save"
 
       - if show_profile_social_tab?
         .tab-pane#tab-social

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -49,8 +49,9 @@
       %fieldset.tips
         %legend Tips:
         %ul
-          %li
-            %p You can change your password on the Account page
+          - if current_user.can_change_password?
+            %li
+              %p You can change your password on the Account page
           - if Gitlab.config.gravatar.enabled
             %li
               %p You can change your avatar at #{link_to "gravatar.com", "http://gravatar.com"}

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -109,6 +109,16 @@ production: &base
     password: '_the_password_of_the_bind_user'
     allow_username_or_email_login: true
 
+  ## PAM settings
+  #  Currently unix_pam do not work as expected, so pam works only with modules like ldap, sssd, krb
+  #  or you need to run gitlab as root (NOT RECOMMENDED!)
+  #  Read more from: https://github.com/canweriotnow/rpam-ruby19/issues/5
+  pam:
+    enabled: false
+    email_domain: 'example.org', # if gecos do not provide email, you need to use this option
+    gecos_map: ['name', 'location', 'phone', 'home_phone', 'email'], # map for gecos attributes
+    service: 'gitlab', # what pam service to use
+
   ## OmniAuth settings
   omniauth:
     # Allow login via Twitter, Google, etc. using OmniAuth providers

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -34,17 +34,12 @@ class Settings < Settingslogic
 end
 
 
-# Default settings
-Settings['ldap'] ||= Settingslogic.new({})
-Settings.ldap['enabled'] = false if Settings.ldap['enabled'].nil?
-Settings.ldap['allow_username_or_email_login'] = false if Settings.ldap['allow_username_or_email_login'].nil?
+# Default settings for gitlab.yml
+# ===============================
 
-
-Settings['omniauth'] ||= Settingslogic.new({})
-Settings.omniauth['enabled']      = false if Settings.omniauth['enabled'].nil?
-Settings.omniauth['providers']  ||= []
-
-Settings['issues_tracker']  ||= {}
+##
+## Gitlab app settings
+##
 
 #
 # GitLab
@@ -78,12 +73,52 @@ Settings.gitlab.default_projects_features['snippets']       = false if Settings.
 Settings.gitlab.default_projects_features['public']         = false if Settings.gitlab.default_projects_features['public'].nil?
 
 #
+# Issue tracker
+#
+Settings['issues_tracker']  ||= {}
+
+#
 # Gravatar
 #
 Settings['gravatar'] ||= Settingslogic.new({})
 Settings.gravatar['enabled']      = true if Settings.gravatar['enabled'].nil?
 Settings.gravatar['plain_url']  ||= 'http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
 Settings.gravatar['ssl_url']    ||= 'https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
+
+##
+## Auth settings
+##
+
+#
+# ldap
+#
+Settings['ldap'] ||= Settingslogic.new({})
+Settings.ldap['enabled'] = false if Settings.ldap['enabled'].nil?
+Settings.ldap['allow_username_or_email_login'] = false if Settings.ldap['allow_username_or_email_login'].nil?
+
+#
+# Omniauth
+#
+Settings['omniauth'] ||= Settingslogic.new({})
+Settings.omniauth['enabled']      = false if Settings.omniauth['enabled'].nil?
+Settings.omniauth['providers']  ||= []
+
+##
+## Advanced settings
+##
+
+#
+# Satellites
+#
+Settings['satellites'] ||= Settingslogic.new({})
+Settings.satellites['path'] = File.expand_path(Settings.satellites['path'] || "tmp/repo_satellites/", Rails.root)
+
+#
+# Backup
+#
+Settings['backup'] ||= Settingslogic.new({})
+Settings.backup['keep_time']  ||= 0
+Settings.backup['path']         = File.expand_path(Settings.backup['path'] || "tmp/backups/", Rails.root)
 
 #
 # GitLab Shell
@@ -100,22 +135,12 @@ Settings.gitlab_shell['owner_group']  ||= Settings.gitlab.user
 Settings.gitlab_shell['ssh_path_prefix'] ||= Settings.send(:build_gitlab_shell_ssh_path_prefix)
 
 #
-# Backup
-#
-Settings['backup'] ||= Settingslogic.new({})
-Settings.backup['keep_time']  ||= 0
-Settings.backup['path']         = File.expand_path(Settings.backup['path'] || "tmp/backups/", Rails.root)
-
-#
 # Git
 #
 Settings['git'] ||= Settingslogic.new({})
 Settings.git['max_size']  ||= 5242880 # 5.megabytes
 Settings.git['bin_path']  ||= '/usr/bin/git'
 Settings.git['timeout']   ||= 10
-
-Settings['satellites'] ||= Settingslogic.new({})
-Settings.satellites['path'] = File.expand_path(Settings.satellites['path'] || "tmp/repo_satellites/", Rails.root)
 
 #
 # Extra customization

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -97,6 +97,12 @@ Settings.ldap['enabled'] = false if Settings.ldap['enabled'].nil?
 Settings.ldap['allow_username_or_email_login'] = false if Settings.ldap['allow_username_or_email_login'].nil?
 
 #
+# pam
+#
+Settings['pam'] ||= Settingslogic.new({})
+Settings.ldap['enabled'] = false if Settings.ldap['enabled'].nil?
+
+#
 # Omniauth
 #
 Settings['omniauth'] ||= Settingslogic.new({})

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -223,6 +223,18 @@ Devise.setup do |config|
       name_proc: email_stripping_proc
   end
 
+  if Gitlab.config.pam.enabled
+    # For good reason omniauth-pam requires gecos_map to be symbols
+    if !Gitlab.config.pam['gecos_map'].nil?
+      Gitlab.config.pam.gecos_map.map! { |item| item.to_sym }
+    end
+
+    config.omniauth :pam,
+      gecos_map:    Gitlab.config.pam['gecos_map'],
+      service:      Gitlab.config.pam['service'],
+      email_domain: Gitlab.config.pam['email_domain']
+  end
+
   Gitlab.config.omniauth.providers.each do |provider|
     case provider['args']
     when Array

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -49,7 +49,17 @@ module Gitlab
         end
 
         def email
-          auth.info.email.downcase unless auth.info.email.nil?
+          email = auth.info.email.downcase unless auth.info.email.nil?
+
+          # we can workaround missing emails in omniauth provider
+          # by setting email_domain option for that provider
+          if email.nil? || email.blank?
+            email_domain = Devise.omniauth_configs[provider.to_sym].strategy[:email_domain]
+            email_user = auth.info.nickname
+            email = "#{email_user}@#{email_domain}" unless email_user.nil? or email_domain.nil?
+          end
+
+          email
         end
 
         def name

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -31,7 +31,7 @@ module Gitlab
           user.save!
           log.info "(OAuth) Creating user #{email} from login with extern_uid => #{uid}"
 
-          if Gitlab.config.omniauth['block_auto_created_users'] && !ldap?
+          if Gitlab.config.omniauth['block_auto_created_users'] && !ldap? && !pam?
             user.block
           end
 
@@ -88,6 +88,10 @@ module Gitlab
 
         def ldap?
           provider == 'ldap'
+        end
+
+        def pam?
+          provider == 'pam'
         end
       end
     end

--- a/lib/gitlab/pam/user.rb
+++ b/lib/gitlab/pam/user.rb
@@ -1,0 +1,77 @@
+require 'gitlab/oauth/user'
+
+# PAM extension for User model
+#
+# * Find or create user from omniauth.auth data
+# * Links PAM account with existing user
+# * Auth PAM user with login and password
+#
+module Gitlab
+  module PAM
+    class User < Gitlab::OAuth::User
+      class << self
+        def find_or_create(auth)
+          @auth = auth
+
+          if uid.blank? || email.blank?
+            raise_error("Account must provide an uid and email address")
+          end
+
+          user = find(auth)
+
+          unless user
+            # Look for user with same emails
+            #
+            # Possible cases:
+            # * When user already has account and need to link his PAM account.
+            # * PAM uid changed for user with same email and we need to update his uid
+            #
+            user = model.find_by_email(email)
+
+            if user
+              user.update_attributes(extern_uid: uid, provider: provider)
+              log.info("(PAM) Updating legacy PAM user #{email} with extern_uid => #{uid}")
+            else
+              # Create a new user inside GitLab database
+              # based on PAM credentials
+              #
+              #
+              user = create(auth)
+            end
+          end
+
+          user
+        end
+
+        def authenticate(login, password)
+          # Check user against PAM backend if user is not authenticated
+          # Only check with valid login and password to prevent anonymous bind results
+          return nil unless pam_conf.enabled && login.present? && password.present?
+
+          # Keep updated by https://github.com/nickcharlton/omniauth-pam/blob/master/lib/omniauth/strategies/pam.rb
+          rpam_opts = Hash.new
+          rpam_opts[:service] = pam_conf[:service] unless pam_conf[:service].nil?
+          return find_by_uid(login) if Rpam.auth(login, password, rpam_opts)
+        end
+
+        private
+
+        def find_by_uid(uid)
+          model.where(provider: provider, extern_uid: uid).last
+        end
+
+        def provider
+          'pam'
+        end
+
+        def raise_error(message)
+          raise OmniAuth::Error, "(PAM) " + message
+        end
+
+        def pam_conf
+          Gitlab.config.pam
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/gitlab/info.rake
+++ b/lib/tasks/gitlab/info.rake
@@ -48,6 +48,7 @@ namespace :gitlab do
       puts "HTTP Clone URL:\t#{http_clone_url}"
       puts "SSH Clone URL:\t#{ssh_clone_url}"
       puts "Using LDAP:\t#{Gitlab.config.ldap.enabled ? "yes".green : "no"}"
+      puts "Using PAM:\t#{Gitlab.config.pam.enabled ? "yes".green : "no"}"
       puts "Using Omniauth:\t#{Gitlab.config.omniauth.enabled ? "yes".green : "no"}"
       puts "Omniauth Providers: #{omniauth_providers.map(&:magenta).join(', ')}" if Gitlab.config.omniauth.enabled
 


### PR DESCRIPTION
This is working implementation for our environment (as required for now).

I created this PR as a notation that implementing omnitauth stuff in gitlab will eventually render omniauth abstraction useless as code is copied from omniauth gem's to gitlab (`lib/gitlab/{ldap,pam}/user.rb`) and thus requires code in gitlab repository for every omniauth backend.

Instead of this we should find a way to fix omniauth in a way that suites our needs. That means we need to implement interface for ldap and pam auhtentication methods. Also we need a way to know how different backends are supposed to be shown on sign in page (button or form).

You can argue that this is not our job (as it's not), but we are the ones who need this fixed.

I had some ideas in omniauth issue, but they didn't want to do those now: https://github.com/intridea/omniauth/issues/691

As gitlab allready uses it's fork for omniauth-ldap, it could fork omniauth and fix these issues for ldap. I very happily implement these on omniauth-pam.
