### PR TITLE
Natural version sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,7 @@ gem 'settingslogic'
 
 # Misc
 gem "foreman"
+gem 'version_sorter'
 
 # Cache
 gem "redis-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,6 +537,7 @@ GEM
       raindrops (~> 0.7)
     unicorn-worker-killer (0.4.2)
       unicorn (~> 4)
+    version_sorter (1.1.0)
     virtus (1.0.1)
       axiom-types (~> 0.0.5)
       coercible (~> 1.0)
@@ -662,4 +663,5 @@ DEPENDENCIES
   underscore-rails (~> 1.4.4)
   unicorn (~> 4.6.3)
   unicorn-worker-killer
+  version_sorter
   webmock

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,7 +89,7 @@ module ApplicationHelper
     "Never"
   end
 
-  def grouped_options_refs(destination = :tree)
+  def grouped_options_refs
     repository = @project.repository
 
     options = [

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,11 +94,10 @@ module ApplicationHelper
 
     options = [
       ["Branches", repository.branch_names],
-      ["Tags", repository.tag_names]
+      ["Tags",     VersionSorter.rsort(repository.tag_names)]
     ]
 
-    # If reference is commit id -
-    # we should add it to branch/tag selectbox
+    # If reference is commit id - we should add it to branch/tag selectbox
     if(@ref && !options.flatten.include?(@ref) &&
        @ref =~ /^[0-9a-zA-Z]{6,52}$/)
       options << ["Commit", [@ref]]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,7 +94,7 @@ module ApplicationHelper
 
     options = [
       ["Branches", repository.branch_names],
-      ["Tags",     VersionSorter.rsort(repository.tag_names)]
+      ["Tags", VersionSorter.rsort(repository.tag_names)]
     ]
 
     # If reference is commit id - we should add it to branch/tag selectbox

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -116,7 +116,45 @@ describe ApplicationHelper do
       allow(self).to receive(:request).and_return(double(:ssl? => false))
       gravatar_icon(user_email).should == gravatar_icon(user_email.upcase + " ")
     end
+  end
 
+  describe "grouped_options_refs" do
+    # Override Rails' grouped_options_for_select helper since HTML is harder to work with
+    def grouped_options_for_select(options, *args)
+      options
+    end
+
+    let(:options) { grouped_options_refs }
+
+    before do
+      # Must be an instance variable
+      @project = create(:project)
+    end
+
+    it "includes a list of branch names" do
+      options[0][0].should == 'Branches'
+      options[0][1].should include('master', 'stable')
+    end
+
+    it "includes a list of tag names" do
+      options[1][0].should == 'Tags'
+      options[1][1].should include('v0.9.4','v1.2.0')
+    end
+
+    it "includes a specific commit ref if defined" do
+      # Must be an instance variable
+      @ref = '2ed06dc41dbb5936af845b87d79e05bbf24c73b8'
+
+      options[2][0].should == 'Commit'
+      options[2][1].should == [@ref]
+    end
+
+    it "sorts tags in a natural order" do
+      # Stub repository.tag_names to make sure we get some valid testing data
+      expect(@project.repository).to receive(:tag_names).and_return(["v1.0.9", "v1.0.10", "v2.0", "v3.1.4.2", "v1.0.9a"])
+
+      options[1][1].should == ["v3.1.4.2", "v2.0", "v1.0.10", "v1.0.9a", "v1.0.9"]
+    end
   end
 
   describe "user_color_scheme_class" do


### PR DESCRIPTION
Requested on the feedback forum: http://goo.gl/vP9TyR and http://goo.gl/uYUXrw

Makes use of the [version_sorter](https://github.com/defunkt/version_sorter) gem, which uses a C extension, so it should be nice and speedy.

Additionally, the grouped_options_refs helper had zero tests, so I added some.
