### PR TITLE
Remove text-shadow from code blocks for all themes

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -129,6 +129,10 @@ p.time {
   }
 }
 
+.highlight {
+  text-shadow: none;
+}
+
 .highlight_word {
   border-bottom: 2px solid #F90;
 }


### PR DESCRIPTION
Several gitlab themes make use of text-shadow's throughout, and that's okay. But unfortunately in some cases, such as code embedded in an issue, the text-shadow gets inherited by the syntax highlight code block. This creates an undesirable effect where code blocks look fuzzy and lose clarity.

I have added a catch-all rule to common.scss that will ensure that themes can use text-shadows without causing blurry code.
