### PR TITLE
Reorder steps to install web server before running gitlab:check

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -304,15 +304,6 @@ Check if GitLab and its environment are configured correctly:
     # or
     sudo /etc/init.d/gitlab restart
 
-## Double-check Application Status
-
-To make sure you didn't miss anything run a more thorough check with:
-
-    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
-
-If all items are green, then congratulations on successfully installing GitLab!
-However there are still a few steps left.
-
 
 # 7. Nginx
 
@@ -343,7 +334,17 @@ Make sure to edit the config file to match your setup:
 
 # Done!
 
-Visit YOUR_SERVER for your first GitLab login.
+## Double-check Application Status
+
+To make sure you didn't miss anything run a more thorough check with:
+
+    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+
+If all items are green, then congratulations on successfully installing GitLab!
+
+## Initial Login
+
+Visit YOUR_SERVER in your web browser for your first GitLab login.
 The setup has created an admin account for you. You can use it to log in:
 
     admin@local.host


### PR DESCRIPTION
I was following the install guide for a fresh install of Gitlab 6.2 and got the point where we "Double Check" everything using `gitlab:check`.  I kept getting an error saying gitlab-shell couldn't start, with no apparent reason.

gitlab-shell cannot start without a running web server, however the installation guide does not instruct to install the webserver until after running `gitlab:check`.

I've updated the docs to run `gitlab:check` after the web server is installed and running.
