### PR TITLE
Fix for edit user as admin

### DIFF
--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -56,8 +56,12 @@
 
       .form-group
         = f.label :admin, class: 'control-label'
-        .col-sm-10= f.check_box :admin
-      - unless @user.new_record?
+        - if current_user == @user
+          .col-sm-10= f.check_box :admin, disabled: true
+          .col-sm-10 You cannot remove your own admin rights
+        - else
+          .col-sm-10= f.check_box :admin
+      - unless @user.new_record? || current_user == @user
         .alert.alert-danger
           - if @user.blocked?
             %p This user is blocked and is not able to login to GitLab


### PR DESCRIPTION
- It fixes an issue where you where able to remove your own
  admin rights. This would result in a 404 error. fixes: #2283
- It fixes an issue where you would be able to block your own
  account on the edit page. This fix makes the behaviour the same
  as on the admin/users overview page
