### PR TITLE
Don't use unicorn worker killer if using Phusion Passenger

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,10 +1,12 @@
 # This file is used by Rack-based servers to start the application.
 
-# Unicorn self-process killer
-require 'unicorn/worker_killer'
+unless defined?(PhusionPassenger)
+  # Unicorn self-process killer
+  require 'unicorn/worker_killer'
 
-# # Max memory size (RSS) per worker
-use Unicorn::WorkerKiller::Oom, (200 * (1 << 20)), (250 * (1 << 20))
+  # Max memory size (RSS) per worker
+  use Unicorn::WorkerKiller::Oom, (200 * (1 << 20)), (250 * (1 << 20))
+end
 
 require ::File.expand_path('../config/environment',  __FILE__)
 


### PR DESCRIPTION
This does as the title suggests. If the user is using Phusion Passenger rather then Unicorn, the worker killer code will break the application.
