### PR TITLE
gitlab:check to be done after nginx

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -304,12 +304,6 @@ Check if GitLab and its environment are configured correctly:
     # or
     sudo /etc/init.d/gitlab restart
 
-## Double-check Application Status
-
-To make sure you didn't miss anything run a more thorough check with:
-
-    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
-
 If all items are green, then congratulations on successfully installing GitLab!
 However there are still a few steps left.
 
@@ -340,7 +334,12 @@ Make sure to edit the config file to match your setup:
 
     sudo service nginx restart
 
+# 8. Double-check Application Status
 
+To make sure you didn't miss anything run a more thorough check with:
+
+    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+    
 # Done!
 
 Visit YOUR_SERVER for your first GitLab login.


### PR DESCRIPTION
Once you do the more thorough check
`sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production`

you get the following errors since nginx is not yet installed/running:

```
Running /home/git/gitlab-shell/bin/check
Check GitLab API access: /usr/local/lib/ruby/2.0.0/net/http.rb:878:in `initialize': Connection refused - connect(2) (Errno::ECONNREFUSED)
    from /usr/local/lib/ruby/2.0.0/net/http.rb:878:in `open'
    from /usr/local/lib/ruby/2.0.0/net/http.rb:878:in `block in connect'
    from /usr/local/lib/ruby/2.0.0/timeout.rb:52:in `timeout'
    from /usr/local/lib/ruby/2.0.0/net/http.rb:877:in `connect'
    from /usr/local/lib/ruby/2.0.0/net/http.rb:862:in `do_start'
    from /usr/local/lib/ruby/2.0.0/net/http.rb:851:in `start'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:62:in `get'
    from /home/git/gitlab-shell/lib/gitlab_net.rb:29:in `check'
    from /home/git/gitlab-shell/bin/check:11:in `<main>'
gitlab-shell self-check failed
  Try fixing it:
  Make sure GitLab is running;
  Check the gitlab-shell configuration file:
  sudo -u git -H editor /home/git/gitlab-shell/config.yml
  Please fix the error above and rerun the checks.
```

Should we do the more thorough gitlab:check after nginx is installed?  Once I had nginx up and running, I no longer received the errors.
