### PR TITLE
Rails uses bin folder we forgot to create it when upgrading

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run


### PR DESCRIPTION
When we upgraded to rals4 we forgot to run `bundle exec rake rails:update:bin` to create the binstubs for rails. They have been added by this PR
