### PR TITLE
Added a note regarding custom ssh_port

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -174,7 +174,9 @@ production: &base
     upload_pack: true
     receive_pack: true
 
-    # If you use non-standard ssh port you need to specify it
+    # If you use non-standard ssh port you need to specify it.
+    # Note that you do not need to set this if you have specified an entry in your ~/.ssh/config file
+    # for your GitLab instance
     # ssh_port: 22
 
   ## Git settings


### PR DESCRIPTION
If you do use a custom SSH port on your gitlab box, you do not need to change the `ssh_port` value in config/gitlab.yml if you have an entry in your ~/.ssh/config file. For example:

```
Host git.domain.com
    HostName git.domain.com
    Port     12345
```

You will still be able to clone using nice pretty URLs: `git@git.domain.com:group/project.git`
