### PR TITLE
Added option to remove issue assignee on project issue page and issue ed...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ v 6.7.0
   - Piwik Integration (Sebastian Winkler)
   - Show contribution guide link for new issue form (Jeroen van Baarsen)
   - Fix CI status for merge requests from fork 
+  - Added option to remove issue assignee on project issue page and issue edit page (Jason Blanchard)
 
 v 6.6.2
   - Fix 500 error on branch/tag create or remove via UI

--- a/app/assets/javascripts/project_users_select.js.coffee
+++ b/app/assets/javascripts/project_users_select.js.coffee
@@ -10,6 +10,16 @@
         query: (query) ->
           Api.projectUsers project_id, query.term, (users) ->
             data = { results: users }
+
+            nullUser = {
+              name: 'Unassigned',
+              avatar: null,
+              username: 'none',
+              id: ''
+            }
+
+            data.results.unshift(nullUser)
+
             query.callback(data)
 
         initSelection: (element, callback) ->
@@ -35,8 +45,13 @@
     else
       avatar = gon.relative_url_root + "/assets/no_avatar.png"
 
+    if user.id == ''
+      avatarMarkup = ''
+    else
+      avatarMarkup = "<div class='user-image'><img class='avatar s24' src='#{avatar}'></div>"
+
     "<div class='user-result'>
-       <div class='user-image'><img class='avatar s24' src='#{avatar}'></div>
+       #{avatarMarkup}
        <div class='user-name'>#{user.name}</div>
        <div class='user-username'>#{user.username}</div>
      </div>"

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -43,6 +43,31 @@ describe "Issues" do
         page.should have_content project.name
       end
     end
+
+  end
+
+  describe "Editing issue assignee" do
+    let!(:issue) do
+      create(:issue,
+             author: @user,
+             assignee: @user,
+             project: project)
+    end
+
+    it 'allows user to select unasigned', :js => true do
+      visit edit_project_issue_path(project, issue)
+
+      page.should have_content "Assign to #{@user.name}"
+
+      page.first('#s2id_issue_assignee_id').click
+      sleep 2 # wait for ajax stuff to complete
+      page.first('.user-result').click
+
+      click_button "Save changes"
+
+      page.should have_content "Assignee: Select assignee"
+      issue.reload.assignee.should be_nil
+    end
   end
 
   describe "Filter issue" do
@@ -243,6 +268,28 @@ describe "Issues" do
 
         visit project_issue_path(project, issue)
         page.should have_content milestone.title
+      end
+    end
+
+    describe 'removing assignee' do
+      let(:user2) { create(:user) }
+
+      before :each do
+        issue.assignee = user2
+        issue.save
+      end
+
+      it 'allows user to remove assignee', :js => true do
+        visit project_issue_path(project, issue)
+        page.should have_content "Assignee: #{user2.name}"
+
+        page.first('#s2id_issue_assignee_id').click
+        sleep 2 # wait for ajax stuff to complete
+        page.first('.user-result').click
+
+        page.should have_content "Assignee: Unassigned"
+        sleep 2 # wait for ajax stuff to complete
+        issue.reload.assignee.should be_nil
       end
     end
   end


### PR DESCRIPTION
This adds an 'Unassigned' option to the assignee drop down menu on the issue page and edit issue page so that users can remove an assignee from the issue.

![screen shot 2014-03-02 at 1 08 40 pm](https://f.cloud.github.com/assets/1238532/2304810/6649bb4a-a236-11e3-90a0-c84101780140.png)

The implementation inserts a null user into the users select list with an empty ID. Selecting this user sets the issue assignee to `nil`.
