### PR TITLE
Add time ago tooltips to show actual date/time

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,7 +72,7 @@ module ApplicationHelper
 
   def last_commit(project)
     if project.repo_exists?
-      time_ago_in_words(project.repository.commit.committed_date) + " ago"
+      time_ago_with_tooltip(project.repository.commit.committed_date) + " ago"
     else
       "Never"
     end
@@ -136,9 +136,9 @@ module ApplicationHelper
     Digest::SHA1.hexdigest string
   end
 
-  def project_last_activity project
+  def project_last_activity(project)
     if project.last_activity_at
-      time_ago_in_words(project.last_activity_at) + " ago"
+      time_ago_with_tooltip(project.last_activity_at, 'bottom', 'last_activity_time_ago') + " ago"
     else
       "Never"
     end
@@ -214,5 +214,15 @@ module ApplicationHelper
     content_tag :div, class: user_color_scheme_class do
       Pygments::Lexer[:js].highlight(string).html_safe
     end
+  end
+
+  def time_ago_with_tooltip(date, placement = 'top', html_class = 'time_ago')
+    capture_haml do
+      haml_tag :time, time_ago_in_words(date),
+        class: html_class, datetime: date, title: date.stamp("Aug 21, 2011 9:23pm"),
+        data: { toggle: 'tooltip', placement: placement }
+
+      haml_tag :script, "$('." + html_class + "').tooltip()"
+    end.html_safe
   end
 end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -31,8 +31,14 @@ module NotesHelper
 
   def note_timestamp(note)
     # Shows the created at time and the updated at time if different
-    ts = "#{time_ago_in_words(note.created_at)} ago"
-    ts << content_tag(:small, " (Edited #{time_ago_in_words(note.updated_at)} ago)") if note.updated_at != note.created_at
+    ts = "#{time_ago_with_tooltip(note.created_at, 'bottom', 'note_created_ago')} ago"
+    if note.updated_at != note.created_at
+      ts << capture_haml do
+        haml_tag :small do
+          haml_concat " (Edited #{time_ago_with_tooltip(note.updated_at, 'bottom', 'note_edited_ago')} ago)"
+        end
+      end
+    end
     ts.html_safe
   end
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -37,8 +37,7 @@
       %p
         = link_to project.name_with_namespace, [:admin, project]
         %span.light.pull-right
-          = time_ago_in_words project.created_at
-          ago
+          #{time_ago_with_tooltip(project.created_at)} ago
 
   .span4
     %h4 Latest users
@@ -48,8 +47,7 @@
         = link_to [:admin, user] do
           = user.name
         %span.light.pull-right
-          = time_ago_in_words user.created_at
-          ago
+          #{time_ago_with_tooltip(user.created_at)} ago
 
   .span4
     %h4 Latest groups
@@ -59,8 +57,7 @@
         = link_to [:admin, group] do
           = group.name
         %span.light.pull-right
-          = time_ago_in_words group.created_at
-          ago
+          #{time_ago_with_tooltip(group.created_at)} ago
 
 %br
 .row

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -1,7 +1,7 @@
 - if event.proper?
   .event-item{class: "#{event.body? ? "event-block" : "event-inline" }"}
     %span.cgray.pull-right
-      #{time_ago_in_words(event.created_at)} ago.
+      #{time_ago_with_tooltip(event.created_at)} ago
 
     = cache event do
       = image_tag avatar_icon(event.author_email, 24), class: "avatar s24", alt:''

--- a/app/views/events/_event_last_push.html.haml
+++ b/app/views/events/_event_last_push.html.haml
@@ -5,9 +5,8 @@
       %strong= truncate(event.ref_name, length: 28)
     at
     %strong= link_to_project event.project
-    %span
-      = time_ago_in_words(event.created_at)
-      ago.
+    #{time_ago_with_tooltip(event.created_at)} ago
+
     .pull-right
       = link_to new_mr_path_from_push_event(event), title: "New Merge Request", class: "btn btn-create btn-small" do
         Create Merge Request

