### PR TITLE
Fix 'gon' gem install failure. refs #5955

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,7 +591,7 @@ DEPENDENCIES
   gitlab_git (~> 4.0.0.pre)
   gitlab_meta (= 6.0)
   gitlab_omniauth-ldap (= 1.0.3)
-  gon!
+  gon (~> 5.0.0)
   grape (~> 0.6.1)
   grape-entity (~> 0.3.0)
   growl


### PR DESCRIPTION
Fix missing 'gon' dependency update. 

As commented in 
https://github.com/gitlabhq/gitlabhq/pull/5955#issuecomment-31593344
