### PR TITLE
Add note for assignee changes

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -82,6 +82,18 @@ class Note < ActiveRecord::Base
       }, without_protection: true)
     end
 
+    def create_assignee_change_note(noteable, project, author, assignee)
+      body = assignee.nil? ? '_Assignee removed_' : "_Reassigned to @#{assignee.username}_"
+
+      create({
+        noteable: noteable,
+        project: project,
+        author: author,
+        note: body,
+        system: true
+      }, without_protection: true)
+    end
+
     def discussions_from_notes(notes)
       discussion_ids = []
       discussions = []

--- a/app/observers/issue_observer.rb
+++ b/app/observers/issue_observer.rb
@@ -19,6 +19,7 @@ class IssueObserver < BaseObserver
   def after_update(issue)
     if issue.is_being_reassigned?
       notification.reassigned_issue(issue, current_user)
+      create_assignee_note(issue)
     end
 
     issue.notice_added_references(issue.project, current_user)
@@ -30,6 +31,10 @@ class IssueObserver < BaseObserver
   # Create issue note with service comment like 'Status changed to closed'
   def create_note(issue)
     Note.create_status_change_note(issue, issue.project, current_user, issue.state, current_commit)
+  end
+
+  def create_assignee_note(issue)
+    Note.create_assignee_change_note(issue, issue.project, current_user, issue.assignee)
   end
 
   def execute_hooks(issue)

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -180,6 +180,31 @@ describe Note do
     end
   end
 
+  describe '#create_assignee_change_note' do
+    let(:project) { create(:project) }
+    let(:thing) { create(:issue, project: project) }
+    let(:author) { create(:user) }
+    let(:assignee) { create(:user) }
+
+    subject { Note.create_assignee_change_note(thing, project, author, assignee) }
+
+    context 'creates and saves a Note' do
+      it { should be_a Note }
+      its(:id) { should_not be_nil }
+    end
+
+    its(:noteable) { should == thing }
+    its(:project) { should == thing.project }
+    its(:author) { should == author }
+    its(:note) { should =~ /Reassigned to @#{assignee.username}/ }
+
+    context 'assignee is removed' do
+      let(:assignee) { nil }
+
+      its(:note) { should =~ /Assignee removed/ }
+    end
+  end
+
   describe '#create_cross_reference_note' do
     let(:project)    { create(:project_with_code) }
     let(:author)     { create(:user) }
@@ -252,6 +277,7 @@ describe Note do
     let(:issue)   { create(:issue, project: project) }
     let(:other)   { create(:issue, project: project) }
     let(:author)  { create(:user) }
+    let(:assignee) { create(:user) }
 
     it 'should recognize user-supplied notes as non-system' do
       @note = create(:note_on_issue)
@@ -265,6 +291,11 @@ describe Note do
 
     it 'should identify cross-reference notes as system notes' do
       @note = Note.create_cross_reference_note(issue, other, author, project)
+      @note.should be_system
+    end
+
+    it 'should identify assignee-change notes as system notes' do
+      @note = Note.create_assignee_change_note(issue, project, author, assignee)
       @note.should be_system
     end
   end


### PR DESCRIPTION
Implements the feature as requested in http://feedback.gitlab.com/forums/176466-general/suggestions/5168130-record-assignee-changes-in-the-comment-timeline.

When an issue assignee is changed a note is generated. The note is italicized to match the status notes (reopened/closed).

![issue_assignee_notes](https://f.cloud.github.com/assets/2394772/1811289/426fe2c4-6e4e-11e3-9e92-bba6b4a72c15.png)
