### PR TITLE
Added spring to the project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,6 +208,10 @@ group :development, :test do
 
   gem 'spork', '~> 1.0rc'
   gem 'jasmine', '2.0.0.rc5'
+
+  gem "spring", '1.1.1'
+  gem "spring-commands-rspec", '1.0.1'
+  gem "spring-commands-spinach", '1.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,11 @@ GEM
       railties (>= 3)
       spinach (>= 0.4)
     spork (1.0.0rc4)
+    spring (1.1.1)
+    spring-commands-rspec (1.0.1)
+      spring (>= 0.9.1)
+    spring-commands-spinach (1.0.0)
+      spring (>= 0.9.1)
     sprockets (2.10.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -637,6 +642,9 @@ DEPENDENCIES
   slim
   spinach-rails
   spork (~> 1.0rc)
+  spring (= 1.1.1)
+  spring-commands-rspec (= 1.0.1)
+  spring-commands-spinach (= 1.0.0)
   stamp
   state_machine
   test_after_commit


### PR DESCRIPTION
This PR will add spring to the project

The production env. is not affected by this PR, it mostly useful for developers contributing to GitLab.

The biggest benefit is, that the spinach tests now also benefit from a pre-loader, since it was not possible to use it with spork.

Also it is not needed to start Spork when you're developing, since everything can be done true Spring

**Available commands**
`spring rspec`
`spring spinach`
`spring rails`
`spring rake`
