### PR TITLE
Api: when password is too short return a 400 instead of a 404

### DIFF
--- a/app/models/concerns/attributes_checkable.rb
+++ b/app/models/concerns/attributes_checkable.rb
@@ -1,0 +1,21 @@
+# == Attributes checkable concern
+#
+# Make attributes checkable for the API
+#
+# Used by User
+#
+module AttributesCheckable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def valid_attribute_value?(attribute_name, value)
+      mock = self.new(attribute_name => value)
+      if mock.valid?
+        true
+      else
+        ! mock.errors.has_key?(attribute_name)
+      end
+    end
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ require 'carrierwave/orm/activerecord'
 require 'file_size_validator'
 
 class User < ActiveRecord::Base
+  include AttributesCheckable
+
   devise :database_authenticatable, :token_authenticatable, :lockable, :async,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable, :confirmable, :registerable
 

--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -89,7 +89,20 @@ module API
     #   keys (required) - A hash consisting of keys that must be present
     def required_attributes!(keys)
       keys.each do |key|
-        bad_request!(key) unless params[key].present?
+        missing_attribute!(key) unless params[key].present?
+      end
+    end
+
+    # Checks the validity of required attributes, each attribute must be valid in the params hash
+    # or a Bad Request error is invoked.
+    #
+    # Parameters:
+    #   keys (required) - A hash consisting of keys that must be valid
+    def valid_attributes!(object, keys)
+      keys.each do |key|
+        if params.key? key
+          invalid_attribute!(key) unless object.valid_attribute_value?(key, params[key])
+        end
       end
     end
 
@@ -107,10 +120,18 @@ module API
       render_api_error!('403 Forbidden', 403)
     end
 
-    def bad_request!(attribute)
-      message = ["400 (Bad request)"]
-      message << "\"" + attribute.to_s + "\" not given"
+    def bad_request!(attribute, error_message)
+      message = ['400 (Bad request)']
+      message << "\"" + attribute.to_s + "\" #{error_message}"
       render_api_error!(message.join(' '), 400)
+    end
+
+    def missing_attribute!(attribute)
+      bad_request! attribute, 'not given'
+    end
+
+    def invalid_attribute!(attribute)
+      bad_request! attribute, 'has an invalid value'
     end
 
     def not_found!(resource = nil)

--- a/lib/api/notes.rb
+++ b/lib/api/notes.rb
@@ -51,7 +51,7 @@ module API
             present @note, with: Entities::Note
           else
             # :note is exposed as :body, but :note is set on error
-            bad_request!(:note) if @note.errors[:note].any?
+            missing_attribute!(:note) if @note.errors[:note].any?
             not_found!
           end
         end

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -47,7 +47,9 @@ module API
       post do
         authenticated_as_admin!
         required_attributes! [:email, :password, :name, :username]
-        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
+        attributes_list = [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
+        valid_attributes! User, attributes_list
+        attrs = attributes_for_keys attributes_list
         user = User.build_user(attrs, as: :admin)
         admin = attrs.delete(:admin)
         user.admin = admin unless admin.nil?
@@ -78,7 +80,9 @@ module API
       put ":id" do
         authenticated_as_admin!
 
-        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
+        attributes_list = [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
+        valid_attributes! User, attributes_list
+        attrs = attributes_for_keys attributes_list
         user = User.find(params[:id])
         not_found!("User not found") unless user
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -114,6 +114,11 @@ describe API::API do
       response.status.should == 400
     end
 
+    it "should return 400 error if password is too short" do
+      post api("/users", admin), attributes_for(:user, projects_limit: 3, password: 'abc')
+      response.status.should == 400
+    end
+
     it "shouldn't available for non admin users" do
       post api("/users", user), attributes_for(:user)
       response.status.should == 403
@@ -192,7 +197,7 @@ describe API::API do
 
     it "should not allow invalid update" do
       put api("/users/#{user.id}", admin), {email: 'invalid email'}
-      response.status.should == 404
+      response.status.should == 400
       user.reload.email.should_not == 'invalid email'
     end
 
@@ -204,6 +209,11 @@ describe API::API do
     it "should return 404 for non-existing user" do
       put api("/users/999999", admin), {bio: 'update should fail'}
       response.status.should == 404
+    end
+
+    it "should return 400 error if password is too short" do
+      put api("/users/#{user.id}", admin), {password: 'abc'}
+      response.status.should == 400
     end
 
     context "with existing user" do


### PR DESCRIPTION
Tried to make it generic for all attributes and in a way that can be easily propagated to other models if this approach is OK
