### PR TITLE
Show only processes owned by the GitLab user on the Admin-Sidekiq page

### DIFF
--- a/app/views/admin/background_jobs/show.html.haml
+++ b/app/views/admin/background_jobs/show.html.haml
@@ -3,7 +3,7 @@
 .ui-box
   %iframe{src: sidekiq_path, width: '100%', height: 900, style: "border: none"}
 %h4 Sidekiq running processes
-- sidekiq_processes = `ps -eo euser,pid,pcpu,pmem,stat,start,command | grep sidekiq | grep -v grep`
+- sidekiq_processes = `ps -U #{Settings.gitlab.user} -o euser,pid,pcpu,pmem,stat,start,command | grep sidekiq | grep -v grep`
 - if sidekiq_processes.empty?
   %b There are no running sidekiq processes
   %b Please restart GitLab


### PR DESCRIPTION
(See the Pull-Request #5191)

**Before:**
![bildschirmfoto von 2013-10-16 08 58 22](https://f.cloud.github.com/assets/327488/1340466/23b9d75e-3631-11e3-9139-4cdc806e8e27.png)

**After:**
![bildschirmfoto von 2013-10-16 09 04 26](https://f.cloud.github.com/assets/327488/1340474/41d06d20-3631-11e3-96a8-cf495b6ceea6.png)
