### PR TITLE
Thumbsup and thumbsdown emoji should be counted when voting

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -157,7 +157,8 @@ class Note < ActiveRecord::Base
   # otherwise false is returned
   def downvote?
     votable? && (note.start_with?('-1') ||
-                 note.start_with?(':-1:')
+                 note.start_with?(':-1:') ||
+                 note.start_with?(':thumbsdown:')
                 )
   end
 
@@ -206,7 +207,8 @@ class Note < ActiveRecord::Base
   # otherwise false is returned
   def upvote?
     votable? && (note.start_with?('+1') ||
-                 note.start_with?(':+1:')
+                 note.start_with?(':+1:') ||
+                 note.start_with?(':thumbsup:')
                 )
   end
 

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -61,6 +61,11 @@ describe Note do
       note.should be_upvote
     end
 
+    it "recognizes a thumbsup emoji as a vote" do
+      note = build(:votable_note, note: ":thumbsup: for this")
+      note.should be_upvote
+    end
+
     it "recognizes a -1 note" do
       note = create(:votable_note, note: "-1 for this")
       note.should be_downvote
@@ -68,6 +73,11 @@ describe Note do
 
     it "recognizes a -1 emoji as a vote" do
       note = build(:votable_note, note: ":-1: for this")
+      note.should be_downvote
+    end
+
+    it "recognizes a thumbsdown emoji as a vote" do
+      note = build(:votable_note, note: ":thumbsdown: for this")
       note.should be_downvote
     end
   end


### PR DESCRIPTION
for Feature Request:
http://feedback.gitlab.com/forums/176466-general/suggestions/5063152-thumbsup-and-thumbsdown-emoji-should-be-counted-wh

**Thumbsup and thumbsdown emoji should be counted when voting**

Right now +1, -1, : +1 : and : -1 : are counted as votes in issues and merge requests, also include : thumbsup : and : thumbsdown : emoji

I have added tests for this voting and added voting with the thumbs emojis : thumbsup : and : thumbsdown :.
