### PR TITLE
Add support for Gemnasium as a project service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 6.7.0
+  - Add support for Gemnasium as a Project Service
+
 v 6.6.0
   - Retrieving user ssh keys publically(github style): http://__HOST__/__USERNAME__.keys
   - Permissions: Developer now can manage issue tracker (modify any issue)

--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,9 @@ gem "hipchat", "~> 0.14.0"
 # Flowdock integration
 gem "gitlab-flowdock-git-hook", "~> 0.4.2"
 
+# Gemnasium integration
+gem "gemnasium-gitlab-service", "~> 0.2"
+
 # d3
 gem "d3_rails", "~> 3.1.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.4)
+    gemnasium-gitlab-service (0.2.1)
+      rugged (~> 0.19)
     gemoji (1.3.1)
     gherkin-ruby (0.3.1)
       racc
@@ -578,6 +580,7 @@ DEPENDENCIES
   fog (~> 1.3.1)
   font-awesome-rails (~> 3.2)
   foreman
+  gemnasium-gitlab-service (~> 0.2)
   gemoji (~> 1.3.0)
   github-markup (~> 0.7.4)!
   gitlab-flowdock-git-hook (~> 0.4.2)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,6 +53,7 @@ class Project < ActiveRecord::Base
   has_one :hipchat_service, dependent: :destroy
   has_one :flowdock_service, dependent: :destroy
   has_one :assembla_service, dependent: :destroy
+  has_one :gemnasium_service, dependent: :destroy
   has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
   has_one :forked_from_project, through: :forked_project_link
 
@@ -256,7 +257,7 @@ class Project < ActiveRecord::Base
   end
 
   def available_services_names
-    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla emails_on_push)
+    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla emails_on_push gemnasium)
   end
 
   def gitlab_ci?

--- a/app/models/project_services/assembla_service.rb
+++ b/app/models/project_services/assembla_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class AssemblaService < Service

--- a/app/models/project_services/campfire_service.rb
+++ b/app/models/project_services/campfire_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class CampfireService < Service

--- a/app/models/project_services/emails_on_push_service.rb
+++ b/app/models/project_services/emails_on_push_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class EmailsOnPushService < Service

--- a/app/models/project_services/gemnasium_service.rb
+++ b/app/models/project_services/gemnasium_service.rb
@@ -16,40 +16,39 @@
 #  api_key     :string(255)
 #
 
-require "flowdock-git-hook"
+require "gemnasium/gitlab_service"
 
-class FlowdockService < Service
-  validates :token, presence: true, if: :activated?
+class GemnasiumService < Service
+  validates :token, :api_key, presence: true, if: :activated?
 
   def title
-    'Flowdock'
+    'Gemnasium'
   end
 
   def description
-    'Flowdock is a collaboration web app for technical teams.'
+    'Gemnasium monitors your project dependencies and alerts you about updates and security vulnerabilities.'
   end
 
   def to_param
-    'flowdock'
+    'gemnasium'
   end
 
   def fields
     [
-      { type: 'text', name: 'token',     placeholder: '' }
+      { type: 'text', name: 'api_key', placeholder: 'Your personal API KEY on gemnasium.com ' },
+      { type: 'text', name: 'token', placeholder: 'The project\'s slug on gemnasium.com' }
     ]
   end
 
   def execute(push_data)
     repo_path = File.join(Gitlab.config.gitlab_shell.repos_path, "#{project.path_with_namespace}.git")
-    Flowdock::Git.post(
-      push_data[:ref],
-      push_data[:before],
-      push_data[:after],
+    Gemnasium::GitlabService.execute(
+      ref: push_data[:ref],
+      before: push_data[:before],
+      after: push_data[:after],
       token: token,
-      repo: repo_path,
-      repo_url: "#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}",
-      commit_url: "#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}/commit/%s",
-      diff_url: "#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}/compare/%s...%s",
+      api_key: api_key,
+      repo: repo_path
       )
   end
 end

--- a/app/models/project_services/gitlab_ci_service.rb
+++ b/app/models/project_services/gitlab_ci_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class GitlabCiService < Service

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class HipchatService < Service

--- a/app/models/project_services/pivotaltracker_service.rb
+++ b/app/models/project_services/pivotaltracker_service.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 class PivotaltrackerService < Service

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -13,12 +13,13 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 # To add new service you should build a class inherited from Service
 # and implement a set of methods
 class Service < ActiveRecord::Base
-  attr_accessible :title, :token, :type, :active
+  attr_accessible :title, :token, :type, :active, :api_key
 
   belongs_to :project
   has_one :service_hook

--- a/db/migrate/20140214102325_add_api_key_to_services.rb
+++ b/db/migrate/20140214102325_add_api_key_to_services.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToServices < ActiveRecord::Migration
+  def change
+    add_column :services, :api_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140209025651) do
+ActiveRecord::Schema.define(version: 20140214102325) do
 
   create_table "broadcast_messages", force: true do |t|
     t.text     "message",    null: false
@@ -240,6 +240,7 @@ ActiveRecord::Schema.define(version: 20140209025651) do
     t.string   "subdomain"
     t.string   "room"
     t.text     "recipients"
+    t.string   "api_key"
   end
 
   add_index "services", ["project_id"], name: "index_services_on_project_id", using: :btree

--- a/spec/models/flowdock_service_spec.rb
+++ b/spec/models/flowdock_service_spec.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 require 'spec_helper'

--- a/spec/models/gemnasium_service_spec.rb
+++ b/spec/models/gemnasium_service_spec.rb
@@ -18,7 +18,7 @@
 
 require 'spec_helper'
 
-describe AssemblaService do
+describe GemnasiumService do
   describe "Associations" do
     it { should belong_to :project }
     it { should have_one :service_hook }
@@ -29,24 +29,19 @@ describe AssemblaService do
     let(:project) { create(:project) }
 
     before do
-      @assembla_service = AssemblaService.new
-      @assembla_service.stub(
+      @gemnasium_service = GemnasiumService.new
+      @gemnasium_service.stub(
         project_id: project.id,
         project: project,
         service_hook: true,
         token: 'verySecret',
-        subdomain: 'project_name'
+        api_key: 'GemnasiumUserApiKey'
       )
       @sample_data = GitPushService.new.sample_data(project, user)
-      @api_url = 'https://atlas.assembla.com/spaces/project_name/github_tool?secret_key=verySecret'
-      WebMock.stub_request(:post, @api_url)
     end
-
-    it "should call Assembla API" do
-      @assembla_service.execute(@sample_data)
-      WebMock.should have_requested(:post, @api_url).with(
-        body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/
-      ).once
+    it "should call Gemnasium service" do
+      Gemnasium::GitlabService.should_receive(:execute).with(an_instance_of(Hash)).once
+      @gemnasium_service.execute(@sample_data)
     end
   end
 end

--- a/spec/models/gitlab_ci_service_spec.rb
+++ b/spec/models/gitlab_ci_service_spec.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 require 'spec_helper'

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -13,6 +13,7 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  api_key     :string(255)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Add support for [Gemnasium](https://gemnasium.com) as a Gitlab project service. 
Gemnasium API needs an api_key attribute on top of project's token, so the PR contains a migration that updates the schema to add this column on the "services" table.
Most of the logic to communicate with Gemnasium API is held in a separate gem: gemnasium-gitlab-service which code is available on its public repository: https://github.com/gemnasium/gemnasium-gitlab-service

I've also updated the CHANGELOG by bumping to v6.7.0 but feel free to consider another versioning.

Thanks.
