### PR TITLE
Fix typo in sample smtp settings

### DIFF
--- a/config/initializers/smtp_settings.rb.sample
+++ b/config/initializers/smtp_settings.rb.sample
@@ -3,7 +3,7 @@
 # 2. Edit settings inside this file
 # 3. Restart GitLab instance
 #
-if Rails.env.production? do
+if Rails.env.production?
   Gitlab::Application.config.action_mailer.delivery_method = :smtp
 
   ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
Default smtp config file had a typo, causing unicorn to fail on startup
Here is a correction.
