### PR TITLE
Fix extra space added in beginning of commit message

### DIFF
--- a/lib/gitlab/satellite/merge_action.rb
+++ b/lib/gitlab/satellite/merge_action.rb
@@ -118,7 +118,7 @@ module Gitlab
 
         # merge the source branch into the satellite
         # will raise CommandFailed when merge fails
-        repo.git.merge(default_options({no_ff: true}), "-m #{message}", "source/#{merge_request.source_branch}")
+        repo.git.merge(default_options({no_ff: true}), "-m#{message}", "source/#{merge_request.source_branch}")
       rescue Grit::Git::CommandFailed => ex
         handle_exception(ex)
       end


### PR DESCRIPTION
Removes extra space in merge commit messages. This seems to have been introduced by the functionality added in 38d8d749d which allows a user to change a merge commit message.

This is probably not the greatest way to fix this but feel it is worth showing what I did to fix in the interim.

Before:
![broken](https://f.cloud.github.com/assets/3237256/2253523/71d3613e-9dc0-11e3-87d3-137859f9fe02.PNG)

After:
![after](https://f.cloud.github.com/assets/3237256/2253525/7bbcb6fa-9dc0-11e3-8ebc-fdc3e02714ad.PNG)
