### PR TITLE
Added support for disabling standard login

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
-v 6.3.0
+﻿v 6.3.0
   - API for adding gitlab-ci service
   - Init script now waits for pids to appear after (re)starting before reporting status (Rovanion Luckey)
   - Restyle project home page
   - Grammar fixes
   - Show branches list (which branches contains commit) on commit page (Andrew Kumanyaev)
+  - Added support for disabling standard login (Only enabled authorization methods are displayed on the sign in page) (Andrew Walton)
 
 v 6.2.0
   - Public project pages are now visible to everyone (files, issues, wik, etc.)

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,22 +1,29 @@
 .login-box
   %h3.page-title Sign in
-  - if ldap_enabled?
-    %ul.nav.nav-tabs
-      %li.active
-        = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
-      %li
-        = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
-    .tab-content
-      %div#tab-ldap.tab-pane.active
-        = render partial: 'devise/sessions/new_ldap'
-      %div#tab-signin.tab-pane
-        = render partial: 'devise/sessions/new_base'
+  - if ldap_enabled? or Gitlab.config.standard.enabled or Gitlab.config.omniauth.enabled
+    - if ldap_enabled? and Gitlab.config.standard.enabled
+      %ul.nav.nav-tabs
+        %li.active
+          = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
+        %li
+          = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
+      .tab-content
+        %div#tab-ldap.tab-pane.active
+          = render partial: 'devise/sessions/new_ldap'
+        %div#tab-signin.tab-pane
+          = render partial: 'devise/sessions/new_base'
+
+    - elsif ldap_enabled?
+      = render partial: 'devise/sessions/new_ldap'
+
+    - elsif Gitlab.config.standard.enabled
+      = render partial: 'devise/sessions/new_base'
+
+    = render 'devise/sessions/oauth_providers' if devise_mapping.omniauthable?
 
   - else
-    = render partial: 'devise/sessions/new_base'
-
-
-  = render 'devise/sessions/oauth_providers' if devise_mapping.omniauthable?
+    %div
+      No authentication methods configured.
 
   - if gitlab_config.signup_enabled
     %hr

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -109,6 +109,10 @@ production: &base
   # 2. Auth settings
   # ==========================
 
+  # Standard settings
+  standard:
+    enabled: true
+
   ## LDAP settings
   ldap:
     enabled: false

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -35,6 +35,9 @@ end
 
 
 # Default settings
+Settings['standard'] ||= Settingslogic.new({})
+Settings.standard['enabled'] = true if Settings.standard['enabled'].nil?
+
 Settings['ldap'] ||= Settingslogic.new({})
 Settings.ldap['enabled'] = false if Settings.ldap['enabled'].nil?
 Settings.ldap['allow_username_or_email_login'] = false if Settings.ldap['allow_username_or_email_login'].nil?


### PR DESCRIPTION
Only enabled authorization methods are displayed on the sign in page. If no authentication methods are enabled, an appropriate message is shown.

This pull request is in reference to a feature request that was for only allowing login via LDAP. The feature request can be found here: http://feedback.gitlab.com/forums/176466-general/suggestions/3788023-only-allow-login-via-ldap.

The original issue that brought this up is issue #605. It has since been closed due to being moved to a feature request.

Screenshots of each possible scenario are attached.
![ldap_and_standard](https://f.cloud.github.com/assets/2180127/1442797/6830bf9e-41c9-11e3-8165-e78ff54fe9e7.png)
![ldap_omniauth](https://f.cloud.github.com/assets/2180127/1442798/683cac8c-41c9-11e3-98c8-a8945bc93009.png)
![ldap_only](https://f.cloud.github.com/assets/2180127/1442799/683db758-41c9-11e3-8adc-2a04867756c5.png)
![ldap_standard_omniauth](https://f.cloud.github.com/assets/2180127/1442800/683e25d0-41c9-11e3-8eb8-b6b38e126fd4.png)
![no_auth_methods](https://f.cloud.github.com/assets/2180127/1442801/684022b8-41c9-11e3-8966-8cd112aa03ee.png)
![omniauth_only](https://f.cloud.github.com/assets/2180127/1442802/68423940-41c9-11e3-9a25-8502c88a2257.png)
![standard_omniauth](https://f.cloud.github.com/assets/2180127/1442803/6846a674-41c9-11e3-8d25-68a6a460d0b2.png)
![standard_only](https://f.cloud.github.com/assets/2180127/1442804/6846ea62-41c9-11e3-8158-940076b52870.png)
