### PR TITLE
Missing gem bundler

### DIFF
--- a/doc/update/ruby.md
+++ b/doc/update/ruby.md
@@ -32,6 +32,7 @@ cd ruby-2.0.0-p353
 ./configure --disable-install-rdoc
 make
 sudo make install # overwrite the existing Ruby in /usr/local/bin
+sudo gem install bundler
 ```
 
 ### 5. Reinstall GitLab gem bundle


### PR DESCRIPTION
Trying to install the gem bundle without bundler fails with:
/usr/local/lib/ruby/2.0.0/rubygems/dependency.rb:296:in `to_specs': Could not find 'bundler' (>= 0) among 8 total gem(s) (Gem::LoadError)
        from /usr/local/lib/ruby/2.0.0/rubygems/dependency.rb:307:in`to_spec'
        from /usr/local/lib/ruby/2.0.0/rubygems/core_ext/kernel_gem.rb:47:in `gem'
        from /usr/local/bin/bundle:22:in`<main>'

Installing the bundler (with sudo gem install bundler) at the end of Step 4 fixes this.
