### PR TITLE
Check if a file is editied "on" a branch or a commit.

### DIFF
--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -45,5 +45,9 @@ class Projects::EditTreeController < Projects::ApplicationController
               end
 
     return access_denied! unless allowed
+
+    unless @repository.branch_names.include?(@ref)
+      redirect_to project_blob_path(@project, @id), notice: "You can only edit this file if you are on top of a branch"
+    end
   end
 end

--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -1,7 +1,10 @@
 .btn-group.tree-btn-group
   -# only show edit link for text files
   - if @blob.text?
-    = link_to "edit", project_edit_tree_path(@project, @id), class: "btn btn-small", disabled: !allowed_tree_edit?
+    - if allowed_tree_edit?
+      = link_to "edit", project_edit_tree_path(@project, @id), class: "btn btn-small"
+    - else
+      %span.btn.btn-small.disabled Edit
   = link_to "raw", project_raw_path(@project, @id), class: "btn btn-small", target: "_blank"
   -# only show normal/blame view links for text files
   - if @blob.text?


### PR DESCRIPTION
The previous behavior was a "disabled" link, which was still clickable and linked to the edit file action.

If the user accesses a path like "/edit/master/README" show the file edit form (just like before).

If the user accesses a path like "/edit/8d5c1f375ce99e5df84e26b0eafbf1448c6a001e/README", redirect the user to the file detail page with a note, that he cannot edit a file "on" a commit.

fixes #5482
