### PR TITLE
setup fails config/application.rb:88: syntax error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -85,7 +85,7 @@ module Gitlab
     config.middleware.use Rack::Cors do
       allow do
         origins '*'
-        resource '/api/*', headers: :any, methods: [:get, :post, :options, :put, :delete]
+        resource '/api/*', :headers => :any, :methods => [:get, :post, :options, :put, :delete]
       end
     end
   end


### PR DESCRIPTION
setup fails because of config/application.rb:88. may depends on env.

$ ruby -v
ruby 1.9.3p0

$ bundle show
- rack-cors (0.2.9)
- rails (4.0.3)
- rake (10.1.1)

$ rake gitlab:setup RAILS_ENV=production
rake aborted!
/home/git/gitlab/config/application.rb:88: syntax error, unexpected ':', expecting kEND
...   resource '/api/*', headers: :any, methods: [:get, :post, ...
