### PR TITLE
Fixes #6187, Update dead links

### DIFF
--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -87,8 +87,8 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 
 Note: We switched from Puma in GitLab 5.4 to unicorn in GitLab 6.0.
 
-* Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/masterconfig/gitlab.yml.example but with your settings.
-* Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/masterconfig/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example but with your settings.
+* Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/unicorn.rb.example but with your settings.
 
 ### 7. Update Init script
 


### PR DESCRIPTION
Links to `gitlab.com` need missing slashes!
