### PR TITLE
Allow user to hide the message to add an ssh key permanently

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
 #  unconfirmed_email      :string(255)
+#  hide_no_ssh_key        :boolean          default(FALSE), not null
 #
 
 require 'carrierwave/orm/activerecord'
@@ -52,7 +53,7 @@ class User < ActiveRecord::Base
 
   attr_accessible :email, :password, :password_confirmation, :remember_me, :bio, :name, :username,
                   :skype, :linkedin, :twitter, :color_scheme_id, :theme_id, :force_random_password,
-                  :extern_uid, :provider, :password_expires_at, :avatar,
+                  :extern_uid, :provider, :password_expires_at, :avatar, :hide_no_ssh_key,
                   as: [:default, :admin]
 
   attr_accessible :projects_limit, :can_create_group,

--- a/app/views/shared/_no_ssh.html.haml
+++ b/app/views/shared/_no_ssh.html.haml
@@ -1,6 +1,8 @@
-- if cookies[:hide_no_ssh_message].blank? && current_user.require_ssh_key?
+- if cookies[:hide_no_ssh_message].blank? && current_user.require_ssh_key? && !current_user.hide_no_ssh_key
   .no-ssh-key-message
     .container
       You won't be able to pull or push project code via SSH until you #{link_to 'add an SSH key', new_profile_key_path} to your profile
-      = link_to '#', class: 'pull-right hide-no-ssh-message' do
-        %i.icon-remove
+      %div.pull-right
+        = link_to "Don't show again", profile_path(user: {hide_no_ssh_key: true}), method: :put, class: 'hide-no-ssh-message', remote: true
+        |
+        = link_to 'Remind later', '#', class: 'hide-no-ssh-message'

--- a/db/migrate/20131214224427_add_hide_no_ssh_key_to_users.rb
+++ b/db/migrate/20131214224427_add_hide_no_ssh_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddHideNoSshKeyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :hide_no_ssh_key, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
This implements the feature in http://feedback.gitlab.com/forums/176466-general/suggestions/4912594-allow-user-to-hide-the-message-to-add-an-ssh-key-p

In this particular implementation the user is given the choice between permanently dismissing the message or just dismissing it for the current browser session. I believe there is value in retaining both options.

Also, I opted to display the two choices as links instead of buttons. I initially favored the buttons and they look very nice. However, I think they attract too much attention. I sought opinion on IRC and several others came to the same conclusion.  I am open to either solution.

Current solution:
![screen shot 2013-12-14 at 8 18 26 pm](https://f.cloud.github.com/assets/2394772/1749667/fff80dbc-652f-11e3-8f7e-7dba98fdfcd0.png)

Alternate solution with buttons:
![screen shot 2013-12-14 at 7 50 08 pm](https://f.cloud.github.com/assets/2394772/1749669/07c69ea0-6530-11e3-9fdc-8d4d7e4ae6dc.png)
