### PR TITLE
Empty repo test webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ doc/code/*
 *.log
 public/uploads.*
 public/assets/
+.powrc

--- a/app/services/git_push_service.rb
+++ b/app/services/git_push_service.rb
@@ -59,7 +59,8 @@ class GitPushService
   def sample_data(project, user)
     @project, @user = project, user
     @push_commits = project.repository.commits(project.default_branch, nil, 3)
-    post_receive_data(@push_commits.last.id, @push_commits.first.id, "refs/heads/#{project.default_branch}")
+    empty_repo_message = 'XXXXX_NO_COMMITS_YET_XXXXX'
+    post_receive_data(@push_commits.last.try(:id) || empty_repo_message, @push_commits.first.try(:id) || empty_repo_message, "refs/heads/#{project.default_branch}")
   end
 
   protected


### PR DESCRIPTION
Currently: when a new repository is created and a new web hook is added to it, clicking 'Test Hook' throws `undefined method`id' for nil:NilClass in GitPushService#sample_data, app/services/git_push_service.rb, line 62`.

After this branch, it does not.
