### PR TITLE
Add markdown preview to issue, MR and milestone descriptions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ v 6.9.0
   - Add ability to set different ssh host, if different from http/https
   - Fix syntax highlighting for code comments blocks
   - Improve comments loading logic
+  - Add markdown preview to issue, merge request and milestone descriptions (Ciro Santilli)
 
 v 6.8.0
   - Ability to at mention users that are participating in issue and merge req. discussion

--- a/app/assets/javascripts/markup_preview.js.coffee
+++ b/app/assets/javascripts/markup_preview.js.coffee
@@ -1,0 +1,41 @@
+class MarkupPreview
+
+  ###
+  Sets up markup preview on all `.js-gfm-input` elements inside given container.
+
+  There can be only one js-gfm-input per form.
+  ###
+  constructor: (container = $(document)) ->
+    GitLab.GfmAutoComplete.setup()
+    @cleanBinding(container)
+    @addBinding(container)
+    input = container.find(".js-gfm-input")
+    disableButtonIfEmptyField(input, ".js-gfm-preview-button")
+    input.trigger("input")
+
+  addBinding: (container) ->
+    $(container).on("click", ".js-gfm-preview-button", @preview)
+
+  cleanBinding: (container) ->
+    $(container).off("click", ".js-gfm-preview-button")
+
+  ###
+  Shows the markup preview.
+
+  Lets the server render GFM into Html and displays it.
+
+  Uses the Toggler behavior to toggle preview/edit views/buttons
+  ###
+  preview: (e) ->
+    e.preventDefault()
+    form = $(@).closest("form")
+    preview = form.find(".js-gfm-preview")
+    text = form.find(".js-gfm-input").val()
+    preview.text "Loading..."
+    $.post($(@).data("url"),
+      text: text,
+      header_anchors: $(@).data("header-anchors")
+    ).done (previewData) ->
+      preview.html previewData
+
+@MarkupPreview = MarkupPreview

--- a/app/assets/stylesheets/generic/files.scss
+++ b/app/assets/stylesheets/generic/files.scss
@@ -53,10 +53,10 @@
       }
     }
 
