### PR TITLE
Fix #5313 hipchat 0.14.0 to use http_proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ gem "redis-rails"
 gem 'tinder', '~> 1.9.2'
 
 # HipChat integration
-gem "hipchat", "~> 0.9.0"
+gem "hipchat", "~> 0.14.0"
 
 # Flowdock integration
 gem "gitlab-flowdock-git-hook", "~> 0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       railties (>= 3.1, < 4.1)
     hashie (1.2.0)
     hike (1.2.3)
-    hipchat (0.9.0)
+    hipchat (0.14.0)
       httparty
       httparty
     http_parser.rb (0.5.3)
@@ -588,7 +588,7 @@ DEPENDENCIES
   guard-rspec
   guard-spinach
   haml-rails
-  hipchat (~> 0.9.0)
+  hipchat (~> 0.14.0)
   httparty
   jasmine
   jquery-atwho-rails (= 0.3.0)


### PR DESCRIPTION
Not a ruby programmer here, I think Gemfile ang Gemfile.lock need changes.
