### PR TITLE
Preselect the current issue tracker with selected="selected"

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -80,7 +80,7 @@ module ProjectsHelper
     @project.milestones.active.order("due_date, title ASC").all
   end
 
-  def project_issues_trackers
+  def project_issues_trackers(current_tracker = nil)
     values = Project.issues_tracker.values.map do |tracker_key|
       if tracker_key.to_sym == :gitlab
         ['GitLab', tracker_key]
@@ -89,7 +89,7 @@ module ProjectsHelper
       end
     end
 
-    options_for_select(values)
+    options_for_select(values, current_tracker)
   end
 
   private

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -67,7 +67,7 @@
             - if Project.issues_tracker.values.count > 1
               .control-group
                 = f.label :issues_tracker, "Issues tracker", class: 'control-label'
-                .controls= f.select(:issues_tracker, project_issues_trackers, {}, { disabled: !@project.issues_enabled })
+                .controls= f.select(:issues_tracker, project_issues_trackers(@project.issues_tracker), {}, { disabled: !@project.issues_enabled })
 
               .control-group
                 = f.label :issues_tracker_id, "Project name or id in issues tracker", class: 'control-label'

--- a/features/project/edit_issuetracker.feature
+++ b/features/project/edit_issuetracker.feature
@@ -1,0 +1,18 @@
+Feature: Project Issue Tracker
+  Background:
+    Given I sign in as a user
+    And I own project "Shop"
+    And project "Shop" has issues enabled
+    And I visit project "Shop" page
+
+  Scenario: I set the issue tracker to "GitLab"
+    When I visit edit project "Shop" page
+    And change the issue tracker to "GitLab"
+    And I save project
+    Then I the project should have "GitLab" as issue tracker
+
+  Scenario: I set the issue tracker to "Redmine"
+    When I visit edit project "Shop" page
+    And change the issue tracker to "Redmine"
+    And I save project
+    Then I the project should have "Redmine" as issue tracker

--- a/features/steps/project/project_issue_tracker.rb
+++ b/features/steps/project/project_issue_tracker.rb
@@ -1,0 +1,31 @@
+class ProjectIssueTracker < Spinach::FeatureSteps
+  include SharedAuthentication
+  include SharedProject
+  include SharedPaths
+
+  step 'project "Shop" has issues enabled' do
+    @project = Project.find_by_name "Shop"
+    @project ||= create(:project_with_code, name: "Shop", namespace: @user.namespace)
+    @project.issues_enabled = true
+  end
+
+  step 'change the issue tracker to "GitLab"' do
+    select 'GitLab', from: 'project_issues_tracker'
+  end
+
+  step 'I the project should have "GitLab" as issue tracker' do
+    find_field('project_issues_tracker').value.should == 'gitlab'
+  end
+
+  step 'change the issue tracker to "Redmine"' do
+    select 'Redmine', from: 'project_issues_tracker'
+  end
+
+  step 'I the project should have "Redmine" as issue tracker' do
+    find_field('project_issues_tracker').value.should == 'redmine'
+  end
+
+  And 'I save project' do
+    click_button 'Save changes'
+  end
+end

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -7,5 +7,17 @@ describe ProjectsHelper do
           "<option value=\"redmine\">Redmine</option>\n" \
           "<option value=\"gitlab\">GitLab</option>"
     end
+
+    it "returns the correct issues trackers available with current tracker 'gitlab' selected" do
+      project_issues_trackers('gitlab').should ==
+          "<option value=\"redmine\">Redmine</option>\n" \
+          "<option value=\"gitlab\" selected=\"selected\">GitLab</option>"
+    end
+
+    it "returns the correct issues trackers available with current tracker 'redmine' selected" do
+      project_issues_trackers('redmine').should ==
+          "<option value=\"redmine\" selected=\"selected\">Redmine</option>\n" \
+          "<option value=\"gitlab\">GitLab</option>"
+    end
   end
 end


### PR DESCRIPTION
The previous behavior was, that the first element of the select was preselected, thus upon saving the project, the previous selected could be overwritten.

before:
![issue_tracker](https://f.cloud.github.com/assets/327488/1454178/73288864-4304-11e3-8424-45f88c65e9ed.gif)

after:
![issue_tracker_new](https://f.cloud.github.com/assets/327488/1454180/7a3d9130-4304-11e3-8fe9-be238747aaea.gif)
