### PR TITLE
Add .adoc file extension for AsciiDoc

### DIFF
--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -40,7 +40,7 @@ module TreeHelper
   # Returns boolean
   def markup?(filename)
     filename.downcase.end_with?(*%w(.textile .rdoc .org .creole
-                                    .mediawiki .rst .asciidoc .pod))
+                                    .mediawiki .rst .adoc .asciidoc .pod))
   end
 
   def gitlab_markdown?(filename)


### PR DESCRIPTION
Add .adoc file extension for AsciiDoc as it's a very popular extension to use and the one recommended by the Asciidoctor project.