+    padding: 25px $md-header-anchor-container-left-padding;
     &.wiki {
       font-size: 14px;
       line-height: 1.6;
-      padding: 25px;
 
       .highlight {
         margin-bottom: 9px;

--- a/app/assets/stylesheets/generic/issue_box.scss
+++ b/app/assets/stylesheets/generic/issue_box.scss
@@ -96,6 +96,7 @@
   }
 
   .title, .context, .description {
+    padding: 15px $md-header-anchor-container-left-padding;
     .clearfix {
       margin: 0;
     }

--- a/app/assets/stylesheets/generic/markup_preview.scss
+++ b/app/assets/stylesheets/generic/markup_preview.scss
@@ -1,0 +1,29 @@
+.gfm-input-preview-and-button {
+  .hint {
+    margin-top: 5px;
+  }
+}
+
+.gfm-input-and-preview {
+  background-color: white;
+  border: 1px solid rgb(204, 204, 204);
+  border-radius: 4px;
+  color: rgb(51, 51, 51);
+  height: 285px;
+  .gfm-input {
+    border: none;
+    height: 100%;
+    resize: none;
+  }
+  .preview-container {
+    height: 100%;
+    overflow: auto;
+  }
+  .wiki {
+    height: 100%;
+  }
+}
+
+.gfm-preview-button {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/main/mixins.scss
+++ b/app/assets/stylesheets/main/mixins.scss
@@ -142,6 +142,8 @@
   }
 }
 
+$md-header-anchor-container-left-padding: 25px;
+
 @mixin page-title {
   color: #333;
   font-size: 20px;

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -143,3 +143,13 @@ form.edit-issue {
     border-color: #E5E5E5;
   }
 }
+
+.issue-form {
+  .description {
+    .gfm-input-and-preview {
+      .preview-container {
+        padding: 15px $md-header-anchor-container-left-padding;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -270,29 +270,21 @@ ul.notes {
   .clearfix {
     margin-bottom: 0;
   }
-  .note_text_and_preview {
-    // makes the "absolute" position for links relative to this
-    position: relative;
+}
 
-    // preview/edit buttons
-    > a {
-      position: absolute;
-      right: 5px;
-      bottom: -60px;
+.new_note, .note-edit-form {
+  .gfm-input-and-preview {
+    height: 200px;
+    .preview-container {
+      padding: 15px;
     }
-    .note_preview {
-      background: #f5f5f5;
-      border: 1px solid #ddd;
-      @include border-radius(4px);
-      min-height: 80px;
-      padding: 4px 6px;
-    }
-    .note_text {
-      border: 1px solid #DDD;
-      box-shadow: none;
-      font-size: 14px;
-      height: 80px;
-      width: 100%;
+  }
+}
+
+.diff-content {
+  .new_note, .note-edit-form {
+    .gfm-input-and-preview {
+      height: 100px;
     }
   }
 }
@@ -309,14 +301,12 @@ ul.notes {
   float: none;
 }
 
-
 .common-note-form {
   margin: 0;
   background: #F9F9F9;
   padding: 3px;
   border: 1px solid #DDD;
 }
-
 
 .note-form-actions {
   background: #F9F9F9;
@@ -327,10 +317,6 @@ ul.notes {
     margin-top: 8px;
     margin-left: 30px;
     @extend .pull-left;
-  }
-
-  .js-notify-commit-author {
-    float: left;
   }
 }
 

--- a/app/assets/stylesheets/sections/wall.scss
+++ b/app/assets/stylesheets/sections/wall.scss
@@ -53,3 +53,14 @@
     }
   }
 }
+
+.new-wall-note {
+  position: relative;
+  .note_text {
+    border: 1px solid #DDD;
+    box-shadow: none;
+    font-size: 14px;
+    height: 80px;
+    width: 100%;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -241,4 +241,15 @@ class ApplicationController < ActionController::Base
       redirect_to profile_path, notice: 'Please complete your profile with email address' and return
     end
   end
+
+  def to_bool(string, default = nil)
+    case string
+    when 'true'
+      true
+    when 'false'
+      false
+    else
+      default
+    end
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -162,6 +162,14 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def markup_preview
+    params_sym = params.symbolize_keys
+    params_sym[:header_anchors] = to_bool(params_sym[:header_anchors], true)
+    text = params_sym.delete(:text)
+    params_sym.slice!(:header_anchors)
+    render text: view_context.markdown(text, params_sym)
+  end
+
   private
 
   def set_title

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -35,7 +35,9 @@ module GitlabMarkdownHelper
                             # see https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch-
                             filter_html: true,
                             with_toc_data: true,
-                            safe_links_only: true
+                            safe_links_only: true,
+                            hard_wrap: true,
+                            header_anchors: true
                           }.merge(options))
       @markdown = Redcarpet::Markdown.new(gitlab_renderer,
                       # see https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -42,4 +42,8 @@ module NotesHelper
       project_id: noteable.project.id,
     }.to_json
   end
+
+  def notes_header_anchors?
+    false
+  end
 end

--- a/app/views/admin/groups/edit.html.haml
+++ b/app/views/admin/groups/edit.html.haml
@@ -13,7 +13,7 @@
   .form-group.group-description-holder
     = f.label :description, "Details", class: 'control-label'
     .col-sm-10
-      = f.text_area :description, maxlength: 250, class: "form-control js-gfm-input", rows: 4
+      = f.text_area :description, maxlength: 250, class: "form-control", rows: 4
 
   .form-group.group_name_holder
     = f.label :path, class: 'control-label' do

--- a/app/views/admin/groups/new.html.haml
+++ b/app/views/admin/groups/new.html.haml
@@ -13,7 +13,7 @@
   .form-group.group-description-holder
     = f.label :description, "Details", class: 'control-label'
     .col-sm-10
-      = f.text_area :description, maxlength: 250, class: "form-control js-gfm-input", rows: 4
+      = f.text_area :description, maxlength: 250, class: "form-control", rows: 4
 
   .form-group
     .col-sm-2

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -35,7 +35,7 @@
               .form-group.group-description-holder
                 = f.label :description, "Details", class: 'control-label'
                 .col-sm-10
-                  = f.text_area :description, maxlength: 250, class: "form-control js-gfm-input", rows: 4
+                  = f.text_area :description, maxlength: 250, class: "form-control", rows: 4
 
               .form-group
                 .col-sm-2

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -11,7 +11,7 @@
   .form-group.group-description-holder
     = f.label :description, "Details", class: 'control-label'
     .col-sm-10
-      = f.text_area :description, maxlength: 250, class: "form-control js-gfm-input", rows: 4
+      = f.text_area :description, maxlength: 250, class: "form-control", rows: 4
 
   .form-group
     .col-sm-2

--- a/app/views/projects/blob/_text.html.haml
+++ b/app/views/projects/blob/_text.html.haml
@@ -1,7 +1,8 @@
 - if gitlab_markdown?(blob.name)
-  .file-content.wiki
-    = preserve do
-      = markdown(blob.data)
+  .file-content
+    .wiki
+      = preserve do
+        = markdown(blob.data)
 - elsif markup?(blob.name)
   .file-content.wiki
     = render_markup(blob.name, blob.data)

--- a/app/views/projects/issues/_form.html.haml
+++ b/app/views/projects/issues/_form.html.haml
@@ -15,12 +15,11 @@
       = f.label :title, class: 'control-label' do
         %strong= 'Title *'
       .col-sm-10
-        = f.text_field :title, maxlength: 255, class: "form-control js-gfm-input", autofocus: true, required: true
+        = f.text_field :title, maxlength: 255, class: "form-control", autofocus: true, required: true
     .form-group
       = f.label :description, 'Description', class: 'control-label'
-      .col-sm-10
-        = f.text_area :description, class: "form-control js-gfm-input", rows: 14
-        %p.hint Issues are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
+      .col-sm-10.description
+        = render 'shared/markup_input_and_preview', {f: f, text_area_args: [:description, {rows: 14}]}
     %hr
     .form-group
       .issue-assignee
@@ -46,8 +45,6 @@
         = f.text_field :label_list, maxlength: 2000, class: "form-control"
         %p.hint Separate labels with commas.
 
-
-
     .form-actions
       - if @issue.new_record?
         = f.submit 'Submit new issue', class: "btn btn-create"
@@ -56,9 +53,6 @@
 
       - cancel_path = @issue.new_record? ? project_issues_path(@project) : project_issue_path(@project, @issue)
       = link_to "Cancel", cancel_path, class: 'btn btn-cancel'
-
-
-
 
 :javascript
   $("#issue_label_list")
@@ -94,3 +88,5 @@
     $('#issue_assignee_id').val("#{current_user.id}").trigger("change");
     e.preventDefault();
   });
+
+  new MarkupPreview()

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for [@project, @merge_request], html: { class: "merge-request-form form-horizontal" } do |f|
+= form_for [@project, @merge_request], html: { class: "issue-form form-horizontal" } do |f|
   .row
     .col-sm-2
     .col-sm-10
@@ -45,12 +45,11 @@
     .form-group
       = f.label :title, class: 'control-label' do
         %strong= "Title *"
-      .col-sm-10= f.text_field :title, class: "form-control pad js-gfm-input", maxlength: 255, rows: 5, required: true
+      .col-sm-10= f.text_field :title, class: "form-control pad", maxlength: 255, rows: 5, required: true
     .form-group
       = f.label :description, "Description", class: 'control-label'
-      .col-sm-10
-        = f.text_area :description, class: "form-control js-gfm-input", rows: 14
-        %p.hint Description is parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
+      .col-sm-10.description
+        = render 'shared/markup_input_and_preview', {f: f, text_area_args: [:description, {rows: 14}]}
 
   .form-actions
     - if @merge_request.new_record?
@@ -83,3 +82,5 @@
   target_branch.on("change", function() {
     $.get("#{branch_to_project_merge_requests_path(@source_project)}", {target_project_id: target_project.val(),ref: $(this).val() });
   });
+
+  new MarkupPreview()

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -31,7 +31,7 @@
             .form-group
               = label_tag :merge_commit_message, "Commit message", class: 'control-label'
               .col-sm-10
-                = text_area_tag :merge_commit_message, @merge_request.merge_commit_message, class: "form-control js-gfm-input", rows: 14, required: true
+                = text_area_tag :merge_commit_message, @merge_request.merge_commit_message, class: "form-control", rows: 14, required: true
                 %p.hint
                   The recommended maximum line length is 52 characters for the first line and 72 characters for all following lines.
 

--- a/app/views/projects/milestones/_form.html.haml
+++ b/app/views/projects/milestones/_form.html.haml
@@ -5,7 +5,7 @@
 
 %hr
 
-= form_for [@project, @milestone], html: {class: "new_milestone form-horizontal"}  do |f|
+= form_for [@project, @milestone], html: {class: "issue-form form-horizontal"}  do |f|
   -if @milestone.errors.any?
     .alert.alert-danger
       %ul
@@ -20,9 +20,8 @@
           %p.hint Required
       .form-group
         = f.label :description, "Description", class: "control-label"
-        .col-sm-10
-          = f.text_area :description, maxlength: 2000, class: "form-control", rows: 10
-          %p.hint Milestones are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
+        .col-sm-10.description
+          = render 'shared/markup_input_and_preview', {f: f, text_area_args: [:description, {maxlength: 2000, rows: 14}]}
     .col-md-6
       .form-group
         = f.label :due_date, "Due Date", class: "control-label"
@@ -45,3 +44,5 @@
     dateFormat: "yy-mm-dd",
     onSelect: function(dateText, inst) { $("#milestone_due_date").val(dateText) }
   }).datepicker("setDate", $.datepicker.parseDate('yy-mm-dd', $('#milestone_due_date').val()));
+
+  new MarkupPreview()

--- a/app/views/projects/notes/_form.html.haml
+++ b/app/views/projects/notes/_form.html.haml
@@ -1,24 +1,13 @@
-= form_for [@project, @note], remote: true, html: { :'data-type' => 'json', multipart: true, id: nil, class: "new_note js-new-note-form common-note-form" }, authenticity_token: true do |f|
+= form_for [@project, @note], remote: true, html: { :'data-type' => 'json', multipart: true, id: nil,
+    class: "new_note js-new-note-form common-note-form" }, authenticity_token: true do |f|
   = note_target_fields
   = f.hidden_field :commit_id
   = f.hidden_field :line_code
   = f.hidden_field :noteable_id
   = f.hidden_field :noteable_type
 
-  .note_text_and_preview.js-toggler-container
-    %a.btn.js-note-preview-button.js-toggler-target.turn-off{ href: "javascript:;", data: {url: preview_project_notes_path(@project)} }
-      %i.icon-eye-open
-      Preview
-    %a.btn.btn-primary.js-note-edit-button.js-toggler-target.turn-off{ href: "javascript:;" }
-      %i.icon-edit
-      Write
-
-    = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on'
-    .note_preview.js-note-preview.turn-off
-
-  .hint
-    .pull-right Comments are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
-  .clearfix
+  .form-group
+    = render 'shared/markup_input_and_preview', {f: f, text_area_args: [:note, {}], header_anchors: notes_header_anchors?}
 
   .note-form-actions
     .buttons

--- a/app/views/projects/notes/_note.html.haml
+++ b/app/views/projects/notes/_note.html.haml
@@ -31,11 +31,11 @@
   .note-body
     .note-text
       = preserve do
-        = markdown(note.note, {no_header_anchors: true})
+        = markdown(note.note, {header_anchors: notes_header_anchors?})
 
     .note-edit-form
       = form_for note, url: project_note_path(@project, note), method: :put, remote: true, authenticity_token: true do |f|
-        = f.text_area :note, class: 'note_text js-note-text js-gfm-input turn-on'
+        = render 'shared/markup_input_and_preview', {f: f, text_area_args: [:note, {}], header_anchors: notes_header_anchors?}
 
         .form-actions.clearfix
           = f.submit 'Save changes', class: "btn btn-primary btn-save"

--- a/app/views/projects/walls/show.html.haml
+++ b/app/views/projects/walls/show.html.haml
@@ -5,8 +5,8 @@
     .note-form-holder
       = form_for [@project, @note], remote: true, html: { multipart: true, id: nil, class: "new_note wall-note-form" }, authenticity_token: true do |f|
         = note_target_fields
-        .note_text_and_preview
-          = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input turn-on'
+        .new-wall-note
+          = f.text_area :note, size: 255, class: 'note_text js-note-text turn-on'
         .note-form-actions
           .buttons
             = f.submit 'Add Comment', class: "btn comment-btn btn-grouped js-comment-button"

--- a/app/views/shared/_markup_input_and_preview.html.haml
+++ b/app/views/shared/_markup_input_and_preview.html.haml
@@ -1,0 +1,22 @@
+.gfm-input-preview-and-button.js-gfm-input-preview-and-button.js-toggler-container
+  - unless defined? header_anchors
+    - header_anchors = true
+  .gfm-input-and-preview
+    - text_area_args.last[:class] ||= ""
+    - text_area_args.last[:class] += " form-control gfm-input js-gfm-input turn-on"
+    - if defined? f
+      = f.text_area(*text_area_args)
+    - else
+      = text_area_tag(*text_area_args)
+    .preview-container.turn-off
+      .wiki.js-gfm-preview
+  .hint
+    .gfm-preview-button
+      %a.btn.js-gfm-preview-button.js-toggler-target.turn-on{ href: "javascript:;",
+          data: {url: markup_preview_project_path(@project), header_anchors: header_anchors.to_s} }
+        %i.icon-eye-open
+        Preview
+      %a.btn.btn-primary.js-gfm-edit-button.js-toggler-target.turn-off{ href: "javascript:;" }
+        %i.icon-edit
+        Write
+    .pull-right Rendered with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,7 @@ Gitlab::Application.routes.draw do
       get :autocomplete_sources
       get :import
       put :retry_import
+      post :markup_preview
     end
 
     scope module: :projects do

--- a/features/project/commits/comments.feature
+++ b/features/project/commits/comments.feature
@@ -14,35 +14,42 @@ Feature: Comments on commits
     Then I should not see the cancel comment button
 
   @javascript
-  Scenario: I can't preview without text
-    Given I haven't written any comment text
-    Then I should not see the comment preview button
-
-  @javascript
-  Scenario: I can preview with text
-    Given I write a comment like "Nice"
-    Then I should see the comment preview button
-
-  @javascript
-  Scenario: I preview a comment
-    Given I preview a comment text like "Bug fixed :smile:"
-    Then I should see the comment preview
-    And I should not see the comment text field
-
-  @javascript
-  Scenario: I can edit after preview
-    Given I preview a comment text like "Bug fixed :smile:"
-    Then I should see the comment edit button
-
-  @javascript
-  Scenario: I have a reset form after posting from preview
-    Given I preview a comment text like "Bug fixed :smile:"
-    And I submit the comment
-    Then I should see an empty comment text field
-    And I should not see the comment preview
-
-  @javascript
   Scenario: I can delete a comment
     Given I leave a comment like "XML attached"
     And I delete a comment
     Then I should not see a comment saying "XML attached"
+
+  # Preview
+
+  @javascript
+  Scenario: I can't preview without text
+    Given I haven't written any comment text
+    Then The markdown preview button should be disabled
+
+  @javascript
+  Scenario: I can preview with text
+    Given I write a comment like "Nice"
+    Then The markdown preview button should be enabled
+
+  @javascript
+  Scenario: I preview a comment
+    Given I preview a markdown input with a header
+    Then I should see the markdown preview
+    And I should not see the markdown input field
+    And The preview header should not have an id
+
+  @javascript
+  Scenario: I can edit after preview
+    Given I preview a markdown input with a header
+    Then I should see the markdown edit button
+    When I click the markdown edit button
+    Then I should see the markdown input field
+    And The input should be the header input
+
+  @javascript
+  Scenario: I have a reset form after posting from preview
+    Given I preview a markdown input with a header
+    And I submit the comment
+    Then I should see an empty comment text field
+    And I should not see the markdown preview
+    Then The markdown preview button should be disabled

--- a/features/project/commits/diff_comments.feature
+++ b/features/project/commits/diff_comments.feature
@@ -9,6 +9,11 @@ Feature: Comments on commit diffs
     Then I should see add a diff comment button
 
   @javascript
+  Scenario: Preview headers have no id
+    Given I preview a diff comment text with a header
+    Then The diff comment preview header should have no id
+
+  @javascript
   Scenario: I can comment on a commit diff
     Given I leave a diff comment like "Typo, please fix"
     Then I should see a diff comment saying "Typo, please fix"
@@ -44,33 +49,35 @@ Feature: Comments on commit diffs
     And I should see an empty diff comment form
 
   @javascript
-  Scenario: I can preview multiple forms separately
-    Given I preview a diff comment text like "Should fix it :smile:"
-    And I preview another diff comment text like "DRY this up"
-    Then I should see two separate previews
-
-  @javascript
   Scenario: I have a reply button in discussions
     Given I leave a diff comment like "Typo, please fix"
     Then I should see a discussion reply button
+
+  # Preview
 
   @javascript
   Scenario: I can't preview without text
     Given I open a diff comment form
     And I haven't written any diff comment text
-    Then I should not see the diff comment preview button
+    Then The diff comment preview button should be disabled
 
   @javascript
   Scenario: I can preview with text
     Given I open a diff comment form
     And I write a diff comment like ":-1: I don't like this"
-    Then I should see the diff comment preview button
+    Then The diff comment preview button should be enabled
 
   @javascript
   Scenario: I preview a diff comment
     Given I preview a diff comment text like "Should fix it :smile:"
     Then I should see the diff comment preview
     And I should not see the diff comment text field
+
+  @javascript
+  Scenario: I can preview multiple forms separately
+    Given I preview a diff comment text like "Should fix it :smile:"
+    And I preview another diff comment text like "DRY this up"
+    Then I should see two separate previews
 
   @javascript
   Scenario: I can edit after preview

--- a/features/project/issues/issues.feature
+++ b/features/project/issues/issues.feature
@@ -56,6 +56,15 @@ Feature: Project Issues
     Then I should see "Release 0.3" in issues
     And I should not see "Release 0.4" in issues
 
+  Scenario: Issues on empty project
+    Given empty project "Empty Project"
+    When I visit empty project page
+    And I see empty project details with ssh clone info
+    When I visit empty project's issues page
+    Given I click link "New Issue"
+    And I submit new issue "500 error on profile"
+    Then I should see issue "500 error on profile"
+
   # Markdown
 
   Scenario: Headers inside the description should have ids generated for them.
@@ -68,11 +77,30 @@ Feature: Project Issues
     And I leave a comment with a header containing "Comment with a header"
     Then The comment with the header should not have an ID
 
-  Scenario: Issues on empty project
-    Given empty project "Empty Project"
-    When I visit empty project page
-    And I see empty project details with ssh clone info
-    When I visit empty project's issues page
+  # Preview
+
+  @javascript
+  Scenario: I can't preview description without text
     Given I click link "New Issue"
-    And I submit new issue "500 error on profile"
-    Then I should see issue "500 error on profile"
+    Then The description preview button should be disabled
+
+  @javascript
+  Scenario: I can preview non empty description before I start editing
+    Given I click link "Release 0.4"
+    And I click link "Edit"
+    Then The description preview button should be enabled
+
+  @javascript
+  Scenario: I preview issue description while creating it
+    Given I click link "New Issue"
+    And I input a description with a header
+    And I click on the description preview button
+    Then The description preview header should have an id
+
+  @javascript
+  Scenario: I preview issue description while editing it
+    Given I click link "Release 0.4"
+    And I click link "Edit"
+    And I input a description with a header
+    And I click on the description preview button
+    Then The description preview header should have an id

--- a/features/project/issues/milestones.feature
+++ b/features/project/issues/milestones.feature
@@ -28,3 +28,20 @@ Feature: Project Milestones
   Scenario: Headers inside the description should have ids generated for them.
     Given I click link "v2.2"
     Then Header "Description header" should have correct id and link
+
+  # Preview
+
+  @javascript
+  Scenario: I preview milestone description while creating it
+    Given I click link "New Milestone"
+    And I input a description with a header
+    And I click on the description preview button
+    Then The description preview header should have an id
+
+  @javascript
+  Scenario: I preview milestone description while editing it
+    Given I click link "v2.2"
+    And I click link "Edit"
+    And I input a description with a header
+    And I click on the description preview button
+    Then The description preview header should have an id

--- a/features/steps/project/comments_on_commit_diffs.rb
+++ b/features/steps/project/comments_on_commit_diffs.rb
@@ -1,6 +1,7 @@
 class CommentsOnCommitDiffs < Spinach::FeatureSteps
   include SharedAuthentication
   include SharedDiffNote
+  include SharedMarkdown
   include SharedPaths
   include SharedProject
 end

--- a/features/steps/project/comments_on_commits.rb
+++ b/features/steps/project/comments_on_commits.rb
@@ -3,4 +3,5 @@ class CommentsOnCommits < Spinach::FeatureSteps
   include SharedNote
   include SharedPaths
   include SharedProject
+  include SharedMarkdown
 end

--- a/features/steps/project/issues.rb
+++ b/features/steps/project/issues.rb
@@ -1,9 +1,10 @@
 class ProjectIssues < Spinach::FeatureSteps
   include SharedAuthentication
-  include SharedProject
+  include SharedIssue
+  include SharedMarkdown
   include SharedNote
   include SharedPaths
-  include SharedMarkdown
+  include SharedProject
 
   Given 'I should see "Release 0.4" in issues' do
     page.should have_content "Release 0.4"

--- a/features/steps/project/merge_requests.rb
+++ b/features/steps/project/merge_requests.rb
@@ -1,9 +1,10 @@
 class ProjectMergeRequests < Spinach::FeatureSteps
   include SharedAuthentication
-  include SharedProject
+  include SharedIssue
+  include SharedMarkdown
   include SharedNote
   include SharedPaths
-  include SharedMarkdown
+  include SharedProject
 
   step 'I click link "New Merge Request"' do
     click_link "New Merge Request"

--- a/features/steps/project/milestones.rb
+++ b/features/steps/project/milestones.rb
@@ -1,5 +1,6 @@
 class ProjectMilestones < Spinach::FeatureSteps
   include SharedAuthentication
+  include SharedIssue
   include SharedProject
   include SharedPaths
   include SharedMarkdown

--- a/features/steps/shared/diff_note.rb
+++ b/features/steps/shared/diff_note.rb
@@ -2,157 +2,162 @@ module SharedDiffNote
   include Spinach::DSL
 
   Given 'I cancel the diff comment' do
-    within(".diff-file") do
-      find(".js-close-discussion-note-form").click
+    within('.diff-file') do
+      find('.js-close-discussion-note-form').click
     end
   end
 
   Given 'I delete a diff comment' do
     find('.note').hover
-    find(".js-note-delete").click
+    find('.js-note-delete').click
   end
 
   Given 'I haven\'t written any diff comment text' do
-    within(".diff-file") do
-      fill_in "note[note]", with: ""
+    within('.diff-file') do
+      fill_in 'note[note]', with: ''
     end
   end
 
   Given 'I leave a diff comment like "Typo, please fix"' do
-    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]').click
-    within(".diff-file form[rel$='586fb7c4e1add2d4d24e27566ed7064680098646_29_14']") do
-      fill_in "note[note]", with: "Typo, please fix"
-      find(".js-comment-button").trigger("click")
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]')
+      .click
+    within(".diff-file form[rel$='586fb7c4e1add2d4d24e2" \
+           "7566ed7064680098646_29_14']") do
+      fill_in 'note[note]', with: 'Typo, please fix'
+      find('.js-comment-button').trigger('click')
       sleep 0.05
     end
   end
 
