### PR TITLE
Fix warning

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -134,7 +134,7 @@ class Commit
     @raw.send(m, *args, &block)
   end
 
-  def respond_to?(method)
+  def respond_to?(method, opt = nil)
     return true if @raw.respond_to?(method)
 
     super


### PR DESCRIPTION
/home/travis/build/zzet/gitlabhq/app/models/commit.rb:137: warning: respond_to? is defined here
/home/travis/.rvm/gems/ruby-2.0.0-p353/gems/rspec-mocks-2.13.1/lib/rspec/mocks/extensions/marshal.rb:5: warning: Commit#respond_to?(:_dump) is old fashion which takes only one parameter
