### PR TITLE
Fixing use of uninitialized default branch

### DIFF
--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -28,7 +28,10 @@
 
         .repo-info
           - unless project.empty_repo?
-            = link_to pluralize(project.repository.round_commit_count, 'commit'), project_commits_path(project, project.default_branch)
+            - unless project.default_branch.nil?
+              = link_to pluralize(project.repository.round_commit_count, 'commit'), project_commits_path(project, project.default_branch)
+            - else
+              = pluralize(project.repository.round_commit_count, 'commit')
             &middot;
             = link_to pluralize(project.repository.branch_names.count, 'branch'), project_branches_path(project)
             &middot;


### PR DESCRIPTION
When there is a non-empty repository with yet uninitialized default_branch page with public projects shows 404. This fixes it
