### PR TITLE
Ensure directory exists before changing in popen

### DIFF
--- a/lib/gitlab/popen.rb
+++ b/lib/gitlab/popen.rb
@@ -1,4 +1,3 @@
-
 require 'fileutils'
 
 module Gitlab
@@ -8,7 +7,7 @@ module Gitlab
       options = { chdir: path }
 
       unless File.directory?(path)
-       FileUtils.mkdir_p(path)
+        FileUtils.mkdir_p(path)
       end
 
       @cmd_output = ""

--- a/lib/gitlab/popen.rb
+++ b/lib/gitlab/popen.rb
@@ -1,8 +1,15 @@
+
+require 'fileutils'
+
 module Gitlab
   module Popen
     def popen(cmd, path)
       vars = { "PWD" => path }
       options = { chdir: path }
+
+      unless File.directory?(path)
+       FileUtils.mkdir_p(path)
+      end
 
       @cmd_output = ""
       @cmd_status = 0


### PR DESCRIPTION
If the directory does not exist, we want to ensure that it does.

Forking repos will fail in some situations because of this issue.

Fixes the exact problems described in https://github.com/gitlabhq/gitlabhq/issues/4016 for me.
