### PR TITLE
added verify false on gitlab_ci integrations

### DIFF
--- a/app/models/project_services/gitlab_ci_service.rb
+++ b/app/models/project_services/gitlab_ci_service.rb
@@ -36,7 +36,7 @@ class GitlabCiService < Service
   end
 
   def commit_status sha
-    response = HTTParty.get(commit_status_path(sha))
+    response = HTTParty.get(commit_status_path(sha), verify: false)
 
     if response.code == 200 and response["status"]
       response["status"]


### PR DESCRIPTION
For those of us running self-signed in gitlab-ci it generates 500s SSL_verify errors if you don't have this.
