### PR TITLE
Check specifically for Unicorn in rack config.ru file

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-unless defined?(PhusionPassenger)
+if defined?(Unicorn)
   require 'unicorn'
   # Unicorn self-process killer
   require 'unicorn/worker_killer'


### PR DESCRIPTION
Don't assume that if the Rack server is not Passenger then it must be Unicorn. There are many other Rack servers in the world (uwsgi being one example that people use a lot).

The reverse check is much more logical, i.e. check explicitly for Unicorn
