### PR TITLE
Fix issue update js

### DIFF
--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -33,8 +33,8 @@
   %span.milestone-nav-link
     - if @issue.milestone
       |
+      %span.light Milestone
       = link_to project_milestone_path(@project, @issue.milestone) do
-        %span.light Milestone
         = @issue.milestone.title
 
 .issue-box

--- a/app/views/projects/issues/update.js.haml
+++ b/app/views/projects/issues/update.js.haml
@@ -8,6 +8,6 @@
   $('.chosen').chosen();
   $('.edit-issue.inline-update input[type="submit"]').hide();
   - if @issue.milestone
-    $('.milestone-nav-link').replaceWith("#{escape_javascript(link_to "| #{@issue.milestone.title}", project_milestone_path(@issue.project, @issue.milestone), :class => 'milestone-nav-link')}")
+    $('.milestone-nav-link').replaceWith("<span class='milestone-nav-link'>| <span class='light'>Milestone</span> #{escape_javascript(link_to @issue.milestone.title, project_milestone_path(@issue.project, @issue.milestone))}</span>")
   - else
     $('.milestone-nav-link').html('')


### PR DESCRIPTION
Previously, when an assignee was changed on an issue the milestone nav text would change. This is unrelated to changing the assignee and it should not happen. Notice the text "To issue list | Milestone v2.0" in the first image below. Now see that "Milestone" is no longer present in the text in the second image. This fix matches the html structure in javascript so each renders identically.

On page load:
![issue_nav1](https://f.cloud.github.com/assets/2394772/1811425/4347560e-6e54-11e3-93fb-4ab5e4aa1aa3.png)

After changing assignee:
![issue_nav2](https://f.cloud.github.com/assets/2394772/1811426/4354947c-6e54-11e3-9156-1c6b8dd22c3b.png)
