### PR TITLE
Changed sudo by su -c

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -41,7 +41,7 @@ test -f /etc/default/gitlab && . /etc/default/gitlab
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then
-  sudo -u "$app_user" -H -i $0 "$@"; exit;
+  eval su - "$app_user" -c $(echo \")$0 "$@"$(echo \"); exit;
 fi
 
 # Switch to the gitlab path, exit on failure.


### PR DESCRIPTION
The sudo command needs a tty to run. If you put this file on a CentOS 6, for example, it will not run in the host startup process. Instead, the 'su -c' runs the command apart if it has or not a tty.

I tested this change in a fresh install of gitlab on a CentOS 6.5 with successful.
