### PR TITLE
Don't use :redis_store in development environment

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,10 +1,20 @@
 # Be sure to restart your server when you modify this file.
 
-Gitlab::Application.config.session_store(
-  :redis_store, # Using the cookie_store would enable session replay attacks.
-  servers: Gitlab::Application.config.cache_store.last, # re-use the Redis config from the Rails cache store
-  key: '_gitlab_session',
-  secure: Gitlab::Application.config.force_ssl,
-  httponly: true,
-  path: (Rails.application.config.relative_url_root.nil?) ? '/' : Rails.application.config.relative_url_root
-)
+session_store = if Rails.env.prod? 
+                  # Using the cookie_store would enable session replay attacks.
+                  :redis_store
+                else
+                  :cache_store 
+                end
+
+store_options = if Rails.env.prod?
+                  {
+                    servers: Gitlab::Application.config.cache_store.last, # re-use the Redis config from the Rails cache store
+                    key: '_gitlab_session',
+                    secure: Gitlab::Application.config.force_ssl,
+                    httponly: true,
+                    path: (Rails.application.config.relative_url_root.nil?) ? '/' : Rails.application.config.relative_url_root
+                  }
+                end
+
+Gitlab::Application.config.session_store(session_store, store_options)


### PR DESCRIPTION
This commit fixes small problem. The problem is if you try to start gitlabhq application in development environment with non-default `redis`  port (e. g. it's possible if you use @boxen) you will have `Rack` exception (`Redis on 127.0.0.1:6379 (ECONNREFUSED)`).

Improper `session_store` configuration causes such a problem.
