### PR TITLE
Add bash syntax highlighting to installation doc

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -278,9 +278,11 @@ sudo -u git cp config/database.yml.mysql config/database.yml
 # Change 'secure password' with the value you have given to $password
 # You can keep the double quotes around the password
 sudo -u git -H editor config/database.yml
+```
 
 or
 
+```
 # PostgreSQL
 sudo -u git cp config/database.yml.postgresql config/database.yml
 
@@ -440,11 +442,13 @@ production: unix:/path/to/redis/socket
 
 If you are running SSH on a non-standard port, you must change the gitlab user's SSH config.
 
-    # Add to /home/git/.ssh/config
-    host localhost          # Give your setup a name (here: override localhost)
-        user git            # Your remote git user
-        port 2222           # Your port number
-        hostname 127.0.0.1; # Your server name or IP
+```yaml
+# Add to /home/git/.ssh/config
+host localhost          # Give your setup a name (here: override localhost)
+    user git            # Your remote git user
+    port 2222           # Your port number
+    hostname 127.0.0.1; # Your server name or IP
+```
 
 You also need to change the corresponding options (e.g. ssh_user, ssh_host, admin_uri) in the `config\gitlab.yml` file.
 

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -282,7 +282,7 @@ sudo -u git -H editor config/database.yml
 
 or
 
-```
+```bash
 # PostgreSQL
 sudo -u git cp config/database.yml.postgresql config/database.yml
 

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -1,6 +1,6 @@
 # Select Version to Install
 Make sure you view this installation guide from the branch (version) of GitLab you would like to install. In most cases
