### PR TITLE
Read configuration variable file (/etc/default/gitlab) if it is present

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -31,6 +31,8 @@ sidekiq_pid_path="$pid_path/sidekiq.pid"
 
 ### Here ends user configuration ###
 
+# Read configuration variable file if it is present
+test -f /etc/default/gitlab && . /etc/default/gitlab
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then


### PR DESCRIPTION
It is standard de-facto that init.d script reads optionally /etc/default/$NAME file which overrides some variables from init.d script.

Please add this feature to your example init.d script.