-  Given 'I preview a diff comment text like "Should fix it :smile:"' do
-    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]').click
-    within(".diff-file form[rel$='586fb7c4e1add2d4d24e27566ed7064680098646_29_14']") do
-      fill_in "note[note]", with: "Should fix it :smile:"
-      find(".js-note-preview-button").trigger("click")
-    end
-  end
-
-  Given 'I preview another diff comment text like "DRY this up"' do
-    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_57_41"]').click
-
-    within(".diff-file form[rel$='586fb7c4e1add2d4d24e27566ed7064680098646_57_41']") do
-      fill_in "note[note]", with: "DRY this up"
-      find(".js-note-preview-button").trigger("click")
-    end
-  end
-
   Given 'I open a diff comment form' do
-    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]').click
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]')
+      .click
   end
 
   Given 'I open another diff comment form' do
-    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_57_41"]').click
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_57_41"]')
+      .click
   end
 
   Given 'I write a diff comment like ":-1: I don\'t like this"' do
-    within(".diff-file") do
-      fill_in "note[note]", with: ":-1: I don\'t like this"
+    within('.diff-file') do
+      fill_in 'note[note]', with: ":-1: I don\'t like this"
     end
   end
 
   Given 'I submit the diff comment' do
-    within(".diff-file") do
-      click_button("Add Comment")
+    within('.diff-file') do
+      click_button('Add Comment')
     end
   end
