### PR TITLE
Add missing configurations and examples for a staging server deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,6 +209,6 @@ group :test do
   gem 'test_after_commit'
 end
 
-group :production do
+group :production, :staging do
   gem "gitlab_meta", '6.0'
 end

--- a/app/views/admin/logs/show.html.haml
+++ b/app/views/admin/logs/show.html.haml
@@ -4,7 +4,14 @@
   %li
     = link_to "application.log", "#application", 'data-toggle' => 'tab'
   %li
-    = link_to "production.log", "#production", 'data-toggle' => 'tab'
+    - if Rails.env.production? then
+      = link_to "production.log", "#production", 'data-toggle' => 'tab'
+    - elsif Rails.env.staging? then
+      = link_to "staging.log", "#staging", 'data-toggle' => 'tab'
+    - elsif Rails.env.development? then
+      = link_to "development.log", "#development", 'data-toggle' => 'tab'
+    - elsif Rails.env.test? then
+      = link_to "test.log", "#test", 'data-toggle' => 'tab'
   %li
     = link_to "sidekiq.log", "#sidekiq", 'data-toggle' => 'tab'
 
@@ -50,6 +57,48 @@
       .file-content.logs
         %ol
           - Gitlab::Logger.read_latest_for('production.log').each do |line|
+            %li
+              %p= line
+  .tab-pane#staging
+    .file-holder#README
+      .file-title
+        %i.icon-file
+        staging.log
+        .pull-right
+          = link_to '#', class: 'log-bottom' do
+            %i.icon-arrow-down
+            Scroll down
+      .file-content.logs
+        %ol
+          - Gitlab::Logger.read_latest_for('staging.log').each do |line|
+            %li
+              %p= line
+  .tab-pane#development
+    .file-holder#README
+      .file-title
+        %i.icon-file
+        development.log
+        .pull-right
+          = link_to '#', class: 'log-bottom' do
+            %i.icon-arrow-down
+            Scroll down
+      .file-content.logs
+        %ol
+          - Gitlab::Logger.read_latest_for('development.log').each do |line|
+            %li
+              %p= line
+  .tab-pane#test
+    .file-holder#README
+      .file-title
+        %i.icon-file
+        test.log
+        .pull-right
+          = link_to '#', class: 'log-bottom' do
+            %i.icon-arrow-down
+            Scroll down
+      .file-content.logs
+        %ol
+          - Gitlab::Logger.read_latest_for('test.log').each do |line|
             %li
               %p= line
   .tab-pane#sidekiq

--- a/config/aws.yml.example
+++ b/config/aws.yml.example
@@ -6,6 +6,12 @@ production:
   bucket: mygitlab.production.us
   region: us-east-1
 
+staging:
+  access_key_id: AKIA1111111111111UA
+  secret_access_key: secret
+  bucket: mygitlab.staging.us
+  region: us-east-1
+
 development:
   access_key_id: AKIA1111111111111UA
   secret_access_key: secret

--- a/config/database.yml.mysql
+++ b/config/database.yml.mysql
@@ -13,6 +13,20 @@ production:
   # socket: /tmp/mysql.sock
 
 #
+# Staging
+#
+staging:
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: gitlabhq_staging
+  pool: 5
+  username: gitlab
+  password: "secure password"
+  # host: localhost
+  # socket: /tmp/mysql.sock
+
+#
 # Development specific
 #
 development:

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,83 @@
+Gitlab::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # Code is not reloaded between requests
+  config.cache_classes = true
+
+  # Full error reports are disabled and caching is turned on
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Disable Rails's static asset server (Apache or nginx will already do this)
+  config.serve_static_assets = false
+
+  # Compress JavaScripts and CSS
+  config.assets.compress = true
+
+  # Don't fallback to assets pipeline if a precompiled asset is missed
+  config.assets.compile = true
+
+  # Generate digests for assets URLs
+  config.assets.digest = true
+
+  # Defaults to nil and saved in location specified by config.assets.prefix
+  # config.assets.manifest = YOUR_PATH
+
+  # Specifies the header that your server uses for sending files
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # See everything in the log (default is :info)
+  # config.log_level = :debug
+
+  # Prepend all log lines with the following tags
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production
+  config_file = Rails.root.join('config', 'resque.yml')
+
+  resque_url = if File.exists?(config_file)
+                 YAML.load_file(config_file)[Rails.env]
+               else
+                 "redis://localhost:6379"
+               end
+  config.cache_store = :redis_store, resque_url
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+  # config.assets.precompile += %w( search.js )
+
+  # Disable delivery errors, bad email addresses will be ignored
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable threaded mode
+  # config.threadsafe! unless $rails_rake_task
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners
+  config.active_support.deprecation = :notify
+
+  # Log the query plan for queries taking more than this (works
+  # with SQLite, MySQL, and PostgreSQL)
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.action_mailer.delivery_method = :sendmail
+  # Defaults to:
+  # # config.action_mailer.sendmail_settings = {
+  # #   location: '/usr/sbin/sendmail',
+  # #   arguments: '-i -t'
+  # # }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+end

--- a/config/resque.yml.example
+++ b/config/resque.yml.example
@@ -1,3 +1,4 @@
 development: redis://localhost:6379
+staging: redis://localhost:6379
 test: redis://localhost:6379
 production: redis://redis.example.com:6379

--- a/db/fixtures/staging/001_admin.rb
+++ b/db/fixtures/staging/001_admin.rb
@@ -1,0 +1,22 @@
+admin = User.create(
+  email: admin@local.host,
+  name: Administrator,
+  username: 'root',
+  password_expires_at: Time.now,
+  theme_id: Gitlab::Theme::MARS
+
+)
+
+admin.projects_limit = 10000
+admin.admin = true
+admin.save!
+admin.confirm!
+
+if admin.valid?
+puts %q[
+Administrator account created:
+
+login.........admin@local.host
+]
+end
+


### PR DESCRIPTION
1. A staging environment config was added (currently just a copy of the production environment, but this can be used as a starting point for staging configurations).
2. Add the default `admin@local.host` account to the staging database.
3. Show the appropriate log file (e.g. staging.log for staging, production.log for production, etc) in the Admin Log Viewer page.
4. Adjust example config files as necessary with a staging config.
