### PR TITLE
Change the blocked? method to search specifically for a 'user' object class

### DIFF
--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -78,7 +78,8 @@ module Gitlab
         # * when ldap account was deactivated by change of OU membership in 'dn'
         def blocked?(dn)
           ldap = OmniAuth::LDAP::Adaptor.new(ldap_conf)
-          ldap.connection.search(base: dn, size: 1).blank?
+          filter = Net::LDAP::Filter.eq("objectclass", "user")
+          ldap.connection.search(base: dn, filter: filter, size: 1).blank?
         end
 
         private


### PR DESCRIPTION
Some users on our system have multiple results returned for a search on their DN which causes the method to erroneously indicate that they are blocked. The change limits the search to the 'user' object class which fixes this issue.
