### PR TITLE
 Added support for Go's repository retrieval.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -201,7 +201,7 @@ class Project < ActiveRecord::Base
     [Gitlab.config.gitlab.url, path_with_namespace].join("/")
   end
 
-  def web_url_without_scheme
+  def web_url_without_protocol
     web_url.split("://")[1]
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -201,6 +201,10 @@ class Project < ActiveRecord::Base
     [Gitlab.config.gitlab.url, path_with_namespace].join("/")
   end
 
+  def web_url_without_scheme
+    [Gitlab.config.gitlab.host, path_with_namespace].join("/")
+  end
+
   def build_commit_note(commit)
     notes.new(commit_id: commit.id, noteable_type: "Commit")
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -202,7 +202,7 @@ class Project < ActiveRecord::Base
   end
 
   def web_url_without_scheme
-    [Gitlab.config.gitlab.host, path_with_namespace].join("/")
+    web_url.split("://")[1]
   end
 
   def build_commit_note(commit)

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -3,7 +3,7 @@
 
   -# Go repository retrieval support.
   - if controller_name == 'projects' && action_name == 'show'
-    %meta{name: "go-import", content: "#{Gitlab.config.gitlab.host}/#{@project.namespace.path}/#{@project.path} git http://#{Gitlab.config.gitlab.host}/#{@project.namespace.path}/#{@project.path}.git"}
+    %meta{name: "go-import", content: "#{@project.web_url_without_scheme} git #{@project.web_url}.git"}
 
   %title
     = "#{title} | " if defined?(title)

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -23,5 +23,5 @@
 
   -# Go repository retrieval support.
   - if controller_name == 'projects' && action_name == 'show'
-    %meta{name: "go-import", content: "#{@project.web_url_without_scheme} git #{@project.web_url}.git"}
+    %meta{name: "go-import", content: "#{@project.web_url_without_protocol} git #{@project.web_url}.git"}
 

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,5 +1,10 @@
 %head
   %meta{charset: "utf-8"}
+
+  -# Go repository retrieval support.
+  - if controller_name == 'projects' && action_name == 'show'
+    %meta{name: "go-import", content: "#{Gitlab.config.gitlab.host}/#{@project.namespace.path}/#{@project.path} git http://#{Gitlab.config.gitlab.host}/#{@project.namespace.path}/#{@project.path}.git"}
+
   %title
     = "#{title} | " if defined?(title)
     GitLab

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,10 +1,5 @@
 %head
   %meta{charset: "utf-8"}
-
-  -# Go repository retrieval support.
-  - if controller_name == 'projects' && action_name == 'show'
-    %meta{name: "go-import", content: "#{@project.web_url_without_scheme} git #{@project.web_url}.git"}
-
   %title
     = "#{title} | " if defined?(title)
     GitLab
@@ -25,3 +20,8 @@
         = auto_discovery_link_tag(:atom, project_commits_url(@project, @ref, format: :atom, private_token: current_user.private_token), title: "Recent commits to #{@project.name}:#{@ref}")
       - if current_controller?(:issues)
         = auto_discovery_link_tag(:atom, project_issues_url(@project, :atom, private_token: current_user.private_token), title: "#{@project.name} issues")
+
+  -# Go repository retrieval support.
+  - if controller_name == 'projects' && action_name == 'show'
+    %meta{name: "go-import", content: "#{@project.web_url_without_scheme} git #{@project.web_url}.git"}
+

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -99,6 +99,11 @@ describe Project do
     project.web_url.should == "#{Gitlab.config.gitlab.url}/somewhere"
   end
 
+  it "returns the web URL without the protocol for this repo" do
+    project = Project.new(path: "somewhere")
+    project.web_url_without_protocol.should == "#{Gitlab.config.gitlab.host}/somewhere"
+  end
+
   describe "last_activity methods" do
     let(:project) { create(:project) }
     let(:last_event) { double(created_at: Time.now) }


### PR DESCRIPTION
- Simply adds the relevant meta link in the project's show action.
- Information about this meta tag can be found here:
  http://golang.org/cmd/go/#hdr-Remote_import_paths

Note I am not sure how to do unit tests for this, but I am willing to do those if someone can point me to how to do it. Also I did not update the CHANGELOG as I am not sure where to put the change. Is it under v6.5.0?
