### PR TITLE
Better check on the validity of emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem "grape", "~> 0.6.1"
 gem "grape-entity", "~> 0.3.0"
 gem 'rack-cors', require: 'rack/cors'
 
+# Email validation
+gem "email_validator", "~> 1.4.0", :require => 'email_validator/strict'
+
 # Format dates and times
 # based on human-friendly examples
 gem "stamp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
+    email_validator (1.4.0)
+      activemodel
     enumerize (0.7.0)
       activesupport (>= 3.2)
     equalizer (0.0.8)
@@ -567,6 +569,7 @@ DEPENDENCIES
   devise (= 3.0.4)
   devise-async (= 0.8.0)
   email_spec
+  email_validator (~> 1.4.0)
   enumerize
   factory_girl_rails
   ffaker

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,7 +103,7 @@ class User < ActiveRecord::Base
   # Validations
   #
   validates :name, presence: true
-  validates :email, presence: true, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/ }, uniqueness: true
+  validates :email, presence: true, email: {strict_mode: true}, uniqueness: true
   validates :bio, length: { maximum: 255 }, allow_blank: true
   validates :extern_uid, allow_blank: true, uniqueness: {scope: :provider}
   validates :projects_limit, presence: true, numericality: {greater_than_or_equal_to: 0}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,6 +74,27 @@ describe User do
     it { should_not allow_value(-1).for(:projects_limit) }
 
     it { should ensure_length_of(:bio).is_within(0..255) }
+
+    describe 'email' do
+      it 'accepts info@example.com' do
+        user = build(:user, email: 'info@example.com')
+        expect(user).to be_valid
+      end
+      it 'accepts info+test@example.com' do
+        user = build(:user, email: 'info+test@example.com')
+        expect(user).to be_valid
+      end
+
+      it 'rejects test@test@example.com' do
+        user = build(:user, email: 'test@test@example.com')
+        expect(user).to be_invalid
+      end
+
+      it 'rejects mailto:test@example.com' do
+        user = build(:user, email: 'mailto:test@example.com')
+        expect(user).to be_invalid
+      end
+    end
   end
 
   describe "Respond to" do


### PR DESCRIPTION
At this moment it was possible to enter emails like:
mailto:info@example.com. This was causing some issue in the frontend,
since those links became html mailto: links.

Fixes: #3516
