### PR TITLE
add rake gitlab:import: all_users_to_all_groups and user_to_groups

### DIFF
--- a/doc/raketasks/user_management.md
+++ b/doc/raketasks/user_management.md
@@ -14,3 +14,19 @@ Notes:
 ```
 bundle exec rake gitlab:import:all_users_to_all_projects
 ```
+
+### Add user as a developer to all projects
+
+```
+bundle exec rake gitlab:import:user_to_groups[username@domain.tld]
+```
+
+### Add all users to all groups
+
+Notes:
+
+* admin users are added as owners so they can add additional users to the group
+
+```
+bundle exec rake gitlab:import:all_users_to_all_groups
+```

--- a/lib/tasks/gitlab/bulk_add_permission.rake
+++ b/lib/tasks/gitlab/bulk_add_permission.rake
@@ -20,5 +20,29 @@ namespace :gitlab do
       puts "Importing #{user.email} users into #{project_ids.size} projects"
       UsersProject.add_users_into_projects(project_ids, Array.wrap(user.id), UsersProject::DEVELOPER)
     end
+
+    desc "GITLAB | Add all users to all groups (admin users are added as owners)"
+    task all_users_to_all_groups: :environment  do |t, args|
+      user_ids = User.where(admin: false).pluck(:id)
+      admin_ids = User.where(admin: true).pluck(:id)
+      groups = Group.all
+
+      puts "Importing #{user_ids.size} users into #{groups.size} groups"
+      puts "Importing #{admin_ids.size} admins into #{groups.size} groups"
+      groups.each do |group|
+        group.add_users(user_ids, UsersGroup::DEVELOPER)
+        group.add_users(admin_ids, UsersGroup::OWNER)
+      end
+    end
+
+    desc "GITLAB | Add a specific user to all groups (as a developer)"
+    task :user_to_groups, [:email] => :environment  do |t, args|
+      user = User.find_by_email args.email
+      groups = Group.all
+      puts "Importing #{user.email} users into #{groups.size} groups"
+      groups.each do |group|
+        group.add_users(Array.wrap(user.id), UsersGroup::DEVELOPER)
+      end
+    end
   end
 end


### PR DESCRIPTION
I opted for admins to be added as "owners" instead of "masters" because project masters can managers members, but only group owners can manage members.
