### PR TITLE
Postgres Client Needed for Ubuntu 13.04

### DIFF
--- a/doc/install/databases.md
+++ b/doc/install/databases.md
@@ -52,7 +52,7 @@ GitLab supports the following databases:
 ## PostgreSQL
 
     # Install the database packages
-    sudo apt-get install -y postgresql-9.1 libpq-dev
+    sudo apt-get install -y postgresql-9.1 postgresql-client libpq-dev
 
     # Login to PostgreSQL
     sudo -u postgres psql -d template1


### PR DESCRIPTION
It looks like the postgresql-9.1 package didn't include the actual client. Needed to install it separately to get this to work.
