### PR TITLE
Fix HTTP push to public repos

### DIFF
--- a/lib/gitlab/backend/grack_auth.rb
+++ b/lib/gitlab/backend/grack_auth.rb
@@ -92,6 +92,9 @@ module Grack
           return false unless can?(user, action, project)
         end
 
+        # Never let git-receive-pack trough unauthenticated; it's
+        # harmless but git < 1.8 doesn't like it
+        return false if user.nil?
         true
       else
         false


### PR DESCRIPTION
When doing an HTTP push, git (as of v1.7.9) first do an info/refs
request, and only if this request requires authentication it asks the
user for its password and authenticates further requests.

The initial request normally clears without auth on public repos as it
doesn't update any ref. This patch forces every git-receive-pack to
provide authentication.
