### PR TITLE
Fix searching by extern_uid for LDAP to be case-insensitive

### DIFF
--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -83,8 +83,13 @@ module Gitlab
 
         private
 
+        def find_by_uid_and_provider
+          find_by_uid(uid)
+        end
+
         def find_by_uid(uid)
-          model.where(provider: provider, extern_uid: uid).last
+          # LDAP distinguished name is case-insensitive
+          model.where("provider = ? and lower(extern_uid) = ?", provider, uid.downcase).last
         end
 
         def provider


### PR DESCRIPTION
When LDAP returns user’s DN in different case (due to same change on LDAP), then GitLab doesn’t find this user and try to create a new one. LDAP distinguished names (DN) are case-insensitive per standard, so GitLab should compare `extern_uid` in case-insensitive manner.
