### PR TITLE
remove dead code: broken_diffs

### DIFF
--- a/app/models/merge_request_diff.rb
+++ b/app/models/merge_request_diff.rb
@@ -69,12 +69,6 @@ class MergeRequestDiff < ActiveRecord::Base
     end
   end
 
-  # When Git::Diff is not able to get diff
-  # because of git timeout it return this value
-  def broken_diffs
-    [Gitlab::Git::Diff::BROKEN_DIFF]
-  end
-
   # Collect array of Git::Commit objects
   # between target and source branches
   def unmerged_commits


### PR DESCRIPTION
As the `BROKEN_DIFF` constant was removed from `gitlab_git`, and `gitlabhq` doesn't use it anymore, these lines can be removed safely!
