### PR TITLE
Fixing create user command for PG in docs

### DIFF
--- a/doc/install/databases.md
+++ b/doc/install/databases.md
@@ -56,9 +56,9 @@ GitLab supports the following databases:
 
     # Login to PostgreSQL
     sudo -u postgres psql -d template1
-
+    
     # Create a user for GitLab. (change $password to a real password)
-    template1=# CREATE USER git;
+    template1=# CREATE USER git WITH PASSWORD '$password';
 
     # Create the GitLab production database & grant all privileges on database
     template1=# CREATE DATABASE gitlabhq_production OWNER git;


### PR DESCRIPTION
Was missing the password parameter to set the "$password" as instructed in the PostgreSQL setup
