### PR TITLE
Added ability to serve files in the wiki repository (images/attachments)

### DIFF
--- a/app/controllers/projects/wikis_controller.rb
+++ b/app/controllers/projects/wikis_controller.rb
@@ -14,11 +14,17 @@ class Projects::WikisController < Projects::ApplicationController
     if @wiki
       render 'show'
     else
-      return render('empty') unless can?(current_user, :write_wiki, @project)
-      @wiki = WikiPage.new(@gollum_wiki)
-      @wiki.title = params[:id]
+      wiki_file = @gollum_wiki.find_file(params[:id], params[:version_id])
 
-      render 'edit'
+      if wiki_file
+        send_data(wiki_file.raw_data, type: wiki_file.mime_type())
+      else
+        return render('empty') unless can?(current_user, :write_wiki, @project)
+        @wiki = WikiPage.new(@gollum_wiki)
+        @wiki.title = params[:id]
+
+        render 'edit'
+      end
     end
   end
 

--- a/app/models/gollum_wiki.rb
+++ b/app/models/gollum_wiki.rb
@@ -70,6 +70,14 @@ class GollumWiki
     end
   end
 
+  def find_file(title, version = nil)
+    if wiki_file = wiki.file(title)
+      wiki_file
+    else
+      nil
+    end
+  end
+
   def create_page(title, content, format = :markdown, message = nil)
     commit = commit_details(:created, message, title)
 


### PR DESCRIPTION
This patch allows for embedding images and using attached files in the wiki, when these files have been placed into the wiki repository.

To use, clone the wiki repository locally (Git Access tab in the wiki section), add and commit images or other files, and push the changes back to your Gitlab installation.

You can then embed images or link to these files for download:

```
![Fallback title when the image isn't found](image.png)

[Download file](attachement.pdf)
```

Note that this doesn't work if files are in subdirectories: they need to be in the repository's top directory.
