### PR TITLE
set maximum filesize for avatar on profile page correct

### DIFF
--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -63,7 +63,7 @@
             &nbsp;
             %span.file_name.js-avatar-filename File name...
             = f.file_field :avatar, class: "js-user-avatar-input hide"
-          %span.help-block The maximum file size allowed is 200KB.
+          %span.help-block The maximum file size allowed is 100KB.
 
   .form-actions
     = f.submit 'Save changes', class: "btn btn-save"


### PR DESCRIPTION
on the profile edit page the maximum file size for the avatar is incorrect.
I have changed this to 100KB.
