### PR TITLE
Fix issue with robots constantly asking for projects archives

### DIFF
--- a/app/views/projects/repositories/_download_archive.html.haml
+++ b/app/views/projects/repositories/_download_archive.html.haml
@@ -3,7 +3,7 @@
 - split_button = split_button || false 
 - if split_button == true
   %span.btn-group{class: btn_class}
-    = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn' do
+    = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn', rel: 'nofollow' do
       %i.icon-download-alt
       %span Download zip
     %a.btn.dropdown-toggle{ 'data-toggle' => 'dropdown' }
@@ -12,26 +12,26 @@
         Select Archive Format
     %ul.dropdown-menu{ role: 'menu' }
       %li
-        = link_to archive_project_repository_path(@project, ref: ref, format: 'zip') do
+        = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), rel: 'nofollow' do
           %i.icon-download-alt
           %span Download zip
       %li
-        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz') do
+        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz'), rel: 'nofollow' do
           %i.icon-download-alt
           %span Download tar.gz
       %li
-        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.bz2') do
+        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.bz2'), rel: 'nofollow' do
           %i.icon-download-alt
           %span Download tar.bz2
       %li
-        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar') do
+        = link_to archive_project_repository_path(@project, ref: ref, format: 'tar'), rel: 'nofollow' do
           %i.icon-download-alt
           %span Download tar
 - else
   %span.btn-group{class: btn_class}
-    = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn' do
+    = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn', rel: 'nofollow' do
       %i.icon-download-alt
       %span zip
-    = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz'), class: 'btn' do
+    = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz'), class: 'btn', rel: 'nofollow' do
       %i.icon-download-alt
       %span tar.gz


### PR DESCRIPTION
This pull request tells robots to not follow archive links. GoogleBot always triggers the creation of archive files (zip, tar…) at each new commit, overloading the disk.
