### PR TITLE
New step for updating the init.d script

### DIFF
--- a/doc/update/upgrader.md
+++ b/doc/update/upgrader.md
@@ -23,8 +23,13 @@ __GitLab Upgrader is available only for GitLab version 6.4.2 or higher__
 
     # it also supports -y option to avoid waiting for user input
     # sudo -u git -H ruby script/upgrade.rb -y
+    
+### 3. Update the init.d script
 
-### 3. Start application
+    cd /home/git/gitlab
+    sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+
+### 4. Start application
 
     sudo service gitlab start
     sudo service nginx restart


### PR DESCRIPTION
This is required because the upgrade.rb script cannot do this itself. Missing this step causes the gitlab:check to fail a step.
