### PR TITLE
Change documentation about sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Start it with [Foreman](https://github.com/ddollar/foreman)
 or start each component separately
 
     bundle exec rails s
-    bundle exec rake sidekiq:start
+    script/background_jobs start
 
 ### Run the tests
 

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -648,7 +648,7 @@ namespace :gitlab do
       else
         puts "no".red
         try_fixing_it(
-          sudo_gitlab("bundle exec rake sidekiq:start RAILS_ENV=production")
+          sudo_gitlab("RAILS_ENV=production script/background_jobs start")
         )
         for_more_information(
           see_installation_guide_section("Install Init Script"),


### PR DESCRIPTION
This pull request fix the gitlab:check message when sidekiq is not running(this was mentioned in #5426). Also the development mode in the readme was talking about sidekiq:start.
