### PR TITLE
Fix deprecation in specs

### DIFF
--- a/spec/tasks/gitlab/backup_rake_spec.rb
+++ b/spec/tasks/gitlab/backup_rake_spec.rb
@@ -39,7 +39,7 @@ describe 'gitlab:app namespace rake task' do
         YAML.stub load_file: {gitlab_version: gitlab_version}
         Rake::Task["gitlab:backup:db:restore"].should_receive :invoke
         Rake::Task["gitlab:backup:repo:restore"].should_receive :invoke
-        expect { run_rake_task }.to_not raise_error SystemExit
+        expect { run_rake_task }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /home/travis/build/gitlabhq/gitlabhq/spec/tasks/gitlab/backup_rake_spec.rb:42:in `block (4 levels) in <top (required)>'.
