### PR TITLE
Provide commands to copy the SSH public key to the clipboard

### DIFF
--- a/app/views/help/ssh.html.haml
+++ b/app/views/help/ssh.html.haml
@@ -26,3 +26,17 @@
   %p.slead
     Copy-paste the key to the 'My SSH Keys' section under the 'SSH' tab in your user profile. 
     Please copy the complete key starting with 'ssh-' and ending with your username and host.
+
+  %p.slead
+    Use code below to copy your public key to the clipboard. Depending on your OS you'll need to use a different command:
+
+  %pre.dark
+    :preserve
+      # windows
+      clip < ~/.ssh/id_rsa.pub
+
+      # mac
+      pbcopy < ~/.ssh/id_rsa.pub
+
+      # linux (requires xclip)
+      xclip -sel clip < ~/.ssh/id_rsa.pub


### PR DESCRIPTION
The help file section on SSL does not provide commands on how to copy the SSL key to the clipboard from the shell itself.
