### PR TITLE
[RFC] Add command to sync an imported repository

### DIFF
--- a/app/contexts/projects/sync_context.rb
+++ b/app/contexts/projects/sync_context.rb
@@ -1,0 +1,55 @@
+module Projects
+  class SyncContext < BaseContext
+    include Gitlab::ShellAdapter
+
+    def initialize(project, user, opts)
+      @project, @current_user = project, user
+
+      @url = opts[:url] || 'origin'
+      @source_branch = opts[:source_branch] || 'master'
+      @dest_branch = opts[:dest_branch] || @source_branch
+    end
+
+    def execute
+      if @project.imported?
+        # Here we need to take the cached count
+        pre_tags = @project.repository.tag_names.count
+        oldhead = @project.repository.commit('HEAD').id
+
+        gitlab_shell.sync_imported_repository(@project.path_with_namespace, @url, @source_branch, @dest_branch)
+
+        # Here we need to take the uncached count
+        post_tags = @project.repository.raw_repository.tag_names.count
+        newhead = @project.repository.commit('HEAD').id
+
+        commits_changed = @project.repository.commits_between(oldhead, newhead).count
+        tags_changed = post_tags - pre_tags
+
+        if tags_changed != 0 || commits_changed != 0
+          # If something changed force a new reload
+          GitPushService.new.execute(@project, @current_user, oldhead, newhead, @dest_branch)
+        end
+
+        if commits_changed > 0
+          notice = "Project was successfully updated: #{commits_changed.abs} new commits."
+        elsif commits_changed < 0
+          notice = "Project was successfully updated: #{commits_changed.abs} commits removed."
+        else
+          notice = "No new commits for this project."
+        end
+
+        if tags_changed > 0
+          notice += " #{tags_changed.abs} new tags."
+        elsif tags_changed < 0
+          notice += " #{tags_changed.abs} tags removed."
+        else
+          notice += "No new tags for this project."
+        end
+
+        notice
+      else
+        raise Exception.new('repository was not imported. Unable to update.')
+      end
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -108,6 +108,23 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def sync_imported
+    opts = {
+      origin: params[:origin],
+      source_branch: params[:source_branch],
+      dest_branch: params[:dest_branch]
+    }
+
+    notice = ::Projects::SyncContext.new(project, current_user, opts).execute
+
+    respond_to do |format|
+      format.html do
+        redirect_to(project, notice: notice)
+      end
+      format.js
+    end
+  end
+
   def autocomplete_sources
     @suggestions = {
       emojis: Emoji.names,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -138,7 +138,8 @@ class Ability
         :admin_merge_request,
         :admin_note,
         :admin_wiki,
-        :admin_project
+        :admin_project,
+        :sync_repository
       ]
     end
 
@@ -147,7 +148,8 @@ class Ability
         :change_namespace,
         :change_public_mode,
         :rename_project,
-        :remove_project
+        :remove_project,
+        :sync_repository
       ]
     end
 

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -56,6 +56,12 @@
           = link_to archive_project_repository_path(@project), class: "btn btn-block" do
             %i.icon-download-alt
             %span Download
+
+        - if @project.imported? and can? current_user, :sync_repository, @project
+          = link_to sync_imported_project_path(@project), class: "btn btn-block", method: "POST" do
+            %i.icon-refresh
+            %span Sync from origin
+
     %br
     .light-well
       %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Gitlab::Application.routes.draw do
       put :transfer
       post :fork
       get :autocomplete_sources
+      post :sync_imported
     end
 
     scope module: :projects do

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -24,6 +24,20 @@ module Gitlab
       system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "import-project", "#{name}.git", url
     end
 
+    # Update an imported repository
+    #
+    # name - project path with namespace
+    # url - remote url
+    # source_branch - remote branch to fetch from
+    # dest_branch - local branch to fetch to
+    #
+    # Ex.
+    #   sync_imported_repository("gitlab/gitlab-ci", "https://github.com/randx/six.git", "orig_branch", "dest_branch")
+    #
+    def sync_imported_repository(name, url, source_branch, dest_branch)
+      system "#{gitlab_shell_user_home}/gitlab-shell/bin/gitlab-projects", "sync-imported-repository", "#{name}.git", url, source_branch, dest_branch
+    end
+
     # Move repository
     #
     # path - project path with namespace


### PR DESCRIPTION
NOTE: This PR is not to be merged, but I just need to get some feedback.

This patch adds support to keep in sync an imported repository with a remote one.
It's not complete, but I need to get some feedback to understand if it'll ever make into master... :wink: 
It's tightly related to this PR: https://github.com/gitlabhq/gitlab-shell/pull/95

Note that it's just a proof of concept and there are several points missing.
Most notably:
- the underlying structure can sync different remotes and different source/dest branches, but the current UI will just synchronize origin and master:master
- tests are missing
- it's unfinished and may eat your pets...
