### PR TITLE
Increased truncation for issue titles on milestone#show

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ v 6.5.0
   - Enable secure cookies if https used
   - Protect users/confirmation with rack_attack
   - Default HTTP headers to protect against MIME-sniffing, force https if enabled
+  - Increased truncation for issue titles on milestone#show (Jason Blanchard)
 
 v6.4.3
   - Don't use unicorn worker killer if PhusionPassenger is defined

--- a/app/views/projects/milestones/_issues.html.haml
+++ b/app/views/projects/milestones/_issues.html.haml
@@ -3,9 +3,9 @@
   %ul.well-list
     - issues.each do |issue|
       %li
-        = link_to [@project, issue] do
-          %span.badge{class: issue.closed? ? 'badge-important' : 'badge-info'} ##{issue.iid}
-        = link_to_gfm truncate(issue.title, length: 40), [@project, issue]
         - if issue.assignee
           .pull-right
             = image_tag avatar_icon(issue.assignee.email, 16), class: "avatar s16"
+        = link_to [@project, issue] do
+          %span.badge{class: issue.closed? ? 'badge-important' : 'badge-info'} ##{issue.iid}
+        = link_to_gfm truncate(issue.title, length: 80), [@project, issue]


### PR DESCRIPTION
Not sure if this is a problem for anyone else, but I find the 40 character truncation for issue titles on the milestone#show page a bit too short. It makes it difficult to browse and keep track of issues on that page.

I've doubled the character limit to 80 characters. I also re-ordered the title div and the user icon div so that it does not get pushed below the title at the first breakpoint.

Before:
![screen shot 2014-01-06 at 6 34 23 pm](https://f.cloud.github.com/assets/1238532/1855573/9bcd245c-7732-11e3-9b9f-cc83d3e95a4f.png)

After:
![screen shot 2014-01-06 at 7 24 22 pm](https://f.cloud.github.com/assets/1238532/1855575/a15fd9a0-7732-11e3-9214-0d639b9cadd2.png)
