### PR TITLE
Remove instructions about setting vim as the default editor

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -41,15 +41,6 @@ up-to-date and install it.
     apt-get upgrade -y
     apt-get install sudo -y
 
-**Note:**
-During this installation some files will need to be edited manually.
-If you are familiar with vim set it as default editor with the commands below.
-If you are not familiar with vim please skip this and keep using the default editor.
-
-    # Install vim and set as default editor
-    sudo apt-get install -y vim
-    sudo update-alternatives --set editor /usr/bin/vim.basic
-
 Install the required packages:
 
     sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl git-core openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev


### PR DESCRIPTION
The default editor of Debian/Ubuntu is nano because it's easy to use for beginners. If a user proficient in vim reads this guide he will either have set vim as his default editor or understand to change editor to vim.

Even if the vim user doesn't understand to make these changes nano is easy to use and will be of no issue to him. Vim on the other hand will confuse the user who accidentally follows the instructions which are entirely unrelated to an already long set of installation instructions and sets vim as editor.
