### PR TITLE
Include public projects in project listings.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -37,6 +37,8 @@ class DashboardController < ApplicationController
                   current_user.authorized_projects.joined(current_user)
                 when 'owned' then
                   current_user.owned_projects
+                when 'all' then
+                  current_user.all_projects
                 else
                   current_user.authorized_projects
                 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -91,7 +91,7 @@ class GroupsController < ApplicationController
   end
 
   def projects
-    @projects ||= current_user.authorized_projects.where(namespace_id: group.id).sorted_by_activity
+    @projects ||= current_user.all_projects.where(namespace_id: group.id).sorted_by_activity
   end
 
   def project_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,6 +258,14 @@ class User < ActiveRecord::Base
                            end
   end
 
+  # Groups user has access to (including public)
+  def all_groups
+    @all_groups ||= begin
+                      group_ids = (groups.pluck(:id) + all_projects.pluck(:namespace_id))
+                      Group.where(id: group_ids).order('namespaces.name ASC')
+                    end
+  end
+
 
   # Projects user has access to
   def authorized_projects
@@ -265,6 +273,14 @@ class User < ActiveRecord::Base
                                project_ids = (personal_projects.pluck(:id) + groups_projects.pluck(:id) + projects.pluck(:id)).uniq
                                Project.where(id: project_ids).joins(:namespace).order('namespaces.name ASC')
                              end
+  end
+
+  # Projects user has access to (including public)
+  def all_projects
+    @all_projects ||= begin
+                        project_ids = (personal_projects.pluck(:id) + groups_projects.pluck(:id) + projects.pluck(:id) + Project.public_only.pluck(:id)).uniq
+                        Project.where(id: project_ids).joins(:namespace).order('namespaces.name ASC')
+                      end
   end
 
   def owned_projects

--- a/app/views/dashboard/_projects_filter.html.haml
+++ b/app/views/dashboard/_projects_filter.html.haml
@@ -1,8 +1,13 @@
 %fieldset
   %ul.nav.nav-pills.nav-stacked
+    = nav_tab :scope, 'all' do
+      = link_to projects_dashboard_filter_path(scope: 'all') do
+        All
+        %span.pull-right
+          = current_user.all_projects.count
     = nav_tab :scope, nil do
       = link_to projects_dashboard_filter_path(scope: nil) do
-        All
+        Authorized
         %span.pull-right
           = current_user.authorized_projects.count
     = nav_tab :scope, 'personal' do

--- a/app/views/dashboard/_zero_authorized_projects.html.haml
+++ b/app/views/dashboard/_zero_authorized_projects.html.haml
@@ -11,9 +11,14 @@
       - if current_user.can_create_project?
         You can create up to
         %strong= pluralize(current_user.projects_limit, "project") + "."
-        Click on the button below to add a new one
+        Click on the button below to add a new one or
+        = link_to public_root_path do
+          browse public projects
+
       - else
-        If you are added to a project, it will be displayed here
+        If you are added to a project, it will be displayed here or
+        = link_to public_root_path do
+          browse public projects
 
     - if current_user.can_create_project?
       .link_holder

--- a/app/views/projects/team_members/import.html.haml
+++ b/app/views/projects/team_members/import.html.haml
@@ -6,7 +6,7 @@
 = form_tag apply_import_project_team_members_path(@project), method: 'post', class: 'form-horizontal' do
   .form-group
     = label_tag :source_project_id, "Project", class: 'control-label'
-    .col-sm-10= select_tag(:source_project_id, options_from_collection_for_select(current_user.authorized_projects, :id, :name_with_namespace), prompt: "Select project", class: "select2 lg", required: true)
+    .col-sm-10= select_tag(:source_project_id, options_from_collection_for_select(current_user.all_projects, :id, :name_with_namespace), prompt: "Select project", class: "select2 lg", required: true)
 
   .form-actions
     = submit_tag 'Import project members', class: "btn btn-create"

--- a/app/views/search/_filter.html.haml
+++ b/app/views/search/_filter.html.haml
@@ -11,7 +11,7 @@
     %li
       = link_to search_path(group_id: nil, search: params[:search]) do
         Any
-    - current_user.authorized_groups.sort_by(&:name).each do |group|
+    - current_user.all_groups.sort_by(&:name).each do |group|
       %li
         = link_to search_path(group_id: group.id, search: params[:search]) do
           = group.name
@@ -29,7 +29,7 @@
     %li
       = link_to search_path(project_id: nil, search: params[:search]) do
         Any
-    - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
+    - current_user.all_projects.sort_by(&:name_with_namespace).each do |project|
       %li
         = link_to search_path(project_id: project.id, search: params[:search]) do
           = project.name_with_namespace


### PR DESCRIPTION
Firstly, this fixes the group page that would 404 even when the user had
public access to some of the projects in a group. This fixes issue #5553.
Public projects are now included in the "All" section of the projects
page. The default dashboard doesn't show public projects though since
that would cause too much of an overload of information if the number of
public projects is very large. We want to make it possible for them to
find public projects easily, but we don't want to overload them with
information in their daily workflow.

Slightly tweaked the message when a user doesn't have access to any
projects on the dashboard. It now includes a link to the public section
of the site so it's more obvious where to look for that information.

The search has also been improved to include public projects.
