### PR TITLE
Refactor search_autocomplete_source

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,51 +98,6 @@ module ApplicationHelper
     grouped_options_for_select(options, @ref || @project.default_branch)
   end
 
-  def search_autocomplete_source
-    return unless current_user
-
-    projects = current_user.authorized_projects.map { |p| { label: "project: #{simple_sanitize(p.name_with_namespace)}", url: project_path(p) } }
-    groups = current_user.authorized_groups.map { |group| { label: "group: #{simple_sanitize(group.name)}", url: group_path(group) } }
-
-    default_nav = [
-      { label: "My Profile settings", url: profile_path },
-      { label: "My SSH Keys", url: profile_keys_path },
-      { label: "My Dashboard", url: root_path },
-      { label: "Admin Section", url: admin_root_path },
-    ]
-
-    help_nav = [
-      { label: "help: API Help", url: help_api_path },
-      { label: "help: Markdown Help", url: help_markdown_path },
-      { label: "help: Permissions Help", url: help_permissions_path },
-      { label: "help: Public Access Help", url: help_public_access_path },
-      { label: "help: Rake Tasks Help", url: help_raketasks_path },
-      { label: "help: SSH Keys Help", url: help_ssh_path },
-      { label: "help: System Hooks Help", url: help_system_hooks_path },
-      { label: "help: Web Hooks Help", url: help_web_hooks_path },
-      { label: "help: Workflow Help", url: help_workflow_path },
-    ]
-
-    project_nav = []
-    if @project && @project.repository.exists? && @project.repository.root_ref
-      project_nav = [
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Files",    url: project_tree_path(@project, @ref || @project.repository.root_ref) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Commits",  url: project_commits_path(@project, @ref || @project.repository.root_ref) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Network",  url: project_network_path(@project, @ref || @project.repository.root_ref) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Graph",    url: project_graph_path(@project, @ref || @project.repository.root_ref) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Issues",   url: project_issues_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Merge Requests", url: project_merge_requests_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Milestones", url: project_milestones_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Snippets", url: project_snippets_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Team",     url: project_team_index_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Wall",     url: project_wall_path(@project) },
-        { label: "#{simple_sanitize(@project.name_with_namespace)} - Wiki",     url: project_wikis_path(@project) },
-      ]
-    end
-
-    [groups, projects, default_nav, project_nav, help_nav].flatten.to_json
-  end
-
   def emoji_autocomplete_source
     # should be an array of strings
     # so to_s can be called, because it is sufficient and to_json is too slow

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -192,7 +192,7 @@ module ApplicationHelper
               alt: "Sign in with #{provider.to_s.titleize}")
   end
 
-  def simple_sanitize str
+  def simple_sanitize(str)
     sanitize(str, tags: %w(a span))
   end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,78 @@
