### PR TITLE
fixed maximum avatar size in changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,7 @@ v 6.2.0
   - Extended User API to expose admin and can_create_group for user creation/updating (Boyan Tabakov)
   - API: Remove group
   - API: Remove project
-  - Avatar upload on profile page with a maximum of 200KB (Steven Thonus)
+  - Avatar upload on profile page with a maximum of 100KB (Steven Thonus)
   - Store the sessions in Redis instead of the cookie store
   - Fixed relative links in markdown
   - User must confirm his email if signup enabled


### PR DESCRIPTION
the file size of 200kb was still in the changelog file...
