### PR TITLE
Fix merge_request_diffs migrations for postgresql

### DIFF
--- a/db/migrate/20140122114406_migrate_mr_diffs.rb
+++ b/db/migrate/20140122114406_migrate_mr_diffs.rb
@@ -1,8 +1,6 @@
 class MigrateMrDiffs < ActiveRecord::Migration
   def self.up
-    execute "INSERT INTO merge_request_diffs ( merge_request_id ) SELECT id FROM merge_requests"
-    execute "UPDATE merge_requests mr, merge_request_diffs md SET md.st_commits = mr.st_commits WHERE md.merge_request_id = mr.id"
-    execute "UPDATE merge_requests mr, merge_request_diffs md SET md.st_diffs = mr.st_diffs WHERE md.merge_request_id = mr.id"
+    execute "INSERT INTO merge_request_diffs ( merge_request_id, st_commits, st_diffs ) SELECT id, st_commits, st_diffs FROM merge_requests"
   end
 
   def self.down

--- a/db/migrate/20140122122549_remove_m_rdiff_fields.rb
+++ b/db/migrate/20140122122549_remove_m_rdiff_fields.rb
@@ -7,7 +7,15 @@ class RemoveMRdiffFields < ActiveRecord::Migration
   def down
     add_column :merge_requests, :st_commits, :text, null: true, limit: 2147483647
     add_column :merge_requests, :st_diffs, :text, null: true, limit: 2147483647
-    execute "UPDATE merge_requests mr, merge_request_diffs md SET mr.st_commits = md.st_commits WHERE md.merge_request_id = mr.id"
-    execute "UPDATE merge_requests mr, merge_request_diffs md SET mr.st_diffs = md.st_diffs WHERE md.merge_request_id = mr.id"
+
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+      execute "UPDATE merge_requests mr
+              SET (st_commits, st_diffs) = (md.st_commits, md.st_diffs)
+              FROM merge_request_diffs md
+              WHERE md.merge_request_id = mr.id"
+    else
+      execute "UPDATE merge_requests mr, merge_request_diffs md SET mr.st_commits = md.st_commits WHERE md.merge_request_id = mr.id"
+      execute "UPDATE merge_requests mr, merge_request_diffs md SET mr.st_diffs = md.st_diffs WHERE md.merge_request_id = mr.id"
+    end
   end
 end


### PR DESCRIPTION
Last migrations doesn't work in postgresql

```
==  RemoveMRdiffFields: reverting =============================================
-- add_column(:merge_requests, :st_commits, :text, {:null=>true, :limit=>2147483647})
   -> 0.0012s
-- add_column(:merge_requests, :st_diffs, :text, {:null=>true, :limit=>2147483647})
   -> 0.0006s
-- execute("UPDATE merge_requests mr, merge_request_diffs md SET mr.st_commits = md.st_commits WHERE md.merge_request_id = mr.id")
rake aborted!
An error has occurred, this and all later migrations canceled:

PG::Error: ERROR:  syntax error at or near ","
LINE 1: UPDATE merge_requests mr, merge_request_diffs md SET mr.st_c...
                                ^
: UPDATE merge_requests mr, merge_request_diffs md SET mr.st_commits = md.st_commits WHERE md.merge_request_id = mr.id/home/skv/.rvm/gems/ruby-2.0.0-p247/gems/activerecord-4.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:128:in `exec'
```
