### PR TITLE
Reset buttons/links on the reset password page

### DIFF
--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -7,5 +7,8 @@
   %div
     = f.password_field :password_confirmation, class: "text bottom", placeholder: "Confirm new password"
   %div
+  .clearfix.append-bottom-10
     = f.submit "Change my password", class: "btn btn-primary"
-    .pull-right= render partial: "devise/shared/links"
+    = link_to "Sign in", new_session_path(resource_name), class: "btn pull-right"
+  %div
+    = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)


### PR DESCRIPTION
The problem was that the button / link were not shown in the right place.
This will fix issue: #5418.

Result before change:
![reset-password-old](https://f.cloud.github.com/assets/1096124/1389170/10db3066-3bd0-11e3-97aa-13459be551da.png)

Result after change:
![reset-password-new](https://f.cloud.github.com/assets/1935984/1415293/326db602-3ef2-11e3-9cd8-af3da9c04a68.png)
