### PR TITLE
Improve Help navigation UI

### DIFF
--- a/app/views/help/_layout.html.haml
+++ b/app/views/help/_layout.html.haml
@@ -1,37 +1,11 @@
 .row
   .span3{:"data-spy" => 'affix'}
-    .ui-box
-      .title
-        Help
-      %ul.well-list
-        %li
-          %strong= link_to "Workflow", help_workflow_path
-        %li
-          %strong= link_to "SSH keys", help_ssh_path
-
-        %li
-          %strong= link_to "GitLab Markdown", help_markdown_path
-
-        %li
-          %strong= link_to "Permissions", help_permissions_path
-
-        %li
-          %strong= link_to "API", help_api_path
-
-        %li
-          %strong= link_to "Web Hooks", help_web_hooks_path
-
-        %li
-          %strong= link_to "Rake Tasks", help_raketasks_path
-
-        %li
-          %strong= link_to "System Hooks", help_system_hooks_path
-
-        %li
-          %strong= link_to "Public Access", help_public_access_path
-
-        %li
-          %strong= link_to "Security", help_security_path
+    %h3.page-title Help
+    %ul.nav.nav-pills.nav-stacked
+      - links = {:"Workflow" => help_workflow_path, :"SSH Keys" => help_ssh_path, :"GitLab Markdown" => help_markdown_path, :"Permissions" => help_permissions_path, :"API" => help_api_path, :"Web Hooks" => help_web_hooks_path, :"Rake Tasks" => help_raketasks_path, :"System Hooks" => help_system_hooks_path, :"Public Access" => help_public_access_path, :"Security" => help_security_path}
+      - links.each do |title,path|
+        %li{class: current_page?(path) ? 'active' : nil}
+          = link_to title, path
 
   .span9.pull-right
     = yield


### PR DESCRIPTION
This PR brings the Help navigation in line with the rest of the sidebar navigation UI. 

Before:
![helpnavbefore](https://f.cloud.github.com/assets/2394772/1647027/d3745ea0-592f-11e3-927a-bd6136029094.png)

After:
![helpnavafter](https://f.cloud.github.com/assets/2394772/1647028/d7eec01a-592f-11e3-97b3-8aef4e475c58.png)
