### PR TITLE
Issue 5716 - Allow removal of avatar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ v 6.4.0
   - Minimal password length increased to 8 symbols
   - Side-by-side diff view (Steven Thonus)
   - Internal projects (Jason Hollingsworth)
+  - Allow removal of avatar (Drew Blessing)
 
 v 6.3.0
   - API for adding gitlab-ci service

--- a/app/assets/stylesheets/sections/profile.scss
+++ b/app/assets/stylesheets/sections/profile.scss
@@ -42,3 +42,7 @@
   margin-right: 12px;
 }
 
+.remove_avatar {
+  margin-top: 10px;
+}
+

--- a/app/controllers/profiles/avatars_controller.rb
+++ b/app/controllers/profiles/avatars_controller.rb
@@ -1,0 +1,11 @@
+class Profiles::AvatarsController < ApplicationController
+  layout "profile"
+
+  def destroy
+    @user = current_user
+    @user.remove_avatar!
+
+    @user.save
+    redirect_to profile_path
+  end
+end

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -59,9 +59,14 @@
         .clearfix
           .profile-avatar-form-option
             %p.light
-              You can upload an avatar here
-              %br
-              or change it at #{link_to "gravatar.com", "http://gravatar.com"}
+              - if @user.avatar?
+                You can change your avatar here
+                %br
+                or remove the current avatar to revert to #{link_to "gravatar.com", "http://gravatar.com"}
+              - else
+                You can upload an avatar here
+                %br
+                or change it at #{link_to "gravatar.com", "http://gravatar.com"}
             %hr
             %a.choose-btn.btn.btn-small.js-choose-user-avatar-button
               %i.icon-paper-clip
@@ -70,6 +75,8 @@
             %span.file_name.js-avatar-filename File name...
             = f.file_field :avatar, class: "js-user-avatar-input hide"
           %span.help-block The maximum file size allowed is 100KB.
+          - if @user.avatar?
+            = link_to 'Remove avatar', profile_avatar_path, confirm: "Avatar will be removed. Are you sure?", method: :delete, class: "btn btn-remove remove_avatar"
 
   .form-actions
     = f.submit 'Save changes', class: "btn btn-save"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Gitlab::Application.routes.draw do
           delete :leave
         end
       end
+      resource :avatar, only: [:destroy]
     end
   end
 

--- a/features/profile/profile.feature
+++ b/features/profile/profile.feature
@@ -26,6 +26,14 @@ Feature: Profile
     Given I visit profile page
     Then I change my avatar
     And I should see new avatar
+    And I should see the "Remove avatar" button
+
+  Scenario: I remove my avatar
+    Given I visit profile page
+    And I have an avatar
+    When I remove my avatar
+    Then I should see my gravatar
+    And I should not see the "Remove avatar" button
 
   Scenario: My password is expired
     Given my password is expired

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -31,6 +31,29 @@ class Profile < Spinach::FeatureSteps
     @user.avatar.url.should == "/uploads/user/avatar/#{ @user.id }/gitlab_logo.png"
   end
 
+  step 'I should see the "Remove avatar" button' do
+    page.should have_link("Remove avatar")
+  end
+
+  step 'I have an avatar' do
+    attach_file(:user_avatar, File.join(Rails.root, 'public', 'gitlab_logo.png'))
+    click_button "Save changes"
+    @user.reload
+  end
+
+  step 'I remove my avatar' do
+    click_link "Remove avatar"
+    @user.reload
+  end
+
+  step 'I should see my gravatar' do
+    @user.avatar?.should be_false
+  end
+
+  step 'I should not see the "Remove avatar" button' do
+    page.should_not have_link("Remove avatar")
+  end
+
   step 'I try change my password w/o old one' do
     within '.update-password' do
       fill_in "user_password", with: "22233344"

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -185,6 +185,13 @@ describe Profiles::KeysController, "routing" do
   end
 end
 
+# profile_avatar DELETE /profile/avatar(.:format) profiles/avatars#destroy
+describe Profiles::AvatarsController, "routing" do
+  it "to #destroy" do
+    delete("/profile/avatar").should route_to('profiles/avatars#destroy')
+  end
+end
+
 #                dashboard GET    /dashboard(.:format)                dashboard#show
 #         dashboard_issues GET    /dashboard/issues(.:format)         dashboard#issues
 # dashboard_merge_requests GET    /dashboard/merge_requests(.:format) dashboard#merge_requests


### PR DESCRIPTION
This PR fixes #5716. It adds a remove checkbox to the profile form if an avatar has been uploaded. It also changes the text to indicate that you can remove the avatar to revert to using gravatar.  CarrierWaveUploader has support for removing the avatar as long as we expose remove_avatar on the model. See https://github.com/carrierwaveuploader/carrierwave#removing-uploaded-files for more information.

I looked at the existing tests to make sure this wouldn't break anything. I also considered adding a test but I'm not sure if this really adds enough functionality to require a test. We're mostly relying on CarrierWaveUploader features here. I'm open to suggestions, though.

When no avatar is present (same UI as before this PR):
![gravatar](https://f.cloud.github.com/assets/2394772/1647467/89de790c-5942-11e3-9ed0-ad9f3d849173.png)

When an avatar has been uploaded:
![avatar](https://f.cloud.github.com/assets/2394772/1647466/8717d2f4-5942-11e3-946a-63fd0f40eedf.png)
