### PR TITLE
Fix dashboard event caching

### DIFF
--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -74,6 +74,7 @@ class Projects::IssuesController < Projects::ApplicationController
 
   def update
     @issue.update_attributes(params[:issue].merge(author_id_of_changes: current_user.id))
+    @issue.reset_events_cache
 
     respond_to do |format|
       format.js

--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -97,6 +97,7 @@ class Projects::MergeRequestsController < Projects::ApplicationController
     if @merge_request.update_attributes(params[:merge_request].merge(author_id_of_changes: current_user.id))
       @merge_request.reload_code
       @merge_request.mark_as_unchecked
+      @merge_request.reset_events_cache
       redirect_to [@merge_request.target_project, @merge_request], notice: 'Merge request was successfully updated.'
     else
       render "edit"

--- a/app/controllers/projects/notes_controller.rb
+++ b/app/controllers/projects/notes_controller.rb
@@ -39,6 +39,7 @@ class Projects::NotesController < Projects::ApplicationController
     @note = @project.notes.find(params[:id])
     return access_denied! unless can?(current_user, :admin_note, @note)
     @note.destroy
+    @note.reset_events_cache
 
     respond_to do |format|
       format.js { render nothing: true }
@@ -50,6 +51,7 @@ class Projects::NotesController < Projects::ApplicationController
     return access_denied! unless can?(current_user, :admin_note, @note)
 
     @note.update_attributes(params[:note])
+    @note.reset_events_cache
 
     respond_to do |format|
       format.js do

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -64,4 +64,18 @@ class Issue < ActiveRecord::Base
   def gfm_reference
     "issue ##{iid}"
   end
+
+  # Reset issue events cache
+  #
+  # Since we do cache @event we need to reset cache in special cases:
+  # * when an issue is updated
+  # Events cache stored like  events/23-20130109142513.
+  # The cache key includes updated_at timestamp.
+  # Thus it will automatically generate a new fragment
+  # when the event is updated because the key changes.
+  def reset_events_cache
+    Event.where(target_id: self.id, target_type: 'Issue').
+      order('id DESC').limit(100).
+      update_all(updated_at: Time.now)
+  end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -305,6 +305,20 @@ class MergeRequest < ActiveRecord::Base
     self.target_project.repository.branch_names.include?(self.target_branch)
   end
 
+  # Reset merge request events cache
+  #
+  # Since we do cache @event we need to reset cache in special cases:
+  # * when a merge request is updated
+  # Events cache stored like  events/23-20130109142513.
+  # The cache key includes updated_at timestamp.
+  # Thus it will automatically generate a new fragment
+  # when the event is updated because the key changes.
+  def reset_events_cache
+    Event.where(target_id: self.id, target_type: 'MergeRequest').
+        order('id DESC').limit(100).
+        update_all(updated_at: Time.now)
+  end
+
   private
 
   def dump_commits(commits)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -239,4 +239,19 @@ class Note < ActiveRecord::Base
   def noteable_type=(sType)
     super(sType.to_s.classify.constantize.base_class.to_s)
   end
+
+  # Reset notes events cache
+  #
+  # Since we do cache @event we need to reset cache in special cases:
+  # * when a note is updated
+  # * when a note is removed
+  # Events cache stored like  events/23-20130109142513.
+  # The cache key includes updated_at timestamp.
+  # Thus it will automatically generate a new fragment
+  # when the event is updated because the key changes.
+  def reset_events_cache
+    Event.where(target_id: self.id, target_type: 'Note').
+      order('id DESC').limit(100).
+      update_all(updated_at: Time.now)
+  end
 end


### PR DESCRIPTION
Fixes #5828 - "Edits in MR comments not get updated on dashboard"

**Problem** If a user updates/destroys an issue, merge request or comment, the corresponding event on the dashboard is not updated/destroyed. 

**Solution** After update/destroy for any issue, merge request or comment, ensure that corresponding events' updated_at timestamps are modified so the correct content is displayed on the dashboard.
