### PR TITLE
gitlab can now init repositories

### DIFF
--- a/app/assets/javascripts/project.js.coffee
+++ b/app/assets/javascripts/project.js.coffee
@@ -10,6 +10,8 @@ class Project
   initEvents: ->
     disableButtonIfEmptyField '#project_name', '.project-submit'
 
+    auto_init_checked = $('#project_auto_init').is(':checked')
+
     $('#project_issues_enabled').change ->
       if ($(this).is(':checked') == true)
         $('#project_issues_tracker').removeAttr('disabled')
@@ -23,6 +25,17 @@ class Project
         $('#project_issues_tracker_id').attr('disabled', 'disabled')
       else
         $('#project_issues_tracker_id').removeAttr('disabled')
+
+    $('#project_import_url').change ->
+      if ($(this).val().length > 0)
+        $('#project_auto_init').attr('disabled', 'disabled')
+        $('#project_auto_init').attr('checked', false)
+      else
+        $('#project_auto_init').removeAttr('disabled')
+        if (auto_init_checked)
+          $('#project_auto_init').attr('checked', true)
+        else 
+          $('#project_auto_init').attr('checked', false)
 
 
 @Project = Project

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -64,8 +64,10 @@ class ProjectsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        if @project.empty_repo?
+        if (@project.empty_repo? && !@project.auto_init?) || (@project.empty_repo? && @project.import?)
           render "projects/empty", layout: user_layout
+        elsif @project.empty_repo? && @project.auto_init? && !@project.import?
+          render "projects/autoinit", layout: user_layout
         else
           if current_user
             @last_push = current_user.recent_push(@project.id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,6 +21,7 @@
 #  imported               :boolean          default(FALSE), not null
 #  import_url             :string(255)
 #  visibility_level       :integer          default(0), not null
+#  auto_init              :boolean          default(TRUE), not null
 #
 
 class Project < ActiveRecord::Base
@@ -32,7 +33,7 @@ class Project < ActiveRecord::Base
 
   attr_accessible :name, :path, :description, :issues_tracker, :label_list,
     :issues_enabled, :wall_enabled, :merge_requests_enabled, :snippets_enabled, :issues_tracker_id,
-    :wiki_enabled, :visibility_level, :import_url, :last_activity_at, as: [:default, :admin]
+    :wiki_enabled, :visibility_level, :auto_init, :import_url, :last_activity_at, as: [:default, :admin]
 
   attr_accessible :namespace_id, :creator_id, as: :admin
 
@@ -499,5 +500,9 @@ class Project < ActiveRecord::Base
   def change_head(branch)
     gitlab_shell.update_repository_head(self.path_with_namespace, branch)
     reload_default_branch
+  end
+
+  def auto_init?
+    auto_init
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -505,4 +505,16 @@ class Project < ActiveRecord::Base
   def auto_init?
     auto_init
   end
+
+  def auto_init_from_template?
+    auto_init_template_dir_exists(Gitlab.config.gitlab.auto_init_template_dir)
+  end
+
+  def auto_init_template_dir_exists(directory)
+    if File.directory?(directory)
+      Dir.entries("#{directory}").size > 2
+    else
+     false
+    end
+  end
 end

--- a/app/observers/project_observer.rb
+++ b/app/observers/project_observer.rb
@@ -13,6 +13,11 @@ class ProjectObserver < BaseObserver
       )
 
       log_info("#{project.owner.name} created a new project \"#{project.name_with_namespace}\"")
+    
+      if project.auto_init?
+        ::Projects::AutoInitService.new(project).execute
+      end
+
     end
 
     if project.wiki_enabled?

