### PR TITLE
fix error with @-sign in branch names

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq/web'
 require 'api/api'
 
+ROUTES_BRANCH_NAME_REGEXP = /[a-zA-Z.\/0-9_\-#%+@]+/
+
 Gitlab::Application.routes.draw do
   #
   # Search
@@ -222,14 +224,14 @@ Gitlab::Application.routes.draw do
         end
       end
 
-      resources :branches, only: [:index, :new, :create, :destroy], constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ } do
+      resources :branches, only: [:index, :new, :create, :destroy], constraints: { id: ROUTES_BRANCH_NAME_REGEXP } do
         collection do
           get :recent
         end
       end
 
-      resources :tags, only: [:index, :new, :create, :destroy], constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ }
-      resources :protected_branches, only: [:index, :create, :destroy], constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ }
+      resources :tags, only: [:index, :new, :create, :destroy], constraints: { id: ROUTES_BRANCH_NAME_REGEXP }
+      resources :protected_branches, only: [:index, :create, :destroy], constraints: { id: ROUTES_BRANCH_NAME_REGEXP }
 
       resources :refs, only: [] do
         collection do
@@ -238,11 +240,11 @@ Gitlab::Application.routes.draw do
 
         member do
           # tree viewer logs
-          get "logs_tree", constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ }
+          get "logs_tree", constraints: { id: ROUTES_BRANCH_NAME_REGEXP }
           get "logs_tree/:path" => "refs#logs_tree",
             as: :logs_file,
             constraints: {
-              id:   /[a-zA-Z.0-9\/_\-#%+]+/,
+              id:   ROUTES_BRANCH_NAME_REGEXP,
               path: /.*/
             }
         end
@@ -284,7 +286,7 @@ Gitlab::Application.routes.draw do
         end
       end
 
-      resources :team_members, except: [:index, :edit], constraints: { id: /[a-zA-Z.\/0-9_\-#%+]+/ } do
+      resources :team_members, except: [:index, :edit], constraints: { id: ROUTES_BRANCH_NAME_REGEXP } do
         collection do
 
           # Used for import team


### PR DESCRIPTION
A branch with @-sign in name caused gitlab to crash with 404 error and message

```
ActionController::RoutingError (No route matches {:controller=>"projects/refs", :action=>"logs_tree", :project_id=>#<Project id: 6, name: "framework", path: "framework", description: "", created_at: "2013-10-17 08:44:38", updated_at: "2013-10-18 08:48:54", creator_id: 4, default_branch: "master", issues_enabled: false, wall_enabled: false, merge_requests_enabled: true, wiki_enabled: false, namespace_id: 5, public: true, issues_tracker: "gitlab", issues_tracker_id: nil, snippets_enabled: false, last_activity_at: "2013-10-18 08:49:22", imported: false, import_url: "">, :id=>"v_1_2@25785", :path=>""}):
  lib/extracts_path.rb:112:in `assign_ref_vars'
```

or 

```
ActionController::RoutingError (No route matches {:action=>"destroy", :controller=>"projects/branches", :project_id=>#<Project id: 6, name: "framework", path: "framework", description: "", created_at: "2013-10-17 08:44:38", updated_at: "2013-10-18 08:48:54", creator_id: 4, default_branch: "master", issues_enabled: false, wall_enabled: false, merge_requests_enabled: true, wiki_enabled: false, namespace_id: 5, public: true, issues_tracker: "gitlab", issues_tracker_id: nil, snippets_enabled: false, last_activity_at: "2013-10-18 08:49:22", imported: false, import_url: "">, :id=>"v_1_0@24788"}):
  app/views/projects/branches/_branch.html.haml:21:in `_app_views_projects_branches__branch_html_haml__473762803366803937_69933361931140'
  app/views/projects/branches/recent.html.haml:8:in `block in _app_views_projects_branches_recent_html_haml__1833156651968247551_69933359948360'
  app/views/projects/branches/recent.html.haml:7:in `each'
  app/views/projects/branches/recent.html.haml:7:in `_app_views_projects_branches_recent_html_haml__1833156651968247551_69933359948360'
```

Such branches are created by git-svn. See: http://stackoverflow.com/questions/11356901/git-svn-clone-spurious-branches

Spotted on 6-1-stable.
