### PR TITLE
Set git-clone-holder cursor to pointer

### DIFF
--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -100,7 +100,7 @@
   }
 
   input[type="text"] {
-    cursor: auto;
+    cursor: pointer;
     @extend .monospace;
     background: #FAFAFA;
     width: 100%;


### PR DESCRIPTION
Bootstrap defaults the cursor to an ugly red sign if an input field is
readonly. Explicitly set the cursor to "pointer" for a nicer interface
that makes it obvious the user is intended to click on the input
element.
