### PR TITLE
Add cache expiry on avatar creation/removal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ v 6.4.0
   - Allow removal of avatar (Drew Blessing)
   - Project web hooks now support issues and merge request events
   - Visiting project page while not logged in will redirect to sign-in instead of 404 (Jason Hollingsworth)
+  - Expire event cache on avatar creation/removal (Drew Blessing)
 
 v 6.3.0
   - API for adding gitlab-ci service

--- a/app/controllers/profiles/avatars_controller.rb
+++ b/app/controllers/profiles/avatars_controller.rb
@@ -6,6 +6,8 @@ class Profiles::AvatarsController < ApplicationController
     @user.remove_avatar!
 
     @user.save
+    @user.reset_events_cache
+
     redirect_to profile_path
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -404,4 +404,18 @@ class User < ActiveRecord::Base
     project.namespace != namespace &&
       project.project_member(self)
   end
+
+  # Reset project events cache related to this user
+  #
+  # Since we do cache @event we need to reset cache in special cases:
+  # * when the user changes their avatar
+  # Events cache stored like  events/23-20130109142513.
+  # The cache key includes updated_at timestamp.
+  # Thus it will automatically generate a new fragment
+  # when the event is updated because the key changes.
+  def reset_events_cache
+    Event.where(author_id: self.id).
+      order('id DESC').limit(1000).
+      update_all(updated_at: Time.now)
+  end
 end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -3,6 +3,8 @@
 class AttachmentUploader < CarrierWave::Uploader::Base
   storage :file
 
+  after :store, :reset_events_cache
+
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
@@ -26,5 +28,9 @@ class AttachmentUploader < CarrierWave::Uploader::Base
 
   def file_storage?
     self.class.storage == CarrierWave::Storage::File
+  end
+
+  def reset_events_cache(file)
+    model.reset_events_cache if model.is_a?(User)
   end
 end


### PR DESCRIPTION
This PR resolves #5496. If you add/remove an avatar the events cache is not updated and results in either a broken image or shows a gravatar instead of the avatar - see screenshots below. By adding a cache "expire/update" on both avatar creation/removal we can eliminate this issue. I took the approach of updating events by author id only and set it to limit to 1000 items. I'm not sure if this is the right limit or if a limit is warranted, but a similar cache reset for projects limits to 100 items.  100 seemed too low in this case because we have to expect that this user will have many events across multiple projects.  

Steps to test (Please note that you cannot test this fix in a development environment without enabling caching)
1. Add an avatar
2. Go to the dashboard and note that the avatars on events are either still showing the gravatar or are showing a broken image link
3. Apply this fix
4. Change the avatar
5. Go to the dashboard and note that the avatars are now showing the new image.
Similarly, you can remove the avatar and note that gravatars are now shown on all events.

Illustration of the issue when an avatar is uploaded. You still see the gravatar/default avatar image:
![avatar_caching_issue](https://f.cloud.github.com/assets/2394772/1675065/603eea22-5d03-11e3-97c7-f6ff98600a68.png)

Illustration of the issue when a user already had an avatar and then changed it:
![avatar_caching_change](https://f.cloud.github.com/assets/2394772/1675078/945dfbe0-5d03-11e3-8b62-5b5f137a67aa.png)