-
-
 
   Then 'I should not see the diff comment form' do
-    within(".diff-file") do
-      page.should_not have_css("form.new_note")
-    end
-  end
-
-  Then 'I should not see the diff comment preview button' do
-    within(".diff-file") do
-      page.should have_css(".js-note-preview-button", visible: false)
+    within('.diff-file') do
+      page.should_not have_css('form.new_note')
     end
   end
 
   Then 'I should not see the diff comment text field' do
-    within(".diff-file") do
-      page.should have_css(".js-note-text", visible: false)
+    within('.diff-content') do
+      page.should have_css('.js-gfm-input', visible: false)
     end
   end
 
   Then 'I should only see one diff form' do
-    within(".diff-file") do
-      page.should have_css("form.new_note", count: 1)
+    within('.diff-file') do
+      page.should have_css('form.new_note', count: 1)
     end
   end
 
   Then 'I should see a diff comment form with ":-1: I don\'t like this"' do
-    within(".diff-file") do
-      page.should have_field("note[note]", with: ":-1: I don\'t like this")
+    within('.diff-file') do
+      page.should have_field('note[note]', with: ":-1: I don\'t like this")
     end
   end
 
   Then 'I should see a diff comment saying "Typo, please fix"' do
-    within(".diff-file .note") do
-      page.should have_content("Typo, please fix")
+    within('.diff-file .note') do
+      page.should have_content('Typo, please fix')
     end
   end
 
   Then 'I should see a discussion reply button' do
