### PR TITLE
Fix minor errors/annoyances in email templates

### DIFF
--- a/app/mailers/emails/groups.rb
+++ b/app/mailers/emails/groups.rb
@@ -5,7 +5,7 @@ module Emails
       @group = @membership.group
 
       mail(to: @membership.user.email,
-           subject: subject("access to group was granted"))
+           subject: subject("Access to group was granted"))
     end
   end
 end

--- a/app/mailers/emails/issues.rb
+++ b/app/mailers/emails/issues.rb
@@ -3,14 +3,14 @@ module Emails
     def new_issue_email(recipient_id, issue_id)
       @issue = Issue.find(issue_id)
       @project = @issue.project
-      mail(to: recipient(recipient_id), subject: subject("new issue ##{@issue.iid}", @issue.title))
+      mail(to: recipient(recipient_id), subject: subject("New issue ##{@issue.iid}", @issue.title))
     end
 
     def reassigned_issue_email(recipient_id, issue_id, previous_assignee_id)
       @issue = Issue.find(issue_id)
       @previous_assignee = User.find_by_id(previous_assignee_id) if previous_assignee_id
       @project = @issue.project
-      mail(to: recipient(recipient_id), subject: subject("changed issue ##{@issue.iid}", @issue.title))
+      mail(to: recipient(recipient_id), subject: subject("Changed issue ##{@issue.iid}", @issue.title))
     end
 
     def closed_issue_email(recipient_id, issue_id, updated_by_user_id)
@@ -27,7 +27,7 @@ module Emails
       @project = @issue.project
       @updated_by = User.find updated_by_user_id
       mail(to: recipient(recipient_id),
-           subject: subject("changed issue ##{@issue.iid}", @issue.title))
+           subject: subject("Changed issue ##{@issue.iid}", @issue.title))
     end
   end
 end

--- a/app/mailers/emails/merge_requests.rb
+++ b/app/mailers/emails/merge_requests.rb
@@ -2,24 +2,24 @@ module Emails
   module MergeRequests
     def new_merge_request_email(recipient_id, merge_request_id)
       @merge_request = MergeRequest.find(merge_request_id)
-      mail(to: recipient(recipient_id), subject: subject("new merge request !#{@merge_request.iid}", @merge_request.title))
+      mail(to: recipient(recipient_id), subject: subject("New merge request ##{@merge_request.iid}", @merge_request.title))
     end
 
     def reassigned_merge_request_email(recipient_id, merge_request_id, previous_assignee_id)
       @merge_request = MergeRequest.find(merge_request_id)
       @previous_assignee = User.find_by_id(previous_assignee_id) if previous_assignee_id
-      mail(to: recipient(recipient_id), subject: subject("changed merge request !#{@merge_request.iid}", @merge_request.title))
+      mail(to: recipient(recipient_id), subject: subject("Changed merge request ##{@merge_request.iid}", @merge_request.title))
     end
 
     def closed_merge_request_email(recipient_id, merge_request_id, updated_by_user_id)
       @merge_request = MergeRequest.find(merge_request_id)
       @updated_by = User.find updated_by_user_id
-      mail(to: recipient(recipient_id), subject: subject("Closed merge request !#{@merge_request.iid}", @merge_request.title))
+      mail(to: recipient(recipient_id), subject: subject("Closed merge request ##{@merge_request.iid}", @merge_request.title))
     end
 
     def merged_merge_request_email(recipient_id, merge_request_id)
       @merge_request = MergeRequest.find(merge_request_id)
-      mail(to: recipient(recipient_id), subject: subject("Accepted merge request !#{@merge_request.iid}", @merge_request.title))
+      mail(to: recipient(recipient_id), subject: subject("Accepted merge request ##{@merge_request.iid}", @merge_request.title))
     end
   end
 

--- a/app/mailers/emails/notes.rb
+++ b/app/mailers/emails/notes.rb
@@ -4,27 +4,27 @@ module Emails
       @note = Note.find(note_id)
       @commit = @note.noteable
       @project = @note.project
-      mail(to: recipient(recipient_id), subject: subject("note for commit #{@commit.short_id}", @commit.title))
+      mail(to: recipient(recipient_id), subject: subject("Note for commit #{@commit.short_id}", @commit.title))
     end
 
     def note_issue_email(recipient_id, note_id)
       @note = Note.find(note_id)
       @issue = @note.noteable
       @project = @note.project
-      mail(to: recipient(recipient_id), subject: subject("note for issue ##{@issue.iid}"))
+      mail(to: recipient(recipient_id), subject: subject("Note for issue ##{@issue.iid}"))
     end
 
     def note_merge_request_email(recipient_id, note_id)
       @note = Note.find(note_id)
       @merge_request = @note.noteable
       @project = @note.project
-      mail(to: recipient(recipient_id), subject: subject("note for merge request ##{@merge_request.iid}"))
+      mail(to: recipient(recipient_id), subject: subject("Note for merge request ##{@merge_request.iid}"))
     end
 
     def note_wall_email(recipient_id, note_id)
       @note = Note.find(note_id)
       @project = @note.project
-      mail(to: recipient(recipient_id), subject: subject("note on wall"))
+      mail(to: recipient(recipient_id), subject: subject("Note on wall"))
     end
   end
 end

--- a/app/mailers/emails/projects.rb
+++ b/app/mailers/emails/projects.rb
@@ -4,14 +4,14 @@ module Emails
       @users_project = UsersProject.find user_project_id
       @project = @users_project.project
       mail(to: @users_project.user.email,
-           subject: subject("access to project was granted"))
+           subject: subject("Access to project was granted"))
     end
 
     def project_was_moved_email(project_id, user_id)
       @user = User.find user_id
       @project = Project.find project_id
       mail(to: @user.email,
-           subject: subject("project was moved"))
+           subject: subject("Project was moved"))
     end
   end
 end

