### PR TITLE
Remove rails4 branch in travis configuration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 branches:
   only:
     - 'master'
-    - 'rails4'
 rvm:
   - 2.0.0
 services:


### PR DESCRIPTION
rails4 is already merged so this watcher is not necessary anymore
