### PR TITLE
Internationalization support

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -131,7 +131,7 @@ class GroupsController < ApplicationController
   end
 
   def set_title
-    @title = 'New Group'
+    @title = I18n.t("gitlab.groups.new_group")
   end
 
   def determine_layout

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -137,7 +137,7 @@ class ProjectsController < ApplicationController
   private
 
   def set_title
-    @title = 'New Project'
+    @title = I18n.t("gitlab.projects.new_project")
   end
 
   def user_layout

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -104,6 +104,6 @@ class SnippetsController < ApplicationController
   end
 
   def set_title
-    @title = 'Snippets'
+    @title = I18n.t("gitlab.snippets.snippets")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,11 +181,11 @@ module ApplicationHelper
 
   def search_placeholder
     if @project && @project.persisted?
-      "Search in this project"
+      t("gitlab.search.search_in_this_project")
     elsif @group && @group.persisted?
-      "Search in this group"
+      t("gitlab.search.search_in_this_group")
     else
-      "Search"
+      t("gitlab.search.search")
     end
   end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -3,10 +3,6 @@ module GroupsHelper
     "Are you sure you want to remove \"#{user.name}\" from \"#{group.name}\"?"
   end
 
-  def leave_group_message(group)
-    "Are you sure you want to leave \"#{group}\" group?"
-  end
-  
   def should_user_see_group_roles?(user, group)
     if user
       user.is_admin? || group.members.exists?(user_id: user.id)

--- a/app/helpers/visibility_level_helper.rb
+++ b/app/helpers/visibility_level_helper.rb
@@ -40,7 +40,7 @@ module VisibilityLevelHelper
   end
 
   def visibility_level_label(level)
-    Project.visibility_levels.key(level)
+    t("gitlab.visibility." + Project.visibility_levels.key(level).downcase )
   end
 
   def restricted_visibility_levels

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,38 +1,42 @@
 %h3.page-title
-  Admin area
+  = t("gitlab.admin.admin_area")
 %p.light
-  You can manage projects, users and other GitLab data from here.
+  = t("gitlab.admin.desc")
 %hr
 .admin-dashboard
   .row
     .col-sm-4
       .light-well
-        %h4 Projects
+        %h4
+          = t("gitlab.projects.projects")
         .data
           = link_to admin_projects_path do
             %h1= Project.count
           %hr
-          = link_to 'New Project', new_project_path, class: "btn btn-new"
+          = link_to t("gitlab.projects.new_project"), new_project_path, class: "btn btn-new"
     .col-sm-4
       .light-well
-        %h4 Users
+        %h4
+          = t("gitlab.users.users")
         .data
           = link_to admin_users_path do
             %h1= User.count
           %hr
-          = link_to 'New User', new_admin_user_path, class: "btn btn-new"
+          = link_to t("gitlab.users.new_user"), new_admin_user_path, class: "btn btn-new"
     .col-sm-4
       .light-well
-        %h4 Groups
+        %h4
+          = t("gitlab.groups.groups")
         .data
           = link_to admin_groups_path do
             %h1= Group.count
           %hr
-          = link_to 'New Group', new_admin_group_path, class: "btn btn-new"
+          = link_to t("gitlab.groups.new_group"), new_admin_group_path, class: "btn btn-new"
 
   .row.prepend-top-10
     .col-md-4
-      %h4 Latest projects
+      %h4
+        = t("gitlab.projects.latest_projects")
       %hr
       - @projects.each do |project|
         %p
@@ -41,7 +45,8 @@
             #{time_ago_with_tooltip(project.created_at)}
 
     .col-md-4
-      %h4 Latest users
+      %h4
+        = t("gitlab.users.latest_users")
       %hr
       - @users.each do |user|
         %p
@@ -51,7 +56,8 @@
             #{time_ago_with_tooltip(user.created_at)}
 
     .col-md-4
-      %h4 Latest groups
+      %h4
+        = t("gitlab.groups.latest_groups")
       %hr
       - @groups.each do |group|
         %p
@@ -63,77 +69,79 @@
   %br
   .row
     .col-md-4
-      %h4 Stats
+      %h4
+        = t("gitlab.admin.stats.stats")
       %hr
       %p
-        Forks
+        = t("gitlab.admin.stats.forks")
         %span.light.pull-right
           = ForkedProjectLink.count
       %p
-        Issues
+        = t("gitlab.admin.stats.issues")
         %span.light.pull-right
           = Issue.count
       %p
-        Merge Requests
+        = t("gitlab.admin.stats.merge_requests")
         %span.light.pull-right
           = MergeRequest.count
       %p
-        Notes
+        = t("gitlab.admin.stats.notes")
         %span.light.pull-right
           = Note.count
       %p
-        Snippets
+        = t("gitlab.admin.stats.snippets")
         %span.light.pull-right
           = Snippet.count
       %p
-        SSH Keys
+        = t("gitlab.admin.stats.ssh_keys")
         %span.light.pull-right
           = Key.count
       %p
-        Milestones
+        = t("gitlab.admin.stats.milestones")
         %span.light.pull-right
           = Milestone.count
     .col-md-4
       %h4
-        Features
+        = t("gitlab.admin.features.features")
       %hr
       %p
-        Sign up
+        = t("gitlab.admin.features.sign_up")
         %span.light.pull-right
           = boolean_to_icon gitlab_config.signup_enabled
       %p
-        LDAP
+        = t("gitlab.admin.features.ldap")
         %span.light.pull-right
           = boolean_to_icon Gitlab.config.ldap.enabled
       %p
-        Gravatar
+        = t("gitlab.admin.features.gravatar")
         %span.light.pull-right
           = boolean_to_icon Gitlab.config.gravatar.enabled
       %p
-        OmniAuth
+        = t("gitlab.admin.features.omniauth")
         %span.light.pull-right
           = boolean_to_icon Gitlab.config.omniauth.enabled
     .col-md-4
-      %h4 Components
+      %h4
+        = t("gitlab.admin.components.components")
       %hr
       %p
-        GitLab
+        = t("gitlab.admin.components.gitlab")
         %span.pull-right
           = Gitlab::VERSION
       %p
-        GitLab Shell
+        = t("gitlab.admin.components.gitlab_shell")
         %span.pull-right
           = Gitlab::Shell.new.version
       %p
-        GitLab API
+        = t("gitlab.admin.components.gitlab_api")
         %span.pull-right
           = API::API::version
       %p
-        Ruby
+        = t("gitlab.admin.components.ruby")
         %span.pull-right
           #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
 
       %p
-        Rails
+        = t("gitlab.admin.components.rails")
         %span.pull-right
           #{Rails::VERSION::STRING}

--- a/app/views/dashboard/_activities.html.haml
+++ b/app/views/dashboard/_activities.html.haml
@@ -4,6 +4,7 @@
 - if @events.any?
   .content_list
 - else
-  .nothing-here-block Projects activity will be displayed here
+  .nothing-here-block
+    = t("gitlab.dashboard.no_activity")
 
 = spinner

--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -5,7 +5,7 @@
       %span.pull-right
         = link_to new_group_path, class: "btn btn-new" do
           %i.icon-plus
-          New group
+          = t("gitlab..groups.new_group")
   %ul.well-list.dash-list
     - groups.each do |group|
       %li.group-row

--- a/app/views/dashboard/_projects.html.haml
+++ b/app/views/dashboard/_projects.html.haml
@@ -1,11 +1,11 @@
 .ui-box
   .title.clearfix
-    = search_field_tag :filter_projects, nil, placeholder: 'Filter by name', class: 'dash-filter form-control'
+    = search_field_tag :filter_projects, nil, placeholder: t("gitlab.dashboard.filter_by_name"), class: 'dash-filter form-control'
     - if current_user.can_create_project?
       %span.pull-right
         = link_to new_project_path, class: "btn btn-new" do
           %i.icon-plus
-          New project
+          = t("gitlab.projects.new_project")
 
   %ul.well-list.dash-list
     - projects.each do |project|

--- a/app/views/dashboard/_projects_filter.html.haml
+++ b/app/views/dashboard/_projects_filter.html.haml
@@ -2,27 +2,27 @@
   %ul.nav.nav-pills.nav-stacked
     = nav_tab :scope, nil do
       = link_to projects_dashboard_filter_path(scope: nil) do
-        All
+        = t("gitlab.projects.filter.all")
         %span.pull-right
           = current_user.authorized_projects.count
     = nav_tab :scope, 'personal' do
       = link_to projects_dashboard_filter_path(scope: 'personal') do
-        Personal
+        = t("gitlab.projects.filter.personal")
         %span.pull-right
           = current_user.personal_projects.count
     = nav_tab :scope, 'joined' do
       = link_to projects_dashboard_filter_path(scope: 'joined') do
-        Joined
+        = t("gitlab.projects.filter.joined")
         %span.pull-right
           = current_user.authorized_projects.joined(current_user).count
     = nav_tab :scope, 'owned' do
       = link_to projects_dashboard_filter_path(scope: 'owned') do
-        Owned
+        = t("gitlab.projects.filter.owned")
         %span.pull-right
           = current_user.owned_projects.count
 
 %fieldset
-  %legend Visibility
+  %legend #{t("gitlab.groups.visibility")}
   %ul.nav.nav-pills.nav-stacked.nav-small.visibility-filter
     - Gitlab::VisibilityLevel.values.each do |level|
       %li{ class: (level.to_s == params[:visibility_level]) ? 'active' : 'light' }
