### PR TITLE
Fix for issue #5431

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -47,6 +47,7 @@ class Admin::UsersController < Admin::ApplicationController
     @user = User.build_user(params[:user].merge(opts), as: :admin)
     @user.admin = (admin && admin.to_i > 0)
     @user.created_by_id = current_user.id
+    @user.generate_password
     @user.confirm!
 
     respond_to do |format|


### PR DESCRIPTION
See for reference: https://github.com/plataformatec/devise/blob/master/lib/devise/models/confirmable.rb

Lines 70-79 - the validation step is skipped under certain circumstances. And `:generate_password` is called as `before_validation` handler.
