### PR TITLE
Respect the configured redis URL when initializing the session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,6 +2,7 @@
 
 Gitlab::Application.config.session_store(
   :redis_store, # Using the cookie_store would enable session replay attacks.
+  servers: Gitlab::Application.config.cache_store.last, # re-use the Redis config from the Rails cache store
   key: '_gitlab_session',
   secure: Gitlab::Application.config.force_ssl,
   httponly: true,


### PR DESCRIPTION
It was not possible to start Gitlab with a redis server running on another host or port. Every other subsystem that uses redis respects the settings in config/resque.yml.

This patch uses the configured url if present and falls back to localhost:6379

Compare this code to the relevant lines in config/environments/production.rb
