### PR TITLE
Fix name of RHEL

### DIFF
--- a/doc/install/requirements.md
+++ b/doc/install/requirements.md
@@ -15,7 +15,7 @@ It should also work on (though they are not officially supported):
 - CentOS
 - Fedora
 - Gentoo
-- RedHat
+- RHEL
 
 ## Other Unix Systems
 


### PR DESCRIPTION
The company is called Red Hat, and its flagship product is Red Hat Enterprise Linux (commonly abbreviated as RHEL). There is no such thing as RedHat (and never was).
