### PR TITLE
Add website url to user

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ v 6.5.0
   - Use jquery timeago plugin
   - Fix 500 error for rdoc files
   - Ability to customize merge commit message (sponsored by Say Media)
+  - Add website url to user profile
 
 v6.4.3
   - Don't use unicorn worker killer if PhusionPassenger is defined

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,8 @@
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
 #  unconfirmed_email      :string(255)
-#  hide_no_ssh_key        :boolean          default(FALSE), not null
+#  hide_no_ssh_key        :boolean          default(FALSE)
+#  website_url            :string(255)      default(""), not null
 #
 
 require 'carrierwave/orm/activerecord'
@@ -52,7 +53,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable, :confirmable, :registerable
 
   attr_accessible :email, :password, :password_confirmation, :remember_me, :bio, :name, :username,
-                  :skype, :linkedin, :twitter, :color_scheme_id, :theme_id, :force_random_password,
+                  :skype, :linkedin, :twitter, :website_url, :color_scheme_id, :theme_id, :force_random_password,
                   :extern_uid, :provider, :password_expires_at, :avatar, :hide_no_ssh_key,
                   as: [:default, :admin]
 
@@ -423,5 +424,15 @@ class User < ActiveRecord::Base
     Event.where(author_id: self.id).
       order('id DESC').limit(1000).
       update_all(updated_at: Time.now)
+  end
+
+  def full_website_url
+    return "http://#{website_url}" if website_url !~ /^https?:\/\//
+
+    website_url
+  end
+
+  def short_website_url
+    website_url.gsub(/https?:\/\//, '')
   end
 end

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -80,6 +80,9 @@
       .form-group
         = f.label :twitter, class: 'control-label'
         .col-sm-10= f.text_field :twitter, class: 'form-control'
+      .form-group
+        = f.label :website_url, class: 'control-label'
+        .col-sm-10= f.text_field :website_url, class: 'form-control'
 
     .form-actions
       - if @user.new_record?

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -47,6 +47,9 @@
         = f.label :twitter, class: "control-label"
         .col-sm-10= f.text_field :twitter, class: "form-control"
       .form-group
+        = f.label :website_url, class: "control-label"
+        .col-sm-10= f.text_field :website_url, class: "form-control"
+      .form-group
         = f.label :bio, class: "control-label"
         .col-sm-10
           = f.text_area :bio, rows: 6, class: "form-control", maxlength: 250

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -17,6 +17,10 @@
       %li
         %span.light Twitter:
         %strong= link_to user.twitter, "http://www.twitter.com/#{user.twitter}"
+    - unless user.website_url.blank?
+      %li
+        %span.light Website url:
+        %strong= link_to user.short_website_url, user.full_website_url
     - unless user.bio.blank?
       %li
         %span.light Bio:

--- a/db/migrate/20140116231608_add_website_url_to_users.rb
+++ b/db/migrate/20140116231608_add_website_url_to_users.rb
@@ -1,0 +1,5 @@
+class AddWebsiteUrlToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :website_url, :string, {:null => false, :default => ''}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131217102743) do
+ActiveRecord::Schema.define(version: 20140116231608) do
 
   create_table "broadcast_messages", force: true do |t|
     t.text     "message",    null: false
@@ -301,6 +301,7 @@ ActiveRecord::Schema.define(version: 20131217102743) do
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.boolean  "hide_no_ssh_key",        default: false
+    t.string   "website_url",            default: "",    null: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree

--- a/doc/api/session.md
+++ b/doc/api/session.md
@@ -26,6 +26,7 @@ __You can login with both GitLab and LDAP credentials now__
   "skype": "",
   "linkedin": "",
   "twitter": "",
+  "website_url": "",
   "dark_scheme": false,
   "theme_id": 1,
   "is_admin": false,

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -20,6 +20,7 @@ GET /users
     "skype": "",
     "linkedin": "",
     "twitter": "",
+    "website_url": "",
     "extern_uid": "john.smith",
     "provider": "provider_name",
     "theme_id": 1,
@@ -38,6 +39,7 @@ GET /users
     "skype": "",
     "linkedin": "",
     "twitter": "",
+    "website_url": "",
     "extern_uid": "jack.smith",
     "provider": "provider_name",
     "theme_id": 1,
@@ -74,6 +76,7 @@ Parameters:
   "skype": "",
   "linkedin": "",
   "twitter": "",
+  "website_url": "",
   "extern_uid": "john.smith",
   "provider": "provider_name",
   "theme_id": 1,
@@ -102,6 +105,7 @@ Parameters:
 + `skype` (optional)            - Skype ID
 + `linkedin` (optional)         - Linkedin
 + `twitter` (optional)          - Twitter account
++ `website_url` (optional)      - Website url
 + `projects_limit` (optional)   - Number of projects user can create
 + `extern_uid` (optional)       - External UID
 + `provider` (optional)         - External provider name
@@ -127,6 +131,7 @@ Parameters:
 + `skype`                             - Skype ID
 + `linkedin`                          - Linkedin
 + `twitter`                           - Twitter account
