### PR TITLE
Removed the backgrounding of the unicorn_rails and sidekiq startup scripts

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -167,7 +167,7 @@ start() {
     # Remove old socket if it exists
     rm -f "$socket_path"/gitlab.socket 2>/dev/null
     # Start the web server
-    RAILS_ENV=$RAILS_ENV script/web start &
+    RAILS_ENV=$RAILS_ENV script/web start
   fi
 
   # If sidekiq is already running, don't start it again.


### PR DESCRIPTION
Unicorn isn't getting enough time to daemonize before the startup script exits. In certain situations this causes unicorn to fail to start.

@brint and @berni2288 have confirmed that this change fixes their situation.
