### PR TITLE
Expand st_diff column size of notes table

### DIFF
--- a/db/migrate/20140121124412_expand_diff_column_size.rb
+++ b/db/migrate/20140121124412_expand_diff_column_size.rb
@@ -1,0 +1,8 @@
+class ExpandDiffColumnSize < ActiveRecord::Migration
+  def up
+    change_column :notes, :st_diff, :text, :limit => 4294967295
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 20140122122549) do
     t.string   "line_code"
     t.string   "commit_id"
     t.integer  "noteable_id"
-    t.text     "st_diff"
+    t.text     "st_diff",       limit: 2147483647
     t.boolean  "system",        default: false, null: false
   end
 


### PR DESCRIPTION
The text column size of MySQL is 64 kb.
The st_diff column of notes table is serialized. If compressed diff size is over, uncompress will fail. So Note#st_diff will return nil.
This situation raise error when rendering view. (example #5234)
#6130 was nothing `db/schema.rb`
