### PR TITLE
When looking up a user by DN, use single scope

### DIFF
--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -78,7 +78,7 @@ module Gitlab
         # * when ldap account was deactivated by change of OU membership in 'dn'
         def blocked?(dn)
           ldap = OmniAuth::LDAP::Adaptor.new(ldap_conf)
-          ldap.connection.search(base: dn, size: 1).blank?
+          ldap.connection.search(base: dn, scope: Net::LDAP::SearchScope_BaseObject, size: 1).blank?
         end
 
         private


### PR DESCRIPTION
The blocked? method is used to check whether a user exists in LDAP.
Prior to this change, if the LDAP server had more objects below the
one pointed to by the DN, those objects would also be picked up by the
search, causing the method to determine the user should be blocked.

One case where this can happen is when using Active Directory and a
user have a mobile phone assigned. In this case, Exchange will add an
entry called ExchangeActiveSyncDevices under the users entry. The
user-visible behaviour is then that a user loses Gitlab access when he
enables a mobile device.

This fix sets the search scope to BaseObject in order to ensure that
only the user itself is returned when looking up the user.
