### PR TITLE
Use init.d/gitlab script from 6-0-stable branch

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -91,7 +91,7 @@ Note: We switched from Puma in GitLab 5.4 to unicorn in GitLab 6.0.
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/master/lib/support/init.d/gitlab
+sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/6-0-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 


### PR DESCRIPTION
Seems like init.d/gitlab script from master branch is not working anymore. Change to a version from 6-0-stable works fine.

It says:

```
Starting the GitLab Unicorn web server...
/etc/init.d/gitlab: 132: /etc/init.d/gitlab: script/web: not found
Starting the GitLab Sidekiq event dispatcher...
/etc/init.d/gitlab: 141: /etc/init.d/gitlab: script/background_jobs: not found
GitLab is not running.
```
