### PR TITLE
Fix 500 error in Ruby 1.9.

### DIFF
--- a/app/views/shared/_file_hljs.html.haml
+++ b/app/views/shared/_file_hljs.html.haml
@@ -1,6 +1,6 @@
 %div.highlighted-data{class: user_color_scheme_class}
   .line-numbers
-    - blob.data.lines.size.times do |index|
+    - blob.data.lines.to_a.size.times do |index|
       - offset = defined?(first_line_number) ? first_line_number : 1
       - i = index + offset
       = link_to "#L#{i}", id: "L#{i}", rel: "#L#{i}" do


### PR DESCRIPTION
Fix the following error.

```
undefined method `size` for #<Enumerator: ...
/home/git/gitlab/app/views/shared/_file_hljs.html.haml:3
```
