### PR TITLE
Fix typo in comment

### DIFF
--- a/doc/update/6.3-to-6.4.md
+++ b/doc/update/6.3-to-6.4.md
@@ -33,10 +33,10 @@ sudo -u git -H git checkout v1.8.0
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 


### PR DESCRIPTION
The MySQL command showed the PostgreSQL command and vice versa. This patch corrects that.
