### PR TITLE
Fix internal LDAP documentation.

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -117,13 +117,13 @@ production: &base
 
   ## LDAP settings
   # You can inspect a sample of the LDAP users with login access by running:
-  #   bundle exec rake gitlab:ldap:check RAILS_ENV=production
+  #   sudo -u git -H bundle exec rake gitlab:ldap:check RAILS_ENV=production
   ldap:
     enabled: false
     host: '_your_ldap_server'
     base: '_the_base_where_you_search_for_users'
     port: 636
-    uid: 'sAMAccountName'
+    uid: 'sAMAccountName' # or 'uid' in some non-ActiveDirectory settings
     method: 'ssl' # "tls" or "ssl" or "plain"
     bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
     password: '_the_password_of_the_bind_user'


### PR DESCRIPTION
Updated recommended LDAP test command on line 120 to match `sudo`ing convention used earlier in this file and in the installation guide. The old command would give permission errors if not executed as user `git`. Also clarification to `uid` field as mentioned at https://github.com/patthoyts/gitlabhq/wiki/Setting-up-ldap-auth
