### PR TITLE
Correct url to pull puplic repos anonymously on project page

### DIFF
--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -1,4 +1,4 @@
 .git-clone-holder
-  %button{class: "btn active", :"data-clone" => @project.ssh_url_to_repo} SSH
-  %button{class: "btn", :"data-clone" => @project.http_url_to_repo}= gitlab_config.protocol.upcase
-  = text_field_tag :project_clone, @project.url_to_repo, class: "one_click_select span5", readonly: true
+  %button{class: "btn #{ current_user ? 'active' : '' }", :"data-clone" => @project.ssh_url_to_repo} SSH
+  %button{class: "btn #{ current_user ? '' : 'active' }", :"data-clone" => @project.http_url_to_repo}= gitlab_config.protocol.upcase
+  = text_field_tag :project_clone, (current_user ? @project.url_to_repo : @project.http_url_to_repo), class: "one_click_select span5", readonly: true

--- a/features/public/public_projects.feature
+++ b/features/public/public_projects.feature
@@ -38,3 +38,14 @@ Feature: Public Projects Feature
     Given I sign in as a user
     When I visit project "Internal" page
     Then I should see project "Internal" home page
+
+  Scenario: I visit public project page
+    When I visit project "Community" page
+    Then I should see project "Community" home page
+    And I should see a http link to the repository
+
+  Scenario: I visit public area as user
+    Given I sign in as a user
+    When I visit project "Community" page
+    Then I should see project "Community" home page
+    And I should see a ssh link to the repository

--- a/features/steps/public/projects_feature.rb
+++ b/features/steps/public/projects_feature.rb
@@ -83,5 +83,15 @@ class Spinach::Features::PublicProjectsFeature < Spinach::FeatureSteps
       page.should have_content 'Internal'
     end
   end
+
+  Then 'I should see a http link to the repository' do
+    project = Project.find_by_name 'Community'
+    page.should have_field('project_clone', with: project.http_url_to_repo)
+  end
+
+  Then 'I should see a ssh link to the repository' do
+    project = Project.find_by_name 'Community'
+    page.should have_field('project_clone', with: project.url_to_repo)
+  end
 end
 


### PR DESCRIPTION
for Feature Request:
http://feedback.gitlab.com/forums/176466-general/suggestions/4968567-correct-url-to-pull-puplic-repos-anonymously-on-pr

**Correct url to pull puplic repos anonymously on project page**

Ability to pull public repos anonymously via http url on public project page. Now it shows the ssh url on the project page when you are logged out.

**GitLab team (Admin, Gitlab) responded  ·  Nov 18, 2013**
Accepting a fix that will show only a http url on the project page when you are not logged in

The GIT url default shown is HTTP when not logged in.
Changing the url to SSH still works.
Spinach tests are provided.
