### PR TITLE
Fixed some deprecations

### DIFF
--- a/app/contexts/issues/bulk_update_context.rb
+++ b/app/contexts/issues/bulk_update_context.rb
@@ -22,7 +22,7 @@ module Issues
       opts[:milestone_id] = milestone_id if milestone_id.present?
       opts[:assignee_id] = assignee_id if assignee_id.present?
 
-      issues = Issue.where(id: issues_ids).all
+      issues = Issue.where(id: issues_ids)
       issues = issues.select { |issue| can?(current_user, :modify_issue, issue) }
 
       issues.each do |issue|

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -18,7 +18,7 @@
         Compare
 
       - if can?(current_user, :admin_project, @project) && branch.name != @repository.root_ref
-        = link_to project_branch_path(@project, branch.name), class: 'btn grouped btn-small remove-row', method: :delete, confirm: 'Removed branch cannot be restored. Are you sure?', remote: true do
+        = link_to project_branch_path(@project, branch.name), class: 'btn grouped btn-small remove-row', method: :delete, data: { confirm: 'Removed branch cannot be restored. Are you sure?'}, remote: true do
           %i.icon-trash
 
   %p

--- a/app/views/projects/tags/index.html.haml
+++ b/app/views/projects/tags/index.html.haml
@@ -37,7 +37,7 @@
                 %i.icon-download-alt
                 Download
             - if can?(current_user, :admin_project, @project)
-              = link_to project_tag_path(@project, tag.name), class: 'btn btn-small remove-row', method: :delete, confirm: 'Removed tag cannot be restored. Are you sure?', remote: true do
+              = link_to project_tag_path(@project, tag.name), class: 'btn btn-small remove-row', method: :delete, data: { confirm: 'Removed tag cannot be restored. Are you sure?'}, remote: true do
                 %i.icon-trash
 
   = paginate @tags, theme: 'gitlab'


### PR DESCRIPTION
- Model.all is deprecacted, use without .all
- confirm: message is deprecated, needed to be wrapped
  in data block