--- a/app/services/projects/auto_init_service.rb
+++ b/app/services/projects/auto_init_service.rb
@@ -1,0 +1,51 @@
+module Projects
+  class AutoInitService < BaseService
+
+    attr_accessor :project, :project_init_dir, :config_auto_init_template_dir
+
+    def initialize(project)
+      @project = project
+      @project_init_dir = File.join(
+        File.expand_path(Rails.root),
+        'tmp',
+        'gitlab-autoinit-template',
+        project.path_with_namespace
+      )
+      @config_auto_init_template_dir = Gitlab.config.gitlab.auto_init_template_dir
+    end
+
+    def execute
+      if !exists(config_auto_init_template_dir) || !has_files(config_auto_init_template_dir)
+        init_from_template = "false"
+      else
+        init_from_template = "true"
+      end
+
+      Gitlab::AppLogger.info("init_from_template = #{init_from_template}")
+
+      GitlabShellWorker.perform_in(
+        1.seconds,
+        :init_repository,
+        project.path_with_namespace,
+        project_init_dir,
+        init_from_template,
+        config_auto_init_template_dir,
+        project.owner.name,
+        project.owner.email
+      )
+    end
+
+    def exists(directory)
+      File.directory?(directory)
+    end
+
+    def has_files(directory)
+      if exists(directory)
+        Dir.entries("#{directory}").size > 2
+      else
+        false
+      end
+    end
+
+  end
+end

--- a/app/services/projects/auto_init_service.rb
+++ b/app/services/projects/auto_init_service.rb
@@ -15,13 +15,11 @@ module Projects
     end
 
     def execute
-      if !exists(config_auto_init_template_dir) || !has_files(config_auto_init_template_dir)
+      if !project.auto_init_from_template?
         init_from_template = "false"
       else
         init_from_template = "true"
       end
-
-      Gitlab::AppLogger.info("init_from_template = #{init_from_template}")
 
       GitlabShellWorker.perform_in(
         1.seconds,
@@ -33,18 +31,6 @@ module Projects
         project.owner.name,
         project.owner.email
       )
-    end
-
-    def exists(directory)
-      File.directory?(directory)
-    end
-
-    def has_files(directory)
-      if exists(directory)
-        Dir.entries("#{directory}").size > 2
-      else
-        false
-      end
     end
 
   end

--- a/app/views/projects/autoinit.html.haml
+++ b/app/views/projects/autoinit.html.haml
@@ -1,0 +1,9 @@
+= render "home_panel"
+
+.save-project-loader
+  %center
+    = image_tag "ajax_loader.gif"
+    %h3 Initializing repository.
+    %p Please wait while we intitializing the repository for you. This pages refreshes automatically.
+    :javascript
+        new ProjectImport();

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -48,10 +48,17 @@
           %span.light (optional)
         .col-sm-10
           = f.text_area :description, placeholder: "Awesome project", class: "form-control", rows: 3, maxlength: 250, tabindex: 3
