### PR TITLE
Remove snippet expiration date from UI

### DIFF
--- a/app/views/projects/snippets/_snippet.html.haml
+++ b/app/views/projects/snippets/_snippet.html.haml
@@ -5,13 +5,6 @@
     %span.cgray.monospace.tiny.pull-right
       = snippet.file_name
 
-  %small.pull-right.cgray
-    Expires:
-    - if snippet.expires_at
-      = snippet.expires_at.to_date.to_s(:short)
-    - else
-      Never
-
   .snippet-info
     = "##{snippet.id}"
     %span


### PR DESCRIPTION
Since expiration date of snippets was removed this also should be removed from UI. Currently it always says: `Expires: Never`
### Before

![screenshot 2014-01-25 08 59 59](https://f.cloud.github.com/assets/278301/2001229/6ee38e80-8598-11e3-8236-1456dc1ab617.png)
### After

![screenshot 2014-01-25 09 00 25](https://f.cloud.github.com/assets/278301/2001231/75b983d6-8598-11e3-96e6-0a11c0a722ca.png)
