### PR TITLE
Add X-Forwarded-For to nginx config

### DIFF
--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -32,6 +32,7 @@ server {
     proxy_set_header   X-Forwarded-Proto $scheme;
     proxy_set_header   Host              $http_host;
     proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
 
     proxy_pass http://gitlab;
   }


### PR DESCRIPTION
I noticed all requests logged in **production.log** come from 127.0.0.1. Adding the X-Forwarded-For header shows the remote IP in logs.
