### PR TITLE
Respect custom gitlab_shell path in gitlab:gitlab_shell:check task

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -489,7 +489,7 @@ namespace :gitlab do
               "sudo -u #{gitlab_shell_ssh_user} ln -sf #{gitlab_shell_hook_file} #{project_hook_file}"
             )
             for_more_information(
-              "#{gitlab_shell_user_home}/gitlab-shell/support/rewrite-hooks.sh"
+              "#{gitlab_shell_path}/support/rewrite-hooks.sh"
             )
             fix_and_rerun
             next
@@ -513,7 +513,7 @@ namespace :gitlab do
     end
 
     def check_gitlab_shell_self_test
-      gitlab_shell_repo_base = File.expand_path('gitlab-shell', gitlab_shell_user_home)
+      gitlab_shell_repo_base = gitlab_shell_path
       check_cmd = File.expand_path('bin/check', gitlab_shell_repo_base)
       puts "Running #{check_cmd}"
       if system(check_cmd, chdir: gitlab_shell_repo_base)
@@ -559,8 +559,8 @@ namespace :gitlab do
     # Helper methods
     ########################
 
-    def gitlab_shell_user_home
-      File.expand_path("~#{Gitlab.config.gitlab_shell.ssh_user}")
+    def gitlab_shell_path
+      Gitlab.config.gitlab_shell.path
     end
 
     def gitlab_shell_version


### PR DESCRIPTION
Prior to this change, if a user customized the config value of
`gitlab_shell.path`, the check would ignore this value in favor of
`"~<gitlab_shell.ssh_user>/gitlab-shell/"` resulting in a failed check
when the configuration was otherwise valid.

Why?

I develop on OSX, and after a recent reformat I found it way more difficult to
get a development environment for Gitlab running than it should have been. I
finally found a workable solution that involved no virtual machines and no
additional dedicated user, but this minor change was necessary to facilitate
it. I'll be writing a blog post a bit later describing what I finally got set
up.

Unless this seriously breaks something else, a merge would be appreciated.

Thanks!

Before:

```
❯ be rake gitlab:gitlab_shell:check
Digest::Digest is deprecated; use Digest
Checking GitLab Shell ...

GitLab Shell version >= 1.7.9 ? ... OK (1.8.0)
Repo base directory exists? ... yes
Repo base directory is a symlink? ... no
Repo base owned by tsigo:tsigo? ... no
  User id for tsigo: 501. Groupd id for tsigo: group tsigo doesn't exist
  Try fixing it:
  sudo chown -R tsigo:tsigo tmp/repositories/
  For more information see:
  doc/install/installation.md in section "GitLab Shell"
  Please fix the error above and rerun the checks.
Repo base access is drwxrws---? ... yes
update hook up-to-date? ... yes
update hooks in repos are links: ...
Documentcloud / Underscore ... ok
Diaspora / Diaspora ... ok
Diaspora / Diaspora Project Site ... ok
Diaspora / Diaspora Client ... ok
Brightbox / Brightbox Cli ... ok
Brightbox / Puppet ... ok
Gitlabhq / Gitlabhq ... ok
Gitlabhq / Gitlab Ci ... ok
Gitlabhq / Gitlab Recipes ... ok
Gitlabhq / Gitlab Shell ... ok
Gitlabhq / Grack ... ok
Gitlabhq / Testme ... ok
Twitter / Flight ... ok
Twitter / Typeahead.Js ... ok
H5bp / Html5 Boilerplate ... ok
H5bp / Mobile Boilerplate ... ok
Administrator / gitlab-self ... repository is empty
Running /Users/tsigo/gitlab-shell/bin/check
gitlab-shell self-check failed
  Try fixing it:
  Make sure GitLab is running;
  Check the gitlab-shell configuration file:
  sudo -u tsigo -H editor /Users/tsigo/gitlab-shell/config.yml
  Please fix the error above and rerun the checks.

Checking GitLab Shell ... Finished
```

After:

```
❯ be rake gitlab:gitlab_shell:check
Digest::Digest is deprecated; use Digest
Checking GitLab Shell ...

GitLab Shell version >= 1.7.9 ? ... OK (1.8.0)
Repo base directory exists? ... yes
Repo base directory is a symlink? ... no
Repo base owned by tsigo:tsigo? ... no
  User id for tsigo: 501. Groupd id for tsigo: group tsigo doesn't exist
  Try fixing it:
  sudo chown -R tsigo:tsigo tmp/repositories/
  For more information see:
  doc/install/installation.md in section "GitLab Shell"
  Please fix the error above and rerun the checks.
Repo base access is drwxrws---? ... yes
update hook up-to-date? ... yes
update hooks in repos are links: ...
Documentcloud / Underscore ... ok
Diaspora / Diaspora ... ok
Diaspora / Diaspora Project Site ... ok
Diaspora / Diaspora Client ... ok
Brightbox / Brightbox Cli ... ok
Brightbox / Puppet ... ok
Gitlabhq / Gitlabhq ... ok
Gitlabhq / Gitlab Ci ... ok
Gitlabhq / Gitlab Recipes ... ok
Gitlabhq / Gitlab Shell ... ok
Gitlabhq / Grack ... ok
Gitlabhq / Testme ... ok
Twitter / Flight ... ok
Twitter / Typeahead.Js ... ok
H5bp / Html5 Boilerplate ... ok
H5bp / Mobile Boilerplate ... ok
Administrator / gitlab-self ... repository is empty
Running /Users/tsigo/Code/external/gitlab-shell/bin/check
Check GitLab API access: OK
Check directories and files:
    /Users/tsigo/Code/rails/gitlabhq/tmp/repositories/: OK
    /Users/tsigo/Code/external/gitlab-shell/authorized_keys: OK
Test redis-cli executable: redis-cli 2.8.7
Send ping to redis server: PONG
gitlab-shell self-check successful

Checking GitLab Shell ... Finished
```
