### PR TITLE
Fix registration error info typo

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -249,7 +249,7 @@ class User < ActiveRecord::Base
   def namespace_uniq
     namespace_name = self.username
     if Namespace.find_by(path: namespace_name)
-      self.errors.add :username, "already exist"
+      self.errors.add :username, "already exists"
     end
   end
 


### PR DESCRIPTION
"Username already exist" is incorrect. This PR corrects the text to "Username already exists".
