### PR TITLE
Non-logic wording and grammar for the new group view

### DIFF
--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -16,11 +16,11 @@
   .control-group
     .controls
       %ul
-        %li Group is kind of directory for several projects
-        %li All created groups are private
-        %li People within a group see only projects they have access to
-        %li All projects of group will be stored in a group directory
-        %li You will be able to move existing projects into group
+        %li A group is a collection of several projects
+        %li Groups are private by default
+        %li Members of a group may only view projects they have permission to access
+        %li Group project URLs are prefixed with the group namespace
+        %li Existing projects may be moved into a group
 
   .form-actions
     = f.submit 'Create group', class: "btn btn-create"


### PR DESCRIPTION
Just some minor grammar fixes. I'm not sure about the wording on "Group project URLs are prefixed with the group namespace", but it's probably close enough. Is the word "namespace" correct?
