### PR TITLE
Mobile UI improvements

### DIFF
--- a/app/assets/stylesheets/generic/common.scss
+++ b/app/assets/stylesheets/generic/common.scss
@@ -327,6 +327,12 @@ li.note {
     color: #fff;
     text-decoration: underline;
   }
+
+  .links-xs {
+    text-align: center;
+    font-size: 16px;
+    padding: 5px;
+  }
 }
 
 .warning_message {
@@ -484,4 +490,8 @@ table {
   fieldset {
     margin-bottom: 15px;
   }
+}
+
+@media (max-width: $screen-xs-max) {
+  .container .content { margin-top: 20px; }
 }

--- a/app/assets/stylesheets/main/layout.scss
+++ b/app/assets/stylesheets/main/layout.scss
@@ -1,5 +1,7 @@
 html {
   overflow-y: scroll;
+
+  &.touch .tooltip { display: none !important; }
 }
 
 body {

--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -29,6 +29,59 @@ header {
         float: right;
         margin-right: 0;
       }
+
+      .navbar-toggle {
+        color: $style_color;
+        margin: 0 -15px 0 0;
+        padding: 10px;
+        border-radius: 0;
+
+        button i { font-size: 22px; }
+
+        &.collapsed { background-color: transparent !important;}
+
+        &:hover {
+          background-color: #EEE;
+        }
+      }
+    }
+
+    @media (max-width: $screen-xs-max) {
+      border-width: 0;
+      font-size: 18px;
+
+      .app_logo { margin-left: -15px; }
+      .project_name {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: top;
+        white-space: nowrap;
+        max-width: 70%;
+      }
+
+      .navbar-collapse {
+        padding-right: 0;
+        padding-left: 0;
+      }
+
+      .navbar-nav {
+        margin: 5px 0;
+
+        .visible-xs, .visable-sm {
+          display: table-cell !important;
+        }
+      }
+
+      li {
+        display: table-cell;
+        width: 1%;
+
+        a {
+          text-align: center;
+          font-size: 18px !important;
+        }
+      }
     }
   }
 
