### PR TITLE
Removed File.basename stripping of filename upon file creation

### DIFF
--- a/app/controllers/projects/new_tree_controller.rb
+++ b/app/controllers/projects/new_tree_controller.rb
@@ -5,7 +5,7 @@ class Projects::NewTreeController < Projects::BaseTreeController
   end
 
   def update
-    file_path = File.join(@path, File.basename(params[:file_name]))
+    file_path = File.join(@path, params[:file_name])
     result = Files::CreateContext.new(@project, current_user, params, @ref, file_path).execute
 
     if result[:status] == :success


### PR DESCRIPTION
Removed `file.baseline` stripping of the `params[:file_name]` so that a new file can be created in a specified directory. This allows creation of a file within a new directory from the web UI. Directory creation occurs by specifying a relative directory path in the file name field on the file creation view. 
