### PR TITLE
Do not check commented sqlite line in config

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -65,6 +65,7 @@ namespace :gitlab do
         puts "no".green
       else
         puts "yes".red
+        puts "Please fix this by removing the SQLite entry from the database.yml".blue
         for_more_information(
           "https://github.com/gitlabhq/gitlabhq/wiki/Migrate-from-SQLite-to-MySQL",
           see_database_guide


### PR DESCRIPTION
The check rake task will fail, telling you that your database is sqlite, if you have the `adapter: sqlite` line commented out. This updates the regex to handle that commented line.
