### PR TITLE
the existence of former ldap users doesn't imply LDAP is enabled.

### DIFF
--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -35,7 +35,9 @@ module API
           user = key.user
 
           return false if user.blocked?
-          return false if user.ldap_user? && Gitlab::LDAP::User.blocked?(user.extern_uid)
+          if Gitlab.config.ldap.enabled
+            return false if user.ldap_user? && Gitlab::LDAP::User.blocked?(user.extern_uid)
+          end
 
           action = case git_cmd
                    when *DOWNLOAD_COMMANDS


### PR DESCRIPTION
When ldap is disabled in the gitlab config, this fixes the API still calling the ldap backend.
This solves #6188 and is a likely cause for #4730
