### PR TITLE
FIX: Browser back button breaks "Loading..." visual

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -56,7 +56,7 @@ window.unbindEvents = ->
 
 document.addEventListener("page:fetch", startSpinner)
 document.addEventListener("page:fetch", unbindEvents)
-document.addEventListener("page:receive", stopSpinner)
+document.addEventListener("page:change", stopSpinner)
 
 $ ->
   # Click a .one_click_select field, select the contents


### PR DESCRIPTION
Fix: #5478 
From: https://github.com/rails/turbolinks/
page:change the page has been parsed and changed to the new version and on DOMContentLoaded

Somehow I cant reproduce the bug on the vagrant machine in development mode, but running the patch in production shows the expected outcome.
