### PR TITLE
Fixed references to stable branch names.

### DIFF
--- a/doc/update/6.2-to-6.3.md
+++ b/doc/update/6.2-to-6.3.md
@@ -21,7 +21,7 @@ sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```bash
 cd /home/git/gitlab
 sudo -u git -H git fetch
-sudo -u git -H git checkout 6.3-stable
+sudo -u git -H git checkout 6-3-stable
 ```
 
 ### 3. Update gitlab-shell
@@ -59,14 +59,14 @@ sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
 
 ### 6. Update config files
 
-TIP: to see what changed in gitlab.yml.example in this release use next command: 
+TIP: to see what changed in gitlab.yml.example in this release use next command:
 
 ```
-git diff 6.2-stable:config/gitlab.yml.example 6.3-stable:config/gitlab.yml.example
+git diff 6-2-stable:config/gitlab.yml.example 6-3-stable:config/gitlab.yml.example
 ```
 
-* Make `/home/git/gitlab/config/gitlab.yml` same as https://github.com/gitlabhq/gitlabhq/blob/6.3-stable/config/gitlab.yml.example but with your settings.
-* Make `/home/git/gitlab/config/unicorn.rb` same as https://github.com/gitlabhq/gitlabhq/blob/6.3-stable/config/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab/config/gitlab.yml` same as https://github.com/gitlabhq/gitlabhq/blob/6-3-stable/config/gitlab.yml.example but with your settings.
+* Make `/home/git/gitlab/config/unicorn.rb` same as https://github.com/gitlabhq/gitlabhq/blob/6-3-stable/config/unicorn.rb.example but with your settings.
 * Copy rack attack middleware config
 
 ```bash
@@ -82,7 +82,7 @@ sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/6.3-stable/lib/support/init.d/gitlab
+sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/6-3-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 
@@ -106,7 +106,7 @@ If all items are green, then congratulations upgrade complete!
 ## Things went south? Revert to previous version (6.2)
 
 ### 1. Revert the code to the previous version
-Follow the [`upgrade guide from 6.1 to 6.2`](6.1-to-6.2.md), except for the database migration 
+Follow the [`upgrade guide from 6.1 to 6.2`](6.1-to-6.2.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:


### PR DESCRIPTION
References to branch names used dot notation, causing instructions to break.
