### PR TITLE
Allow merges from parents to children

### DIFF
--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -157,7 +157,13 @@ class Projects::MergeRequestsController < Projects::ApplicationController
   protected
 
   def selected_target_project
-    ((@project.id.to_s == params[:target_project_id]) || @project.forked_project_link.nil?) ? @project : @project.forked_project_link.forked_from_project
+    if @project.id.to_s == params[:target_project_id]
+      @project
+    elsif @project.forked_from_project && @project.forked_from_project.id.to_s == params[:target_project_id]
+      @project.forked_from_project
+    else
+      Project.forked_to(@project).find {|proj|proj.id.to_s == params[:target_project_id]}
+    end
   end
 
   def merge_request

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -118,6 +118,7 @@ class Project < ActiveRecord::Base
   scope :public_or_internal_only, ->(user) { where("visibility_level IN (:levels)", levels: user ? [ INTERNAL, PUBLIC ] : [ PUBLIC ]) }
 
   scope :non_archived, -> { where(archived: false) }
+  scope :forked_to, ->(project) { joins(:forked_project_link).where("forked_project_links.forked_from_project_id = ?", project.id)}
 
   enumerize :issues_tracker, in: (Gitlab.config.issues_tracker.keys).append(:gitlab), default: :gitlab
 
@@ -411,6 +412,18 @@ class Project < ActiveRecord::Base
 
   def forked?
     !(forked_project_link.nil? || forked_project_link.forked_from_project.nil?)
+  end
+
+  def forked_to?
+    !(Project.forked_to(self)).empty?
+  end
+
+  def mergeable_to
+    projects = []
+    projects << self
+    projects << forked_from_project if forked?
+    projects = projects + Project.forked_to(self) if forked_to?
+    projects
   end
 
   def personal?

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -21,8 +21,7 @@
       .span5
         .clearfix
           .pull-left
-            - projects =  @project.forked_from_project.nil? ? [@project] : [ @project,@project.forked_from_project]
-            = f.select(:target_project_id, options_from_collection_for_select(projects, 'id', 'path_with_namespace'), {}, { class: 'target_project chosen span3', disabled: @merge_request.persisted? })
+            = f.select(:target_project_id, options_from_collection_for_select(projects.mergable_to, 'id', 'path_with_namespace'), {}, { class: 'target_project chosen span3', disabled: @merge_request.persisted? })
           .pull-left
             &nbsp;
             = f.select(:target_branch, @target_branches, { include_blank: "Select branch" }, {class: 'target_branch chosen span2'})

--- a/features/project/forked_merge_requests.feature
+++ b/features/project/forked_merge_requests.feature
@@ -32,3 +32,10 @@ Feature: Project Forked Merge Requests
     And I fill out an invalid "Merge Request On Forked Project" merge request
     And I submit the merge request
     Then I should see validation errors
+
+  @javascript
+  Scenario: I submit new unassigned merge request to a to forked project
+    Given I click "New Merge Request" button from "Shop" merge requests page
+    And I fill out a "Merge Request To Forked Project" merge request
+    And I submit the merge request
+    Then I should see merge request "Merge Request To Forked Project"


### PR DESCRIPTION
Discovered you could do this in github cause one of our people were apparently using it all the time... Turned out to not be too terribly difficult

Conflicts:
    app/views/projects/merge_requests/_form.html.haml
    features/project/forked_merge_requests.feature
