### PR TITLE
Patch for new usename creation when oauth provider(s) is used for athentication to GitLab

### DIFF
--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -58,7 +58,7 @@ module Gitlab
         end
 
         def username
-          email.match(/^[^@]*/)[0]
+          uid.gsub('@','.')
         end
 
         def provider


### PR DESCRIPTION
Implemented patch solve issue of creating new GitLab username when  multiple oauth provider and multiple domain in same oauth provider(Shibboleth) have same uid parts of email address.

For example email address:
pero@gmail.com (Gmail)
pero@facebook.com (Facebook)
pero@pero.hr (Shibboleth)

in previous situation only one first user can be created (uid part of email address is used).

In new patched situation all users may be created. uid attribute is used for username creation, and sign @ is supstitute with sign . .

So new GitLab username will be :
pero.gmail.com
pero.facebook.com
pero.pero.hr
