### PR TITLE
Fixed attachment identifier displaying underneath note text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ v 6.6.0
   - Restyle Issue#show page and MR#show page
   - Ability to filter by multiple labels for Issues page
   - Rails version to 4.0.3
+  - Fixed attachment identifier displaying underneath note text (Jason Blanchard)
 
 v 6.5.1
   - Fix branch selectbox when create merge request from fork

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -87,7 +87,6 @@ ul.notes {
     }
     .attachment {
       font-size: 14px;
-      margin-top: -20px;
     }
     .note-body {
       @include md-typography;
@@ -302,6 +301,7 @@ ul.notes {
   @extend .col-md-4;
   @extend .thumbnail;
   margin-left: 45px;
+  float: none;
 }
 
 


### PR DESCRIPTION
Fixed issue where the attachment text is displayed too close to not text at the second breakpoint. I've moved it below the attachment to make the text feel less crowded.

Was:
![screen shot 2014-02-19 at 8 09 54 pm](https://f.cloud.github.com/assets/1238532/2214343/074def62-99d0-11e3-8d8e-fa5584cc2a6b.png)

Now:
![screen shot 2014-02-19 at 8 29 50 pm](https://f.cloud.github.com/assets/1238532/2214347/0e0ed514-99d0-11e3-8af0-3a3a4590b3b2.png)
