### PR TITLE
Popen (at least on OSX) expects an Array, not a String

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -255,7 +255,7 @@ namespace :gitlab do
     def check_redis_version
       print "Redis version >= 2.0.0? ... "
 
-      if run_and_match("redis-cli --version", /redis-cli 2.\d.\d/)
+      if run_and_match(%W(redis-cli --version), /redis-cli 2.\d.\d/)
         puts "yes".green
       else
         puts "no".red


### PR DESCRIPTION
This was causing the gitlab:check task to exit prematurely with the error
"System commands must be given as an array of strings."
