### PR TITLE
set layout margin-bottom 50px

### DIFF
--- a/app/assets/stylesheets/main/layout.scss
+++ b/app/assets/stylesheets/main/layout.scss
@@ -16,5 +16,5 @@ body {
 }
 
 .container .content {
-  margin: 0 0;
+  margin: 0 0 50px;
 }


### PR DESCRIPTION
The page will attach to the bottom without any space, it's ugly, So I give it 50px margin-bottom.

You can also make any space with other solution. The screenshot is from http://demo.gitlab.com/gitlab/gitlab-recipes/issues/27

![screenshot 2014-02-21 2 50 32](https://f.cloud.github.com/assets/360661/2227532/88026b02-9ac4-11e3-8cbd-e02a9e009430.png)
