### PR TITLE
Viewing IPython notebooks in GitLab

### DIFF
--- a/app/assets/stylesheets/generic/files.scss
+++ b/app/assets/stylesheets/generic/files.scss
@@ -64,6 +64,18 @@
       }
     }
 
+    &.ipython-notebook {
+      iframe {
+        width: 100%;
+        /* It is quite hard to choose a good height for the IFrame since we
+           cannot relate it to its contents (it's cross-domain/protocol). We
+           choose to have it very high, so we usually don't get nesting of
+           scrollbars (GitLab page and the IFrame). */
+        height: 16000px;
+        border: none;
+      }
+    }
+
     &.blob_file {
 
     }

--- a/app/views/projects/blob/_blob.html.haml
+++ b/app/views/projects/blob/_blob.html.haml
@@ -27,7 +27,9 @@
         = blob.name
         %small= number_to_human_size blob.size
       %span.options= render "actions"
-    - if blob.text?
+    - if Gitlab.config.ipython_notebook.render && ipython_notebook?(blob.name)
+      = render "ipython_notebook", blob: blob
+    - elsif blob.text?
       = render "text", blob: blob
     - elsif blob.image?
       = render "image", blob: blob

--- a/app/views/projects/blob/_ipython_notebook.html.haml
+++ b/app/views/projects/blob/_ipython_notebook.html.haml
@@ -1,0 +1,3 @@
+.file-content.ipython-notebook
+  - data = Base64.encode64(render_notebook(blob.data))
+  %iframe{src: "data:text/html;base64,#{ data }"}

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -222,6 +222,11 @@ production: &base
     #   ![Company Logo](http://www.companydomain.com/logo.png)
     #   [Learn more about CompanyName](http://www.companydomain.com/)
 
+  ## Settings for rendering IPython notebooks
+  ipython_notebook:
+    render: true
+    nbconvert: ipython nbconvert --to html --FilesWriter.build_directory=%{build_dir} %{notebook}
+
 development:
   <<: *base
 

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -140,6 +140,13 @@ Settings['satellites'] ||= Settingslogic.new({})
 Settings.satellites['path'] = File.expand_path(Settings.satellites['path'] || "tmp/repo_satellites/", Rails.root)
 
 #
+# IPython notebook
+#
+Settings['ipython_notebook'] ||= Settingslogic.new({})
+Settings.ipython_notebook['render']      = true if Settings.ipython_notebook['render'].nil?
+Settings.ipython_notebook['nbconvert'] ||= 'ipython nbconvert --to html --FilesWriter.build_directory=%{build_dir} %{notebook}'
+
+#
 # Extra customization
 #
 Settings['extra'] ||= Settingslogic.new({})


### PR DESCRIPTION
Dear GitLab maintainers,

With this pull request I intend to get some feedback on extending GitLab with live inline rendering of IPython Notebooks.
## Introduction and rationale

The [IPython Notebook](http://ipython.org/notebook.html) is a web-based interactive environment for editing documents containing both executable code and rich text. The platform is becoming increasingly popular in the scientific community amongst others.

These documents are serialized as JSON and can be converted to HTML, PDF, and other formats using the IPython nbconvert tool. Static HTML renderings can also be shared over the web using the [IPython Notebook Viewer](http://nbviewer.ipython.org/) and indeed this is quite popular for viewing notebooks stored in GitHub.

However, due to GitLab's focus being more on repositories with controlled access, it is not possible to use the IPython Notebook Viewer service with notebooks stored in GitLab. Even if it were possible, this would bring unwanted security issues since everything on the Notebook Viewer is public.
## Implementation

This pull request is an ad-hoc implementation of live inline rendering of notebooks in GitLab. Clicking a notebook file in the GitLab web interface will convert the notebook to HTML using the IPython nbconvert tool and include it in the GitLab blob view as a base64 encoded data URI for an IFrame. The obvious benefit here is that everything happens inside the GitLab access controlled view of the blob.

[You can find some more documentation on the patch here](https://gist.github.com/martijnvermaat/6926070/).

Since this is only a proof-of-concept, I can point out some obvious areas for improvement:
- Somehow cache the nbconvert results.
- Test (and presumably fix) files (in the same repository) linked from the notebook.
- Add unit tests.
## Request for feedback

I think this would be a great feature for IPython Notebook and GitLab users and it would give GitLab a clear advantage over GitHub for hosting IPython Notebook, especially in private repositories.

Are you interested in a feature like this? If so, let's discuss necessary improvements. If not, I'll try to keep my own branch up-to-date (and still welcome any feedback!).
