### PR TITLE
fixed h3, h4 font-sizing for gitlab-flavored markdown (solves issue #6211)

### DIFF
--- a/app/assets/stylesheets/main/mixins.scss
+++ b/app/assets/stylesheets/main/mixins.scss
@@ -106,12 +106,12 @@
 
   h3 {
     margin-top: 35px;
-    font-size: 2em;
+    font-size: 1.5em;
   }
 
   h4 {
     margin-top: 30px;
-    font-size: 1.5em;
+    font-size: 1.2em;
   }
 
   blockquote p {


### PR DESCRIPTION
[GitLab Markdown Documentation](https://github.com/gitlabhq/gitlabhq/blob/master/doc/markdown/markdown.md#h2) shows h2 & h3 as being different font-sizes, correctly; however, currently only the padding is different in the sass mixin. This issue was opened by @rskuipers in issue [#6211](https://github.com/gitlabhq/gitlabhq/issues/6211).

The README displays the proper font sizes, which should be:
h3 {font-size: 1.5em}
h4 {font-size: 1.2em}
