### PR TITLE
Fix the sigil for merge request emails

### DIFF
--- a/app/mailers/emails/notes.rb
+++ b/app/mailers/emails/notes.rb
@@ -18,7 +18,7 @@ module Emails
       @note = Note.find(note_id)
       @merge_request = @note.noteable
       @project = @note.project
-      mail(to: recipient(recipient_id), subject: subject("note for merge request !#{@merge_request.iid}"))
+      mail(to: recipient(recipient_id), subject: subject("note for merge request ##{@merge_request.iid}"))
     end
 
     def note_wall_email(recipient_id, note_id)

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -320,7 +320,7 @@ describe Notify do
         it_behaves_like 'a note email'
 
         it 'has the correct subject' do
-          should have_subject /note for merge request !#{merge_request.iid}/
+          should have_subject /note for merge request ##{merge_request.iid}/
         end
 
         it 'contains a link to the merge request note' do


### PR DESCRIPTION
Merge request emails say "Hey, check out merge request !5" instead of "#5". I'm almost certain this isn't on purpose. Tiny fix but I'm OCD. ;)
