### PR TITLE
Adding omniauth support for Google Apps authentication (Issue #1635)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'omniauth', "~> 1.1.3"
 gem 'omniauth-google-oauth2'
 gem 'omniauth-twitter'
 gem 'omniauth-github'
+gem 'omniauth-google-apps'
 
 # Extracting information from a git repository
 # Provide access to Gitlab::Git library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,11 @@ GEM
     omniauth-github (1.1.0)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
+    omniauth-google-apps (0.1.0)
+      omniauth (~> 1.0)
+      omniauth-openid (~> 1.0)
+      ruby-openid (~> 2.3.0)
+      ruby-openid-apps-discovery (~> 1.2.0)
     omniauth-google-oauth2 (0.1.19)
       omniauth (~> 1.0)
       omniauth-oauth2
@@ -309,6 +314,9 @@ GEM
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
+    omniauth-openid (1.0.1)
+      omniauth (~> 1.0)
+      rack-openid (~> 1.3.1)
     omniauth-twitter (0.0.17)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
@@ -342,6 +350,9 @@ GEM
       rack (>= 1.1.3)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
+    rack-openid (1.3.1)
+      rack (>= 1.1.0)
+      ruby-openid (>= 2.1.8)
     rack-protection (1.5.0)
       rack
     rack-ssl (1.3.3)
@@ -425,6 +436,9 @@ GEM
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
     ruby-hmac (0.4.0)
+    ruby-openid (2.3.0)
+    ruby-openid-apps-discovery (1.2.0)
+      ruby-openid (>= 2.1.7)
     ruby-progressbar (1.2.0)
     rubyntlm (0.1.1)
     rubyzip (0.9.9)
@@ -606,6 +620,7 @@ DEPENDENCIES
   mysql2
   omniauth (~> 1.1.3)
   omniauth-github
+  omniauth-google-apps
   omniauth-google-oauth2
   omniauth-twitter
   pg

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -143,6 +143,7 @@ production: &base
       # - { name: 'google_oauth2', app_id: 'YOUR APP ID',
       #     app_secret: 'YOUR APP SECRET',
       #     args: { access_type: 'offline', approval_prompt: '' } }
+      # - { name: 'google_apps', domain: 'YOUR GOOGLE APPS DOMAIN' }
       # - { name: 'twitter', app_id: 'YOUR APP ID',
       #     app_secret: 'YOUR APP SECRET'}
       # - { name: 'github', app_id: 'YOUR APP ID',

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -234,7 +234,13 @@ Devise.setup do |config|
       # A Hash from the configuration will be passed as is.
       config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret'], provider['args']
     else
-      config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret']
+      case provider['name']
+      when 'google_apps'
+        config.omniauth provider['name'].to_sym,
+        domain: provider['domain']
+      else
+        config.omniauth provider['name'].to_sym, provider['app_id'], provider['app_secret']
+      end
     end
   end
 end


### PR DESCRIPTION
Adding support for omniauth Google Apps strategy so that people can restrict the login to their own Google Apps domain.

The changes in config/initializers/devise.rb must seem like a hack, but I an pretty new to gitlab's code and couldn't possibly figure out how to put that google_apps support in so had to make that hack. If someone can revise that and put the right logic, it would be great.

Thanks !
