### PR TITLE
Added dropdown menus to issue#show page for assignee and milestone

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 6.5.0
+  - Dropdown menus on issue#show page for assignee and milestone (Jason Blanchard)
+
 v 6.4.0
   - Added sorting to project issues page (Jason Blanchard)
   - Assembla integration (Carlos Paramio)

--- a/app/assets/javascripts/issues.js.coffee
+++ b/app/assets/javascripts/issues.js.coffee
@@ -79,3 +79,9 @@
       $("#update_issues_ids").val []
       $(".issues_bulk_update").hide()
       $(".issues-filters").show()
+
+$ ->
+  $('.edit-issue.inline-update input[type="submit"]').hide();
+  $("body").on "change", ".edit-issue.inline-update select", ->
+      $(this).submit()
+

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -119,3 +119,8 @@ input.check_all_issues {
     background-color: #f4f4f4;
   }
 }
+
+.edit-issue.inline-update select {
+  width: 100%;
+  max-width: 230px;
+}

--- a/app/views/projects/issues/_issue_context.html.haml
+++ b/app/views/projects/issues/_issue_context.html.haml
@@ -1,0 +1,31 @@
+= form_for [@project, @issue], :remote => true, :html => {:class => 'edit-issue inline-update'} do |f|
+  .pull-right
+  Created by #{link_to_member(@project, issue.author)}
+  - if issue.assignee
+    \ and currently assigned to
+
+  - if can?(current_user, :modify_issue, @issue)
+    = link_to profile_path(issue.assignee) do
+      = image_tag(avatar_icon(issue.assignee.email), :class => 'avatar avatar-inline s16 assignee') if issue.assignee
+    = f.select(:assignee_id, @project.team.members.sort_by(&:name).map {|p| [ p.name, p.id ] }, { include_blank: "Assign to user (none):" }, {class: 'chosen'})
+  - elsif issue.assignee
+    = link_to_member(@project, @issue.assignee)
+
+  - if issue.milestone
+    - milestone = issue.milestone
+    %cite.cgray and attached to milestone
+  
+  - if can?(current_user, :modify_issue, @issue)
+    = f.select(:milestone_id, @project.milestones.active.all.collect {|p| [ p.title, p.id ] }, { include_blank: "Select milestone (none):" }, {class: 'chosen'})
+
+    = hidden_field_tag :issue_context
+    = f.submit :class => 'btn'
+  - elsif issue.milestone
+    = link_to issue.milestone.title, project_milestone_path
+
+.pull-right
+  - issue.labels.each do |label|
+    %span{class: "label #{label_css_class(label.name)}"}
+      %i.icon-tag
+      = label.name
+    &nbsp;

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -26,7 +26,12 @@
 .back-link
   = link_to project_issues_path(@project) do
     &larr; To issues list
-
+  %span.milestone-nav-link
+    - if @issue.milestone
+      | 
+      = link_to project_milestone_path(@project, @issue.milestone) do
+        <strong>Milestone:</strong>
+        = @issue.milestone.title
 
 .ui-box.ui-box-show
   .ui-box-head
@@ -39,21 +44,7 @@
 
   .ui-box-body
     %cite.cgray
-      Created by #{link_to_member(@project, @issue.author)}
-      - if @issue.assignee
-        \ and currently assigned to #{link_to_member(@project, @issue.assignee)}
-
-    - if @issue.milestone
-      - milestone = @issue.milestone
-      %cite.cgray and attached to milestone
-      %strong= link_to_gfm truncate(milestone.title, length: 20), project_milestone_path(milestone.project, milestone)
-
-    .pull-right
-      - @issue.labels.each do |label|
-        %span{class: "label #{label_css_class(label.name)}"}
-          %i.icon-tag
-          = label.name
-        &nbsp;
+      = render partial: 'issue_context', locals: { issue: @issue }
 
   - if @issue.description.present?
     .ui-box-bottom

--- a/app/views/projects/issues/update.js.haml
+++ b/app/views/projects/issues/update.js.haml
@@ -2,3 +2,12 @@
   - if @issue.valid?
     :plain
       $("##{dom_id(@issue)}").fadeOut();
+- elsif params[:issue_context]
+  $('.ui-box-body').html("#{escape_javascript(render partial: 'issue_context', locals: { issue: @issue })}");
+  $('.ui-box-body').effect('highlight');
+  $('.chosen').chosen();
+  $('.edit-issue.inline-update input[type="submit"]').hide();
+  - if @issue.milestone
+    $('.milestone-nav-link').replaceWith("#{escape_javascript(link_to "| #{@issue.milestone.title}", project_milestone_path(@issue.project, @issue.milestone), :class => 'milestone-nav-link')}")
+  - else
+    $('.milestone-nav-link').html('')

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -175,6 +175,84 @@ describe "Issues" do
     end
   end
 
+  describe 'update assignee from issue#show' do
+    let(:issue) { create(:issue, project: project, author: @user) }
+
+    context 'by autorized user' do
+
+      it 'with dropdown menu' do
+        visit project_issue_path(project, issue)
+
+        find('.edit-issue.inline-update').select(project.team.members.first.name, from: 'issue_assignee_id')
+        click_button 'Update Issue'
+
+        page.should have_content "currently assigned to"
+        page.has_select?('issue_assignee_id', :selected => project.team.members.first.name)
+      end
+    end
+
+    context 'by unauthorized user' do
+    
+      let(:guest) { create(:user) }
+      
+      before :each do
+        project.team << [[guest], :guest]
+        issue.assignee = @user
+        issue.save
+      end
+
+      it 'shows assignee text' do
+        logout
+        login_with guest
+
+        visit project_issue_path(project, issue)
+        page.should have_content "currently assigned to #{issue.assignee.name}"
+
+      end
+    end
+
+  end
+
+  describe 'update milestone from issue#show' do
+    let!(:issue) { create(:issue, project: project, author: @user) }
+    let!(:milestone) { create(:milestone, project: project) }
+
+    context 'by authorized user' do
+
+      it 'with dropdown menu' do
+        visit project_issue_path(project, issue)
+
+        p find('.edit-issue.inline-update').text
+
+        find('.edit-issue.inline-update').select(milestone.title, from: 'issue_milestone_id')
+        click_button 'Update Issue'
+
+        page.should have_content "and attached to milestone"
+        page.has_select?('issue_assignee_id', :selected => milestone.title)
+      end
+    end
+
+    context 'by unauthorized user' do
+      
+      let(:guest) { create(:user) }
+      
+      before :each do
+        project.team << [[guest], :guest]
+        issue.milestone = milestone
+        issue.save
+      end
+
+      it 'shows milestone text' do
+        logout
+        login_with guest
+
+        visit project_issue_path(project, issue)
+
+        page.should have_content "attached to milestone #{milestone.title}"
+      end
+    end
+  end
+
   def first_issue
     all("ul.issues-list li").first.text
   end


### PR DESCRIPTION
**Feature**: Dropdown menus to add assignee and milestone from the issue#show page.

![screen shot 2013-12-15 at 6 47 03 pm](https://f.cloud.github.com/assets/1238532/1751416/176f5fa8-65e5-11e3-9f95-4f3982718bc8.png)

This feels like something I should be able to do easily without editing other parts of the issue to speed up the ticket workflow.

**Implementation**: Added form on `issue#show` with select fields for assignee and milestone. This form will submit remote to the `issue#update` action. JS response re-renders the `issue_context` partial based on the `params[:issue_context]` value. The form includes a submit button for graceful degradation and testing.

I'm not sure this is the right placement for these dropdown menus, so I'm definitely open to suggestions here :)
