### PR TITLE
Take the default title and description from commit when creating merge request

### DIFF
--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -147,9 +147,9 @@ class MergeRequest < ActiveRecord::Base
     end
   end
 
-  def reload_code
+  def reload_code(save = true)
     if merge_request_diff && open?
-      merge_request_diff.reload_content
+      merge_request_diff.reload_content(save)
     end
   end
 

--- a/app/models/merge_request_diff.rb
+++ b/app/models/merge_request_diff.rb
@@ -39,9 +39,10 @@ class MergeRequestDiff < ActiveRecord::Base
 
   after_create :reload_content
 
-  def reload_content
+  def reload_content(save = true)
     reload_commits
     reload_diffs
+    self.save if save
   end
 
   def diffs
@@ -108,8 +109,6 @@ class MergeRequestDiff < ActiveRecord::Base
     if commit_objects.present?
       self.st_commits = dump_commits(commit_objects)
     end
-
-    save
   end
 
   # Reload diffs between branches related to current merge request from repo
@@ -143,7 +142,6 @@ class MergeRequestDiff < ActiveRecord::Base
     end
 
     self.st_diffs = new_diffs
-    self.save
   end
 
   # Collect array of Git::Diff objects

--- a/app/views/projects/merge_requests/_branch.js.haml
+++ b/app/views/projects/merge_requests/_branch.js.haml
@@ -1,0 +1,22 @@
+:plain
+  var target_branch_selected = $("#merge_request_target_branch").val().length > 0;
+
+- if title.present?
+  :plain
+    if (target_branch_selected) {
+      var mrTitle = $('#merge_request_title');
+
+      if (mrTitle.val().length == 0) {
+        mrTitle.val(#{title.to_json});
+      }
+    }
+
+- if description.present?
+  :plain
+    if (target_branch_selected) {
+      var mrDescription = $('#merge_request_description');
+
+      if (mrDescription.val().length == 0) {
+        mrDescription.val(#{description.to_json});
+      }
+    }

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -71,15 +71,24 @@
     , target_branch = $("#merge_request_target_branch")
     , target_project = $("#merge_request_target_project_id");
 
-  $.get("#{branch_from_project_merge_requests_path(@source_project)}", {ref: source_branch.val() });
-  $.get("#{branch_to_project_merge_requests_path(@source_project)}", {target_project_id: target_project.val(),ref: target_branch.val() });
+  var serialized_form = $("#new_merge_request").serialize();
+
+  serialized_form.ref = source_branch.val();
+  $.get("#{branch_from_project_merge_requests_path(@source_project)}", serialized_form);
+
+  serialized_form.ref = target_branch.val();
+  $.get("#{branch_to_project_merge_requests_path(@source_project)}", serialized_form);
 
   target_project.on("change", function() {
     $.get("#{update_branches_project_merge_requests_path(@source_project)}", {target_project_id:  $(this).val() });
   });
   source_branch.on("change", function() {
-    $.get("#{branch_from_project_merge_requests_path(@source_project)}", {ref: $(this).val() });
+    var serialized_form = $("#new_merge_request").serialize();
+    serialized_form.ref =  $(this).val()
+    $.get("#{branch_from_project_merge_requests_path(@source_project)}", serialized_form);
   });
   target_branch.on("change", function() {
-    $.get("#{branch_to_project_merge_requests_path(@source_project)}", {target_project_id: target_project.val(),ref: $(this).val() });
+    var serialized_form = $("#new_merge_request").serialize();
+    serialized_form.ref =  $(this).val()
+    $.get("#{branch_to_project_merge_requests_path(@source_project)}", serialized_form);
   });

--- a/app/views/projects/merge_requests/branch_from.js.haml
+++ b/app/views/projects/merge_requests/branch_from.js.haml
@@ -1,4 +1,8 @@
 :plain
-  $(".mr_source_commit").html("#{commit_to_html(@source_commit, @source_project, false)}");
+  $(".mr_source_commit").html("#{commit_to_html(@source_commit,
+    @source_project, false)}");
 
-= render "branch", title: @title, description: @description, source_commit: @source_commit
+= render "branch",
+  title: @commit_helper.title,
+  description: @commit_helper.description,
+  source_commit: @source_commit

--- a/app/views/projects/merge_requests/branch_from.js.haml
+++ b/app/views/projects/merge_requests/branch_from.js.haml
@@ -1,7 +1,4 @@
 :plain
-  $(".mr_source_commit").html("#{commit_to_html(@commit, @source_project, false)}");
-  var mrTitle = $('#merge_request_title');
+  $(".mr_source_commit").html("#{commit_to_html(@source_commit, @source_project, false)}");
 
-  if(mrTitle.val().length == 0) {
-    mrTitle.val("#{params[:ref].titleize.humanize}");
-  }
+= render "branch", title: @title, description: @description, source_commit: @source_commit

--- a/app/views/projects/merge_requests/branch_to.js.haml
+++ b/app/views/projects/merge_requests/branch_to.js.haml
@@ -1,2 +1,4 @@
 :plain
-  $(".mr_target_commit").html("#{commit_to_html(@commit, @target_project, false)}");
+  $(".mr_target_commit").html("#{commit_to_html(@target_commit, @target_project, false)}");
+
+= render "branch", title: @title, description: @description, source_commit: @source_commit

--- a/app/views/projects/merge_requests/branch_to.js.haml
+++ b/app/views/projects/merge_requests/branch_to.js.haml
@@ -1,4 +1,8 @@
 :plain
-  $(".mr_target_commit").html("#{commit_to_html(@target_commit, @target_project, false)}");
+  $(".mr_target_commit").html("#{commit_to_html(@target_commit,
+    @target_project, false)}");
 
-= render "branch", title: @title, description: @description, source_commit: @source_commit
+= render "branch",
+  title: @commit_helper.title,
+  description: @commit_helper.description,
+  source_commit: @source_commit


### PR DESCRIPTION
When creating a new merge request it will now only set the default title and description if both the source branch and target branch is selected.

If the merge request consists of a single commit, the commit message will be used to set the default title and description. If the merge request consists of more than one commit it will fallback to the current behavior of using the name of the source branch for the title and leave the description blank.
