### PR TITLE
Improve status message on merge request page

### DIFF
--- a/app/views/projects/merge_requests/show/_mr_box.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_box.html.haml
@@ -13,13 +13,14 @@
   .ui-box-body
     %div
       %cite.cgray
-        Created on #{@merge_request.created_at.stamp("Aug 21, 2011")} by #{link_to_member(@project, @merge_request.author)}
+        Created on #{@merge_request.created_at.stamp("Aug 21, 2011")} by #{link_to_member(@project, @merge_request.author)}.
         - if @merge_request.assignee
-          \, currently assigned to #{link_to_member(@project, @merge_request.assignee)}
+          Currently assigned to #{link_to_member(@project, @merge_request.assignee)}.
       - if @merge_request.milestone
         - milestone = @merge_request.milestone
-        %cite.cgray and attached to milestone
+        %cite.cgray Attached to milestone
         %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
+        \.
 
 
   - if @merge_request.description.present?


### PR DESCRIPTION
The status message currently looks like:

  Created on Oct 24, 2013 by John , currently assigned to Bob

There is a space between the author name and the comma, which is
incorrect.  Also, there is no period at the end of the sentence,
which makes it inconsistent with the following line:

  Merged by Bob 5 minutes ago.

Change it to:

  Created on Oct 24, 2013 by John.  Currently assigned to Bob.

Also change the milestone information from:

  and attached to milestone XYZ

to:

  Attached to milestone XYZ.
