### PR TITLE
Fix Markdown help page: escape file link syntax example to leave it unprocessed

### DIFF
--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -187,7 +187,7 @@ GFM will recognize the following:
 * !123 : for merge requests
 * $123 : for snippets
 * 1234567 : for commits
-* [file](path/to/file) : for file references
+* \[file\](path/to/file) : for file references
 
 <a name="standard"/>
 


### PR DESCRIPTION
Here is how it looks now (before patching):

![2013-10-30 12:26:47](https://f.cloud.github.com/assets/370680/1436054/f5bffa90-414d-11e3-87ab-6b2773a7dd5a.png)