@@ -127,6 +180,8 @@ header {
       .navbar-inner {
         background: #708090;
         border-bottom: 1px solid #AAA;
+
+        .navbar-toggle { color: #fff; }
 
         .nav > li > a {
           color: #AAA;

--- a/app/assets/stylesheets/sections/nav.scss
+++ b/app/assets/stylesheets/sections/nav.scss
@@ -83,4 +83,38 @@
       padding-top: 2px;
     }
   }
+
+  @media (max-width: $screen-xs-max) {
+    font-size: 18px;
+    margin: 0;
+
+    max-height: none;
+
+    &, .container {
+      padding: 0;
+      border-top: 0;
+    }
+
+    ul {
+      height: auto;
+
+      li {
+        display: list-item;
+        width: auto;
+        padding: 5px 0;
+
+        &.active {
+          background-color: $primary_color;
+
+          a {
+            color: #fff;
+            font-weight: normal;
+            text-shadow: none;
+
+            &:after { display: none; }
+          }
+        }
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/ui_color.scss
+++ b/app/assets/stylesheets/themes/ui_color.scss
@@ -18,7 +18,7 @@
       .navbar-inner {
         background: #547;
         border-bottom: 1px solid #435;
-        .app_logo {
+        .app_logo, .navbar-toggle {
           &:hover {
             background-color: #435;
           }

--- a/app/assets/stylesheets/themes/ui_gray.scss
+++ b/app/assets/stylesheets/themes/ui_gray.scss
@@ -18,7 +18,7 @@
       .navbar-inner {
         background: #373737;
         border-bottom: 1px solid #272727;
-        .app_logo {
+        .app_logo, .navbar-toggle {
           &:hover {
             background-color: #272727;
           }

--- a/app/assets/stylesheets/themes/ui_mars.scss
+++ b/app/assets/stylesheets/themes/ui_mars.scss
@@ -18,7 +18,7 @@
       .navbar-inner {
         background: #474D57;
         border-bottom: 1px solid #373D47;
-        .app_logo {
+        .app_logo, .navbar-toggle {
           &:hover {
             background-color: #373D47;
           }

--- a/app/assets/stylesheets/themes/ui_modern.scss
+++ b/app/assets/stylesheets/themes/ui_modern.scss
@@ -18,7 +18,7 @@
       .navbar-inner {
         background: #345;
         border-bottom: 1px solid #234;
-        .app_logo {
+        .app_logo, .navbar-toggle {
           &:hover {
             background-color: #234;
           }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -2,7 +2,7 @@
   .dashboard.row
     .activities.col-md-8
       = render 'activities'
-    .side.col-md-4.hidden-sm
+    .side.col-md-4.hidden-sm.hidden-xs
       = render 'sidebar'
 
 - else

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -14,14 +14,14 @@
 
       .navbar-collapse.collapse
         %ul.nav.navbar-nav
-          %li
+          %li.hidden-sm.hidden-xs
             %a
               %div.hide.turbolink-spinner
                 %i.icon-refresh.icon-spin
                 Loading...
-          %li.hidden-sm
+          %li.hidden-sm.hidden-xs
             = render "layouts/search"
-          %li.visible-sm
+          %li.visible-sm.visible-xs
             = link_to search_path, title: "Search", class: 'has_bottom_tooltip', 'data-original-title' => 'Search area' do
               %i.icon-search
           %li

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -4,7 +4,7 @@
   %body{class: "#{app_theme} admin", :'data-page' => body_data_page}
     = render "layouts/head_panel", title: "Admin area"
     = render "layouts/flash"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/admin'
 
     .container

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/broadcast"
     = render "layouts/head_panel", title: "Dashboard"
     = render "layouts/flash"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/dashboard'
 
     .container

--- a/app/views/layouts/group.html.haml
+++ b/app/views/layouts/group.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/broadcast"
     = render "layouts/head_panel", title: "group: #{@group.name}"
     = render "layouts/flash"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/group'
 
     .container

--- a/app/views/layouts/profile.html.haml
+++ b/app/views/layouts/profile.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/broadcast"
     = render "layouts/head_panel", title: "Profile"
     = render "layouts/flash"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/profile'
 
     .container

--- a/app/views/layouts/project_settings.html.haml
+++ b/app/views/layouts/project_settings.html.haml
@@ -9,7 +9,7 @@
     - if can?(current_user, :download_code, @project)
       = render 'shared/no_ssh'
 
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/project'
 
     .container

--- a/app/views/layouts/projects.html.haml
+++ b/app/views/layouts/projects.html.haml
@@ -9,7 +9,7 @@
     - if can?(current_user, :download_code, @project)
       = render 'shared/no_ssh'
 
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/project'
 
     .container

--- a/app/views/layouts/public_projects.html.haml
+++ b/app/views/layouts/public_projects.html.haml
@@ -3,7 +3,7 @@
   = render "layouts/head", title: @project.name_with_namespace
   %body{class: "#{app_theme} application", :'data-page' => body_data_page}
     = render "layouts/public_head_panel"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/project'
     .container
       .content= yield

--- a/app/views/layouts/user_team.html.haml
+++ b/app/views/layouts/user_team.html.haml
@@ -4,7 +4,7 @@
   %body{class: "#{app_theme} application", :'data-page' => body_data_page}
     = render "layouts/head_panel", title: "team: #{@team.name}"
     = render "layouts/flash"
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/team'
 
     .container

--- a/app/views/shared/_no_ssh.html.haml
+++ b/app/views/shared/_no_ssh.html.haml
@@ -2,7 +2,13 @@
   .no-ssh-key-message
     .container
       You won't be able to pull or push project code via SSH until you #{link_to 'add an SSH key', new_profile_key_path} to your profile
-      %div.pull-right
+      .pull-right.hidden-xs
         = link_to "Don't show again", profile_path(user: {hide_no_ssh_key: true}), method: :put, class: 'hide-no-ssh-message', remote: true
         |
         = link_to 'Remind later', '#', class: 'hide-no-ssh-message'
+      .links-xs.visible-xs
+        = link_to "Add key", new_profile_key_path
+        |
+        = link_to "Don't show again", profile_path(user: {hide_no_ssh_key: true}), method: :put, class: 'hide-no-ssh-message', remote: true
+        |
+        = link_to 'Later', '#', class: 'hide-no-ssh-message'


### PR DESCRIPTION
These changes drastically improve the mobile experience. The changes mostly pertain to navigation plus the no ssh key message.  

Note: Some of the navbar toggles have a blue outline around them in these screenshots. That's because I took the screenshots with Chrome in mobile emulation mode. Clicking some links causes it to be outlined. This does not happen on mobile. All of these changes were tested on an actual mobile device.

Also, there is a one-liner in here that disables tooltips for touch enabled devices. Tooltips on mobile end up requiring 2 taps to execute the click. The first tap renders the tooltip and the second executes the link. 

Please let me know if you have any questions about specific changes.
## Before:

The main nav looks decent but if there are too many items they just go off the screen. The navbar toggle is small.
![before1](https://f.cloud.github.com/assets/2394772/2001973/9b86b3de-85db-11e3-8cd9-7932fb397238.png)

Tap the navbar toggle and you get a mess.
![before2](https://f.cloud.github.com/assets/2394772/2001974/9b9462b8-85db-11e3-83d7-1910c785ec9d.png)

The no ssh key message is small. The links are hard to tap with big fingers ;)
![before3](https://f.cloud.github.com/assets/2394772/2001987/6d555384-85dc-11e3-91f3-70f61d726bcd.png)
## After:

Navbar toggle is bigger and is spaced nicely.

![after1](https://f.cloud.github.com/assets/2394772/2001978/ededd2ec-85db-11e3-9665-74c98d77da0e.png)

Tap the navbar toggle and you see bigger header nav buttons. Also, the main nav is stacked and will expand to fit any number of items.
![after2](https://f.cloud.github.com/assets/2394772/2001979/edeeb932-85db-11e3-94f4-02cf85c6cff6.png)

The links are bigger and centered. Also, for mobile only I added an "Add key" link that is easier to tap than the inline link.
![after3](https://f.cloud.github.com/assets/2394772/2001993/8dbb5e66-85dc-11e3-85cd-0c373f7b6d42.png)

The no ssh key message when nav is expanded. 
![after4](https://f.cloud.github.com/assets/2394772/2001994/8dbb8c56-85dc-11e3-96ba-16965734f4a3.png)

Shots of the light theme to show that things still look as expected.
![after5](https://f.cloud.github.com/assets/2394772/2002003/e6ef9a24-85dc-11e3-8254-a45a1f708d19.png)
![after6](https://f.cloud.github.com/assets/2394772/2002004/e6f186c2-85dc-11e3-85ff-11c8dc99b2e7.png)