+      .form-group
+        = f.label :auto_init, class: 'control-label' do
+          Initialize
+        .col-sm-10
+          %span.checkbox.auto_init
+            = f.check_box :auto_init, checked: (gitlab_config.default_projects_features.auto_init == true), tabindex: 4
+            Project will be initialized with a README file (only if you're creating a new project without importing from another one).
       = render "visibility_level", f: f, visibility_level: gitlab_config.default_projects_features.visibility_level, can_change_visibility_level: true
 
       .form-actions
-        = f.submit 'Create project', class: "btn btn-create project-submit", tabindex: 4
+        = f.submit 'Create project', class: "btn btn-create project-submit", tabindex: 5
 
         - if current_user.can_create_group?
           .pull-right

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -32,7 +32,7 @@
       .form-group
         .col-sm-2
         .col-sm-10
-          = link_to "#", id: 'import_project_appear_link', class: 'appear-link' do
+          = link_to "#", class: 'appear-link' do
             %i.icon-upload-alt
             %span Import existing repository?
       .form-group.appear-data.import-url-data

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -32,7 +32,7 @@
       .form-group
         .col-sm-2
         .col-sm-10
-          = link_to "#", class: 'appear-link' do
+          = link_to "#", id: 'import_project_appear_link', class: 'appear-link' do
             %i.icon-upload-alt
             %span Import existing repository?
       .form-group.appear-data.import-url-data
@@ -54,7 +54,10 @@
         .col-sm-10
           %span.checkbox.auto_init
             = f.check_box :auto_init, checked: (gitlab_config.default_projects_features.auto_init == true), tabindex: 4
-            Project will be initialized with a README file (only if you're creating a new project without importing from another one).
+            - if @project.auto_init_from_template?
+              Initialize the repository with default template.
+            - else
+              Initialize the repository with a README file.
       = render "visibility_level", f: f, visibility_level: gitlab_config.default_projects_features.visibility_level, can_change_visibility_level: true
 
       .form-actions

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -75,6 +75,8 @@ production: &base
       wall: false
       snippets: false
       visibility_level: "private"  # can be "private" | "internal" | "public"
+      auto_init: true # if set to true gitlab will add a README file and inits the repo
+
 
   ## External issues trackers
   issues_tracker:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -94,6 +94,8 @@ Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant_array, Gitlab::VisibilityLevel, Settings.gitlab['restricted_visibility_levels'], [])
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['issue_closing_pattern'] = '([Cc]loses|[Ff]ixes) #(\d+)' if Settings.gitlab['issue_closing_pattern'].nil?
+Settings.gitlab['auto_init_template_dir']  ||=  File.expand_path(File.join(Settings.gitlab['user_home'],'gitlab-autoinit-template'))
+
 Settings.gitlab['default_projects_features'] ||= {}
 Settings.gitlab.default_projects_features['issues']         = true if Settings.gitlab.default_projects_features['issues'].nil?
 Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.gitlab.default_projects_features['merge_requests'].nil?
@@ -101,6 +103,8 @@ Settings.gitlab.default_projects_features['wiki']           = true if Settings.g
 Settings.gitlab.default_projects_features['wall']           = false if Settings.gitlab.default_projects_features['wall'].nil?
 Settings.gitlab.default_projects_features['snippets']       = false if Settings.gitlab.default_projects_features['snippets'].nil?
 Settings.gitlab.default_projects_features['visibility_level']    = Settings.send(:verify_constant, Gitlab::VisibilityLevel, Settings.gitlab.default_projects_features['visibility_level'], Gitlab::VisibilityLevel::PRIVATE)
+Settings.gitlab.default_projects_features['auto_init']           = true if Settings.gitlab.default_projects_features['auto_init'].nil?
+
 
 #
 # Gravatar

--- a/db/migrate/20140121080605_add_auto_init_to_project.rb
+++ b/db/migrate/20140121080605_add_auto_init_to_project.rb
@@ -1,0 +1,5 @@
+class AddAutoInitToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :auto_init, :boolean, :default => true, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 20140116231608) do
     t.string   "import_url"
     t.integer  "visibility_level",       default: 0,        null: false
     t.boolean  "archived",               default: false,    null: false
+    t.boolean  "auto_init",              default: true,     null: false
   end
 
   add_index "projects", ["creator_id"], name: "index_projects_on_owner_id", using: :btree

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -203,6 +203,11 @@ You can change `6-4-stable` to `master` if you want the *bleeding edge* version,
     # Create directory for satellites
     sudo -u git -H mkdir /home/git/gitlab-satellites
 
+    # Create directory for automatic project initialisation
+    # Put everything which should be included in every project
+    # If you don't want to copy such files, leave it empty, GitLab will create a README.md file for you
+    sudo -u git -H mkdir /home/git/gitlab-autoinit-template
+
     # Create directories for sockets/pids and make sure GitLab can write to them
     sudo -u git -H mkdir tmp/pids/
     sudo -u git -H mkdir tmp/sockets/

--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -13,6 +13,21 @@ module Gitlab
       system "#{gitlab_shell_path}/bin/gitlab-projects", "add-project", "#{name}.git"
     end
 
+    # Auto init new repository
+    #
+    # name - project path with namespace
+    # tmp_path - path for creation of init file
+    # init_from_template - init repository from template
+    # config_auto_init_template_dir - copy all files from this directory into the new repo
+    # project_owner_name - "Administrator"
+    # project_owner_email - "admin@local.host"
+    #
+    # Ex.
+    #    init_repository("root/example/", "true", "/home/git/gitlab/tmp/gitlab-autoinit-template/example", "Administrator", "admin@local.host")
+    def init_repository(name, tmp_path, init_from_template, config_auto_init_template_dir, project_owner_name, project_owner_email)
+      system "#{gitlab_shell_path}/bin/gitlab-projects", "init-project", name, tmp_path, init_from_template, config_auto_init_template_dir, project_owner_name, project_owner_email
+    end
+
     # Import repository
     #
     # name - project path with namespace


### PR DESCRIPTION
gitlab changes for gitlab_shell changes in pull-request https://github.com/gitlabhq/gitlab-shell/pull/126
- Users can now init repos right after creation of project.
- If "gitlab-autoinit-template" in home dir of gitlab-user exists everything from this folder will be copied into the new repository