--- a/app/views/profiles/keys/_key.html.haml
+++ b/app/views/profiles/keys/_key.html.haml
@@ -4,8 +4,6 @@
   %span
     (#{key.fingerprint})
   %span.cgray
-    added
-    = time_ago_in_words(key.created_at)
-    ago
+    added #{time_ago_with_tooltip(key.created_at)} ago
 
   = link_to 'Remove', profile_key_path(key), data: { confirm: 'Are you sure?'}, method: :delete, class: "btn btn-small btn-remove delete-key pull-right"

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -27,6 +27,4 @@
     = image_tag avatar_icon(commit.author_email), class: "avatar s16", alt: ''
     %span.light
       = gfm escape_once(truncate(commit.title, length: 40))
-    %span
-      = time_ago_in_words(commit.committed_date)
-      ago
+    #{time_ago_with_tooltip(commit.committed_date)} ago

--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -23,16 +23,14 @@
   %span.light Authored by
   %strong
     = commit_author_link(@commit, avatar: true, size: 24)
-  %time{title: @commit.authored_date.stamp("Aug 21, 2011 9:23pm")}
-    #{time_ago_in_words(@commit.authored_date)} ago
+  #{time_ago_with_tooltip(@commit.authored_date)} ago
 
 - if @commit.different_committer?
   .commit-info-row
     %span.light Committed by
     %strong
       = commit_committer_link(@commit, avatar: true, size: 24)
-    %time{title: @commit.committed_date.stamp("Aug 21, 2011 9:23pm")}
-      #{time_ago_in_words(@commit.committed_date)} ago
+    #{time_ago_with_tooltip(@commit.committed_date)} ago
 
 .commit-info-row
   %span.cgray= pluralize(@commit.parents.count, "parent")

--- a/app/views/projects/commits/_commit.html.haml
+++ b/app/views/projects/commits/_commit.html.haml
@@ -13,7 +13,4 @@
 
   .commit-row-info
     = commit_author_link(commit, avatar: true, size: 16)
-    %time.committed_ago{ datetime: commit.committed_date, title: commit.committed_date.stamp("Aug 21, 2011 9:23pm") }
-      = time_ago_in_words(commit.committed_date)
-      ago
-      &nbsp;
+    #{time_ago_with_tooltip(commit.committed_date)} ago &nbsp;

--- a/app/views/projects/commits/_inline_commit.html.haml
+++ b/app/views/projects/commits/_inline_commit.html.haml
@@ -3,7 +3,4 @@
     = link_to commit.short_id(8), project_commit_path(project, commit), class: "commit_short_id"
     &nbsp;
     = link_to_gfm truncate(commit.title, length: 40), project_commit_path(project, commit.id), class: "commit-row-message"
-    %time.committed_ago{ datetime: commit.committed_date, title: commit.committed_date.stamp("Aug 21, 2011 9:23pm") }
-      = time_ago_in_words(commit.committed_date)
-      ago
-      &nbsp;
+    #{time_ago_with_tooltip(commit.committed_date)} ago &nbsp;

--- a/app/views/projects/deploy_keys/_deploy_key.html.haml
+++ b/app/views/projects/deploy_keys/_deploy_key.html.haml
@@ -21,5 +21,4 @@
     - deploy_key.projects.map(&:name_with_namespace).each do |project_name|
       %span.label= project_name
     %small.pull-right
-      Created #{time_ago_in_words(deploy_key.created_at)} ago
-
+      Created #{time_ago_with_tooltip(deploy_key.created_at)} ago

--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -26,7 +26,7 @@
         %i.icon-time
         = issue.milestone.title
     .pull-right
-      %small updated #{time_ago_in_words(issue.updated_at)} ago
+      %small updated #{time_ago_with_tooltip(issue.updated_at, 'bottom', 'issue_update_ago')} ago
 
     .issue-labels
       - issue.labels.each do |label|

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -34,4 +34,4 @@
 
 
     .pull-right
-      %small updated #{time_ago_in_words(merge_request.updated_at)} ago
+      %small updated #{time_ago_with_tooltip(merge_request.updated_at, 'bottom', 'merge_request_updated_ago')} ago

--- a/app/views/projects/merge_requests/show/_mr_box.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_box.html.haml
@@ -34,13 +34,13 @@
       %span
         %i.icon-remove
         Closed by #{link_to_member(@project, @merge_request.closed_event.author)}
-        %span #{time_ago_in_words(@merge_request.closed_event.created_at)} ago.
+        #{time_ago_with_tooltip(@merge_request.closed_event.created_at)} ago.
   - if @merge_request.merged?
     .ui-box-bottom.alert-success
       %span
         %i.icon-ok
         Merged by #{link_to_member(@project, @merge_request.merge_event.author)}
-        #{time_ago_in_words(@merge_request.merge_event.created_at)} ago.
+        #{time_ago_with_tooltip(@merge_request.merge_event.created_at)} ago.
   - if !@closes_issues.empty? && @merge_request.opened?
     .ui-box-bottom.alert-info
       %span

--- a/app/views/projects/notes/_discussion.html.haml
+++ b/app/views/projects/notes/_discussion.html.haml
@@ -32,8 +32,7 @@
       last updated by
       = link_to_member(@project, last_note.author, avatar: false)
       %span.discussion-last-update
-        = time_ago_in_words(last_note.updated_at)
-        ago
+        #{time_ago_with_tooltip(last_note.updated_at, 'bottom', 'discussion_updated_ago')} ago
   .discussion-body
     - if note.for_diff_line?
       - if note.active?

--- a/app/views/projects/protected_branches/index.html.haml
+++ b/app/views/projects/protected_branches/index.html.haml
@@ -46,8 +46,6 @@
                 = commit.short_id
               %span.light
                 = gfm escape_once(truncate(commit.title, length: 40))
-              %span
-                = time_ago_in_words(commit.committed_date)
-                ago
+              #{time_ago_with_tooltip(commit.committed_date)} ago
             - else
               (branch was removed from repository)

--- a/app/views/projects/refs/logs_tree.js.haml
+++ b/app/views/projects/refs/logs_tree.js.haml
@@ -5,5 +5,5 @@
 
   :plain
     var row = $("table.table_#{@hex_path} tr.file_#{hexdigest(file_name)}");
-    row.find("td.tree_time_ago").html('#{escape_javascript time_ago_in_words(commit.committed_date)} ago');
+    row.find("td.tree_time_ago").html('#{escape_javascript time_ago_with_tooltip(commit.committed_date)} ago');
     row.find("td.tree_commit").html('#{escape_javascript render("projects/tree/tree_commit_column", commit: commit)}');

--- a/app/views/projects/snippets/_snippet.html.haml
+++ b/app/views/projects/snippets/_snippet.html.haml
@@ -18,4 +18,5 @@
       by
       = image_tag avatar_icon(snippet.author_email), class: "avatar avatar-inline s16"
       = snippet.author_name
-      %span.light #{time_ago_in_words(snippet.created_at)} ago
+      %span.light
+        #{time_ago_with_tooltip(snippet.created_at)} ago

--- a/app/views/projects/tags/index.html.haml
+++ b/app/views/projects/tags/index.html.haml
@@ -24,8 +24,7 @@
           .pull-right
             %small.cdark
               %i.icon-calendar
-              = time_ago_in_words(commit.committed_date)
-              ago
+              #{time_ago_with_tooltip(commit.committed_date)} ago
         %p.prepend-left-20
           = link_to commit.short_id(8), project_commit_path(@project, commit), class: "monospace"
           &ndash;

--- a/app/views/projects/wikis/history.html.haml
+++ b/app/views/projects/wikis/history.html.haml
@@ -23,8 +23,7 @@
         %td
           = commit.title
         %td
-          = time_ago_in_words(version.date)
-          ago
+          #{time_ago_with_tooltip(version.date)} ago
         %td
           %strong
             = @wiki.page.wiki.page(@wiki.page.name, commit.id).try(:format)

--- a/app/views/projects/wikis/pages.html.haml
+++ b/app/views/projects/wikis/pages.html.haml
@@ -8,4 +8,4 @@
         = link_to wiki_page.title.titleize, project_wiki_path(@project, wiki_page)
         %small (#{wiki_page.format})
         .pull-right
-          %small Last edited #{time_ago_in_words(wiki_page.commit.created_at)} ago
+          %small Last edited #{time_ago_with_tooltip(wiki_page.commit.created_at)} ago

--- a/app/views/projects/wikis/show.html.haml
+++ b/app/views/projects/wikis/show.html.haml
@@ -12,4 +12,4 @@
     = preserve do
       = render_wiki_content(@wiki)
 
-%p.time Last edited by #{commit_author_link(@wiki.commit, avatar: true, size: 16)} #{time_ago_in_words @wiki.commit.created_at} ago
+%p.span Last edited by #{commit_author_link(@wiki.commit, avatar: true, size: 16)} #{time_ago_with_tooltip(@wiki.commit.created_at)} ago

--- a/app/views/snippets/_snippet.html.haml
+++ b/app/views/snippets/_snippet.html.haml
@@ -20,4 +20,4 @@
       = link_to user_snippets_path(snippet.author) do
         = image_tag avatar_icon(snippet.author_email), class: "avatar avatar-inline s16", alt: ''
         = snippet.author_name
-      %span.light #{time_ago_in_words(snippet.created_at)} ago
+      %span.light #{time_ago_with_tooltip(snippet.created_at)} ago


### PR DESCRIPTION
This implements the feature as requested in http://feedback.gitlab.com/forums/176466-general/suggestions/4910071-gitlab-should-show-yesterday-and-actual-dates-in

Each tooltip was visually inspected to make sure it looked good in its context. Most tooltips appear above the text. In a few cases it looked better to put the tooltip below the text.

Dashboard tooltip example:
![dashboard](https://f.cloud.github.com/assets/2394772/1749261/7ee15982-6506-11e3-8150-152fa726a716.png)

Examples where the tooltip appears below the text:
Project last activity - to avoid covering the project name
![project_activity](https://f.cloud.github.com/assets/2394772/1749274/977de3c0-6506-11e3-8868-586acdd3675d.png)

Comments - the top tooltip would appear behind the previous comment
![comments](https://f.cloud.github.com/assets/2394772/1749276/ab6f18b8-6506-11e3-97da-dd1f9b3717ff.png)

Merge requests - to avoid covering merge request details "BRANCH > BRANCH" or "MERGED"
![merge_request](https://f.cloud.github.com/assets/2394772/1749277/c07d293e-6506-11e3-8bf3-74d4b1fab392.png)

Please let me know if you would like additional screenshots. 
