### PR TITLE
Change Devise.confirm_within to Devise.allow_unconfirmed_access_for

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -77,11 +77,11 @@ Devise.setup do |config|
   # ==> Configuration for :confirmable
   # The time you want to give a user to confirm their account. During this time
   # they will be able to access your application without confirming. Default is 0.days
-  # When confirm_within is zero, the user won't be able to sign in without confirming.
+  # When allow_unconfirmed_access_for is zero, the user won't be able to sign in without confirming.
   # You can use this to let your user access some features of your application
   # without confirming the account, but blocking it after a certain period
   # (ie 2 days).
-  # config.confirm_within = 2.days
+  # config.allow_unconfirmed_access_for = 2.days
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [ :email ]


### PR DESCRIPTION
According to Devise's changelog
(https://github.com/plataformatec/devise/blob/master/CHANGELOG.md),
Devise.confirm_within was deprecated in favor of
Devise.allow_unconfirmed_access_for in version 2.0.0.
