### PR TITLE
Expand st_diff column size of notes table

### DIFF
--- a/db/migrate/20140121124412_expand_diff_column_size.rb
+++ b/db/migrate/20140121124412_expand_diff_column_size.rb
@@ -1,0 +1,8 @@
+class ExpandDiffColumnSize < ActiveRecord::Migration
+  def up
+    change_column :notes, :st_diff, :text, :limit => 4294967295
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
The text column size of MySQL is 64 kb.
The st_diff column of notes table is serialized. If compressed diff size is over, uncompress will fail. So Note#st_diff will return nil.
This situation raise error when rendering view. (example #5234)
