### PR TITLE
Updated gitlab.yaml.example's issue_closing_pattern to single quotes

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -65,7 +65,7 @@ production: &base
     # If a commit message matches this regular expression, all issues referenced from the matched text will be closed.
     # This happens when the commit is pushed or merged into the default branch of a project.
     # When not specified the default issue_closing_pattern as specified below will be used.
-    # issue_closing_pattern: "([Cc]lose[sd]|[Ff]ixe[sd]) +#\d+"
+    # issue_closing_pattern: '([Cc]lose[sd]|[Ff]ixe[sd]) +#\d+'
 
     ## Default project features settings
     default_projects_features:


### PR DESCRIPTION
… (misused double quotes here), should resolve #6032 and #6071
