### PR TITLE
Split the user ssh keys by newline, not the characters "\n"

### DIFF
--- a/app/controllers/profiles/keys_controller.rb
+++ b/app/controllers/profiles/keys_controller.rb
@@ -41,7 +41,7 @@ class Profiles::KeysController < ApplicationController
       begin
         user = User.find_by_username(params[:username])
         if user.present?
-          render text: user.all_ssh_keys.join('\n')
+          render text: user.all_ssh_keys.join("\n")
         else
           render_404 and return
         end

--- a/spec/controllers/profile_keys_controller_spec.rb
+++ b/spec/controllers/profile_keys_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Profiles::KeysController do
+  let(:user)    { create(:user) }
+
+  describe "#get_keys" do
+    describe "non existant user" do
+      it "should generally not work" do
+        get :get_keys, username: 'not-existent'
+
+        expect(response).not_to be_success
+      end
+    end
+
+    describe "user with no keys" do
+      it "should generally work" do
+        get :get_keys, username: user.username
+
+        expect(response).to be_success
+      end
+
+      it "should render all keys separated with a new line" do
+        get :get_keys, username: user.username
+
+        expect(response.body).to eq("")
+      end
+    end
+
+    describe "user with keys" do
+      before do
+        user.keys << create(:key)
+        user.keys << create(:another_key)
+      end
+
+      it "should generally work" do
+        get :get_keys, username: user.username
+
+        expect(response).to be_success
+      end
+
+      it "should render all keys separated with a new line" do
+        get :get_keys, username: user.username
+
+        expect(response.body).not_to eq("")
+        expect(response.body).to eq(user.all_ssh_keys.join("\n"))
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -207,6 +207,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :another_key do
+      key do
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmTillFzNTrrGgwaCKaSj+QCz81E6jBc/s9av0+3b1Hwfxgkqjl4nAK/OD2NjgyrONDTDfR8cRN4eAAy6nY8GLkOyYBDyuc5nTMqs5z3yVuTwf3koGm/YQQCmo91psZ2BgDFTor8SVEE5Mm1D1k3JDMhDFxzzrOtRYFPci9lskTJaBjpqWZ4E9rDTD2q/QZntCqbC3wE9uSemRQB5f8kik7vD/AD8VQXuzKladrZKkzkONCPWsXDspUitjM8HkQdOf0PsYn1CMUC1xKYbCxkg5TkEosIwGv6CoEArUrdu/4+10LVslq494mAvEItywzrluCLCnwELfW+h/m8UHoVhZ"
+      end
+    end
+
     factory :invalid_key do
       key do
         "ssh-rsa this_is_invalid_key=="


### PR DESCRIPTION
**before:**

```
GET /user.keys

ssh-rsa ...\nssh-rsa ...\nssh-rsa ...
```

Sourcecode:
![bildschirmfoto von 2014-02-11 19 02 27](https://f.cloud.github.com/assets/327488/2140275/0f7f9406-934a-11e3-856a-cadd50daeb62.png)
Browser-View:
![bildschirmfoto von 2014-02-11 19 04 25](https://f.cloud.github.com/assets/327488/2140296/607bddb0-934a-11e3-8abe-3c042de35245.png)

**after:**

```
GET /user.keys

ssh-rsa ...
ssh-rsa ...
sha-rsa ...
```

Sourcecode:
![bildschirmfoto von 2014-02-11 19 01 36](https://f.cloud.github.com/assets/327488/2140274/0f6a5e9c-934a-11e3-8529-47db34c9f178.png)
