### PR TITLE
Commit message textareas have 72 char mark line.

### DIFF
--- a/app/assets/stylesheets/generic/forms.scss
+++ b/app/assets/stylesheets/generic/forms.scss
@@ -75,3 +75,26 @@ label {
     width: 200px;
   }
 }
+
+.commit-message-container {
+  background-color: $body-bg;
+  position: relative;
+  font-family: $monospace_font;
+  $left: 12px;
+  .max-width-marker {
+    color: rgba(0, 0, 0, 0.0);
+    font-family: inherit;
+    left: $left;
+    height: 100%;
+    border-right: 1px solid mix($input-border, white);
+    position: absolute;
+    z-index: 1;
+  }
+  > textarea {
+    background-color: rgba(0, 0, 0, 0.0);
+    font-family: inherit;
+    padding-left: $left;
+    position: relative;
+    z-index: 2;
+  }
+}

--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -151,3 +151,5 @@
     }
   }
 }
+
+#modal-remove-blob > .modal-dialog { width: 850px; }

--- a/app/views/projects/blob/_remove.html.haml
+++ b/app/views/projects/blob/_remove.html.haml
@@ -14,7 +14,8 @@
             = label_tag 'commit_message', class: "control-label" do
               Commit message
             .col-sm-10
-              = text_area_tag 'commit_message', params[:commit_message], placeholder: "Removed this file because...", required: true, rows: 3, class: 'form-control'
+              = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
+                  params[:commit_message], placeholder: "Removed this file because...", required: true, rows: 3, class: 'form-control')}
           .form-group
             .col-sm-2
             .col-sm-10

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -19,7 +19,8 @@
       = label_tag 'commit_message', class: "control-label" do
         Commit message
       .col-sm-10
-        = text_area_tag 'commit_message', '', placeholder: "Update #{@blob.name}", required: true, rows: 3, class: 'form-control'
+        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message', '',
+            placeholder: "Update #{@blob.name}", required: true, rows: 3, class: 'form-control')}
     .form-actions
       = hidden_field_tag 'last_commit', @last_commit
       = hidden_field_tag 'content', '', id: "file-content"

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -21,7 +21,6 @@
             = link_to "click here", "#modal_merge_info", class: "how_to_merge_link vlink", title: "How To Merge", "data-toggle" => "modal"
           for instructions.
 
-
         .js-toggle-container
           %p
             If you want to modify merge commit message -
@@ -31,7 +30,8 @@
             .form-group
               = label_tag :merge_commit_message, "Commit message", class: 'control-label'
               .col-sm-10
-                = text_area_tag :merge_commit_message, @merge_request.merge_commit_message, class: "form-control js-gfm-input", rows: 14, required: true
+                = render 'shared/commit_message_container', {textarea: text_area_tag(:merge_commit_message,
+                    @merge_request.merge_commit_message, class: "form-control js-gfm-input", rows: 14, required: true)}
                 %p.hint
                   The recommended maximum line length is 52 characters for the first line and 72 characters for all following lines.
 

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -24,7 +24,8 @@
       = label_tag 'commit_message', class: "control-label" do
         Commit message
       .col-sm-10
-        = text_area_tag 'commit_message', params[:commit_message], placeholder: "Added new file", required: true, rows: 3, class: 'form-control'
+        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
+            params[:commit_message], placeholder: "Added new file", required: true, rows: 3, class: 'form-control')}
 
     .file-holder
       .file-title

--- a/app/views/shared/_commit_message_container.html.haml
+++ b/app/views/shared/_commit_message_container.html.haml
@@ -1,0 +1,5 @@
+.commit-message-container
+  .max-width-marker
+    -# When the `ch` CSS length unit becomes widely supported `http://www.quirksmode.org/css/units-values` remove this workaround.
+    = 'a' * 72
+  = textarea


### PR DESCRIPTION
Fixes ACCEPTING MR at: http://feedback.gitlab.com/forums/176466-general/suggestions/5337507-show-72-character-mark-in-commits?tracking_code=284b0e5fd832f6885a68d90447c08d2a

All textareas that take a commit message now have the same monospace font in which they are shown under the `commits` tab, and a 72 character width vertical marker line.

I have only found commit message textareas in the following places:
- new, edit and remove file from web interface views.
- merge request custom commit message

Please notify me if there are any more of them.

**screenshots**

Edit file:

![screenshot from 2014-02-22 18 48 18 edit](https://f.cloud.github.com/assets/1429315/2238625/66b4990e-9bf8-11e3-94ec-2700c99f5678.png)

New file is analogous.

The remove popup had to be made wider because it did not have place for 72 characters before:

![screenshot from 2014-02-22 20 23 08 rm](https://f.cloud.github.com/assets/1429315/2238628/6e5a6120-9bf8-11e3-96bd-7035391823b0.png)

Custom MR commit message:

![screenshot from 2014-02-22 18 52 21 mr](https://f.cloud.github.com/assets/1429315/2238629/79d9a632-9bf8-11e3-8c72-daabfd0dba1c.png)

**doubts**

How to use exactly the same Bootstrap values of `textarea.form-control` `padding-left` for `.max-width-marker` `left`?

I could not find it, so I just set hardcoded the current Bootstrap value of `12px` for both the `padding` and the `left`.

This way it will never break, but it will not evolve automatically if the page style is modified.

One possibility to solve this is to set all missing values ourselves in our SASS via variables to their current values so that those variables can be used in other places.
