### PR TITLE
Fix for LDAP auth failing when LDAP email has a leading space

### DIFF
--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -58,7 +58,7 @@ module Gitlab
         end
 
         def username
-          email.match(/^[^@]*/)[0]
+          email.match(/^[^@]*/)[0].strip
         end
 
         def provider


### PR DESCRIPTION
Easy fix: after getting the leading part from the email, use .strip() Fixes #1603 for me