-this should be the highest numbered stable branch (example shown below). 
+this should be the highest numbered stable branch (example shown below).
 
 ![capture](https://f.cloud.github.com/assets/1192780/564911/2f9f3e1e-c5b7-11e2-9f89-98e527d1adec.png)
 
@@ -36,76 +36,92 @@ The GitLab installation consists of setting up the following components:
 `sudo` is not installed on Debian by default. Make sure your system is
 up-to-date and install it.
 
-    # run as root!
-    apt-get update -y
-    apt-get upgrade -y
-    apt-get install sudo -y
+```bash
+# run as root!
+apt-get update -y
+apt-get upgrade -y
+apt-get install sudo -y
+```
 
 **Note:**
 During this installation some files will need to be edited manually.
 If you are familiar with vim set it as default editor with the commands below.
 If you are not familiar with vim please skip this and keep using the default editor.
 
-    # Install vim and set as default editor
-    sudo apt-get install -y vim
-    sudo update-alternatives --set editor /usr/bin/vim.basic
+```bash
+# Install vim and set as default editor
+sudo apt-get install -y vim
+sudo update-alternatives --set editor /usr/bin/vim.basic
+```
 
 Install the required packages:
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate
+```bash
+sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate
+```
 
 Make sure you have the right version of Python installed.
 
-    # Install Python
-    sudo apt-get install -y python
+```bash
+# Install Python
+sudo apt-get install -y python
 
-    # Make sure that Python is 2.5+ (3.x is not supported at the moment)
-    python --version
+# Make sure that Python is 2.5+ (3.x is not supported at the moment)
+python --version
 
-    # If it's Python 3 you might need to install Python 2 separately
-    sudo apt-get install -y python2.7
+# If it's Python 3 you might need to install Python 2 separately
+sudo apt-get install -y python2.7
 
-    # Make sure you can access Python via python2
-    python2 --version
+# Make sure you can access Python via python2
+python2 --version
 
-    # If you get a "command not found" error create a link to the python binary
-    sudo ln -s /usr/bin/python /usr/bin/python2
+# If you get a "command not found" error create a link to the python binary
+sudo ln -s /usr/bin/python /usr/bin/python2
 
-    # For reStructuredText markup language support install required package:
-    sudo apt-get install -y python-docutils
+# For reStructuredText markup language support install required package:
+sudo apt-get install -y python-docutils
+```
 
 Make sure you have the right version of Git installed
 
-    # Install Git
-    sudo apt-get install -y git-core
 
-    # Make sure Git is version 1.7.10 or higher, for example 1.7.12 or 1.8.4
-    git --version
+```bash
+# Install Git
+sudo apt-get install -y git-core
+
+# Make sure Git is version 1.7.10 or higher, for example 1.7.12 or 1.8.4
+git --version
+```
+
 
 Is the system packaged Git too old? Remove it and compile from source.
 
-    # Remove packaged Git
-    sudo apt-get remove git-core
+```bash
+# Remove packaged Git
+sudo apt-get remove git-core
 
-    # Install dependencies
-    sudo apt-get install -y libcurl4-openssl-dev libexpat1-dev gettext libz-dev libssl-dev build-essential
+# Install dependencies
+sudo apt-get install -y libcurl4-openssl-dev libexpat1-dev gettext libz-dev libssl-dev build-essential
 
-    # Download and compile from source
-    cd /tmp
-    curl --progress https://git-core.googlecode.com/files/git-1.8.4.1.tar.gz | tar xz
-    cd git-1.8.4.1/
-    make prefix=/usr/local all
+# Download and compile from source
+cd /tmp
+curl --progress https://git-core.googlecode.com/files/git-1.8.4.1.tar.gz | tar xz
+cd git-1.8.4.1/
+make prefix=/usr/local all
 
-    # Install into /usr/local/bin
-    sudo make prefix=/usr/local install
+# Install into /usr/local/bin
+sudo make prefix=/usr/local install
 
-    # When editing config/gitlab.yml (Step 6), change the git bin_path to /usr/local/bin/git
+# When editing config/gitlab.yml (Step 6), change the git bin_path to /usr/local/bin/git
+```
 
 **Note:** In order to receive mail notifications, make sure to install a
 mail server. By default, Debian is shipped with exim4 whereas Ubuntu
 does not ship with one. The recommended mail server is postfix and you can install it with:
 
-	sudo apt-get install -y postfix 
+```bash
+sudo apt-get install -y postfix
+```
 
 Then select 'Internet Site' and press enter to confirm the hostname.
 
@@ -113,53 +129,61 @@ Then select 'Internet Site' and press enter to confirm the hostname.
 
 Remove the old Ruby 1.8 if present
 
-    sudo apt-get remove ruby1.8
+```bash
+sudo apt-get remove ruby1.8
+```
 
 Download Ruby and compile it:
 
-    mkdir /tmp/ruby && cd /tmp/ruby
-    curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz | tar xz
-    cd ruby-2.0.0-p247
-    ./configure --disable-install-rdoc
-    make
-    sudo make install
+```bash
+mkdir /tmp/ruby && cd /tmp/ruby
+curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz | tar xz
+cd ruby-2.0.0-p247
+./configure --disable-install-rdoc
+make
+sudo make install
+```
 
 Install the Bundler Gem:
 
-    sudo gem install bundler --no-ri --no-rdoc
+```bash
+sudo gem install bundler --no-ri --no-rdoc
+```
 
 
 # 3. System Users
 
 Create a `git` user for Gitlab:
 
-    sudo adduser --disabled-login --gecos 'GitLab' git
-
+```bash
+sudo adduser --disabled-login --gecos 'GitLab' git
+```
 
 # 4. GitLab shell
 
 GitLab Shell is an ssh access and repository management software developed specially for GitLab.
 
-    # Go to home directory
-    cd /home/git
+```bash
+# Go to home directory
+cd /home/git
 
-    # Clone gitlab shell
-    sudo -u git -H git clone https://github.com/gitlabhq/gitlab-shell.git
+# Clone gitlab shell
+sudo -u git -H git clone https://github.com/gitlabhq/gitlab-shell.git
 
-    cd gitlab-shell
+cd gitlab-shell
 
-    # switch to right version
-    sudo -u git -H git checkout v1.7.9
+# switch to right version
+sudo -u git -H git checkout v1.7.9
 
-    sudo -u git -H cp config.yml.example config.yml
+sudo -u git -H cp config.yml.example config.yml
 
-    # Edit config and replace gitlab_url
-    # with something like 'http://domain.com/'
-    sudo -u git -H editor config.yml
+# Edit config and replace gitlab_url
+# with something like 'http://domain.com/'
+sudo -u git -H editor config.yml
 
-    # Do setup
-    sudo -u git -H ./bin/install
-
+# Do setup
+sudo -u git -H ./bin/install
+```
 
 # 5. Database
 
@@ -168,147 +192,170 @@ To setup the MySQL/PostgreSQL database and dependencies please see [`doc/install
 
 # 6. GitLab
 
-    # We'll install GitLab into home directory of the user "git"
-    cd /home/git
+```bash
+# We'll install GitLab into home directory of the user "git"
+cd /home/git
+```
 
 ## Clone the Source
 
-    # Clone GitLab repository
-    sudo -u git -H git clone https://github.com/gitlabhq/gitlabhq.git gitlab
+```bash
+# Clone GitLab repository
+sudo -u git -H git clone https://github.com/gitlabhq/gitlabhq.git gitlab
 
-    # Go to gitlab dir
-    cd /home/git/gitlab
+# Go to gitlab dir
+cd /home/git/gitlab
 
-    # Checkout to stable release
-    sudo -u git -H git checkout 6-2-stable
+# Checkout to stable release
+sudo -u git -H git checkout 6-2-stable
+```
 
 **Note:**
 You can change `6-2-stable` to `master` if you want the *bleeding edge* version, but never install master on a production server!
 
 ## Configure it
 
-    cd /home/git/gitlab
+```bash
+cd /home/git/gitlab
 
-    # Copy the example GitLab config
-    sudo -u git -H cp config/gitlab.yml.example config/gitlab.yml
+# Copy the example GitLab config
+sudo -u git -H cp config/gitlab.yml.example config/gitlab.yml
 
-    # Make sure to change "localhost" to the fully-qualified domain name of your
-    # host serving GitLab where necessary
-    #
-    # If you installed Git from source, change the git bin_path to /usr/local/bin/git
-    sudo -u git -H editor config/gitlab.yml
+# Make sure to change "localhost" to the fully-qualified domain name of your
+# host serving GitLab where necessary
+#
+# If you installed Git from source, change the git bin_path to /usr/local/bin/git
+sudo -u git -H editor config/gitlab.yml
 
-    # Make sure GitLab can write to the log/ and tmp/ directories
-    sudo chown -R git log/
-    sudo chown -R git tmp/
-    sudo chmod -R u+rwX  log/
-    sudo chmod -R u+rwX  tmp/
+# Make sure GitLab can write to the log/ and tmp/ directories
+sudo chown -R git log/
+sudo chown -R git tmp/
+sudo chmod -R u+rwX  log/
+sudo chmod -R u+rwX  tmp/
 
-    # Create directory for satellites
-    sudo -u git -H mkdir /home/git/gitlab-satellites
+# Create directory for satellites
+sudo -u git -H mkdir /home/git/gitlab-satellites
 
-    # Create directories for sockets/pids and make sure GitLab can write to them
-    sudo -u git -H mkdir tmp/pids/
-    sudo -u git -H mkdir tmp/sockets/
-    sudo chmod -R u+rwX  tmp/pids/
-    sudo chmod -R u+rwX  tmp/sockets/
+# Create directories for sockets/pids and make sure GitLab can write to them
+sudo -u git -H mkdir tmp/pids/
+sudo -u git -H mkdir tmp/sockets/
+sudo chmod -R u+rwX  tmp/pids/
+sudo chmod -R u+rwX  tmp/sockets/
 
-    # Create public/uploads directory otherwise backup will fail
-    sudo -u git -H mkdir public/uploads
-    sudo chmod -R u+rwX  public/uploads
+# Create public/uploads directory otherwise backup will fail
+sudo -u git -H mkdir public/uploads
+sudo chmod -R u+rwX  public/uploads
 
-    # Copy the example Unicorn config
-    sudo -u git -H cp config/unicorn.rb.example config/unicorn.rb
+# Copy the example Unicorn config
+sudo -u git -H cp config/unicorn.rb.example config/unicorn.rb
 
-    # Enable cluster mode if you expect to have a high load instance
-    # Ex. change amount of workers to 3 for 2GB RAM server
-    sudo -u git -H editor config/unicorn.rb
+# Enable cluster mode if you expect to have a high load instance
+# Ex. change amount of workers to 3 for 2GB RAM server
+sudo -u git -H editor config/unicorn.rb
 
-    # Copy the example Rack attack config
-    sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers/rack_attack.rb
+# Copy the example Rack attack config
+sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers/rack_attack.rb
 
-    # Configure Git global settings for git user, useful when editing via web
-    # Edit user.email according to what is set in gitlab.yml
-    sudo -u git -H git config --global user.name "GitLab"
-    sudo -u git -H git config --global user.email "gitlab@localhost"
-    sudo -u git -H git config --global core.autocrlf input
+# Configure Git global settings for git user, useful when editing via web
+# Edit user.email according to what is set in gitlab.yml
+sudo -u git -H git config --global user.name "GitLab"
+sudo -u git -H git config --global user.email "gitlab@localhost"
+sudo -u git -H git config --global core.autocrlf input
+```
 
 **Important Note:**
 Make sure to edit both `gitlab.yml` and `unicorn.rb` to match your setup.
 
 ## Configure GitLab DB settings
 
-    # Mysql
-    sudo -u git cp config/database.yml.mysql config/database.yml
+```bash
+# Mysql
+sudo -u git cp config/database.yml.mysql config/database.yml
 
-    # Make sure to update username/password in config/database.yml.
-    # You only need to adapt the production settings (first part).
-    # If you followed the database guide then please do as follows:
-    # Change 'secure password' with the value you have given to $password
-    # You can keep the double quotes around the password
-    sudo -u git -H editor config/database.yml
+# Make sure to update username/password in config/database.yml.
+# You only need to adapt the production settings (first part).
+# If you followed the database guide then please do as follows:
+# Change 'secure password' with the value you have given to $password
+# You can keep the double quotes around the password
+sudo -u git -H editor config/database.yml
 
-    or
+or
 
-    # PostgreSQL
-    sudo -u git cp config/database.yml.postgresql config/database.yml
+# PostgreSQL
+sudo -u git cp config/database.yml.postgresql config/database.yml
 
-    
-    # Make config/database.yml readable to git only
-    sudo -u git -H chmod o-rwx config/database.yml
+
+# Make config/database.yml readable to git only
+sudo -u git -H chmod o-rwx config/database.yml
+```
 
 ## Install Gems
 
-    cd /home/git/gitlab
+```bash
+cd /home/git/gitlab
 
-    # For MySQL (note, the option says "without ... postgres")
-    sudo -u git -H bundle install --deployment --without development test postgres aws
+# For MySQL (note, the option says "without ... postgres")
+sudo -u git -H bundle install --deployment --without development test postgres aws
 
-    # Or for PostgreSQL (note, the option says "without ... mysql")
-    sudo -u git -H bundle install --deployment --without development test mysql aws
+# Or for PostgreSQL (note, the option says "without ... mysql")
+sudo -u git -H bundle install --deployment --without development test mysql aws
+```
 
 
 ## Initialize Database and Activate Advanced Features
 
-    sudo -u git -H bundle exec rake gitlab:setup RAILS_ENV=production
+```bash
+sudo -u git -H bundle exec rake gitlab:setup RAILS_ENV=production
 
-    # Type 'yes' to create the database.
+# Type 'yes' to create the database.
 
-    # When done you see 'Administrator account created:'
-
+# When done you see 'Administrator account created:'
+```
 
 ## Install Init Script
 
 Download the init script (will be /etc/init.d/gitlab):
 
-    sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-    sudo chmod +x /etc/init.d/gitlab
+```bash
+sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+sudo chmod +x /etc/init.d/gitlab
+```
 
 Make GitLab start on boot:
 
-    sudo update-rc.d gitlab defaults 21
+```bash
+sudo update-rc.d gitlab defaults 21
+```
 
 ## Set up logrotate
 
-    sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
+```bash
+sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
+```
 
 ## Check Application Status
 
 Check if GitLab and its environment are configured correctly:
 
-    sudo -u git -H bundle exec rake gitlab:env:info RAILS_ENV=production
+```bash
+sudo -u git -H bundle exec rake gitlab:env:info RAILS_ENV=production
+```
 
 ## Start Your GitLab Instance
 
-    sudo service gitlab start
-    # or
-    sudo /etc/init.d/gitlab restart
+```bash
+sudo service gitlab start
+# or
+sudo /etc/init.d/gitlab restart
+```
 
 ## Double-check Application Status
 
 To make sure you didn't miss anything run a more thorough check with:
 
-    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+```bash
+sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+```
 
 If all items are green, then congratulations on successfully installing GitLab!
 However there are still a few steps left.
@@ -321,24 +368,33 @@ Nginx is the officially supported web server for GitLab. If you cannot or do not
 [GitLab recipes](https://github.com/gitlabhq/gitlab-recipes).
 
 ## Installation
-    sudo apt-get install -y nginx
+
+```bash
+sudo apt-get install -y nginx
+```
 
 ## Site Configuration
 
 Download an example site config:
 
-    sudo cp lib/support/nginx/gitlab /etc/nginx/sites-available/gitlab
-    sudo ln -s /etc/nginx/sites-available/gitlab /etc/nginx/sites-enabled/gitlab
+```bash
+sudo cp lib/support/nginx/gitlab /etc/nginx/sites-available/gitlab
+sudo ln -s /etc/nginx/sites-available/gitlab /etc/nginx/sites-enabled/gitlab
+```
 
 Make sure to edit the config file to match your setup:
 
-    # Change YOUR_SERVER_FQDN to the fully-qualified
-    # domain name of your host serving GitLab.
-    sudo editor /etc/nginx/sites-available/gitlab
+```bash
+# Change YOUR_SERVER_FQDN to the fully-qualified
+# domain name of your host serving GitLab.
+sudo editor /etc/nginx/sites-available/gitlab
+```
 
 ## Restart
 
-    sudo service nginx restart
+```bash
+sudo service nginx restart
+```
 
 
 # Done!
@@ -367,14 +423,18 @@ If you'd like Resque to connect to a Redis server on a non-standard port or on
 a different host, you can configure its connection string via the
 `config/resque.yml` file.
 
-    # example
-    production: redis://redis.example.tld:6379
+```yaml
+# example
+production: redis://redis.example.tld:6379
+```
 
-If you want to connect the Redis server via socket, then use the "unix:" URL scheme 
+If you want to connect the Redis server via socket, then use the "unix:" URL scheme
 and the path to the Redis socket file in the `config/resque.yml` file.
 
-    # example
-    production: unix:/path/to/redis/socket
+```yaml
+# example
+production: unix:/path/to/redis/socket
+```
 
 ## Custom SSH Connection
 
@@ -406,7 +466,7 @@ These steps are fairly general and you will need to figure out the exact details
 * Add provider specific configuration options to your `config/gitlab.yml` (you can use the [auth providers section of the example config](https://github.com/gitlabhq/gitlabhq/blob/master/config/gitlab.yml.example) as a reference)
 
 * Add the gem to your [Gemfile](https://github.com/gitlabhq/gitlabhq/blob/master/Gemfile)
-                `gem "omniauth-your-auth-provider"` 
+                `gem "omniauth-your-auth-provider"`
 * If you're using MySQL, install the new Omniauth provider gem by running the following command:
 		`sudo -u git -H bundle install --without development test postgres --path vendor/bundle --no-deployment`
 


### PR DESCRIPTION
Hey! I modified the installation doc to use tagged code fences instead of blocks so it will syntax highlight the shell statements. I think this improves the document's readability.
