### PR TITLE
Add option to perform a standard fast-forward merge when accepting merge requests

### DIFF
--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -25,11 +25,23 @@
     .accept_merge_request {
       font-size: 13px;
       float: left;
+      line-height: 22px;
     }
     .remove_branch_holder {
       margin-left: 20px;
       margin-right: 10px;
       float: left;
+
+      div {
+        line-height: normal;
+
+        label {
+          margin-top: 0;
+          margin-bottom: 0;
+          padding-top: 0;
+          width: auto;
+        }
+      }
     }
     label {
       color: #444;

--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -99,6 +99,7 @@ class Projects::MergeRequestsController < Projects::ApplicationController
 
     if @merge_request.opened? && @merge_request.can_be_merged?
       @merge_request.should_remove_source_branch = params[:should_remove_source_branch]
+      @merge_request.fast_forward = params[:fast_forward]
       @merge_request.automerge!(current_user)
       @status = true
     else
@@ -181,6 +182,8 @@ class Projects::MergeRequestsController < Projects::ApplicationController
 
     @target_type = :merge_request
     @target_id = @merge_request.id
+
+    @fast_forward = Gitlab.config.git[:fast_forward]
   end
 
   def allowed_to_merge?

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -18,9 +18,14 @@
             = f.submit "Accept Merge Request", class: "btn btn-create accept_merge_request"
             - unless @merge_request.disallow_source_branch_removal?
               .remove_branch_holder
-                = label_tag :should_remove_source_branch, class: "checkbox" do
-                  = check_box_tag :should_remove_source_branch
-                  Remove source-branch
+                %div
+                  = label_tag :should_remove_source_branch, class: "checkbox" do
+                    = check_box_tag :should_remove_source_branch
+                    Remove source-branch
+                %div
+                  = label_tag :fast_forward, class: "checkbox" do
+                    = check_box_tag :fast_forward, 1, @fast_forward
+                    Fast-forward merge
           .clearfix
 
 

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -191,6 +191,10 @@ production: &base
     max_size: 5242880 # 5.megabytes
     # Git timeout to read a commit, in seconds
     timeout: 10
+    # Setting this to true will by default check the "fast-forward merge"
+    # checkbox for merge requests. When this checkbox is checked a standard
+    # fast-forward merge will be performed when accepting merge requests.
+    # fast_forward: true
 
   #
   # 4. Extra customization


### PR DESCRIPTION
Adds a new checkbox next to the "Remove source-branch" checkbox that when checked will perform a standard fast-forward merge when accepting the merge request. A new config entry is also added allowing to set the default state of the checkbox.

![fast-forward merge](https://f.cloud.github.com/assets/306980/1640634/8f46fa5e-583e-11e3-84ba-e1399c1310d5.png)
