### PR TITLE
Assembla service: Project name was hardcoded (oops)

### DIFF
--- a/app/models/project_services/assembla_service.rb
+++ b/app/models/project_services/assembla_service.rb
@@ -16,6 +16,8 @@
 #
 
 class AssemblaService < Service
+  attr_accessible :subdomain
+
   include HTTParty
 
   validates :token, presence: true, if: :activated?
@@ -34,12 +36,13 @@ class AssemblaService < Service
 
   def fields
     [
-      { type: 'text', name: 'token', placeholder: '' }
+      { type: 'text', name: 'token', placeholder: '' },
+      { type: 'text', name: 'subdomain', placeholder: '' }
     ]
   end
 
   def execute(push)
-    url = "https://atlas.assembla.com/spaces/ouposp/github_tool?secret_key=#{token}"
+    url = "https://atlas.assembla.com/spaces/#{subdomain}/github_tool?secret_key=#{token}"
     AssemblaService.post(url, body: { payload: push }.to_json, headers: { 'Content-Type' => 'application/json' })
   end
 end

--- a/spec/models/assembla_service_spec.rb
+++ b/spec/models/assembla_service_spec.rb
@@ -33,14 +33,15 @@ describe AssemblaService do
         project_id: project.id,
         project: project,
         service_hook: true,
-        token: 'verySecret'
+        token: 'verySecret',
+        subdomain: 'project_name'
       )
       @sample_data = GitPushService.new.sample_data(project, user)
-      @api_url = 'https://atlas.assembla.com/spaces/ouposp/github_tool?secret_key=verySecret'
+      @api_url = 'https://atlas.assembla.com/spaces/project_name/github_tool?secret_key=verySecret'
       WebMock.stub_request(:post, @api_url)
     end
 
-    it "should call FlowDock API" do
+    it "should call Assembla API" do
       @assembla_service.execute(@sample_data)
       WebMock.should have_requested(:post, @api_url).with(
         body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/


### PR DESCRIPTION
The URL that the service uses had the project name hardcoded. This patch allows entering the project name as the "subdomain" (since it was the best name of the current available service attributes I found). I wonder if, now that gitlabhq has a bunch of services each one with different parameters required, if it would be a good time to serialize all those parameters into a single attribute, instead of continuing to append more or reuse the existent ones when their names are not the most intuitive for a particular service.
