### PR TITLE
enable ldap filters in gitlab

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -123,7 +123,10 @@ production: &base
     host: '_your_ldap_server'
     base: '_the_base_where_you_search_for_users'
     port: 636
+    # If you are planning on using LDAP filters, comment out "uid" line and 
+    # uncomment "filter"
     uid: 'sAMAccountName'
+    # filter: '(&(uid=%{username})(memberOf=cn=gitlab,ou=groups,dc=mydomain))'
     method: 'ssl' # "tls" or "ssl" or "plain"
     bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
     password: '_the_password_of_the_bind_user'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -219,6 +219,7 @@ Devise.setup do |config|
       host:     Gitlab.config.ldap['host'],
       base:     Gitlab.config.ldap['base'],
       uid:      Gitlab.config.ldap['uid'],
+      filter:   Gitlab.config.ldap['filter'],
       port:     Gitlab.config.ldap['port'],
       method:   Gitlab.config.ldap['method'],
       bind_dn:  Gitlab.config.ldap['bind_dn'],


### PR DESCRIPTION
Most of the work has been done by jhollingsworth with the following pull request: https://github.com/gitlabhq/omniauth-ldap/pull/10
This commit just enables filter usage by gitlab itself.
