### PR TITLE
PostgreSQL bundle issue on clean Debian 7

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -271,6 +271,7 @@ Make sure to edit both `gitlab.yml` and `unicorn.rb` to match your setup.
     sudo -u git -H bundle install --deployment --without development test postgres aws
 
     # Or for PostgreSQL (note, the option says "without ... mysql")
+    sudo apt-get install libpq-dev
     sudo -u git -H bundle install --deployment --without development test mysql aws
 
 


### PR DESCRIPTION
Resolves issue during bundle install:

```
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /usr/local/bin/ruby extconf.rb
checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/ruby
        --with-pg
        --without-pg
        --with-pg-dir
        --without-pg-dir
        --with-pg-include
        --without-pg-include=${pg-dir}/include
        --with-pg-lib
        --without-pg-lib=${pg-dir}/
        --with-pg-config
        --without-pg-config
        --with-pg_config
        --without-pg_config


Gem files will remain installed in /home/git/gitlab/vendor/bundle/ruby/2.0.0/gems/pg-0.15.1 for inspection.
Results logged to /home/git/gitlab/vendor/bundle/ruby/2.0.0/gems/pg-0.15.1/ext/gem_make.out
An error occurred while installing pg (0.15.1), and Bundler cannot continue.
Make sure that `gem install pg -v '0.15.1'` succeeds before bundling.
```

I felt that this was the most appropriate place for the package change since it is PostgreSQL specific.
