### PR TITLE
Get CI status when source and target project are different

### DIFF
--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -124,7 +124,8 @@ class Projects::MergeRequestsController < Projects::ApplicationController
   end
 
   def ci_status
-    status = project.gitlab_ci_service.commit_status(merge_request.last_commit.sha)
+    source_project = @merge_request.nil? ? @project : @merge_request.source_project
+    status = source_project.gitlab_ci_service.commit_status(merge_request.last_commit.sha)
     response = {status: status}
 
     render json: response


### PR DESCRIPTION
After created a merge request from a forked repo, it shows `Cannot connect to CI server. Please check your setting` on the merge request page.

This issue is probably related to: 
- https://github.com/gitlabhq/gitlabhq/issues/4764#issuecomment-22614158
- https://groups.google.com/forum/#!topic/gitlabhq/EHxDsHCqKKo