@@ -32,7 +32,7 @@
 
 - if @groups.present?
   %fieldset
-    %legend Groups
+    %legend #{t("gitlab.groups.groups")}
     %ul.nav.nav-pills.nav-stacked.nav-small
       - @groups.each do |group|
         %li{ class: (group.name == params[:group]) ? 'active' : 'light' }

--- a/app/views/dashboard/_sidebar.html.haml
+++ b/app/views/dashboard/_sidebar.html.haml
@@ -1,11 +1,11 @@
 %ul.nav.nav-tabs.dash-sidebar-tabs
   %li.active
     = link_to '#projects', 'data-toggle' => 'tab', id: 'sidebar-projects-tab' do
-      Projects
+      = t("gitlab.projects.projects")
       %span.badge= @projects_count
   %li
     = link_to '#groups', 'data-toggle' => 'tab', id: 'sidebar-groups-tab' do
-      Groups
+      = t("gitlab.groups.groups")
       %span.badge= @groups.count
 
 .tab-content

--- a/app/views/dashboard/issues.html.haml
+++ b/app/views/dashboard/issues.html.haml
@@ -1,9 +1,9 @@
 %h3.page-title
-  Issues
-  %span.pull-right #{@issues.total_count} issues
-
+  = t("gitlab.issues.issues")
+  %span.pull-right
+    = t("gitlab.issues.issues_no", :count => @issues.total_count)
 %p.light
-  List all issues from all projects you have access to.
+  = t("gitlab.issues.list_of_all_issues")
 %hr
 
 .row

--- a/app/views/dashboard/merge_requests.html.haml
+++ b/app/views/dashboard/merge_requests.html.haml
@@ -1,10 +1,10 @@
 %h3.page-title
-  Merge Requests
-  %span.pull-right #{@merge_requests.total_count} merge requests
+  = t("gitlab.merge_requests.merge_requests")
+  %span.pull-right #{@merge_requests.total_count} #{t("gitlab.merge_requests.total_count__merge_requests")}
 
 
 %p.light
-  List all merge requests from all projects you have access to.
+  = t("gitlab.merge_requests.list_of_all_merge_requests")
 %hr
 .row
   .col-md-3

--- a/app/views/dashboard/projects.html.haml
+++ b/app/views/dashboard/projects.html.haml
@@ -1,5 +1,5 @@
 %h3.page-title
-  My Projects
+  = t("gitlab.projects.my_projects")
 .pull-right
   .dropdown.inline
     %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
@@ -7,22 +7,22 @@
       - if @sort.present?
         = @sort.humanize
       - else
-        Name
+        = t("gitlab.sort.name")
       %b.caret
     %ul.dropdown-menu
       %li
         = link_to projects_dashboard_filter_path(sort: nil) do
-          Name
+          = t("gitlab.sort.name")
         = link_to projects_dashboard_filter_path(sort: 'newest') do
-          Newest
+          = t("gitlab.sort.newest")
         = link_to projects_dashboard_filter_path(sort: 'oldest') do
-          Oldest
+          = t("gitlab.sort.oldest")
         = link_to projects_dashboard_filter_path(sort: 'recently_updated') do
-          Recently updated
+          = t("gitlab.sort.recently_updated")
         = link_to projects_dashboard_filter_path(sort: 'last_updated') do
-          Last updated
+          = t("gitlab.sort.last_updated")
 %p.light
-  All projects you have access to are listed here. Public projects are not included here unless you are a member
+  = t("gitlab.projects.all_projects_you_have_access_to_are_listed_here")
 %hr
 .row
   .col-md-3.hidden-sm.hidden-xs.side-filters

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,15 +1,15 @@
 .login-box
-  %h3.page-title Resend confirmation instructions
+  %h3.page-title #{t("gitlab.login.resend_confirmation_instructions")}
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     .devise-errors
       = devise_error_messages!
     .clearfix.append-bottom-20
       = f.email_field :email, placeholder: 'Email', class: "form-control", required: true
     .clearfix.append-bottom-10
-      = f.submit "Resend confirmation instructions", class: 'btn btn-success'
+      = f.submit t("gitlab.login.resend_confirmation_instructions"), class: 'btn btn-success'
   %hr
   %p
     %span.light
-      Already have login and password?
+      = t("gitlab.login.already_have_login_and_password")
     %strong
-      = link_to "Sign in", new_session_path(resource_name)
+      = link_to t("gitlab.login.sign_in"), new_session_path(resource_name)

--- a/app/views/devise/sessions/_new_base.html.haml
+++ b/app/views/devise/sessions/_new_base.html.haml
@@ -1,14 +1,15 @@
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  = f.text_field :login, class: "form-control top", placeholder: "Username or Email", autofocus: "autofocus"
+  = f.text_field :login, class: "form-control top", placeholder: t("gitlab.login.username_or_email"), autofocus: "autofocus"
   = f.password_field :password, class: "form-control bottom", placeholder: "Password"
   - if devise_mapping.rememberable?
     .clearfix.append-bottom-10
       %label.checkbox.remember_me{for: "user_remember_me"}
         = f.check_box :remember_me
-        %span Remember me
+        %span
+          = t("gitlab.login.remember_me")
   %div
-    = f.submit "Sign in", class: "btn-create btn"
+    = f.submit t("gitlab.login.sign_in"), class: "btn-create btn"
     .pull-right
-      = link_to "Forgot your password?", new_password_path(resource_name), class: "btn"
+      = link_to t("gitlab.login.forgot_your_password"), new_password_path(resource_name), class: "btn"
 
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,6 @@
 .login-box
-  %h3.page-title Sign in
+  %h3.page-title
+    = t("gitlab.login.sign_in")
   - if ldap_enabled?
     %ul.nav.nav-tabs
       %li.active
@@ -27,8 +28,8 @@
         = link_to "Sign up", new_registration_path(resource_name)
 
   %p
-    %span.light Did not receive confirmation email?
-    = link_to "Send again", new_confirmation_path(resource_name)
+    %span.light #{t("gitlab.login.did_not_receive_confirmation_email")}
+    = link_to t("gitlab.login.send_again"), new_confirmation_path(resource_name)
 
 
   - if extra_config.has_key?('sign_in_text')

--- a/app/views/groups/_projects.html.haml
+++ b/app/views/groups/_projects.html.haml
@@ -1,14 +1,15 @@
 .ui-box
   .title
-    Projects (#{projects.count})
+    = t("gitlab.groups.projects_no", :count => projects.count)
     - if can? current_user, :manage_group, @group
       %span.pull-right
         = link_to new_project_path(namespace_id: @group.id), class: "btn btn-new" do
           %i.icon-plus
-          New project
+          = t("gitlab.projects.new_project")
   %ul.well-list
     - if projects.blank?
-      .nothing-here-block This groups has no projects yet
+      .nothing-here-block
+        = t("gitlab.groups.no_projects")
     - projects.each do |project|
       %li.project-row
         = link_to project_path(project), class: dom_class(project) do

--- a/app/views/groups/issues.html.haml
+++ b/app/views/groups/issues.html.haml
@@ -1,13 +1,12 @@
 %h3.page-title
-  Issues
-  %span.pull-right #{@issues.total_count} issues
+  = t("gitlab.issues.issues")
+  %span.pull-right
+    = t("gitlab.issues.issues_no", :count => @issues.total_count)
 
 %p.light
-  Only issues from
-  %strong #{@group.name}
-  group are listed here.
+  = t("gitlab.groups.only_issues_from_group", :group => @group.name)
   - if current_user
-    To see all issues you should visit #{link_to 'dashboard', issues_dashboard_path} page.
+    = t("gitlab.groups.all_groups_dashboard", :dashboard_link => link_to('dashboard', issues_dashboard_path)).html_safe
 %hr
 
 .row

--- a/app/views/groups/merge_requests.html.haml
+++ b/app/views/groups/merge_requests.html.haml
@@ -1,13 +1,12 @@
 %h3.page-title
-  Merge Requests
-  %span.pull-right #{@merge_requests.total_count} merge requests
+  = t("gitlab.merge_requests.merge_requests")
+  %span.pull-right
+    = t("gitlab.merge_requests.merge_requests_no", :count => @merge_requests.total_count)
 
 %p.light
-  Only merge requests from
-  %strong #{@group.name}
-  group are listed here.
+  = t("gitlab.groups.only_merge_requests_from_group", :group => @group.name)
   - if current_user
-    To see all merge requests you should visit #{link_to 'dashboard', merge_requests_dashboard_path} page.
+    = t("gitlab.groups.all_groups_dashboard", :dashboard_link => link_to('dashboard', merge_requests_dashboard_path))
 %hr
 .row
   .col-md-3

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -4,12 +4,12 @@
       %span= @group.errors.full_messages.first
   .form-group
     = f.label :name, class: 'control-label' do
-      Group name
+      = t("gitlab.groups.group_name")
     .col-sm-10
-      = f.text_field :name, placeholder: "Ex. OpenSource", class: "form-control"
+      = f.text_field :name, placeholder: t("gitlab.groups.group_name_example"), class: "form-control"
 
   .form-group.group-description-holder
-    = f.label :description, "Details", class: 'control-label'
+    = f.label :description, t("gitlab.groups.details"), class: 'control-label'
     .col-sm-10
       = f.text_area :description, maxlength: 250, class: "form-control js-gfm-input", rows: 4
 
@@ -17,13 +17,13 @@
     .col-sm-2
     .col-sm-10
       %ul
-        %li A group is a collection of several projects
-        %li Groups are private by default
-        %li Members of a group may only view projects they have permission to access
-        %li Group project URLs are prefixed with the group namespace
-        %li Existing projects may be moved into a group
+        %li #{t("gitlab.groups.desc_1")}
+        %li #{t("gitlab.groups.desc_2")}
+        %li #{t("gitlab.groups.desc_3")}
+        %li #{t("gitlab.groups.desc_4")}
+        %li #{t("gitlab.groups.desc_5")}
 
   .form-actions
-    = f.submit 'Create group', class: "btn btn-create"
+    = f.submit t("gitlab.groups.create_group"), class: "btn btn-create"
 
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,17 +1,18 @@
-.dashboard
-  .activities.col-md-8.hidden-sm
+.dasctivities.col-md-8.hidden-sm
     - if current_user
       = render "events/event_last_push", event: @last_push
       = link_to dashboard_path, class: 'btn btn-tiny' do
-        &larr; To dashboard
+        &larr; #{ t("gitlab.groups.to_dashboard") }
       &nbsp;
-    %span.cgray You will only see events from projects in this group
+    %span.cgray
+      = t("gitlab.groups.desc")
     %hr
     = render 'shared/event_filter'
     - if @events.any?
       .content_list
     - else
-      .nothing-here-block Project activity will be displayed here
+      .nothing-here-block
+        = t("gitlab.groups.no_activity") }
     = spinner
   .side.col-md-4
     .light-well.append-bottom-20