+module SearchHelper
+  def search_autocomplete_source
+    return unless current_user
+
+    [
+      groups_autocomplete,
+      projects_autocomplete,
+      default_autocomplete,
+      project_autocomplete,
+      help_autocomplete
+    ].flatten.to_json
+  end
+
+  private
+
+  # Autocomplete results for various settings pages
+  def default_autocomplete
+    [
+      { label: "My Profile settings", url: profile_path },
+      { label: "My SSH Keys",         url: profile_keys_path },
+      { label: "My Dashboard",        url: root_path },
+      { label: "Admin Section",       url: admin_root_path },
+    ]
+  end
+
+  # Autocomplete results for internal help pages
+  def help_autocomplete
+    [
+      { label: "help: API Help",           url: help_api_path },
+      { label: "help: Markdown Help",      url: help_markdown_path },
+      { label: "help: Permissions Help",   url: help_permissions_path },
+      { label: "help: Public Access Help", url: help_public_access_path },
+      { label: "help: Rake Tasks Help",    url: help_raketasks_path },
+      { label: "help: SSH Keys Help",      url: help_ssh_path },
+      { label: "help: System Hooks Help",  url: help_system_hooks_path },
+      { label: "help: Web Hooks Help",     url: help_web_hooks_path },
+      { label: "help: Workflow Help",      url: help_workflow_path },
+    ]
+  end
+
+  # Autocomplete results for the current project, if it's defined
+  def project_autocomplete
+    if @project && @project.repository.exists? && @project.repository.root_ref
+      prefix = simple_sanitize(@project.name_with_namespace)
+      ref    = @ref || @project.repository.root_ref
+
+      [
+        { label: "#{prefix} - Files",          url: project_tree_path(@project, ref) },
+        { label: "#{prefix} - Commits",        url: project_commits_path(@project, ref) },
+        { label: "#{prefix} - Network",        url: project_network_path(@project, ref) },
+        { label: "#{prefix} - Graph",          url: project_graph_path(@project, ref) },
+        { label: "#{prefix} - Issues",         url: project_issues_path(@project) },
+        { label: "#{prefix} - Merge Requests", url: project_merge_requests_path(@project) },
+        { label: "#{prefix} - Milestones",     url: project_milestones_path(@project) },
+        { label: "#{prefix} - Snippets",       url: project_snippets_path(@project) },
+        { label: "#{prefix} - Team",           url: project_team_index_path(@project) },
+        { label: "#{prefix} - Wall",           url: project_wall_path(@project) },
+        { label: "#{prefix} - Wiki",           url: project_wikis_path(@project) },
+      ]
+    else
+      []
+    end
+  end
+
+  # Autocomplete results for the current user's groups
+  def groups_autocomplete
+    current_user.authorized_groups.map do |group|
+      { label: "group: #{simple_sanitize(group.name)}", url: group_path(group) }
+    end
+  end
+
+  # Autocomplete results for the current user's projects
+  def projects_autocomplete
+    current_user.authorized_projects.map do |p|
+      { label: "project: #{simple_sanitize(p.name_with_namespace)}", url: project_path(p) }
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -123,4 +123,21 @@ describe ApplicationHelper do
     end
   end
 
+  describe "simple_sanitize" do
+    let(:a_tag) { '<a href="#">Foo</a>' }
+
+    it "allows the a tag" do
+      simple_sanitize(a_tag).should == a_tag
+    end
+
+    it "allows the span tag" do
+      input = '<span class="foo">Bar</span>'
+      simple_sanitize(input).should == input
+    end
+
+    it "disallows other tags" do
+      input = "<strike><b>#{a_tag}</b></strike>"
+      simple_sanitize(input).should == a_tag
+    end
+  end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe SearchHelper do
+  # Override simple_sanitize for our testing purposes
+  def simple_sanitize(str)
+    str
+  end
+
+  describe 'search_autocomplete_source' do
+    context "with no current user" do
+      before { stub!(:current_user).and_return(nil) }
+
+      it "it returns nil" do
+        search_autocomplete_source.should be_nil
+      end
+    end
+
+    context "with a user" do
+      let(:user)   { create(:user) }
+      let(:result) { JSON.parse(search_autocomplete_source) }
+
+      before do
+        stub!(:current_user).and_return(user)
+      end
+
+      it "includes Help sections" do
+        result.select { |h| h['label'] =~ /^help:/ }.length.should == 9
+      end
+
+      it "includes default sections" do
+        result.count { |h| h['label'] =~ /^(My|Admin)\s/ }.should == 4
+      end
+
+      it "includes the user's groups" do
+        create(:group).add_owner(user)
+        result.count { |h| h['label'] =~ /^group:/ }.should == 1
+      end
+
+      it "includes the user's projects" do
+        create(:project, namespace: create(:namespace, owner: user))
+        result.count { |h| h['label'] =~ /^project:/ }.should == 1
+      end
+
+      context "with a current project" do
+        before { @project = create(:project_with_code) }
+
+        it "includes project-specific sections" do
+          result.count { |h| h['label'] =~ /^#{@project.name_with_namespace} - / }.should == 11
+        end
+
+        it "uses @ref in urls if defined" do
+          @ref = "foo_bar"
+          result.count { |h| h['url'] == project_tree_path(@project, @ref) }.should == 1
+        end
+      end
+
+      context "with no current project" do
+        it "does not include project-specific sections" do
+          result.count { |h| h['label'] =~ /Files$/ }.should == 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi guys, been a while!

Supposedly this method had the most complexity in the project, and it
didn't have test coverage, to boot. So I've tried to correct that. Also
reduces some duplication in what became `project_autocomplete`.

Also covers simple_sanitize which didn't have specs, since
search_autocomplete_source makes use of that method.
