### PR TITLE
Made the skype and twitter username clickable

### DIFF
--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -8,7 +8,7 @@
     - unless user.skype.blank?
       %li
         %span.light Skype:
-        %strong= user.skype
+        %strong= link_to user.skype, "skype:#{user.skype}"
     - unless user.linkedin.blank?
       %li
         %span.light LinkedIn:
@@ -16,7 +16,7 @@
     - unless user.twitter.blank?
       %li
         %span.light Twitter:
-        %strong= user.twitter
+        %strong= link_to user.twitter, "http://www.twitter.com/#{user.twitter}"
     - unless user.bio.blank?
       %li
         %span.light Bio:


### PR DESCRIPTION
- I was not able to link the linkedin username,
  since linkedin does not provide predictable URLS
- The skype url will start skype, and asks if you want to
  call the particular user.
- The Twitter link will just go to the twitter profile
  of the given user
