### PR TITLE
added max height to side-by-side diffs

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -48,6 +48,10 @@
     background: #FFF;
     color: #333;
     font-size: 12px;
+    .text-file-parallel {
+      max-height: 600px;
+      overflow-x: auto;
+    }
     .old {
       span.idiff {
         background-color: #FAA;


### PR DESCRIPTION
long files take up the whole screen.
With this css the diff scrolls when longer than 600px in height