-    within(".diff-file") do
-      page.should have_link("Reply")
+    within('.diff-file') do
+      page.should have_link('Reply')
     end
   end
 
   Then 'I should see a temporary diff comment form' do
-    within(".diff-file") do
-      page.should have_css(".js-temp-notes-holder form.new_note")
+    within('.diff-file') do
+      page.should have_css('.js-temp-notes-holder form.new_note')
     end
   end
 
   Then 'I should see add a diff comment button' do
-    page.should have_css(".js-add-diff-note-button", visible: false)
+    page.should have_css('.js-add-diff-note-button', visible: false)
   end
 
   Then 'I should see an empty diff comment form' do
-    within(".diff-file") do
-      page.should have_field("note[note]", with: "")
+    within('.diff-file') do
+      page.should have_field('note[note]', with: '')
     end
   end
 
   Then 'I should see the cancel comment button' do
-    within(".diff-file form") do
-      page.should have_css(".js-close-discussion-note-form", text: "Cancel")
+    within('.diff-file form') do
+      page.should have_css('.js-close-discussion-note-form', text: 'Cancel')
     end
   end
 
-  Then 'I should see the diff comment preview' do
-    within(".diff-file form") do
-      page.should have_css(".js-note-preview", visible: false)
-    end
+  # Preview
+
+  Given 'I preview a diff comment text like "Should fix it :smile:"' do
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]')
+      .click
+    preview_markdown_with(".diff-content form[rel$='586fb7c4e1add2d4d24e275" \
+                          "66ed7064680098646_29_14']", 'Should fix it :smile:')
   end
 
-  Then 'I should see the diff comment edit button' do
-    within(".diff-file") do
-      page.should have_css(".js-note-edit-button", visible: true)
-    end
-  end
-
-  Then 'I should see the diff comment preview button' do
-    within(".diff-file") do
-      page.should have_css(".js-note-preview-button", visible: true)
-    end
+  Given 'I preview another diff comment text like "DRY this up"' do
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_57_41"]')
+      .click
+    preview_markdown_with(".diff-content form[rel$='586fb7c4e1add2d4d24e2756" \
+                          "6ed7064680098646_57_41']", 'DRY this up')
   end
 
   Then 'I should see two separate previews' do
-    within(".diff-file") do
-      page.should have_css(".js-note-preview", visible: true, count: 2)
-      page.should have_content("Should fix it")
-      page.should have_content("DRY this up")
+    within('.diff-content') do
+      page.should have_css('.js-gfm-preview', visible: true, count: 2)
+      page.should have_content('Should fix it')
+      page.should have_content('DRY this up')
     end
+  end
+
+  Then 'The diff comment preview button should be enabled' do
+    markdown_preview_button_should_be_enabled('.diff-content', true)
+  end
+
+  Then 'The diff comment preview button should be disabled' do
+    markdown_preview_button_should_be_enabled('.diff-content', false)
+  end
+
+  Then 'I should see the diff comment preview' do
+    should_see_the_markdown_preview('.diff-content form', true)
+  end
+
+  Then 'I should see the diff comment edit button' do
+    should_see_markdown_edit_button('.diff-content', true)
+  end
+
+  Given 'I preview a diff comment text with a header' do
+    find('a[data-line-code="586fb7c4e1add2d4d24e27566ed7064680098646_29_14"]')
+      .click
+    preview_markdown_with_header(".diff-content form[rel$='586fb7c4e1add2d4d2" \
+                                 "4e27566ed7064680098646_29_14']")
+  end
+
+  Then 'The diff comment preview header should have no id' do
+    preview_header_should_not_have_id(".diff-content form[rel$='586fb7c4e1add" \
+                                      "2d4d24e27566ed7064680098646_29_14']")
   end
 end

--- a/features/steps/shared/issue.rb
+++ b/features/steps/shared/issue.rb
@@ -1,0 +1,37 @@
+# Steps that can be shared between similar views such as issues,
+# merge requests and milestones.
+module SharedIssue
+  include Spinach::DSL
+
+  step 'I click link "Edit"' do
+    click_link 'Edit'
+  end
+
+  step 'The description preview button should be enabled' do
+    markdown_preview_button_should_be_enabled('.description', true)
+  end
+
+  step 'The description preview button should be disabled' do
+    markdown_preview_button_should_be_enabled('.description', false)
+  end
+
+  step 'I input a description with a header' do
+    within('.description') do
+      find('textarea').set('# Description header')
+    end
+  end
+
+  step 'I click on the description preview button' do
+    click_markdown_preview_button('.description')
+  end
+
+  step 'The description preview header should have an id' do
+    header_should_have_correct_id_and_link(1, 'Description header',
+                                           'description-header', '.description')
+  end
+
+  step 'Header "Description header" should have correct id and link' do
+    header_should_have_correct_id_and_link(1, 'Description header',
+                                           'description-header')
+  end
+end

