### PR TITLE
Show branches list (which branches contains commit) on commit page

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -123,6 +123,10 @@ $ ->
     $(@).next('table').show()
     $(@).remove()
 
+  $(".content").on "click", ".js-details-expand", ->
+    $(@).next('.js-details-contain').removeClass("hide")
+    $(@).remove()
+
 (($) ->
   _chosen = $.fn.chosen
   $.fn.extend chosen: (options) ->

--- a/app/contexts/commit_load_context.rb
+++ b/app/contexts/commit_load_context.rb
@@ -18,6 +18,7 @@ class CommitLoadContext < BaseContext
       result[:note] = project.build_commit_note(commit)
       result[:line_notes] = line_notes
       result[:notes_count] = project.notes.for_commit_id(commit.id).count
+      result[:branches] = project.repository.branch_names_contains(commit.id)
 
       begin
         result[:suppress_diff] = true if commit.diff_suppress? && !params[:force_show_diff]

--- a/app/controllers/projects/commit_controller.rb
+++ b/app/controllers/projects/commit_controller.rb
@@ -22,6 +22,7 @@ class Projects::CommitController < Projects::ApplicationController
 
     @note        = result[:note]
     @line_notes  = result[:line_notes]
+    @branches    = result[:branches]
     @notes_count = result[:notes_count]
     @target_type = :commit
     @target_id   = @commit.id

--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -94,6 +94,17 @@ module CommitsHelper
     crumbs.html_safe
   end
 
+  # Return Project default branch, if it present in array
+  # Else - first branch in array (mb last actual branch)
+  def commit_default_branch(project, branches)
+    branches.include?(project.default_branch) ? branches.delete(project.default_branch) : branches.pop
+  end
+
+  # Returns the sorted alphabetically links to branches, separated by a comma
+  def commit_branches_links(project, branches)
+    branches.sort.map { |branch| link_to(branch, project_tree_path(project, branch)) }.join(", ").html_safe
+  end
+
   protected
 
   # Private: Returns a link to a person. If the person has a matching user and

--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -39,6 +39,18 @@
   - @commit.parents.each do |parent|
     = link_to parent.id[0...10], project_commit_path(@project, parent)
 
+.commit-info-row
+  %span.cgray
+    Exists in
+  %span
+    - branch = commit_default_branch(@project, @branches)
+    = link_to(branch, project_tree_path(@project, branch))
+    - if @branches.any?
+      and in
+      = link_to("#{pluralize(@branches.count, "other branch")}", "#", class: "js-details-expand")
+      %span.js-details-contain.hide
+        = commit_branches_links(@project, @branches)
+
 .commit-box
   %h3.commit-title
     = gfm escape_once(@commit.title)


### PR DESCRIPTION
Shown in the first screenshot:
![commit-box when the page loads](http://puu.sh/4SZAf.png)

it looks like commit-box when the page loads. 

For example:
In any project there default_branch ( branch defaults to the first commit to the repository and can be changed later in the project settings ). If a commit in a branch that is set as the "_default branch_" - that is displayed:

"Exist in `default branch`, `and in other branches count branch(es)`". 

What stood out in the text `so` - a links . 
When you click on `and in other branches count branch(es)` - immediately displays a list of links to other branches on the spot phrase `and in other_branches_count branch(es)`.

![commit-box when the page loads](http://puu.sh/4SZBc.png)

If the default branch is not contains commit in  - then the first branch from the list of branches, which include a commit displayed in place `default branch`.

Refs to http://feedback.gitlab.com/forums/176466-general/suggestions/4164763-show-which-branches-contain-a-commit
