### PR TITLE
Use the gitlab-shell path from the config in Gitlab:check

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -513,7 +513,7 @@ namespace :gitlab do
     end
 
     def check_gitlab_shell_self_test
-      gitlab_shell_repo_base = File.expand_path('gitlab-shell', gitlab_shell_user_home)
+      gitlab_shell_repo_base = File.expand_path(Gitlab.config.gitlab_shell.path)
       check_cmd = File.expand_path('bin/check', gitlab_shell_repo_base)
       puts "Running #{check_cmd}"
       if system(check_cmd, chdir: gitlab_shell_repo_base)


### PR DESCRIPTION
This fixes an issue in the self check, if you have Gitlab-shell in a subdirectory, the check would fail, because it would only check for`~/#{gitlab_shell_user_home}/gitlab-shell`. 

But when you have it in an subdirectory it had to check like:
`~/#{gitlab_shell_user_home}/#{sub_dir}/gitlab-shell`