@@ -24,10 +25,10 @@
     = render "projects", projects: @projects
     - if current_user
       .prepend-top-20
-        = link_to group_path(@group, { format: :atom, private_token: current_user.private_token }), title: "Feed" do
+        = link_to group_path(@group, { format: :atom, private_token: current_user.private_token }), title: t("gitlab.feed") do
           %strong
             %i.icon-rss
-            News Feed
+            = t("gitlab.news_feed")
 
     %hr
     = render 'shared/promo'

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -3,8 +3,8 @@
     .container
       %div.app_logo
         %span.separator
-        = link_to root_path, class: "home has_bottom_tooltip", title: "Dashboard" do
-          %h1 GITLAB
+        = link_to root_path, class: "home has_bottom_tooltip", title: t("gitlab.dashboard.dashboard") do
+          %h1 #{t("gitlab.name")}
         %span.separator
       %h1.title= title
 
@@ -24,25 +24,25 @@
             = link_to search_path, title: "Search", class: 'has_bottom_tooltip', 'data-original-title' => 'Search area' do
               %i.icon-search
           %li
-            = link_to public_root_path, title: "Public area", class: 'has_bottom_tooltip', 'data-original-title' => 'Public area' do
+            = link_to public_root_path, title: t("gitlab.panel.public_area"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.public_area") do
               %i.icon-globe
           %li
-            = link_to user_snippets_path(current_user), title: "My snippets", class: 'has_bottom_tooltip', 'data-original-title' => 'My snippets' do
+            = link_to user_snippets_path(current_user), title: t("gitlab.panel.my_snippets"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.my_snippets") do
               %i.icon-paste
           - if current_user.is_admin?
             %li
-              = link_to admin_root_path, title: "Admin area", class: 'has_bottom_tooltip', 'data-original-title' => 'Admin area' do
+              = link_to admin_root_path, title: t("gitlab.panel.admin_area"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.admin_area") do
                 %i.icon-cogs
           - if current_user.can_create_project?
             %li
-              = link_to new_project_path, title: "New project", class: 'has_bottom_tooltip', 'data-original-title' => 'New project'  do
+              = link_to new_project_path, title: t("gitlab.panel.new_project"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.new_project")  do
                 %i.icon-plus
           %li
-            = link_to profile_path, title: "Profile settings", class: 'has_bottom_tooltip', 'data-original-title' => 'Profile settings"'  do
+            = link_to profile_path, title: t("gitlab.panel.profile_settings"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.profile_settings")  do
               %i.icon-user
           %li
-            = link_to destroy_user_session_path, class: "logout", method: :delete, title: "Logout", class: 'has_bottom_tooltip', 'data-original-title' => 'Logout'  do
+            = link_to destroy_user_session_path, class: "logout", method: :delete, title: t("gitlab.panel.logout"), class: 'has_bottom_tooltip', 'data-original-title' => t("gitlab.panel.logout")  do
               %i.icon-signout
           %li
             = link_to current_user, class: "profile-pic", id: 'profile-pic' do
-              = image_tag avatar_icon(current_user.email, 26), alt: 'User activity'
+              = image_tag avatar_icon(current_user.email, 26), alt: t("gitlab.panel.user_activity")

--- a/app/views/layouts/_public_head_panel.html.haml
+++ b/app/views/layouts/_public_head_panel.html.haml
@@ -4,12 +4,13 @@
       %div.app_logo
         %span.separator
         = link_to public_root_path, class: "home" do
-          %h1 GITLAB
+          %h1
+            = t("gitlab.name")
         %span.separator
       %h1.title= title
 
       .pull-right
-        = link_to "Sign in", new_session_path(:user), class: 'btn btn-sign-in btn-new'
+        = link_to t("gitlab.login.sign_in"), new_session_path(:user), class: 'btn btn-sign-in btn-new'
 
       %ul.nav.navbar-nav
         %li

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,9 +1,9 @@
 !!! 5
 %html{ lang: "en"}
-  = render "layouts/head", title: "Dashboard"
+  = render "layouts/head", title: t("gitlab.dashboard.dashboard")
   %body{class: "#{app_theme} application", :'data-page' => body_data_page }
     = render "layouts/broadcast"
-    = render "layouts/head_panel", title: "Dashboard"
+    = render "layouts/head_panel", title: t("gitlab.dashboard.dashboard")
     = render "layouts/flash"
     %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/dashboard'

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -6,11 +6,12 @@
     .container
       .content
         %center
-          %h1 GitLab
+          %h1
+            = t("gitlab.name")
           %p.light
-            GitLab is open source software to collaborate on code.
+            = t("gitlab.description")
             %br
-            #{link_to "Sign in", new_user_session_path} or browse for #{link_to "public projects", public_projects_path}.
+            #{link_to t("gitlab.login.sign_in"), new_user_session_path} #{t("gitlab.login.or_browse_for")} #{link_to t("gitlab.public_projects"), public_projects_path}.
     %hr
     .container
       .content

--- a/app/views/layouts/nav/_dashboard.html.haml
+++ b/app/views/layouts/nav/_dashboard.html.haml
@@ -4,15 +4,15 @@
       %i.icon-home
   = nav_link(path: 'dashboard#projects') do
     = link_to projects_dashboard_path do
-      Projects
+      = t("gitlab.dashboard.menu.projects")
   = nav_link(path: 'dashboard#issues') do
     = link_to issues_dashboard_path do
-      Issues
+      = t("gitlab.dashboard.menu.issues")
       %span.count= current_user.assigned_issues.opened.count
   = nav_link(path: 'dashboard#merge_requests') do
     = link_to merge_requests_dashboard_path do
-      Merge Requests
+      = t("gitlab.dashboard.menu.merge_requests")
       %span.count= current_user.assigned_merge_requests.opened.count
   = nav_link(controller: :help) do
-    = link_to "Help", help_path
+    = link_to t("gitlab.dashboard.menu.help"), help_path
 

--- a/app/views/layouts/nav/_group.html.haml
+++ b/app/views/layouts/nav/_group.html.haml
@@ -1,22 +1,22 @@
 %ul
   = nav_link(path: 'groups#show', html_options: {class: 'home'}) do
-    = link_to group_path(@group), title: "Home" do
+    = link_to group_path(@group), title: t("gitlab.groups.home") do
       %i.icon-home
   = nav_link(path: 'groups#issues') do
     = link_to issues_group_path(@group) do
-      Issues
+      = t("gitlab.issues.issues")
       - if current_user
         %span.count= current_user.assigned_issues.opened.of_group(@group).count
   = nav_link(path: 'groups#merge_requests') do
     = link_to merge_requests_group_path(@group) do
-      Merge Requests
+      = t("gitlab.merge_requests.merge_requests")
       - if current_user
         %span.count= current_user.cared_merge_requests.opened.of_group(@group).count
   = nav_link(path: 'groups#members') do
-    = link_to "Members", members_group_path(@group)
+    = link_to t("gitlab.groups.members"), members_group_path(@group)
 
   - if can?(current_user, :manage_group, @group)
     = nav_link(path: 'groups#edit') do
       = link_to edit_group_path(@group), class: "tab " do
-        Settings
+        = t("gitlab.groups.settings")
 

--- a/app/views/layouts/nav/_profile.html.haml
+++ b/app/views/layouts/nav/_profile.html.haml
@@ -3,24 +3,24 @@
     = link_to profile_path, title: "Profile" do
       %i.icon-home
   = nav_link(controller: :accounts) do
-    = link_to "Account", profile_account_path
+    = link_to t("gitlab.profile.menu.account"), profile_account_path
   = nav_link(controller: :emails) do
     = link_to profile_emails_path do
       Emails
       %span.count= current_user.emails.count + 1
   - unless current_user.ldap_user?
     = nav_link(controller: :passwords) do
-      = link_to "Password", edit_profile_password_path
+      = link_to t("gitlab.profile.menu.password"), edit_profile_password_path
   = nav_link(controller: :notifications) do
-    = link_to "Notifications", profile_notifications_path
+    = link_to t("gitlab.profile.menu.notifications"), profile_notifications_path
   = nav_link(controller: :keys) do
     = link_to profile_keys_path do
-      SSH Keys
+      = t("gitlab.profile.menu.ssh_keys")
       %span.count= current_user.keys.count
   = nav_link(path: 'profiles#design') do
-    = link_to "Design", design_profile_path
+    = link_to t("gitlab.profile.menu.design"), design_profile_path
   = nav_link(controller: :groups) do
-    = link_to "Groups", profile_groups_path
+    = link_to t("gitlab.profile.menu.groups"), profile_groups_path
   = nav_link(path: 'profiles#history') do
-    = link_to "History", history_profile_path
+    = link_to t("gitlab.profile.menu.history"), history_profile_path
 

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -1,10 +1,10 @@
 !!! 5
 %html{ lang: "en"}
-  = render "layouts/head", title: "Public Projects"
+  = render "layouts/head", title: t("gitlab.projects.public_projects")
   %body{class: "#{app_theme} application", :'data-page' => body_data_page}
     = render "layouts/broadcast"
     - if current_user
-      = render "layouts/head_panel", title: "Public Projects"
+      = render "layouts/head_panel", title: t("gitlab.projects.public_projects")
     - else
       = render "layouts/public_head_panel", title: "Public Projects"
     .container.navless-container

--- a/app/views/profiles/accounts/show.html.haml
+++ b/app/views/profiles/accounts/show.html.haml
@@ -1,7 +1,7 @@
 %h3.page-title
-  Account settings
+  = t("gitlab.profile.account.account_settings")
 %p.light
-  You can change your username and private token here.
+  = t("gitlab.profile.account.you_can_change_username_here")
   - if current_user.ldap_user?
     Some options are unavailable for LDAP accounts
 %hr
@@ -10,22 +10,22 @@
 .account-page
   %fieldset.update-token
     %legend
-      Private token
+      = t("gitlab.profile.account.private_token")
     %div
       = form_for @user, url: reset_private_token_profile_path, method: :put do |f|
         .data
           %p
-            Your private token is used to access application resources without authentication.
+            = t("gitlab.profile.account.token_desc_1")
             %br
-            It can be used for atom feeds or the API.
+            = t("gitlab.profile.account.token_desc_2")
             %span.cred
-              Keep it secret!
+              = t("gitlab.profile.account.keep_it_secret")
 
           %p.cgray
             - if current_user.private_token
               = text_field_tag "token", current_user.private_token, class: "form-control"
               %div
-                = f.submit 'Reset', data: { confirm: "Are you sure?" }, class: "btn btn-primary btn-build-token"
+                = f.submit t("gitlab.profile.account.reset"), data: { confirm: t("gitlab.profile.account.are_you_sure") }, class: "btn btn-primary btn-build-token"
             - else
               %span You don`t have one yet. Click generate to fix it.
               = f.submit 'Generate', class: "btn success btn-build-token"
@@ -43,10 +43,10 @@
   - if show_profile_username_tab?
     %fieldset.update-username
       %legend
-        Username
+        = t("gitlab.profile.account.username")
       = form_for @user, url: update_username_profile_path,  method: :put, remote: true do |f|
         %p
-          Changing your username will change path to all personal projects!
+          = t("gitlab.profile.account.path_change_msg")
         %div
           = f.text_field :username, required: true, class: 'form-control'
           &nbsp;
@@ -57,7 +57,7 @@
         %p.light
           = user_url(@user)
         %div
-          = f.submit 'Save username', class: "btn btn-save"
+          = f.submit t("gitlab.profile.account.save_username"), class: "btn btn-save"
 
   - if show_profile_remove_tab?
     %fieldset.remove-account

--- a/app/views/profiles/design.html.haml
+++ b/app/views/profiles/design.html.haml
@@ -1,38 +1,38 @@
 %h3.page-title
-  My appearance settings
+  = t("gitlab.profile.design.my_appearance_settings")
 %p.light
-  Appearance settings saved to your profile and available across all devices
+  = t("gitlab.profile.design.appearance_settings_description")
 %hr
 
 = form_for @user, url: profile_path, remote: true, method: :put do |f|
   %fieldset.application-theme
     %legend
-      Application theme
+      = t("gitlab.profile.design.application_theme")
     .themes_opts
       = label_tag do
         .prev.default
         = f.radio_button :theme_id, 1
-        Default
+        = t("gitlab.profile.design.themes.default")
 
       = label_tag do
         .prev.classic
         = f.radio_button :theme_id, 2
-        Classic
+        = t("gitlab.profile.design.themes.classic")
 
       = label_tag do
         .prev.modern
         = f.radio_button :theme_id, 3
-        Modern
+        = t("gitlab.profile.design.themes.modern")
 
       = label_tag do
         .prev.gray
         = f.radio_button :theme_id, 4
-        Gray
+        = t("gitlab.profile.design.themes.gray")
 
       = label_tag do
         .prev.violet
         = f.radio_button :theme_id, 5
-        Violet
+        = t("gitlab.profile.design.themes.violet")
     %br
     .clearfix
 

--- a/app/views/profiles/groups/index.html.haml
+++ b/app/views/profiles/groups/index.html.haml
@@ -1,16 +1,17 @@
 %h3.page-title
-  Group membership
+  = t("gitlab.profile.groups.title")
   - if current_user.can_create_group?
     %span.pull-right
       = link_to new_group_path, class: "btn btn-new" do
         %i.icon-plus
-        New Group
+        = t("gitlab.groups.new_group")
 %p.light
-  Group members have access to all a group's projects
+  = t("gitlab.profile.groups.desc")
 %hr
 .ui-box
   .title
-    %strong Groups
+    %strong
+    = t("gitlab.groups.groups")
     (#{@user_groups.count})
   %ul.well-list
     - @user_groups.each do |user_group|
@@ -20,18 +21,19 @@
           - if can?(current_user, :manage_group, group)
             = link_to edit_group_path(group), class: "btn-small btn btn-grouped" do
               %i.icon-cogs
-              Settings
+              = t("gitlab.groups.settings")
 
           - if can?(current_user, :destroy, user_group)
-            = link_to leave_profile_group_path(group), data: { confirm: leave_group_message(group.name) }, method: :delete, class: "btn-small btn btn-grouped", title: 'Remove user from group' do
+            = link_to leave_profile_group_path(group), data: { confirm: t("gitlab.groups.leave_confirm", :group => group.name) }, method: :delete, class: "btn-small btn btn-grouped", title: t("gitlab.groups.leave_title") do
               %i.icon-signout
-              Leave
+              = t("gitlab.groups.leave")
 
         = link_to group, class: 'group-name' do
           %strong= group.name
 
-        as
-        %strong #{user_group.human_access}
+        = t("gitlab.groups.as")
+        %strong
+        = t("gitlab.access." + user_group.human_access.downcase)
 
         %div.light
           #{pluralize(group.projects.count, "project")}, #{pluralize(group.users.count, "user")}

--- a/app/views/profiles/keys/_form.html.haml
+++ b/app/views/profiles/keys/_form.html.haml
@@ -7,15 +7,15 @@
             %li= msg
 
     .form-group
-      = f.label :title, class: 'control-label'
+      = f.label :title, t("gitlab.profile.ssh_keys.title"), class: 'control-label'
       .col-sm-10= f.text_field :title, class: "form-control"
     .form-group
-      = f.label :key, class: 'control-label'
+      = f.label :key, t("gitlab.profile.ssh_keys.key"), class: 'control-label'
       .col-sm-10
         = f.text_area :key, class: "form-control", rows: 8
 
 
     .form-actions
-      = f.submit 'Add key', class: "btn btn-create"
-      = link_to "Cancel", profile_keys_path, class: "btn btn-cancel"
+      = f.submit t("gitlab.profile.ssh_keys.add_key"), class: "btn btn-create"
+      = link_to t("gitlab.profile.ssh_keys.cancel"), profile_keys_path, class: "btn btn-cancel"
 

--- a/app/views/profiles/keys/index.html.haml
+++ b/app/views/profiles/keys/index.html.haml
@@ -1,22 +1,23 @@
 %h3.page-title
-  My SSH keys
+  = t("gitlab.profile.ssh_keys.my_ssh_keys")
   .pull-right
-    = link_to "Add SSH Key", new_profile_key_path, class: "btn btn-new"
+    = link_to t("gitlab.profile.ssh_keys.add_ssh_key"), new_profile_key_path, class: "btn btn-new"
 %p.light
-  SSH keys allow you to establish a secure connection between your computer and GitLab
+  = t("gitlab.profile.ssh_keys.desc1")
   %br
-  Before you can add an SSH key you need to
-  = link_to "generate it", help_ssh_path
+  = t("gitlab.profile.ssh_keys.desc2")
+  = link_to t("gitlab.profile.ssh_keys.generate_it"), help_ssh_path
 %hr
 
 
 .ui-box
   .title
-    SSH Keys (#{@keys.count})
+    #{t("gitlab.profile.ssh_keys.ssh_keys")} (#{@keys.count})
   %ul.well-list#keys-table
     = render @keys
     - if @keys.blank?
       %li
-        .nothing-here-block There are no SSH keys with access to your account.
+        .nothing-here-block
+          = t("gitlab.profile.ssh_keys.no_ssh_keys")
 
 

--- a/app/views/profiles/keys/new.html.haml
+++ b/app/views/profiles/keys/new.html.haml
@@ -1,6 +1,7 @@
-%h3.page-title Add an SSH Key
+%h3.page-title
+  = t("gitlab.profile.ssh_keys.add_ssh_key")
 %p.light
-  Paste your public key here. Read more about how to generate a key on #{link_to "the SSH help page", help_ssh_path}.
+  #{t("gitlab.profile.ssh_keys.paste_your_public_key_here")}  #{link_to t("gitlab.profile.ssh_keys.ssh_help_page"), help_ssh_path}.
 %hr
 = render 'form'
 

--- a/app/views/profiles/notifications/show.html.haml
+++ b/app/views/profiles/notifications/show.html.haml
@@ -1,8 +1,8 @@
 %h3.page-title
-  Notifications settings
+  = t("gitlab.profile.notifications.notifications_settings")
 %p.light
-  GitLab uses the email specified in your profile for notifications
-%hr
+  = t("gitlab.profile.notifications.notifications_description")
+%h
 = form_tag profile_notifications_path, method: :put, remote: true, class: 'update-notifications form-horizontal global-notifications-form' do
   = hidden_field_tag :notification_type, 'global'
 
@@ -12,22 +12,25 @@
       = label_tag nil, class: '' do
         = radio_button_tag :notification_level, Notification::N_DISABLED, @notification.disabled?, class: 'trigger-submit'
         .level-title
-          Disabled
-        %p You will not get any notifications via email
+          = t("gitlab.profile.notifications.disabled")
+        %p #{t("gitlab.profile.notifications.disabled_description")}
 
     .radio
       = label_tag nil, class: '' do
         = radio_button_tag :notification_level, Notification::N_PARTICIPATING, @notification.participating?, class: 'trigger-submit'
         .level-title
-          Participating
-        %p You will only receive notifications from related resources (e.g. from your commits or assigned issues)
+          = t("gitlab.profile.notifications.participating")
+        %p #{t("gitlab.profile.notifications.participating_description")}
+
+          = t("gitlab.profile.notifications.participating")
+    &ndash; #{t("gitlab.profile.notifications.participating_description")}
 
     .radio
       = label_tag nil, class: '' do
         = radio_button_tag :notification_level, Notification::N_WATCH, @notification.watch?, class: 'trigger-submit'
         .level-title
-          Watch
-        %p You will receive all notifications from projects in which you participate
+          = t("gitlab.profile.notifications.watch")
+        %p #{t("gitlab.profile.notifications.watch_description")}
 
 .clearfix
   %hr
@@ -37,14 +40,16 @@
     By default all projects and groups uses notification level set above
 .row.all-notifications
   .col-md-6
-    %h4 Groups:
+    %h4
+      = t("gitlab.profile.notifications.groups")
     %ul.bordered-list
       - @users_groups.each do |users_group|
         - notification = Notification.new(users_group)
         = render 'settings', type: 'group', membership: users_group, notification: notification
 
   .col-md-6
-    %h4 Projects:
+    %h4
+      = t("gitlab.profile.notifications.projects")
     %ul.bordered-list
       - @users_projects.each do |users_project|
         - notification = Notification.new(users_project)

--- a/app/views/profiles/passwords/edit.html.haml
+++ b/app/views/profiles/passwords/edit.html.haml
@@ -1,33 +1,34 @@
-%h3.page-title Password
+%h3.page-title
+  = t("gitlab.profile.password.title")
 %p.light
-  Change your password or recover your current one.
+  = t("gitlab.profile.password.change_your_password_description")
 %hr
 .update-password
   = form_for @user, url: profile_password_path, method: :put, html: { class: 'form-horizontal' }  do |f|
     %div
       %p.slead
-        You must provide current password in order to change it.
+        = t("gitlab.profile.password.must_provide_current_password")
         %br
-        After a successful password update you will be redirected to login page where you should login with your new password
+        = t("gitlab.profile.password.you_will_be_redirected_to_login_page")
       -if @user.errors.any?
         .alert.alert-danger
           %ul
             - @user.errors.full_messages.each do |msg|
               %li= msg
       .form-group
-        = f.label :current_password, class: 'control-label'
+        = f.label :current_password, t("gitlab.profile.password.current_password"), class: 'control-label'
         .col-sm-10
           = f.password_field :current_password, required: true, class: 'form-control'
           %div
-            = link_to "Forgot your password?", reset_profile_password_path, method: :put
+            = link_to t("gitlab.login.forgot_your_password"), reset_profile_password_path, method: :put
 
       .form-group
-        = f.label :password, 'New password', class: 'control-label'
+        = f.label :password, t("gitlab.profile.password.new_password"), class: 'control-label'
         .col-sm-10
           = f.password_field :password, required: true, class: 'form-control'
       .form-group
-        = f.label :password_confirmation, class: 'control-label'
+        = f.label :password_confirmation, t("gitlab.profile.password.password_confirmation"), class: 'control-label'
         .col-sm-10
           = f.password_field :password_confirmation, required: true, class: 'form-control'
       .form-actions
-        = f.submit 'Save password', class: "btn btn-save"
+        = f.submit t("gitlab.profile.password.save_password"), class: "btn btn-save"

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,7 +1,7 @@
 %h3.page-title
-  Profile settings
+  = t("gitlab.profile.profile_settings")
 %p.light
-  This information appears on your profile.
+  = t("gitlab.profile.this_information_appears_on_your_profile")
   - if current_user.ldap_user?
     Some options are unavailable for LDAP accounts
 %hr
@@ -17,13 +17,14 @@
   .row
     .col-md-7
       .form-group
-        = f.label :name, class: "control-label"
+        = f.label :name, t("gitlab.profile.name"), class: "control-label"
         .col-sm-10
           = f.text_field :name, class: "form-control", required: true
-          %span.help-block Enter your name, so people you know can recognize you.
+          %span.help-block
+            = t("gitlab.profile.enter_your_name")
 
       .form-group
-        = f.label :email, class: "control-label"
+        = f.label :email, t("gitlab.profile.email"), class: "control-label"
         .col-sm-10
           - if @user.ldap_user?
             = f.text_field :email, class: "form-control", required: true, readonly: true
@@ -36,7 +37,8 @@
                 We sent confirmation email to
                 %strong #{@user.unconfirmed_email}
             - else
-              %span.help-block We also use email for avatar detection if no avatar is uploaded.
+              %span.help-block
+                = t("gitlab.profile.email_for_avatar_detection")
       .form-group
         = f.label :skype, class: "control-label"
         .col-sm-10= f.text_field :skype, class: "form-control"
@@ -47,13 +49,14 @@
         = f.label :twitter, class: "control-label"
         .col-sm-10= f.text_field :twitter, class: "form-control"
       .form-group
-        = f.label :website_url, 'Website', class: "control-label"
+        = f.label :website_url, t("gitlab.profile.website"), class: "control-label"
         .col-sm-10= f.text_field :website_url, class: "form-control"
       .form-group
-        = f.label :bio, class: "control-label"
+        = f.label :bio, t("gitlab.profile.bio"), class: "control-label"
         .col-sm-10
           = f.text_area :bio, rows: 6, class: "form-control", maxlength: 250
-          %span.help-block Tell us about yourself in fewer than 250 characters.
+          %span.help-block
+            = t("gitlab.profile.bio_description")
 
     .col-md-5
       .light-well
@@ -83,4 +86,4 @@
               = link_to 'Remove avatar', profile_avatar_path, data: { confirm: "Avatar will be removed. Are you sure?"}, method: :delete, class: "btn btn-remove btn-small remove-avatar"
 
   .form-actions
-    = f.submit 'Save changes', class: "btn btn-save"
+    = f.submit t("gitlab.profile.save_changes"), class: "btn btn-save"

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -6,16 +6,16 @@
     = form_for @project, remote: true, html: { class: 'new_project form-horizontal' } do |f|
       .form-group.project-name-holder
         = f.label :name, class: 'control-label' do
-          %strong Project name
+          %strong #{t("gitlab.projects.project_name")}
         .col-sm-10
-          = f.text_field :name, placeholder: "Example Project", class: "form-control", tabindex: 1, autofocus: true
+          = f.text_field :name, placeholder: t("gitlab.projects.example_project"), class: "form-control", tabindex: 1, autofocus: true
           .help-inline
             = link_to "#", class: 'js-toggle-visibility-link' do
-              %span Customize repository name?
+              %span #{t("gitlab.projects.customize_directory_name")}
 
       .form-group.js-toggle-visibility-container.hide
         = f.label :path, class: 'control-label' do
-          %span Repository name
+          %span #{t("gitlab.projects.repository_name")}
         .col-sm-10
           .input-group
             = f.text_field :path, class: 'form-control'
@@ -25,7 +25,7 @@
       - if current_user.can_select_namespace?
         .form-group
           = f.label :namespace_id, class: 'control-label' do
-            %span Namespace
+            %span #{t("gitlab.projects.namespace")}
           .col-sm-10
             = f.select :namespace_id, namespaces_options(params[:namespace_id] || :current_user), {}, {class: 'select2', tabindex: 2}
 
@@ -34,31 +34,31 @@
         .col-sm-10
           = link_to "#", class: 'appear-link' do
             %i.icon-upload-alt
-            %span Import existing repository?
+            %span #{t("gitlab.projects.import_existing_repository_question")}
       .form-group.appear-data.import-url-data
         = f.label :import_url, class: 'control-label' do
-          %span Import existing repo
+          %span #{t("gitlab.projects.import_existing_repository")}
         .col-sm-10
           = f.text_field :import_url, class: 'form-control', placeholder: 'https://github.com/randx/six.git'
           .light
-            URL must be cloneable
+            = t("gitlab.projects.url_must_be_cloneable")
       .form-group
         = f.label :description, class: 'control-label' do
-          Description
-          %span.light (optional)
+          = t("gitlab.projects.description")
+          %span.light #{t("gitlab.projects.optional")}
         .col-sm-10
-          = f.text_area :description, placeholder: "Awesome project", class: "form-control", rows: 3, maxlength: 250, tabindex: 3
+          = f.text_area :description, placeholder: t("gitlab.projects.description_example"), class: "form-control", rows: 3, maxlength: 250, tabindex: 3
       = render "visibility_level", f: f, visibility_level: gitlab_config.default_projects_features.visibility_level, can_change_visibility_level: true
 
       .form-actions
-        = f.submit 'Create project', class: "btn btn-create project-submit", tabindex: 4
+        = f.submit t("gitlab.projects.create_project"), class: "btn btn-create project-submit", tabindex: 4
 
         - if current_user.can_create_group?
           .pull-right
             .light
-              Need a group for several dependent projects?
+              = t("gitlab.projects.need_a_group_for_dependent_projects")
               = link_to new_group_path, class: "btn btn-tiny" do
-                Create a group
+                = t("gitlab.projects.create_a_group")
 
 .save-project-loader.hide
   %center

--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -1,15 +1,15 @@
 %h3.page-title
-  Projects (#{@projects.total_count})
+  #{t("gitlab.projects.projects")} (#{@projects.total_count})
 .light
-  You can browse public projects in read-only mode until signed in.
+  = t("gitlab.projects.public_projects_read_only")
 %hr
 .clearfix
   .pull-left
     = form_tag public_projects_path, method: :get, class: 'form-inline form-tiny' do |f|
       .form-group
-        = search_field_tag :search, params[:search], placeholder: "Filter by name", class: "form-control search-text-input input-mn-300", id: "projects_search"
+        = search_field_tag :search, params[:search], placeholder: t("gitlab.projects.filter_by_name"), class: "form-control search-text-input input-mn-300", id: "projects_search"
       .form-group
-        = submit_tag 'Search', class: "btn btn-primary wide"
+        = submit_tag t("gitlab.search.search"), class: "btn btn-primary wide"
 
   .pull-right
     .dropdown.inline
@@ -18,20 +18,20 @@
         - if @sort.present?
           = @sort.humanize
         - else
-          Name
+          = t("gitlab.sort.name")
         %b.caret
       %ul.dropdown-menu
         %li
           = link_to public_projects_path(sort: nil) do
-            Name
+            = t("gitlab.sort.name")
           = link_to public_projects_path(sort: 'newest') do
-            Newest
+            = t("gitlab.sort.newest")
           = link_to public_projects_path(sort: 'oldest') do
-            Oldest
+            = t("gitlab.sort.oldest")
           = link_to public_projects_path(sort: 'recently_updated') do
-            Recently updated
+            = t("gitlab.sort.recently_updated")
           = link_to public_projects_path(sort: 'last_updated') do
-            Last updated
+            = t("gitlab.sort.last_updated")
 
 %hr
 .public-projects
@@ -64,5 +64,6 @@
             Empty repository
     - unless @projects.present?
       .nothing-here-block No public projects
+        = t("gitlab.projects.no_public_projects")
 
   = paginate @projects, theme: "gitlab"

--- a/app/views/shared/_event_filter.html.haml
+++ b/app/views/shared/_event_filter.html.haml
@@ -1,5 +1,5 @@
 .event_filter
-  = event_filter_link EventFilter.push, 'Push events'
-  = event_filter_link EventFilter.merged, 'Merge events'
-  = event_filter_link EventFilter.comments, 'Comments'
-  = event_filter_link EventFilter.team, 'Team'
+  = event_filter_link EventFilter.push, t("gitlab.events.push_events")
+  = event_filter_link EventFilter.merged, t("gitlab.events.merge_events")
+  = event_filter_link EventFilter.comments, t("gitlab.events.comments")
+  = event_filter_link EventFilter.team, t("gitlab.events.team")

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -5,29 +5,29 @@
         %ul.nav.nav-pills.nav-stacked
           %li{class: ("active" if params[:scope] == 'assigned-to-me')}
             = link_to filter_path(entity, scope: 'assigned-to-me') do
-              Assigned to me
+              = t("gitlab.filter.assigned_to_me")
           %li{class: ("active" if params[:scope] == 'authored')}
             = link_to filter_path(entity, scope: 'authored') do
-              Created by me
+              = t("gitlab.filter.created_by_me")
           %li{class: ("active" if params[:scope] == 'all')}
             = link_to filter_path(entity, scope: 'all') do
-              Everyone's
+              = t("gitlab.filter.everyones")
 
     %fieldset.status-filter
-      %legend State
+      %legend #{t("gitlab.filter.state")}
       %ul.nav.nav-pills
         %li{class: ("active" if params[:state] == 'opened')}
           = link_to filter_path(entity, state: 'opened') do
-            Open
+            = t("gitlab.filter.open")
         %li{class: ("active" if params[:state] == 'closed')}
           = link_to filter_path(entity, state: 'closed') do
-            Closed
+            = t("gitlab.filter.closed")
         %li{class: ("active" if params[:state] == 'all')}
           = link_to filter_path(entity, state: 'all') do
-            All
+            = t("gitlab.filter.all")
 
     %fieldset
-      %legend Projects
+      %legend #{t("gitlab.filter.projects")}
       %ul.nav.nav-pills.nav-stacked.nav-small
         - @projects.each do |project|
           - unless entities_per_project(project, entity).zero?
@@ -40,5 +40,5 @@
       - if params[:state].present? || params[:project_id].present?
         = link_to filter_path(entity, state: nil, project_id: nil), class: 'pull-right cgray' do
           %i.icon-remove
-          %strong Clear filter
+          %strong #{t("gitlab.filter.clear_filter")}
 

--- a/app/views/shared/_issues.html.haml
+++ b/app/views/shared/_issues.html.haml
@@ -11,5 +11,6 @@
           = render 'projects/issues/issue', issue: issue
   = paginate @issues, theme: "gitlab"
 - else
-  .nothing-here-block No issues to show
+  .nothing-here-block
+    = t("gitlab.issues.nothing_here")
 

--- a/app/views/shared/_merge_requests.html.haml
+++ b/app/views/shared/_merge_requests.html.haml
@@ -11,4 +11,5 @@
   = paginate @merge_requests, theme: "gitlab"
 
 - else
-  .nothing-here-block No merge requests to show
+  .nothing-here-block
+    = t("gitlab.merge_requests.nothing_here")

--- a/app/views/snippets/_blob.html.haml
+++ b/app/views/snippets/_blob.html.haml
@@ -5,7 +5,7 @@
     %span.options
       .btn-group.tree-btn-group.pull-right
         - if @snippet.author == current_user
-          = link_to "Edit", edit_snippet_path(@snippet), class: "btn btn-tiny", title: 'Edit Snippet'
-          = link_to "Delete", snippet_path(@snippet), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-tiny", title: 'Delete Snippet'
-        = link_to "Raw", raw_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
+          = link_to t("gitlab.snippets.edit"), edit_snippet_path(@snippet), class: "btn btn-tiny", title: t("gitlab.snippets.edit_snippet")
+          = link_to t("gitlab.snippets.delete"), snippet_path(@snippet), method: :delete, data: { confirm: t("gitlab.snippets.are_you_sure") }, class: "btn btn-tiny", title: t("gitlab.snippets.delete_snippet")
+        = link_to t("gitlab.snippets.raw"), raw_snippet_path(@snippet), class: "btn btn-tiny", target: "_blank"
   = render 'snippets/blob_content'

--- a/app/views/snippets/_form.html.haml
+++ b/app/views/snippets/_form.html.haml
@@ -1,5 +1,5 @@
 %h3.page-title
-  = @snippet.new_record? ? "New Snippet" : "Edit Snippet ##{@snippet.id}"
+  = @snippet.new_record? ? t("gitlab.snippets.new_snippet") : "#{t("gitlab.snippets.edit_snippet")} ##{@snippet.id}"
 %hr
 .snippet-form-holder
   = form_for @snippet, as: :personal_snippet, url: url, html: { class: "form-horizontal snippet-form" } do |f|
@@ -10,44 +10,44 @@
             %li= msg
 
     .form-group
-      = f.label :title, class: 'control-label'
-      .col-sm-10= f.text_field :title, placeholder: "Example Snippet", class: 'form-control', required: true
+      = f.label :title, t("gitlab.snippets.title"), class: 'control-label'
+      .col-sm-10= f.text_field :title, placeholder: t("gitlab.snippets.example_snippet"), class: 'form-control', required: true
     .form-group
-      = f.label "Access", class: 'control-label'
+      = f.label :access, t("gitlab.snippets.access"), class: 'control-label'
       .col-sm-10
         = f.label :private_true, class: 'radio-label' do
           = f.radio_button :private, true
           %span
-            %strong Private
-            (only you can see this snippet)
+            %strong
+              = t("gitlab.snippets.private")
         %br
         = f.label :private_false, class: 'radio-label' do
           = f.radio_button :private, false
           %span
-            %strong Public
-            (GitLab users can see this snippet)
+            %strong
+              = t("gitlab.snippets.public")
 
     .form-group
       .file-editor
-        = f.label :file_name, "File", class: 'control-label'
+        = f.label :file_name, t("gitlab.snippets.file"), class: 'control-label'
         .col-sm-10
           .file-holder.snippet
             .file-title
-              = f.text_field :file_name, placeholder: "example.rb", class: 'form-control snippet-file-name', required: true
+              = f.text_field :file_name, placeholder: t("gitlab.snippets.example_filename"), class: 'form-control snippet-file-name', required: true
             .file-content.code
               %pre#editor= @snippet.content
               = f.hidden_field :content, class: 'snippet-file-content'
 
     .form-actions
       - if @snippet.new_record?
-        = f.submit 'Create snippet', class: "btn-create btn"
+        = f.submit t("gitlab.snippets.create_snippet"), class: "btn-create btn"
       - else
-        = f.submit 'Save', class: "btn-save btn"
+        = f.submit t("gitlab.snippets.save"), class: "btn-save btn"
 
       - unless @snippet.new_record?
         .pull-right.prepend-left-20
-          = link_to 'Remove', snippet_path(@snippet), data: { confirm: 'Removed snippet cannot be restored! Are you sure?'}, method: :delete, class: "btn btn-remove delete-snippet", id: "destroy_snippet_#{@snippet.id}"
-      = link_to "Cancel", snippets_path(@project), class: "btn btn-cancel"
+          = link_to t("gitlab.snippets.remove"), snippet_path(@snippet), data: { confirm: t("gitlab.snippets.remove_snippet_warning")}, method: :delete, class: "btn btn-remove delete-snippet", id: "destroy_snippet_#{@snippet.id}"
+      = link_to t("gitlab.snippets.cancel"), snippets_path(@project), class: "btn btn-cancel"
 
 
 :javascript

--- a/app/views/snippets/current_user_index.html.haml
+++ b/app/views/snippets/current_user_index.html.haml
@@ -1,13 +1,13 @@
 %h3.page-title
-  My Snippets
+  = t("gitlab.snippets.my_snippets")
   .pull-right
     = link_to new_snippet_path, class: "btn btn-new btn-grouped", title: "New Snippet" do
-      Add new snippet
+      = t("gitlab.snippets.add_new_snippet")
     = link_to snippets_path, class: "btn btn-grouped"  do
-      Discover snippets
+      = t("gitlab.snippets.discover_snippets")
 
 %p.light
-  Share code pastes with others out of git repository
+  = t("gitlab.snippets.description")
 %hr
 
 .row
@@ -15,17 +15,17 @@
     %ul.nav.nav-pills.nav-stacked
       = nav_tab :scope, nil do
         = link_to user_snippets_path(@user) do
-          All
+          = t("gitlab.filter.all")
           %span.pull-right
             = @user.snippets.count
       = nav_tab :scope, 'private' do
         = link_to user_snippets_path(@user, scope: 'private') do
-          Private
+          = t("gitlab.filter.private")
           %span.pull-right
             = @user.snippets.private.count
       = nav_tab :scope, 'public' do
         = link_to user_snippets_path(@user, scope: 'public') do
-          Public
+          = t("gitlab.filter.public")
           %span.pull-right
             = @user.snippets.public.count
 

--- a/app/views/snippets/index.html.haml
+++ b/app/views/snippets/index.html.haml
@@ -1,14 +1,14 @@
 %h3.page-title
-  Public snippets
+  = t("gitlab.snippets.public_snippets")
 
   .pull-right
     = link_to new_snippet_path, class: "btn btn-new btn-grouped", title: "New Snippet" do
-      Add new snippet
+      = t("gitlab.snippets.add_new_snippet")
     = link_to user_snippets_path(current_user), class: "btn btn-grouped"  do
-      My snippets
+      = t("gitlab.snippets.my_snippets")
 
 %p.light
-  Public snippets created by you and other users are listed here
+  = t("gitlab.snippets.description")
 
 %hr
 = render 'snippets'

--- a/app/views/snippets/show.html.haml
+++ b/app/views/snippets/show.html.haml
@@ -8,7 +8,7 @@
 
   .pull-right
     = link_to new_snippet_path, class: "btn btn-new btn-small", title: "New Snippet" do
-      Add new snippet
+      = t("gitlab.snippets.add_new_snippet")
 
 
 .append-bottom-20
@@ -23,9 +23,9 @@
   .back-link
     - if @snippet.author == current_user
       = link_to user_snippets_path(current_user) do
-        &larr; my snippets
+        &larr; #{t("gitlab.snippets.my_snippets")}
     - else
       = link_to snippets_path do
-        &larr; discover snippets
+        &larr; #{t("gitlab.snippets.discover_snippets")}
 
 %div= render 'blob'

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -1,9 +1,10 @@
 .ui-box
   .title
-    Profile
+    = t("gitlab.users.profile")
   %ul.well-list
     %li
-      %span.light Member since
+      %span.light
+        = t("gitlab.users.member_since")
       %strong= user.created_at.stamp("Aug 21, 2011")
     - unless user.skype.blank?
       %li

--- a/app/views/users/_projects.html.haml
+++ b/app/views/users/_projects.html.haml
@@ -1,5 +1,5 @@
 .ui-box
-  .title Projects
+  .title #{ t("gitlab.projects.projects") }
   %ul.well-list
     - @projects.each do |project|
       %li

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,16 +7,17 @@
         .pull-right
           = link_to profile_path, class: 'btn' do
             %i.icon-edit
-            Edit Profile settings
+            = t("gitlab.users.edit_profile_settings")
       %br
       %span.user-show-username #{@user.username}
       %br
-      %small member since #{@user.created_at.stamp("Nov 12, 2031")}
+      %small #{t("gitlab.users.member_since")} #{@user.created_at.stamp("Nov 12, 2031")}
     .clearfix
     %h4 Groups:
     = render 'groups', groups: @groups
     %hr
-    %h4 User Activity:
+    %h4
+      = t("gitlab.users.user_activity")
     = render @events
   .col-md-4
     = render 'profile', user: @user

--- a/app/views/users_groups/_users_group.html.haml
+++ b/app/views/users_groups/_users_group.html.haml
@@ -17,10 +17,10 @@
             %i.icon-edit
         - if can?(current_user, :destroy, member)
           - if current_user == member.user
-            = link_to leave_profile_group_path(@group), data: { confirm: leave_group_message(@group.name)}, method: :delete, class: "btn-tiny btn btn-remove", title: 'Remove user from group' do
+            = link_to leave_profile_group_path(@group), data: { confirm: t("gitlab.groups.leave_confirm", :group => @group.name) }, method: :delete, class: "btn-tiny btn btn-remove", title: t("gitlab.groups.leave_title") do
               %i.icon-minus.icon-white
           - else
-            = link_to group_users_group_path(@group, member), data: { confirm: remove_user_from_group_message(@group, user) }, method: :delete, remote: true, class: "btn-tiny btn btn-remove", title: 'Remove user from group' do
+            = link_to group_users_group_path(@group, member), data: { confirm: remove_user_from_group_message(@group, user) }, method: :delete, remote: true, class: "btn-tiny btn btn-remove", title: t("gitlab.groups.leave_title") do
               %i.icon-minus.icon-white
   
     .edit-member.hide.js-toggle-content

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,8 +37,8 @@ module Gitlab
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-    config.i18n.enforce_available_locales = false
+
+    config.i18n.default_locale = :en
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,443 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
 en:
-  hello: "Hello world"
-  errors:
+  gitlab:
+    name: "GitLab"
+    description: "GitLab is open source software to collaborate on code."
+    public_projects: "public projects"
+    dashboard:
+      dashboard: "Dashboard"
+      filter_by_name: "Filter by name"
+      last_activity: "Last activity:"
+      no_activity: "Projects activity will be displayed here"
+      menu:
+        help: "Help"
+        issues: "Issues"
+        merge_requests: "Merge Requests"
+        projects: "Projects"
+    events:
+      comments: "Comments"
+      merge_events: "Merge events"
+      push_events: "Push events"
+      team: "Team"
+    filter:
+      all: "All"
+      assigned_to_me: "Assigned to me"
+      clear_filter: "Clear filter"
+      closed: "Closed"
+      created_by_me: "Created by me"
+      open: "Open"
+      private: "Private"
+      projects: "Projects"
+      public: "Public"
+      state: "State"
+    groups:
+      create_group: "Create group"
+      desc_1: "A group is a collection of several projects"
+      desc_2: "Groups are private by default"
+      desc_3: "Members of a group may only view projects they have permission to access"
+      desc_4: "Group project URLs are prefixed with the group namespace"
+      desc_5: "Existing projects may be moved into a group"
+      details: "Details"
+      group_name: "Group name"
+      group_name_example: "Ex. OpenSource"
+      groups: "Groups"
+      all_groups_dashboard: "To see all issues you should visit %{dashboard_link} page."
+      new_group: "New Group"
+      visibility: "Visibility"
+      only_issues_from_group: "Only issues from <strong>%{group}</strong> group are listed here. To see all issues you should visit %{dashboard_link} page."
+      only_merge_requests_from_group: "Only merge requests from <strong>%{group}</strong> group are listed here. To see all merge requests you should visit %{dashboard_link} page."
+    issues:
+      issues: "Issues"
+      list_of_all_issues: "List all issues from all projects you have access to."
+      nothing_here: "No issues to show"
+      total_count__issues: "issues"
+    login:
+      already_have_login_and_password: "Already have login and password?"
+      did_not_receive_confirmation_email: "Did not receive confirmation email?"
+      forgot_your_password: "Forgot your password?"
+      or_browse_for: "or browse for"
+      remember_me: "Remember me"
+      resend_confirmation_instructions: "Resend confirmation instructions"
+      send_again: "Send again"
+      sign_in: "Sign in"
+      username_or_email: "Username or Email"
+    merge_requests:
+      list_of_all_merge_requests: "List all merge requests from all projects you have access to."
+      merge_requests: "Merge Requests"
+      merge_requests_no: "%{count} merge requests"
+      nothing_here: "No merge requests to show"
+      total_count__merge_requests: "merge requests"
+    panel:
+      admin_area: "Admin area"
+      logout: "Logout"
+      my_snippets: "My snippets"
+      new_project: "New project"
+      profile_settings: "Profile settings"
+      public_area: "Public area"
+      user_activity: "User activity"
+    profile:
+      bio: "Bio"
+      bio_description: "Tell us about yourself in fewer than 250 characters."
+      email: "Email"
+      email_for_avatar_detection: "We also use email for avatar detection if no avatar is uploaded."
+      enter_you_name: "Enter your name, so people you know can recognize you."
+      name: "Name"
+      profile_settings: "Profile settings"
+      save_changes: "Save changes"
+      this_information_appears_on_your_profile: "This information appears on your profile."
+      website: "Website"
+      account:
+        account_settings: "Account settings"
+        are_you_sure: "Are you sure?"
+        keep_it_secret: "Keep it secret!"
+        path_change_msg: "Changing your username will change path to all personal projects!"
+        private_token: "Private token"
+        reset: "Reset"
+        save_username: "Save username"
+        token_desc_1: "Your private token is used to access application resources without authentication."
+        token_desc_2: "It can be used for atom feeds or the API."
+        username: "Username"
+        you_can_change_username_here: "You can change your username and private token here."
+      password:
+        change_your_password_description: "Change your password or recover your current one."
+        current_password: "Current password"
+        must_provide_current_password: "You must provide current password in order to change it."
+        new_password: "New password"
+        password_confirmation: "Password confirmation"
+        save_password: "Save password"
+        title: "Password"
+        you_will_be_redirected_to_login_page: "After a successful password update you will be redirected to login page where you should login with your new password"
+      menu:
+        account: "Account"
+        design: "Design"
+        groups: "Groups"
+        history: "History"
+        notifications: "Notifications"
+        password: "Password"
+        ssh_keys: "SSH Keys"
+      notifications:
+        advanced_notifications_settings: "Advanced notifications settings:"
+        disabled: "Disabled"
+        disabled_description: "You will not get any notifications via email"
+        groups: "Groups:"
+        notifications_description: "GitLab uses the email specified in your profile for notifications"
+        notifications_settings: "Notifications settings"
+        participating: "Participating"
+        participating_description: "You will only receive notifications from related resources (e.g. from your commits or assigned issues)"
+        projects: "Projects:"
+        watch: "Watch"
+        watch_description: "You will receive all notifications from projects in which you participate"
+      ssh_keys:
+        add_key: "Add key"
+        add_ssh_key: "Add SSH Key"
+        add_ssh_key: "Add an SSH Key"
+        cancel: "Cancel"
+        desc1: "SSH keys allow you to establish a secure connection between your computer and GitLab"
+        desc2: "Before you can add an SSH key you need to"
+        generate_it: "generate it"
+        key: "Key"
+        my_ssh_keys: "My SSH keys"
+        no_ssh_keys: "There are no SSH keys with access to your account."
+        paste_your_public_key_here: "Paste your public key here. Read more about how to generate a key on"
+        ssh_help_page: "the SSH help page"
+        ssh_keys: "SSH Keys"
+        title: "Title"
+      design:
+        appearance_settings_description: "Appearance settings saved to your profile and available across all devices"
+        application_theme: "Application theme"
+        code_review_theme: "Code preview theme"
+        my_appearance_settings: "My appearance settings"
+        themes:
+          classic: "Classic"
+          default: "Default"
+          gray: "Gray"
+          modern: "Modern"
+          violet: "Violet"
+    projects:
+      all_projects_you_have_access_to_are_listed_here: "All projects you have access to are listed here. Public projects are not included here unless you are a member"
+      create_a_group: "Create a group"
+      create_project: "Create project"
+      customize_directory_name: "Customize repository name?"
+      description: "Description"
+      description_example: "Awesome project"
+      example_project: "Example Project"
+      filter_by_name: "Filter by name"
+      import_existing_repository: "Import existing repository"
+      import_existing_repository_question: "Import existing repository?"
+      my_projects: "My Projects"
+      namespace: "Namespace"
+      need_a_group_for_dependent_projects: "Need a group for several dependent projects?"
+      new_project: "New Project"
+      no_public_projects: "No public projects"
+      optional: "(optional)"
+      project_name: "Project name"
+      projects: "Projects"
+      public_projects: "Public Projects"
+      public_projects_read_only: "You can browse public projects in read-only mode until signed in."
+      repository_name: "Repository name"
+      url_must_be_cloneable: "URL must be cloneable"
+      filter:
+        all: "All"
+        everyones: "Everyone's"
+        joined: "Joined"
+        owned: "Owned"
+        personal: "Personal"
+    search:
+      search: "Search"
+      search_in_this_group: "Search in this group"
+      search_in_this_project: "Search in this project"
+    snippets:
+      access: "Access"
+      add_new_snippet: "Add new snippet"
+      are_you_sure: "Are you sure?"
+      cancel: "Cancel"
+      create_snippet: "Create snippet"
+      delete: "Delete"
+      delete_snippet: "Delete Snippet"
+      description: "Share code pastes with others out of git repository"
+      discover_snippets: "Discover snippets"
+      edit: "Edit"
+      edit_snippet: "Edit Snippet"
+      edit_title: "Edit Snippet"
+      example_filename: "example.rb"
+      example_snippet: "Example Snippet"
+      file: "File"
+      my_snippets: "My Snippets"
+      new_snippet: "New Snippet"
+      private: "Private (only you can see this snippet)"
+      public: "Public (GitLab users can see this snippet)"
+      public_snippets: "Public snippets"
+      public_snippets_description: "Public snippets created by you and other users are listed here"
+      raw: "Raw"
+      remove: "Remove"
+      remove_snippet_warning: "Removed snippet cannot be restored! Are you sure?"
+      save: "Save"
+      snippets: "Snippets"
+      title: "Title"
+    sort:
+      last_updated: "Last updated"
+      name: "Name"
+      newest: "Newest"
+      oldest: "Oldest"
+      recently_updated: "Recently updated"
+    users:
+      edit_profile_settings: "Edit Profile settings"
+      member_since: "Member since"
+      profile: "Profile"
+      user_activity: "User Activity"
+    visibility:
+      internal: "Internal"
+      private: "Private"
+      public: "Public"
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: ! '%Y-%m-%d'
+      long: ! '%B %d, %Y'
+      short: ! '%b %d'
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_days:
+        one: 1 day
+        other: ! '%{count} days'
+      x_minutes:
+        one: 1 minute
+        other: ! '%{count} minutes'
+      x_months:
+        one: 1 month
+        other: ! '%{count} months'
+      x_seconds:
+        one: 1 second
+        other: ! '%{count} seconds'
+    prompts:
+      day: Day
+      hour: Hour
+      minute: Minute
+      month: Month
+      second: Seconds
+      year: Year
+  errors: &errors
+    format: ! '%{attribute} %{message}'
     messages:
-      wrong_size: "is the wrong size (should be %{file_size})"
-      size_too_small: "is too small (should be at least %{file_size})"
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: ! "doesn't match %{attribute}"
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      present: must be blank
+      record_invalid: ! 'Validation failed: %{errors}'
       size_too_big: "is too big (should be at most %{file_size})"
+      size_too_small: "is too small (should be at least %{file_size})"
+      wrong_size: "is the wrong size (should be %{file_size})"
+      restrict_dependent_destroy:
+        one: "Cannot delete record because a dependent %{record} exists"
+        many: "Cannot delete record because dependent %{record} exist"
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+      other_than: "must be other than %{count}"
+    template:
+      body: ! 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: ! '%{count} errors prohibited this %{model} from being saved'
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ! ','
+        format: ! '%u%n'
+        precision: 2
+        separator: .
+        significant: false
+        strip_insignificant_zeros: false
+        unit: $
+    format:
+      delimiter: ! ','
+      precision: 3
+      separator: .
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: ! '%n %u'
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: ! '%n %u'
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ! ', and '
+      two_words_connector: ! ' and '
+      words_connector: ! ', '
+  time:
+    am: am
+    formats:
+      default: ! '%a, %d %b %Y %H:%M:%S %z'
+      long: ! '%B %d, %Y %H:%M'
+      short: ! '%d %b %H:%M'
+    pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors


### PR DESCRIPTION
Hi,
as per #692, this is an approach to add internationalization support to GitLab.
Not all pages are yet translated, most notably admin and help pages, but this can be done later.
I'm willing to maintain translation is a separate repository and, as it was suggested, use Transifex to collect translations.
As to concerns that this could slow down development I think this won't be the case if only English version will be supported, additionally it will simplify scenarios where a helper method was used to repeat the same message.