--- a/features/steps/shared/markdown.rb
+++ b/features/steps/shared/markdown.rb
@@ -1,12 +1,104 @@
 module SharedMarkdown
   include Spinach::DSL
 
-  def header_should_have_correct_id_and_link(level, text, id, parent = ".wiki")
-    page.find(:css, "#{parent} h#{level}##{id}").text.should == text
-    page.find(:css, "#{parent} h#{level}##{id} > :last-child")[:href].should =~ /##{id}$/
+  protected
+
+  # Header anchors
+
+  def header_should_have_correct_id_and_link(level, text, id, parent = '.wiki')
+    page.find("#{parent} h#{level}##{id}").text.should == text
+    page.find("#{parent} h#{level}##{id} > :last-child")[:href]
+      .should =~ /##{id}$/
   end
 
-  step 'Header "Description header" should have correct id and link' do
-    header_should_have_correct_id_and_link(1, 'Description header', 'description-header')
+  def header_should_not_have_id(level = 1, parent = '.wiki')
+    within(parent) do
+      find("h#{level}")[:id].should == nil
+    end
+  end
+
+  def preview_header_should_have_id(within_selector = 'body')
+    within(within_selector) do
+      header_should_have_correct_id_and_link(1, '# Header',
+                                             'header', '.js-gfm-preview')
+    end
+  end
+
+  def preview_header_should_not_have_id(within_selector = 'body')
+    within(within_selector) do
+      header_should_not_have_id(1, '.js-gfm-preview')
+    end
+  end
+
+  # Preview
+
+  def markdown_preview_button_should_be_enabled(within_selector, enabled = true)
+    within(within_selector) do
+      if enabled
+        find('.js-gfm-preview-button', visible: true)[:disabled].should == nil
+      else
+        find('.js-gfm-preview-button', visible: true)[:disabled]
+          .should == 'disabled'
+      end
+    end
+  end
+
+  def should_see_markdown_edit_button(within_selector, visible = true)
+    within(within_selector) do
+      if visible
+        page.should have_css('.js-gfm-edit-button', visible: true)
+      else
+        page.should_not have_css('.js-gfm-edit-button', visible: true)
+      end
+    end
+  end
+
+  def click_markdown_edit_button(within_selector = 'body')
+    within(within_selector) do
+      find('.js-gfm-edit-button', visible: true).click
+    end
+  end
+
+  def should_see_the_markdown_preview(within_selector, visible = true)
+    within(within_selector) do
+      if visible
+        page.should have_css('.js-gfm-preview', visible: true)
+      else
+        page.should_not have_css('.js-gfm-preview', visible: true)
+      end
+    end
+  end
+
+  def should_see_the_markdown_input(within_selector, visible = true)
+    within(within_selector) do
+      if visible
+        page.should have_css('.js-gfm-input', visible: true)
+      else
+        page.should_not have_css('.js-gfm-input', visible: true)
+      end
+    end
+  end
+
+  def click_markdown_preview_button(within_selector = 'body')
+    within(within_selector) do
+      find('.js-gfm-preview-button').click
+    end
+  end
+
+  def preview_markdown_with(within_selector, input)
+    within(within_selector) do
+      find('.js-gfm-input').set(input)
+      find('.js-gfm-preview-button').click
+    end
+  end
+
+  def preview_markdown_with_header(within_selector = 'body')
+    preview_markdown_with(within_selector, '# Header')
+  end
+
+  def input_should_be_header_input(within_selector = 'body')
+    within(within_selector) do
+      find('.js-gfm-input').value.should == '# Header'
+    end
   end
 end

--- a/features/steps/shared/note.rb
+++ b/features/steps/shared/note.rb
@@ -3,120 +3,123 @@ module SharedNote
 
   Given 'I delete a comment' do
     find('.note').hover
-    find(".js-note-delete").click
+    find('.js-note-delete').click
   end
 
   Given 'I haven\'t written any comment text' do
-    within(".js-main-target-form") do
-      fill_in "note[note]", with: ""
+    within('.js-main-target-form') do
+      fill_in 'note[note]', with: ''
     end
   end
 
   Given 'I leave a comment like "XML attached"' do
-    within(".js-main-target-form") do
-      fill_in "note[note]", with: "XML attached"
-      click_button "Add Comment"
+    within('.js-main-target-form') do
+      fill_in 'note[note]', with: 'XML attached'
+      click_button 'Add Comment'
       sleep 0.05
     end
   end
 
-  Given 'I preview a comment text like "Bug fixed :smile:"' do
-    within(".js-main-target-form") do
-      fill_in "note[note]", with: "Bug fixed :smile:"
-      find(".js-note-preview-button").trigger("click")
-    end
-  end
-
   Given 'I submit the comment' do
-    within(".js-main-target-form") do
-      click_button "Add Comment"
+    within('.js-main-target-form') do
+      click_button 'Add Comment'
     end
   end
 
   Given 'I write a comment like "Nice"' do
-    within(".js-main-target-form") do
-      fill_in "note[note]", with: "Nice"
+    within('.js-main-target-form') do
+      fill_in 'note[note]', with: 'Nice'
     end
   end
 
   Then 'I should not see a comment saying "XML attached"' do
-    page.should_not have_css(".note")
+    page.should_not have_css('.note')
   end
 
   Then 'I should not see the cancel comment button' do
-    within(".js-main-target-form") do
-      should_not have_link("Cancel")
-    end
-  end
-
-  Then 'I should not see the comment preview' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-preview", visible: false)
-    end
-  end
-
-  Then 'I should not see the comment preview button' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-preview-button", visible: false)
-    end
-  end
-
-  Then 'I should not see the comment text field' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-text", visible: false)
+    within('.js-main-target-form') do
+      should_not have_link('Cancel')
     end
   end
 
   Then 'I should see a comment saying "XML attached"' do
-    within(".note") do
-      page.should have_content("XML attached")
+    within('.note') do
+      page.should have_content('XML attached')
     end
   end
 
   Then 'I should see an empty comment text field' do
-    within(".js-main-target-form") do
-      page.should have_field("note[note]", with: "")
-    end
-  end
-
-  Then 'I should see the comment edit button' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-edit-button", visible: true)
-    end
-  end
-
-  Then 'I should see the comment preview' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-preview", visible: true)
-    end
-  end
-
-  Then 'I should see the comment preview button' do
-    within(".js-main-target-form") do
-      page.should have_css(".js-note-preview-button", visible: true)
+    within('.js-main-target-form') do
+      page.should have_field('note[note]', with: '', visible: true)
     end
   end
 
   Then 'I should see comment "XML attached"' do
-    within(".note") do
-      page.should have_content("XML attached")
+    within('.note') do
+      page.should have_content('XML attached')
     end
   end
 
   # Markdown
 
   step 'I leave a comment with a header containing "Comment with a header"' do
