### PR TITLE
reference to linguist-library for a list of supported syntax-highlighter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ v 6.7.0
   - Fix CI status for merge requests from fork 
   - Added option to remove issue assignee on project issue page and issue edit page (Jason Blanchard)
   - Converted all the help sections into markdown
+  - Added reference to linguist-library for supported syntax-highlighting
 
 v 6.6.2
   - Fix 500 error on branch/tag create or remove via UI

--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -494,3 +494,4 @@ Code above produces next output:
 * This document leveraged heavily from the [Markdown-Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 * The [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) at Daring Fireball is an excellent resource for a detailed explanation of standard markdown.
 * [Dillinger.io](http://dillinger.io) is a handy tool for testing standard markdown.
+* The Linguist-Library with a list of the supported syntax-highlighters (https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)


### PR DESCRIPTION
changed:   doc/markdown/markdown.md
- reference to linguist-library for a list of supported syntax-highlighter
