### PR TITLE
Added autocomplete="off" to the login password fields.

### DIFF
--- a/app/views/devise/sessions/_new_base.html.haml
+++ b/app/views/devise/sessions/_new_base.html.haml
@@ -1,6 +1,6 @@
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   = f.text_field :login, class: "text top", placeholder: "Username or Email", autofocus: "autofocus"
-  = f.password_field :password, class: "text bottom", placeholder: "Password"
+  = f.password_field :password, class: "text bottom", placeholder: "Password", autocomplete: "off"
   - if devise_mapping.rememberable?
     .clearfix.append-bottom-10
       %label.checkbox.remember_me{for: "user_remember_me"}

--- a/app/views/devise/sessions/_new_ldap.html.haml
+++ b/app/views/devise/sessions/_new_ldap.html.haml
@@ -1,5 +1,5 @@
 = form_tag(user_omniauth_callback_path(:ldap), id: 'new_ldap_user' ) do
   = text_field_tag :username, nil, {class: "text top", placeholder: "LDAP Login", autofocus: "autofocus"}
-  = password_field_tag :password, nil, {class: "text bottom", placeholder: "Password"}
+  = password_field_tag :password, nil, {class: "text bottom", placeholder: "Password", autocomplete: "off"}
   %br/
   = submit_tag "LDAP Sign in", class: "btn-create btn"


### PR DESCRIPTION
I added autocomplete="off" to the two password fields on the login page for standard login and LDAP login, which appears to be consistent with other password fields elsewhere in GitLab.
