### PR TITLE
Add envrc to git-ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ doc/code/*
 *.log
 public/uploads.*
 public/assets/
+.envrc


### PR DESCRIPTION
envrc files are created when you use direnv (Its recommended in
combination with spring, see: https://github.com/rails/spring#setup)