-    within(".js-main-target-form") do
-      fill_in "note[note]", with: "# Comment with a header"
-      click_button "Add Comment"
+    within('.js-main-target-form') do
+      fill_in 'note[note]', with: '# Comment with a header'
+      click_button 'Add Comment'
       sleep 0.05
     end
   end
 
   step 'The comment with the header should not have an ID' do
-    within(".note-text") do
-      page.should     have_content("Comment with a header")
-      page.should_not have_css("#comment-with-a-header")
+    within('.note-text') do
+      page.should     have_content('Comment with a header')
+      page.should_not have_css('#comment-with-a-header')
     end
+  end
+
+  # Preview
+
+  step 'The markdown preview button should be enabled' do
+    markdown_preview_button_should_be_enabled('.js-main-target-form', true)
+  end
+
+  step 'The markdown preview button should be disabled' do
+    markdown_preview_button_should_be_enabled('.js-main-target-form', false)
+  end
+
+  step 'I should see the markdown edit button' do
+    should_see_markdown_edit_button('.js-main-target-form', true)
+  end
+
+  step 'I click the markdown edit button' do
+    click_markdown_edit_button('.js-main-target-form')
+  end
+
+  step 'I should see the markdown preview' do
+    should_see_the_markdown_preview('.js-main-target-form', true)
+  end
+
+  step 'I should not see the markdown preview' do
+    should_see_the_markdown_preview('.js-main-target-form', false)
+  end
+
+  step 'I should see the markdown input field' do
+    should_see_the_markdown_input('.js-main-target-form', true)
+  end
+
+  step 'I should not see the markdown input field' do
+    should_see_the_markdown_input('.js-main-target-form', false)
+  end
+
+  step 'I preview a markdown input with a header' do
+    preview_markdown_with_header('.js-main-target-form')
+  end
+
+  step 'The input should be the header input' do
+    input_should_be_header_input('.js-main-target-form')
+  end
+
+  step 'The preview header should not have an id' do
+    preview_header_should_not_have_id('.js-main-target-form')
   end
 end

--- a/lib/redcarpet/render/gitlab_html.rb
+++ b/lib/redcarpet/render/gitlab_html.rb
@@ -36,12 +36,12 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
   end
 
   def header(text, level)
-    if @options[:no_header_anchors]
-      "<h#{level}>#{text}</h#{level}>"
-    else
+    if @options[:header_anchors]
       id = ActionController::Base.helpers.strip_tags(h.gfm(text)).downcase() \
           .gsub(/[^a-z0-9_-]/, '-').gsub(/-+/, '-').gsub(/^-/, '').gsub(/-$/, '')
       "<h#{level} id=\"#{id}\">#{text}<a href=\"\##{id}\"></a></h#{level}>"
+    else
+      "<h#{level}>#{text}</h#{level}>"
     end
   end
 

--- a/spec/features/notes_on_merge_requests_spec.rb
+++ b/spec/features/notes_on_merge_requests_spec.rb
@@ -14,10 +14,15 @@ describe "On a merge request", js: true, feature: true do
 
   describe "the note form" do
     it 'should be valid' do
-      should have_css(".js-main-target-form", visible: true, count: 1)
-      find(".js-main-target-form input[type=submit]").value.should == "Add Comment"
-      within(".js-main-target-form") { should_not have_link("Cancel") }
-      within(".js-main-target-form") { should have_css(".js-note-preview-button", visible: false) }
+      should have_css('.js-main-target-form', visible: true, count: 1)
+      find('.js-main-target-form input[type=submit]')
+        .value.should == 'Add Comment'
+      within('.js-main-target-form') do
+        should_not have_link('Cancel')
+      end
+      within('.js-main-target-form') do
+        should have_css('.js-gfm-preview-button', visible: true)
+      end
     end
 
     describe "with text" do
@@ -28,47 +33,66 @@ describe "On a merge request", js: true, feature: true do
       end
 
       it 'should have enable submit button and preview button' do
-        within(".js-main-target-form") { should_not have_css(".js-comment-button[disabled]") }
-        within(".js-main-target-form") { should have_css(".js-note-preview-button", visible: true) }
+        within('.js-main-target-form') do
+          should_not have_css('.js-comment-button[disabled]')
+        end
+        within('.js-main-target-form') do
+          should have_css('.js-gfm-preview-button', visible: true)
+        end
       end
     end
 
-    describe "with preview" do
+    describe 'with preview' do
       before do
-        within(".js-main-target-form") do
-          fill_in "note[note]", with: "This is awesome"
-          find(".js-note-preview-button").trigger("click")
+        within('.js-main-target-form') do
+          fill_in 'note[note]', with: 'This is awesome'
+          find('.js-gfm-preview-button').trigger('click')
         end
       end
 
       it 'should have text and visible edit button' do
-        within(".js-main-target-form") { should have_css(".js-note-preview", text: "This is awesome", visible: true) }
-        within(".js-main-target-form") { should have_css(".js-note-preview-button", visible: false) }
-        within(".js-main-target-form") { should have_css(".js-note-edit-button", visible: true) }
+        within('.js-main-target-form') do
+          should have_css('.js-gfm-preview', text: 'This is awesome',
+                          visible: true)
+        end
+        within('.js-main-target-form') do
+          should_not have_css('.js-gfm-preview-button', visible: true)
+        end
+        within('.js-main-target-form') do
+          should have_css('.js-gfm-edit-button', visible: true)
+        end
       end
     end
   end
 
   describe "when posting a note" do
     before do
-      within(".js-main-target-form") do
-        fill_in "note[note]", with: "This is awsome!"
-        find(".js-note-preview-button").trigger("click")
-        click_button "Add Comment"
+      within('.js-main-target-form') do
+        fill_in 'note[note]', with: 'This is awsome!'
+        find('.js-gfm-preview-button').trigger('click')
+        click_button 'Add Comment'
       end
     end
 
     it 'should be added and form reset' do
-      should have_content("This is awsome!")
-      within(".js-main-target-form") { should have_no_field("note[note]", with: "This is awesome!") }
-      within(".js-main-target-form") { should have_css(".js-note-preview", visible: false) }
-      within(".js-main-target-form") { should have_css(".js-note-text", visible: true) }
+      should have_content('This is awsome!')
+      within('.js-main-target-form') do
+        should have_no_field('note[note]', with: 'This is awesome!')
+      end
+      within('.js-main-target-form') do
+        should_not have_css('.js-gfm-preview', visible: true)
+      end
+      within('.js-main-target-form') do
+        should have_css('.js-gfm-input', visible: true)
+      end
     end
   end
 
   describe "when editing a note", js: true do
-    it "should contain the hidden edit form" do
-      within("#note_#{note.id}") { should have_css(".note-edit-form", visible: false) }
+    it 'should contain the hidden edit form' do
+      within("#note_#{note.id}") do
+        should_not have_css('.note-edit-form', visible: true)
+      end
     end
 
     describe "editing the note" do
@@ -91,7 +115,7 @@ describe "On a merge request", js: true, feature: true do
         within(".note-edit-form") do
           fill_in "note[note]", with: "Some new content"
           find(".btn-cancel").click
-          find(".js-note-text", visible: false).text.should == note.note
+          find('.js-gfm-input', visible: false).text.should == note.note
         end
       end
 

