### PR TITLE
Integration with Assembla

### DIFF
--- a/app/models/assembla_service.rb
+++ b/app/models/assembla_service.rb
@@ -1,0 +1,45 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id          :integer          not null, primary key
+#  type        :string(255)
+#  title       :string(255)
+#  token       :string(255)
+#  project_id  :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  active      :boolean          default(FALSE), not null
+#  project_url :string(255)
+#  subdomain   :string(255)
+#  room        :string(255)
+#
+
+class AssemblaService < Service
+  include HTTParty
+
+  validates :token, presence: true, if: :activated?
+
+  def title
+    'Assembla'
+  end
+
+  def description
+    'Project Management Software (Source Commits Endpoint)'
+  end
+
+  def to_param
+    'assembla'
+  end
+
+  def fields
+    [
+      { type: 'text', name: 'token', placeholder: '' }
+    ]
+  end
+
+  def execute(push)
+    url = "https://atlas.assembla.com/spaces/ouposp/github_tool?secret_key=#{token}"
+    AssemblaService.post(url, body: { payload: push }.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,6 +50,7 @@ class Project < ActiveRecord::Base
   has_one :pivotaltracker_service, dependent: :destroy
   has_one :hipchat_service, dependent: :destroy
   has_one :flowdock_service, dependent: :destroy
+  has_one :assembla_service, dependent: :destroy
   has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
   has_one :forked_from_project, through: :forked_project_link
 
@@ -224,7 +225,7 @@ class Project < ActiveRecord::Base
   end
 
   def available_services_names
-    %w(gitlab_ci campfire hipchat pivotaltracker flowdock)
+    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla)
   end
 
   def gitlab_ci?

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -30,3 +30,9 @@ Feature: Project Services
     And I click Flowdock service link
     And I fill Flowdock settings
     Then I should see Flowdock service settings saved
+
+  Scenario: Activate Assembla service
+    When I visit project "Shop" services page
+    And I click Assembla service link
+    And I fill Assembla settings
+    Then I should see Assembla service settings saved

--- a/features/steps/project/project_services.rb
+++ b/features/steps/project/project_services.rb
@@ -12,6 +12,7 @@ class ProjectServices < Spinach::FeatureSteps
     page.should have_content 'Campfire'
     page.should have_content 'Hipchat'
     page.should have_content 'GitLab CI'
+    page.should have_content 'Assembla'
   end
 
   And 'I click gitlab-ci service link' do
@@ -70,6 +71,20 @@ class ProjectServices < Spinach::FeatureSteps
   end
 
   Then 'I should see Flowdock service settings saved' do
+    find_field('Token').value.should == 'verySecret'
+  end
+
+  And 'I click Assembla service link' do
+    click_link 'Assembla'
+  end
+
+  And 'I fill Assembla settings' do
+    check 'Active'
+    fill_in 'Token', with: 'verySecret'
+    click_button 'Save'
+  end
+
+  Then 'I should see Assembla service settings saved' do
     find_field('Token').value.should == 'verySecret'
   end
 end

--- a/spec/models/assembla_service_spec.rb
+++ b/spec/models/assembla_service_spec.rb
@@ -1,0 +1,50 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id          :integer          not null, primary key
+#  type        :string(255)
+#  title       :string(255)
+#  token       :string(255)
+#  project_id  :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  active      :boolean          default(FALSE), not null
+#  project_url :string(255)
+#  subdomain   :string(255)
+#  room        :string(255)
+#
+
+require 'spec_helper'
+
+describe AssemblaService do
+  describe "Associations" do
+    it { should belong_to :project }
+    it { should have_one :service_hook }
+  end
+
+  describe "Execute" do
+    let(:user)    { create(:user) }
+    let(:project) { create(:project_with_code) }
+
+    before do
+      @assembla_service = AssemblaService.new
+      @assembla_service.stub(
+        project_id: project.id,
+        project: project,
+        service_hook: true,
+        token: 'verySecret'
+      )
+      @sample_data = GitPushService.new.sample_data(project, user)
+      @api_url = 'https://atlas.assembla.com/spaces/ouposp/github_tool?secret_key=verySecret'
+      WebMock.stub_request(:post, @api_url)
+    end
+
+    it "should call FlowDock API" do
+      @assembla_service.execute(@sample_data)
+      WebMock.should have_requested(:post, @api_url).with(
+        body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/
+      ).once
+    end
+  end
+end


### PR DESCRIPTION
This set of changes adds support for the integration of Gitlab with the Assembla project manager. Assembla supports external Github repositories, but the POST webhook of Gitlab differs from the Github format in that Github sends the paylod under a "payload" form parameter. This service allows Gitlab to follow that format, so Assembla can receive notifications about new commits and update tickets accordingly. It has been tested with a real project.
