### PR TITLE
Fixes #6207 Allow raw download of *.msi files

### DIFF
--- a/app/controllers/projects/raw_controller.rb
+++ b/app/controllers/projects/raw_controller.rb
@@ -11,11 +11,7 @@ class Projects::RawController < Projects::ApplicationController
     @blob = @repository.blob_at(@commit.id, @path)
 
     if @blob
-      type = if @blob.mime_type =~ /html|javascript/
-               'text/plain; charset=utf-8'
-             else
-               @blob.mime_type
-             end
+      type = get_blob_type
 
       headers['X-Content-Type-Options'] = 'nosniff'
 
@@ -27,6 +23,18 @@ class Projects::RawController < Projects::ApplicationController
       )
     else
       not_found!
+    end
+  end
+
+  private
+
+  def get_blob_type
+    if @blob.mime_type =~ /html|javascript/
+      'text/plain; charset=utf-8'
+    elsif @blob.name =~ /(?:msi|exe|rar|r0\d|7z|7zip|zip)$/
+      'application/octet-stream'
+    else
+      @blob.mime_type
     end
   end
 end


### PR DESCRIPTION
This PR also allows for download of [exe,rar,r0n,7z,7zip,zip]
Fix was originaly proposed by @MensSana
