### PR TITLE
[API] add parent_ids to specific commit informations

### DIFF
--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -259,7 +259,12 @@ Parameters:
   "title": "Sanitize for network graph",
   "author_name": "randx",
   "author_email": "dmitriy.zaporozhets@gmail.com",
-  "created_at": "2012-09-20T09:06:12+03:00"
+  "created_at": "2012-09-20T09:06:12+03:00",
+  "committed_date": "2012-09-20T09:06:12+03:00",
+  "authored_date": "2012-09-20T09:06:12+03:00",
+  "parent_ids" : [
+      "ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"
+   ]
 }
 ```
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -91,6 +91,10 @@ module API
       expose :id, :short_id, :title, :author_name, :author_email, :created_at
     end
 
+    class RepoCommitDetail < RepoCommit
+      expose :parent_ids, :committed_date, :authored_date
+    end
+
     class ProjectSnippet < Grape::Entity
       expose :id, :title, :file_name
       expose :author, using: Entities::UserBasic

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -110,7 +110,7 @@ module API
         sha = params[:sha]
         commit = user_project.repository.commit(sha)
         not_found! "Commit" unless commit
-        present commit, with: Entities::RepoCommit
+        present commit, with: Entities::RepoCommitDetail
       end
 
       # Get the diff for a specific commit of a project


### PR DESCRIPTION
The current api does not indicate the parents of a commit, which is a very useful information for moving inside the commits history. This merge request add this information to the api for a specific commit in order to not bloat the generic version.

Also add `comitted_date` and `authored_date` information because `created_at` is ambiguous  (eg. #4666)
