### PR TITLE
Fix grammar in fork error message.

### DIFF
--- a/app/views/projects/fork.html.haml
+++ b/app/views/projects/fork.html.haml
@@ -3,9 +3,9 @@
     %i.icon-code-fork
     Fork Error!
   %p
-    You are trying to fork
+    You tried to fork
     = link_to_project @project
-    but it fails due to next reason:
+    but it failed for the following reason:
 
 
   - if @forked_project && @forked_project.errors.any?


### PR DESCRIPTION
Revised the "fork failed" error message because the original phrasing seemed awkward.
