### PR TITLE
Issue and MR descriptions have white background.

### DIFF
--- a/app/assets/stylesheets/generic/issue_box.scss
+++ b/app/assets/stylesheets/generic/issue_box.scss
@@ -23,24 +23,27 @@
     line-height: 32px;
   }
 
+  $border: 1px solid #EEE;
+  $padding: 15px 25px;
+
   .title {
     font-size: 22px;
     font-weight: 500;
     line-height: 1.5;
     margin: 0;
     color: #333;
-    padding-bottom: 0;
-    padding: 15px 25px;
+    padding: $padding;
   }
 
   .context {
-    border: none;
-    border-top: 1px solid #eee;
-    padding: 15px 25px;
+    border-top: $border;
+    padding: $padding;
   }
 
   .description {
-    padding: 0 25px 15px 25px;
+    background: $body-bg;
+    border-top: $border;
+    padding: $padding;
   }
 
   .title, .context, .description {


### PR DESCRIPTION
- more uniform with other places that render large chunks of markdown
- easier to distinguish title and metadata from main description. We already have the vertical border to visually unite the metadata with the description.
- more similar to GitHub: https://github.com/cirosantilli/test/issues/5

New:

![screenshot from 2014-02-23 12 29 55 new](https://f.cloud.github.com/assets/1429315/2240197/67d298fa-9c7e-11e3-81ab-bd5f01f35bba.png)

Old:

![screenshot from 2014-02-23 12 15 42 old](https://f.cloud.github.com/assets/1429315/2240198/6ed01786-9c7e-11e3-8027-811e6e7b8b73.png)

Analogous for MRs and milestones.

**Implementation Notes**

If the background is white, it becomes apparent that there is no `padding-top` and no `border-top`, so some was added to the description.
