### PR TITLE
Show avatars of groups on profile screen that user belongs to

### DIFF
--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -26,3 +26,5 @@ $ ->
     form = $(this).closest("form")
     filename = $(this).val().replace(/^.*[\\\/]/, '')
     form.find(".js-avatar-filename").text(filename)
+
+  $('.profile-groups-avatars').tooltip("placement": "top")

--- a/app/assets/stylesheets/sections/profile.scss
+++ b/app/assets/stylesheets/sections/profile.scss
@@ -105,3 +105,12 @@
     }
   }
 }
+
+.profile-groups-avatars {
+  margin: 0 5px 10px 0;
+
+  img {
+    width: 50px;
+    height: 50px;
+  }
+}

--- a/app/views/users/_groups.html.haml
+++ b/app/views/users/_groups.html.haml
@@ -1,0 +1,3 @@
+- groups.each do |group|
+  = link_to group, class: 'profile-groups-avatars', :title => group.name do
+    = image_tag group_icon(group.path)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -13,6 +13,8 @@
       %br
       %small member since #{@user.created_at.stamp("Nov 12, 2031")}
     .clearfix
+    %h4 Groups:
+    = render 'groups', groups: @user.groups 
     %hr
     %h4 User Activity:
     = render @events

--- a/features/profile/profile.feature
+++ b/features/profile/profile.feature
@@ -6,6 +6,13 @@ Feature: Profile
     Given I visit profile page
     Then I should see my profile info
 
+  Scenario: I can see groups I belong to
+    Given I have group with projects
+    When I visit profile page
+    And I click on my profile picture
+    Then I should see my user page
+    And I should see groups I belong to
+
   Scenario: I edit profile
     Given I visit profile page
     Then I change my profile info

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -173,4 +173,17 @@ class Profile < Spinach::FeatureSteps
       page.should have_content current_user.name
     end
   end
+
+  step 'I have group with projects' do
+    @group   = create(:group)
+    @group.add_owner(current_user)
+    @project = create(:project, namespace: @group)
+    @event   = create(:closed_issue_event, project: @project)
+    
+    @project.team << [current_user, :master]
+  end
+
+  step 'I should see groups I belong to' do
+    page.should have_css('.profile-groups-avatars', visible: true)
+  end
 end


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/31543/2107180/d86053ec-8fc1-11e3-8617-e660633a7bb2.png)

Similar to Github's organization avatars on user profile page. 
This was possible thanks to #6178

Cheers!!
