### PR TITLE
By default, target original repository if it's a fork when creating new MR.

### DIFF
--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -60,7 +60,11 @@ class Projects::MergeRequestsController < Projects::ApplicationController
   def new
     @merge_request = MergeRequest.new(params[:merge_request])
     @merge_request.source_project = @project unless @merge_request.source_project
-    @merge_request.target_project = @project unless @merge_request.target_project
+    @merge_request.target_project ||= (@project.forked_from_project || @project)
+    @target_branches = @merge_request.target_project.nil? ? [] : @merge_request.target_project.repository.branch_names
+
+    @merge_request.target_branch ||= @merge_request.target_project.default_branch
+
     @source_project = @merge_request.source_project
     @merge_request
   end

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -1,8 +1,9 @@
 module MergeRequestsHelper
   def new_mr_path_from_push_event(event)
+    target_project = event.project.forked_from_project || event.project
     new_project_merge_request_path(
       event.project,
-      new_mr_from_push_event(event, event.project)
+      new_mr_from_push_event(event, target_project)
     )
   end
 

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -25,7 +25,7 @@
         .clearfix
           .pull-left
             - projects =  @project.forked_from_project.nil? ? [@project] : [ @project,@project.forked_from_project]
-            = f.select(:target_project_id, options_from_collection_for_select(projects, 'id', 'path_with_namespace'), {}, { class: 'target_project select2 span3', disabled: @merge_request.persisted? })
+            = f.select(:target_project_id, options_from_collection_for_select(projects, 'id', 'path_with_namespace', f.object.target_project_id), {}, { class: 'target_project select2 span3', disabled: @merge_request.persisted? })
           .pull-left
             &nbsp;
             = f.select(:target_branch, @merge_request.target_branches, { include_blank: "Select branch" }, {class: 'target_branch select2 span2'})

--- a/features/project/forked_merge_requests.feature
+++ b/features/project/forked_merge_requests.feature
@@ -32,3 +32,9 @@ Feature: Project Forked Merge Requests
     And I fill out an invalid "Merge Request On Forked Project" merge request
     And I submit the merge request
     Then I should see validation errors
+
+  @javascript
+  Scenario: Merge request should target fork repository by default
+    Given I visit project "Forked Shop" merge requests page
+    And I click link "New Merge Request"
+    Then the target repository should be the original repository

--- a/features/steps/project/project_forked_merge_requests.rb
+++ b/features/steps/project/project_forked_merge_requests.rb
@@ -159,8 +159,11 @@ class ProjectForkedMergeRequests < Spinach::FeatureSteps
   step 'I fill out an invalid "Merge Request On Forked Project" merge request' do
     #If this isn't filled in the rest of the validations won't be triggered
     fill_in "merge_request_title", with: "Merge Request On Forked Project"
+
+    select "Select branch", from: "merge_request_target_branch"
+
     find(:select, "merge_request_source_project_id", {}).value.should == @forked_project.id.to_s
-    find(:select, "merge_request_target_project_id", {}).value.should == @forked_project.id.to_s
+    find(:select, "merge_request_target_project_id", {}).value.should == project.id.to_s
     find(:select, "merge_request_source_branch", {}).value.should == ""
     find(:select, "merge_request_target_branch", {}).value.should == ""
   end
@@ -168,7 +171,10 @@ class ProjectForkedMergeRequests < Spinach::FeatureSteps
   step 'I should see validation errors' do
     page.should have_content "Source branch can't be blank"
     page.should have_content "Target branch can't be blank"
-    page.should have_content "Branch conflict You can not use same project/branch for source and target"
+  end
+
+  step 'the target repository should be the original repository' do
+    page.should have_select("merge_request_target_project_id", selected: project.path_with_namespace)
   end
 
   def project


### PR DESCRIPTION
The workflow we use at work to add new code in our projects is the same as on Github.
1. Fork the project
2. Make the changes in a topic branch
3. Create a merge/pull request for the topic branch

Since most work is done in the forks and the changes should go back to the original repository via merge requests it's a lot more convenient that when creating a new merge request the target repository is by default, if it's a fork, the original repository (upstream). I never had the need to create a merge request from one branch to another in the same repository.

Also the default target branch will be the default branch of the target project. While the default source branch will be the latest created branch in the source project.

The above is achieved by first checking if the source project is a fork, if it is then the original project is used as the target project. If it's not, it falls back to the current behavior.

The target branch is by default selected to be the default branch of the target project. The source branch will be the latest branch in the source project. This is a simple heuristic method based on the idea that the branch that was just created (the latest branch) is the branch one most likely want to use as the source branch.
