### PR TITLE
Allow underscore as the first char for project names.

### DIFF
--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -7,7 +7,7 @@ module Gitlab
     end
 
     def project_name_regex
-      /\A[a-zA-Z0-9][a-zA-Z0-9_\-\. ]*\z/
+      /\A[a-zA-Z0-9_][a-zA-Z0-9_\-\. ]*\z/
     end
 
     def name_regex
@@ -49,7 +49,7 @@ module Gitlab
     protected
 
     def default_regex
-      /\A[.?]?[a-zA-Z0-9][a-zA-Z0-9_\-\.]*(?<!\.git)\z/
+      /\A[.?]?[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*(?<!\.git)\z/
     end
   end
 end


### PR DESCRIPTION
Not sure if the default_regex really has to be expanded for this special use case. We tried to extend only the project_name_regex first, but that didn't help.
