### PR TITLE
Set correct data-original-title value for my snippets

### DIFF
--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -28,7 +28,7 @@
             = link_to public_root_path, title: "Public area", class: 'has_bottom_tooltip', 'data-original-title' => 'Public area' do
               %i.icon-globe
           %li
-            = link_to user_snippets_path(current_user), title: "My snippets", class: 'has_bottom_tooltip', 'data-original-title' => 'Public area' do
+            = link_to user_snippets_path(current_user), title: "My snippets", class: 'has_bottom_tooltip', 'data-original-title' => 'My snippets' do
               %i.icon-paste
           - if current_user.is_admin?
             %li


### PR DESCRIPTION
Hello,
There was an obvious discrepancy so I've fixed it, but I'm not really sure what browsers will take data-original-title into account. I've tested on FF, safari and chromium and none of them cared.