++ `website_url`                       - Website url
 + `projects_limit`                    - Limit projects each user can create
 + `extern_uid`                        - External UID
 + `provider`                          - External provider name
@@ -174,6 +179,7 @@ GET /user
   "skype": "",
   "linkedin": "",
   "twitter": "",
+  "website_url": "",
   "theme_id": 1,
   "color_scheme_id": 2,
   "is_admin": false,

--- a/features/profile/profile.feature
+++ b/features/profile/profile.feature
@@ -8,8 +8,8 @@ Feature: Profile
 
   Scenario: I edit profile
     Given I visit profile page
-    Then I change my contact info
-    And I should see new contact info
+    Then I change my profile info
+    And I should see new profile info
 
   Scenario: I change my password without old one
     Given I visit profile password page

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -6,18 +6,20 @@ class Profile < Spinach::FeatureSteps
     page.should have_content "Profile settings"
   end
 
-  step 'I change my contact info' do
+  step 'I change my profile info' do
     fill_in "user_skype", with: "testskype"
     fill_in "user_linkedin", with: "testlinkedin"
     fill_in "user_twitter", with: "testtwitter"
+    fill_in "user_website_url", with: "testurl"
     click_button "Save changes"
     @user.reload
   end
 
-  step 'I should see new contact info' do
+  step 'I should see new profile info' do
     @user.skype.should == 'testskype'
     @user.linkedin.should == 'testlinkedin'
     @user.twitter.should == 'testtwitter'
+    @user.website_url.should == 'testurl'
   end
 
   step 'I change my avatar' do

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -1,7 +1,7 @@
 module API
   module Entities
     class User < Grape::Entity
-      expose :id, :username, :email, :name, :bio, :skype, :linkedin, :twitter,
+      expose :id, :username, :email, :name, :bio, :skype, :linkedin, :twitter, :website_url,
              :theme_id, :color_scheme_id, :state, :created_at, :extern_uid, :provider
       expose :is_admin?, as: :is_admin
       expose :can_create_group?, as: :can_create_group

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -36,6 +36,7 @@ module API
       #   skype                             - Skype ID
       #   linkedin                          - Linkedin
       #   twitter                           - Twitter account
+      #   website_url                       - Website url
       #   projects_limit                    - Number of projects user can create
       #   extern_uid                        - External authentication provider UID
       #   provider                          - External provider
@@ -67,6 +68,7 @@ module API
       #   skype                             - Skype ID
       #   linkedin                          - Linkedin
       #   twitter                           - Twitter account
+      #   website_url                       - Website url
       #   projects_limit                    - Limit projects each user can create
       #   extern_uid                        - External authentication provider UID
       #   provider                          - External provider
@@ -78,7 +80,7 @@ module API
       put ":id" do
         authenticated_as_admin!
 
-        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
+        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :website_url, :projects_limit, :username, :extern_uid, :provider, :bio, :can_create_group, :admin]
         user = User.find(params[:id])
         not_found!("User not found") unless user
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,6 +41,8 @@
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
 #  unconfirmed_email      :string(255)
+#  hide_no_ssh_key        :boolean          default(FALSE)
+#  website_url            :string(255)      default(""), not null
 #
 
 require 'spec_helper'
@@ -291,6 +293,50 @@ describe User do
     it "should be false if avatar is html page" do
       user.update_attribute(:avatar, 'uploads/avatar.html')
       user.avatar_type.should == ["only images allowed"]
+    end
+  end
+
+  describe '#full_website_url' do
+    let(:user) { create(:user) }
+
+    it 'begins with http if website url omits it' do
+      user.website_url = 'test.com'
+
+      expect(user.full_website_url).to eq 'http://test.com'
+    end
+
+    it 'begins with http if website url begins with http' do
+      user.website_url = 'http://test.com'
+
+      expect(user.full_website_url).to eq 'http://test.com'
+    end
+
+    it 'begins with https if website url begins with https' do
+      user.website_url = 'https://test.com'
+
+      expect(user.full_website_url).to eq 'https://test.com'
+    end
+  end
+
+  describe '#short_website_url' do
+    let(:user) { create(:user) }
+
+    it 'does not begin with http if website url omits it' do
+      user.website_url = 'test.com'
+
+      expect(user.short_website_url).to eq 'test.com'
+    end
+
+    it 'does not begin with http if website url begins with http' do
+      user.website_url = 'http://test.com'
+
+      expect(user.short_website_url).to eq 'test.com'
+    end
+
+    it 'does not begin with https if website url begins with https' do
+      user.website_url = 'https://test.com'
+
+      expect(user.short_website_url).to eq 'test.com'
     end
   end
 end


### PR DESCRIPTION
I thought it could be useful to be able to fill in a website url (may it be company related or not) in one's profile.

![profile view](https://f.cloud.github.com/assets/236461/1947612/39843b98-805e-11e3-82f7-0d25a60a4f91.png)

![profile edit](https://f.cloud.github.com/assets/236461/1948111/db03fa12-807c-11e3-85fa-ffb9333884e1.png)
