### PR TITLE
remove link for avatar on profile page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ActiveRecord::Base
 
   attr_accessible :email, :password, :password_confirmation, :remember_me, :bio, :name, :username,
                   :skype, :linkedin, :twitter, :color_scheme_id, :theme_id, :force_random_password,
-                  :extern_uid, :provider, :password_expires_at, :avatar,
+                  :extern_uid, :provider, :password_expires_at, :avatar, :remove_avatar,
                   as: [:default, :admin]
 
   attr_accessible :projects_limit, :can_create_group,

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -70,6 +70,10 @@
             %span.file_name.js-avatar-filename File name...
             = f.file_field :avatar, class: "js-user-avatar-input hide"
           %span.help-block The maximum file size allowed is 100KB.
+          .span2
+            .control-group
+              = f.label :remove_avatar, class: "control-label"
+              .controls= f.check_box :remove_avatar, class: "input-xlarge"
 
   .form-actions
     = f.submit 'Save changes', class: "btn btn-save"

--- a/features/profile/profile.feature
+++ b/features/profile/profile.feature
@@ -27,6 +27,11 @@ Feature: Profile
     Then I change my avatar
     And I should see new avatar
 
+  Scenario: I delete my avatar
+    Given I visit profile page
+    Then I remove my avatar
+    And I should see no avatar
+
   Scenario: My password is expired
     Given my password is expired
     And I am not an ldap user

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -31,6 +31,17 @@ class Profile < Spinach::FeatureSteps
     @user.avatar.url.should == "/uploads/user/avatar/#{ @user.id }/gitlab_logo.png"
   end
 
+  step 'I remove my avatar' do
+    check 'user_remove_avatar'
+    click_button "Save changes"
+    @user.reload
+  end
+
+  step 'I should see no avatar' do
+    @user.avatar.should be_instance_of AttachmentUploader
+    @user.avatar.url.should == nil
+  end
+
   step 'I try change my password w/o old one' do
     within '.update-password' do
       fill_in "user_password", with: "22233344"


### PR DESCRIPTION
since there were requests for the removal of an uploaded avatar, I've added this.

It works and has tests.

Only the display of the remove_avatar checkobox can be a bit neater.
