### PR TITLE
Fixed readme title

### DIFF
--- a/app/views/projects/tree/_readme.html.haml
+++ b/app/views/projects/tree/_readme.html.haml
@@ -1,7 +1,7 @@
 .readme-holder#README
   %h4.readme-file-title
     %i.icon-file
-      = readme.name
+    = readme.name
   .wiki
     - if gitlab_markdown?(readme.name)
       = preserve do


### PR DESCRIPTION
On the Files tab, the Readme view incorrectly renders the readme's title inside of the `<i>` tag, which causes the text to render in the FontAwesome font, looking quite silly. This PR fixes that.
