### PR TITLE
New MR default target branch is default of target.

### DIFF
--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -62,6 +62,8 @@ class Projects::MergeRequestsController < Projects::ApplicationController
     @merge_request.source_project = @project unless @merge_request.source_project
     @merge_request.target_project = @project unless @merge_request.target_project
     @source_project = @merge_request.source_project
+    p "= MergeReqestsController#new ==="
+    p "@merge_request.target_project.default_branch = " + @merge_request.target_project.default_branch
     @merge_request
   end
 

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -28,7 +28,8 @@
             = f.select(:target_project_id, options_from_collection_for_select(projects, 'id', 'path_with_namespace'), {}, { class: 'target_project select2 span3', disabled: @merge_request.persisted? })
           .pull-left
             &nbsp;
-            = f.select(:target_branch, @merge_request.target_branches, { include_blank: "Select branch" }, {class: 'target_branch select2 span2'})
+            = f.select(:target_branch, @merge_request.target_branches, { include_blank: "Select branch",
+                selected: @merge_request.target_project.default_branch }, {class: 'target_branch select2 span2'})
         .mr_target_commit
 
   %hr

--- a/features/project/merge_requests.feature
+++ b/features/project/merge_requests.feature
@@ -10,6 +10,16 @@ Feature: Project Merge Requests
     Then I should see "Bug NS-04" in merge requests
     And I should not see "Feature NS-03" in merge requests
 
+  @javascript
+  Scenario: The selected target branch should be the default branch of target repository.
+    When I click link "New Merge Request"
+    Then The selected target branch should be "master"
+    When I change the default branch to "master_bk"
+    And I visit project "Shop" merge requests page
+    And I click link "New Merge Request"
+    # TODO: FAILS because branch did not change.
+    #Then The selected target branch should be "master_bk"
+
   Scenario: I should see closed merge requests
     Given I click link "Closed"
     Then I should see "Feature NS-03" in merge requests

--- a/features/steps/project/project_merge_requests.rb
+++ b/features/steps/project/project_merge_requests.rb
@@ -192,4 +192,16 @@ class ProjectMergeRequests < Spinach::FeatureSteps
       page.should have_content message
     end
   end
+
+  def selected_target_branch_should_be(branch)
+    find('#s2id_merge_request_target_branch .select2-chosen').text.should == branch
+  end
+
+  step 'The selected target branch should be "master"' do
+    selected_target_branch_should_be('master')
+  end
+
+  step 'The selected target branch should be "master_bk"' do
+    selected_target_branch_should_be('master_bk')
+  end
 end

--- a/features/steps/shared/project.rb
+++ b/features/steps/shared/project.rb
@@ -1,5 +1,6 @@
 module SharedProject
   include Spinach::DSL
+  include Select2Helper
 
   # Create a project without caring about what it's called
   And "I own a project" do
@@ -121,5 +122,19 @@ module SharedProject
     project = Project.find_by(name: "Community")
     project ||= create :project, name: 'Community', visibility_level: Gitlab::VisibilityLevel::PUBLIC
     project.team << [user, :master]
+  end
+
+  def change_default_branch_to(branch)
+    @project.change_head(branch)
+
+    #click_link("Settings")
+    #select2(branch, from: "#project_default_branch")
+    #select2(branch, from: "Default Branch")
+    #select2(branch, from: "asdfqwer") # No error!
+    #click_button("Save changes")
+  end
+
+  step 'I change the default branch to "master_bk"' do
+    change_default_branch_to('master_bk')
   end
 end


### PR DESCRIPTION
Fixes ACCEPTING MR at http://feedback.gitlab.com/forums/176466-general/suggestions/5518180-smarter-merge-request-target-repo-and-branch-form-

One liner changer + tests ;~

Behavior before this PR: when creating a new MR, the target branch is the first one alphabetically.

Behavior after this PR: when creating a new MR, the target branch is the default of the target repo (which is currently always the current repo).

**help me**

Works well on interactive tests, but for the unit tests I am unable to change the current branch.

I have tried things like

```
@project.change_head(branch)
```

and

```
click_link("Settings")
select2(branch, from: "Default Branch")
click_button("Save changes")
```

and many variations without success.

Once this is settled I'll remove the test comments and prints.
