### PR TITLE
Fix relative links in markdown. Related to #6182

### DIFF
--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -166,18 +166,18 @@ module GitlabMarkdownHelper
 
   def file_exists?(path)
     return false if path.nil? || path.empty?
-    File.exists?(path_on_fs(path))
+    return @repository.blob_at(current_ref, path).present? || Tree.new(@repository, current_ref, path).entries.any?
   end
 
   # Check if the path is pointing to a directory(tree) or a file(blob)
   # eg. doc/api is directory and doc/README.md is file
   def local_path(path)
-    File.directory?(path_on_fs(path)) ? "tree" : "blob"
+    return "tree" if Tree.new(@repository, current_ref, path).entries.any?
+    return "blob"
   end
 
-  # Path to the file in the satellites repository on the filesystem
-  def path_on_fs(path)
-    [@path_to_satellite, path].join("/")
+  def current_ref
+    @commit.nil? ? "master" : @commit.id
   end
 
   # We will assume that if no ref exists we can point to master

--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -16,6 +16,7 @@ describe GitlabMarkdownHelper do
   before do
     # Helper expects a @project instance variable
     @project = project
+    @repository = project.repository
   end
 
   describe "#gfm" do


### PR DESCRIPTION
Related to #6182

Also include simple fix for images

``` ruby
return "raw" if @repository.blob_at(current_ref, path).image?
```