--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -348,8 +348,10 @@ describe GitlabMarkdownHelper do
     it "should handle references in headers" do
       actual = "\n# Working around ##{issue.iid}\n## Apply !#{merge_request.iid}"
 
-      markdown(actual, {no_header_anchors:true}).should match(%r{<h1[^<]*>Working around <a.+>##{issue.iid}</a></h1>})
-      markdown(actual, {no_header_anchors:true}).should match(%r{<h2[^<]*>Apply <a.+>!#{merge_request.iid}</a></h2>})
+      markdown(actual, header_anchors: false)
+        .should match(%r{<h1[^<]*>Working around <a.+>##{issue.iid}</a></h1>})
+      markdown(actual, header_anchors: false)
+        .should match(%r{<h2[^<]*>Apply <a.+>!#{merge_request.iid}</a></h2>})
     end
 
     it "should add ids and links to headers" do
@@ -357,7 +359,7 @@ describe GitlabMarkdownHelper do
       text = '..Ab_c-d. e..'
       id = 'ab_c-d-e'
       markdown("# #{text}").should match(%r{<h1 id="#{id}">#{text}<a href="[^"]*##{id}"></a></h1>})
-      markdown("# #{text}", {no_header_anchors:true}).should == "<h1>#{text}</h1>"
+      markdown("# #{text}", header_anchors: false).should == "<h1>#{text}</h1>"
 
       id = 'link-text'
       markdown("# [link text](url) ![img alt](url)").should match(


### PR DESCRIPTION
Fixes both feedbacks [5409046](http://feedback.gitlab.com/forums/176466-general/suggestions/5409046-markdown-preview-for-creating-issues) and [5209446](http://feedback.gitlab.com/forums/176466-general/suggestions/5209446-markdown-preview-on-merge-requests).

Before this MR, markdown could only be previewed on notes (comments on issues, MR, MR diff notes, commits, snippets).

Now it can also be previewed for descriptions at creation and edit of:
- issues
- merge requests
- milestones

It is still _not_ possible to preview it for:
- wiki (gfm / rdoc)
- readme / blob (any format possible)

since in those cases the situation is a bit more complicated because there can be multiple possible formats of input markup, so I decided then to leave those for a future MR.

As a reference to what is feasible, GitHub only has a single wiki format, and handles file previews somewhat intelligently based on extension.

For the custom merge request commit messages, see doubts below.

**Screenshots**

The preview button is disabled if the input is empty:

![screenshot from 2014-02-18 14 29 10 button deactivate](https://f.cloud.github.com/assets/1429315/2208499/896629a6-9980-11e3-8835-e519a8d9ff93.png)

In the past, it was invisible, but I felt this behavior was better because:
- it matches that of the submit button
- you always know where the button is, so it is less surprising

Input not empty:

![screenshot from 2014-02-14 12 05 23 issue before preview](https://f.cloud.github.com/assets/1429315/2208391/87cac530-997f-11e3-9fb4-547da252955a.png)

New issue preview:

![screenshot from 2014-02-14 15 06 11 issue preview](https://f.cloud.github.com/assets/1429315/2208394/9269abf0-997f-11e3-82f9-f957c38c83f3.png)

Header anchors appear only if the displayed markdown will have them also.

The situation is exactly analogous for MR and Milestone descriptions.

Comments and diff notes preview behave like before, but their style now matches that of the description inputs:

![screenshot from 2014-02-20 22 46 39 comment preview 2](https://f.cloud.github.com/assets/1429315/2223965/d2ae9154-9a78-11e3-84e7-74ee727bf242.png)

![screenshot from 2014-02-20 22 48 36 diff note 2](https://f.cloud.github.com/assets/1429315/2223968/d7448eb2-9a78-11e3-8a81-fce5e70e936b.png)

The preview for comments has no header anchors.

So that the Preview / Write button always be at the same place I have:
1. enabled scroll vertical for the preview
2. disabled textarea resizing

![screenshot from 2014-04-14 22 54 00 scroll](https://cloud.githubusercontent.com/assets/1429315/2700734/4cf82d18-c417-11e3-8503-ff2294331585.png)

**Doubts**

1) Where should I put the default `.gfm-input-and-preview` CSS? For now I left it at `generic/forms` for lack of better place, but I also see the following possibilities:
- `common`
- `typography`
- a new file named `generic/markup-preview` or something

2) On `stylesheets/generic/forms.scss`, I had to add the lines:

```
background-color: white;
border: 1px solid rgb(204, 204, 204);
border-radius: 4px;
color: rgb(51, 51, 51);
```

whose only objective is to restore the default format set by Twitter Bootstrap for site when inside other divs.

For example, inside the green merge request div the preview would be green.

How to do that without resetting every single property manually?

I asked it on [StackOverflow](http://stackoverflow.com/questions/21764595/restore-bootstrap-defaults-in-div) to no avail so far.

3) Shall I document the markdown rendering as part of the REST API? [GitHub does](https://developer.github.com/v3/markdown/).

If yes, what should be the response status in case of invalid values, e.g. `tru` instead of `true`? Microsoft says 400: http://msdn.microsoft.com/en-us/library/windowsazure/dd179357.aspx

4) What is the correct place to put integration tests, `spec/features`, `features`, or both are OK?

Having both is bad because it requires developers to look into both to see it tests already exist or not.

**Implementation notes**

1) The functionality was essentially extracted from the existing notes preview under `javacripts/notes.js` and `view/project/notes/_form.html.haml`, encapsulated into `javascripts/markup_preview.js` and  `views/shared/_markup_input_and_preview.html.haml`, and used uniformly on all implemented previews.

2) Removed `.js-notify-commit-author` CSS class since it is not used in any view anymore.

3) Removed duplicate of method `setupNoteForm`, which was absolutely identical to the other one once `js-notify-commit-author` was removed.

4) Extracted `GitLab.GfmAutoComplete.setup()` from `setupNoteForm` into `setupDiscussionNoteForm`, since it was only being called from two places:
- `setupMainTargetNoteForm`, which is only called once for the page, call which will be made by the extracted `new MarkupPreview` call.
- `setupDiscussionNoteForm`, to where it was extracted.

5) Removed class `js-gfm-input` from:
- group create and edit forms on group and admin pages
- wall
- merge request edit commit message, since it is not possible to preview it, and it does not really render like normal gfm.

since those inputs are currently never rendered as markdown.

Removed `.note_text_and_preview` CSS class from wall since it has _no_ preview. This was the last occurrence of that class, so removed it from existence and ported its style from `notes.css` to `wall.css` with new name `new-wall-note`. The appearance and behavior of the wall are untouched.

6) Modified `_commit_box_html.haml` to use the `markdown` method instead of `gfm`, like every other place that renders markdown.

7) Modified file view to use a single technique for the reserved space for the header anchor links: `.wiki` inside a container with padding.

8) Renamed `no_header_anchors` option to `header_anchors`.

9) Corrected some always passing tests which assumed that `visible: false` does not target visible elements: it actually targets both visible _and_ invisible elements: http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Finders#find-instance_method. Those tests need `should_not visible:true` instead.
