### PR TITLE
Add internal_id to MergeRequest API

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -114,6 +114,7 @@ module API
     class MergeRequest < Grape::Entity
       expose :id, :target_branch, :source_branch, :title, :state, :upvotes, :downvotes
       expose :target_project_id, as: :project_id
+      expose :iid, as: :internal_id
       expose :author, :assignee, using: Entities::UserBasic
     end
 


### PR DESCRIPTION
This patch adds iid as internal_id to the Merge Request API for generating the url link to MR page.
