### PR TITLE
Always link to comments for merge request notes.

### DIFF
--- a/app/views/notify/note_merge_request_email.html.haml
+++ b/app/views/notify/note_merge_request_email.html.haml
@@ -1,8 +1,5 @@
 %p
-  - if @note.for_diff_line?
-    = link_to "New comment on diff", diffs_project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")
-  - else
-    = link_to "New comment", project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")
+  = link_to "New comment", project_merge_request_url(@merge_request.target_project, @merge_request, anchor: "note_#{@note.id}")
   for Merge Request ##{@merge_request.iid}
   %cite "#{truncate(@merge_request.title, length: 20)}"
 = render 'note_message'


### PR DESCRIPTION
This will avoid issues with updated merge requests where the comments are outdated.