--- a/app/views/notify/new_merge_request_email.html.haml
+++ b/app/views/notify/new_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "New Merge Request !#{@merge_request.iid}"
+  = "New Merge Request ##{@merge_request.iid}"
 %p
   = link_to_gfm truncate(@merge_request.title, length: 40), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p

--- a/app/views/notify/new_merge_request_email.text.erb
+++ b/app/views/notify/new_merge_request_email.text.erb
@@ -1,4 +1,4 @@
-New Merge Request <%= @merge_request.iid %>
+New Merge Request #<%= @merge_request.iid %>
 
 <%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request)) %>
 

--- a/app/views/notify/reassigned_merge_request_email.html.haml
+++ b/app/views/notify/reassigned_merge_request_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Reassigned Merge Request !#{@merge_request.iid}"
+  = "Reassigned Merge Request ##{@merge_request.iid}"
   = link_to_gfm truncate(@merge_request.title, length: 30), project_merge_request_url(@merge_request.target_project, @merge_request)
 %p
   Assignee changed

--- a/app/views/notify/reassigned_merge_request_email.text.erb
+++ b/app/views/notify/reassigned_merge_request_email.text.erb
@@ -1,4 +1,4 @@
-Reassigned Merge Request <%= @merge_request.iid %>
+Reassigned Merge Request #<%= @merge_request.iid %>
 
 <%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request)) %>
 

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -110,7 +110,7 @@ describe Notify do
           it_behaves_like 'an assignee email'
 
           it 'has the correct subject' do
-            should have_subject /#{project.name} \| new issue ##{issue.iid} \| #{issue.title}/
+            should have_subject /#{project.name} \| New issue ##{issue.iid} \| #{issue.title}/
           end
 
           it 'contains a link to the new issue' do
@@ -126,7 +126,7 @@ describe Notify do
           it_behaves_like 'a multiple recipients email'
 
           it 'has the correct subject' do
-            should have_subject /changed issue ##{issue.iid} \| #{issue.title}/
+            should have_subject /Changed issue ##{issue.iid} \| #{issue.title}/
           end
 
           it 'contains the name of the previous assignee' do
@@ -148,7 +148,7 @@ describe Notify do
           subject { Notify.issue_status_changed_email(recipient.id, issue.id, status, current_user) }
 
           it 'has the correct subject' do
-            should have_subject /changed issue ##{issue.iid} \| #{issue.title}/i
+            should have_subject /Changed issue ##{issue.iid} \| #{issue.title}/i
           end
 
           it 'contains the new status' do
@@ -175,7 +175,7 @@ describe Notify do
           it_behaves_like 'an assignee email'
 
           it 'has the correct subject' do
-            should have_subject /new merge request !#{merge_request.iid}/
+            should have_subject /New merge request ##{merge_request.iid}/
           end
 
           it 'contains a link to the new merge request' do
@@ -199,7 +199,7 @@ describe Notify do
           it_behaves_like 'a multiple recipients email'
 
           it 'has the correct subject' do
-            should have_subject /changed merge request !#{merge_request.iid}/
+            should have_subject /Changed merge request ##{merge_request.iid}/
           end
 
           it 'contains the name of the previous assignee' do
@@ -224,7 +224,7 @@ describe Notify do
       subject { Notify.project_was_moved_email(project.id, user.id) }
 
       it 'has the correct subject' do
-        should have_subject /project was moved/
+        should have_subject /Project was moved/
       end
 
       it 'contains name of project' do
@@ -244,7 +244,7 @@ describe Notify do
                                    user: user) }
       subject { Notify.project_access_granted_email(users_project.id) }
       it 'has the correct subject' do
-        should have_subject /access to project was granted/
+        should have_subject /Access to project was granted/
       end
       it 'contains name of project' do
         should have_body_text /#{project.name}/
@@ -302,7 +302,7 @@ describe Notify do
         it_behaves_like 'a note email'
 
         it 'has the correct subject' do
-          should have_subject /note for commit #{commit.short_id}/
+          should have_subject /Note for commit #{commit.short_id}/
         end
 
         it 'contains a link to the commit' do
@@ -320,7 +320,7 @@ describe Notify do
         it_behaves_like 'a note email'
 
         it 'has the correct subject' do
-          should have_subject /note for merge request ##{merge_request.iid}/
+          should have_subject /Note for merge request ##{merge_request.iid}/
         end
 
         it 'contains a link to the merge request note' do
@@ -338,7 +338,7 @@ describe Notify do
         it_behaves_like 'a note email'
 
         it 'has the correct subject' do
-          should have_subject /note for issue ##{issue.iid}/
+          should have_subject /Note for issue ##{issue.iid}/
         end
 
         it 'contains a link to the issue note' do
@@ -356,7 +356,7 @@ describe Notify do
     subject { Notify.group_access_granted_email(membership.id) }
 
     it 'has the correct subject' do
-      should have_subject /access to group was granted/
+      should have_subject /Access to group was granted/
     end
 
     it 'contains name of project' do


### PR DESCRIPTION
There was some funny syntax in merge request email templates. There was a ! before
the merge request number when there probably should be a #. This may be some carry over
from markdown but should not be in email templates.  There were also some capitalization
discrepancies among the subject lines. For those OCD people out there I standardized the
capitalization. :)
