### PR TITLE
Configuration example for issue tracking in Trac. And added :project_name placeholder in URLs for tickets.

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -21,6 +21,7 @@ module IssuesHelper
     else
       url = Gitlab.config.issues_tracker[@project.issues_tracker]["project_url"]
       url.gsub(':project_id', @project.id.to_s)
+         .gsub(':project_name', @project.name)
          .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
     end
   end
@@ -33,6 +34,7 @@ module IssuesHelper
     else
       url = Gitlab.config.issues_tracker[@project.issues_tracker]["new_issue_url"]
       url.gsub(':project_id', @project.id.to_s)
+        .gsub(':project_name', @project.name)
         .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
     end
   end
@@ -46,6 +48,7 @@ module IssuesHelper
       url = Gitlab.config.issues_tracker[@project.issues_tracker]["issues_url"]
       url.gsub(':id', issue_iid.to_s)
         .gsub(':project_id', @project.id.to_s)
+        .gsub(':project_name', @project.name)
         .gsub(':issues_tracker_id', @project.issues_tracker_id.to_s)
     end
   end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -83,12 +83,14 @@ production: &base
     #   ## If not nil, link 'Issues' on project page will be replaced with this
     #   ## Use placeholders:
     #   ##  :project_id        - GitLab project identifier
+    #   ##  :project_name      - GitLab project name
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   project_url: "http://redmine.sample/projects/:issues_tracker_id"
     #
     #   ## If not nil, links from /#\d/ entities from commit messages will replaced with this
     #   ## Use placeholders:
     #   ##  :project_id        - GitLab project identifier
+    #   ##  :project_name      - GitLab project name
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   ##  :id                - Issue id (from commit messages)
     #   issues_url: "http://redmine.sample/issues/:id"
@@ -96,6 +98,7 @@ production: &base
     #   ## If not nil, linkis to creating new issues will be replaced with this
     #   ## Use placeholders:
     #   ##  :project_id        - GitLab project identifier
+    #   ##  :project_name      - GitLab project name
     #   ##  :issues_tracker_id - Project Name or Id in external issue tracker
     #   new_issue_url: "http://redmine.sample/projects/:issues_tracker_id/issues/new"
     # 
@@ -104,6 +107,15 @@ production: &base
     #   project_url: "http://jira.sample/issues/?jql=project=:issues_tracker_id"
     #   issues_url: "http://jira.sample/browse/:id"
     #   new_issue_url: "http://jira.sample/secure/CreateIssue.jspa"
+
+    # Example for multiple trac instancess hosted on the same host.
+    # Multiple gitlab repositories can map into a single trac instance using keywords field in tickets.
+    # trac:
+    #   title: "Trac"
+    #   project_url:   "http://trac.example.com/:issues_tracker_id/query?keywords=~:project_name"
+    #   issues_url:    "http://trac.example.com/:issues_tracker_id/ticket/:id?q=:project_name"
+    #   new_issue_url: "http://trac.example.com/:issues_tracker_id/newticket?keywords=:project_name"
+
 
   ## Gravatar
   gravatar:


### PR DESCRIPTION
Example for multiple trac instances hosted on the same host.
Multiple gitlab repositories can map into a single trac instance using keywords field in tickets.

Had to add :project_name placeholder in URLs for tickets to use it in Trac ticket keywords.
