### PR TITLE
Fix messages typo

### DIFF
--- a/app/contexts/files/create_context.rb
+++ b/app/contexts/files/create_context.rb
@@ -21,13 +21,13 @@ module Files
       file_path = path
 
       unless file_name =~ Gitlab::Regex.path_regex
-        return error("Your changes could not be commited, because file name contains not allowed characters")
+        return error("Your changes could not be committed, because file name contains not allowed characters")
       end
 
       blob = repository.blob_at(ref, file_path)
 
       if blob
-        return error("Your changes could not be commited, because file with such name exists")
+        return error("Your changes could not be committed, because file with such name exists")
       end
 
       new_file_action = Gitlab::Satellite::NewFileAction.new(current_user, project, ref, file_path)
@@ -39,7 +39,7 @@ module Files
       if created_successfully
         success
       else
-        error("Your changes could not be commited, because the file has been changed")
+        error("Your changes could not be committed, because the file has been changed")
       end
     end
   end

--- a/app/contexts/files/delete_context.rb
+++ b/app/contexts/files/delete_context.rb
@@ -33,7 +33,7 @@ module Files
       if deleted_successfully
         success
       else
-        error("Your changes could not be commited, because the file has been changed")
+        error("Your changes could not be committed, because the file has been changed")
       end
     end
   end

--- a/app/contexts/files/update_context.rb
+++ b/app/contexts/files/update_context.rb
@@ -32,7 +32,7 @@ module Files
       if created_successfully
         success
       else
-        error("Your changes could not be commited, because the file has been changed")
+        error("Your changes could not be committed, because the file has been changed")
       end
     end
   end

--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -16,7 +16,7 @@ class Projects::BlobController < Projects::ApplicationController
     result = Files::DeleteContext.new(@project, current_user, params, @ref, @path).execute
 
     if result[:status] == :success
-      flash[:notice] = "Your changes have been successfully commited"
+      flash[:notice] = "Your changes have been successfully committed"
       redirect_to project_tree_path(@project, @ref)
     else
       flash[:alert] = result[:error]

--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -10,7 +10,7 @@ class Projects::EditTreeController < Projects::BaseTreeController
     result = Files::UpdateContext.new(@project, current_user, params, @ref, @path).execute
 
     if result[:status] == :success
-      flash[:notice] = "Your changes have been successfully commited"
+      flash[:notice] = "Your changes have been successfully committed"
       redirect_to project_blob_path(@project, @id)
     else
       flash[:alert] = result[:error]

--- a/app/controllers/projects/new_tree_controller.rb
+++ b/app/controllers/projects/new_tree_controller.rb
@@ -9,7 +9,7 @@ class Projects::NewTreeController < Projects::BaseTreeController
     result = Files::CreateContext.new(@project, current_user, params, @ref, file_path).execute
 
     if result[:status] == :success
-      flash[:notice] = "Your changes have been successfully commited"
+      flash[:notice] = "Your changes have been successfully committed"
       redirect_to project_blob_path(@project, File.join(@ref, file_path))
     else
       flash[:alert] = result[:error]


### PR DESCRIPTION
Fix message typo (change from `commited` to `committed`)

There is no effect of the test of this change :smiling_imp: 
