### PR TITLE
[6.6] Fixes a bug with group member administration

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -240,6 +240,7 @@ class Ability
       can_manage = group_abilities(user, group).include?(:manage_group)
       if can_manage && (user != target_user)
         rules << :modify
+        rules << :destroy
       end
       if !group.last_owner?(user) && (can_manage || (user == target_user))
         rules << :destroy

--- a/features/group.feature
+++ b/features/group.feature
@@ -74,7 +74,7 @@ Feature: Groups
     When I visit group "Owned" members page
     Then I should see user "John Doe" in team list
     Then I should see user "Mary Jane" in team list
-    Then I should not see the "Remove User From Group" button for "Mary Jane"
+    Then I should not see the "Remove User From Group" button for "John Doe"
 
   @javascript
   Scenario: Guest should be able to remove himself from group


### PR DESCRIPTION
Group owners were not able to remove any users from their group if they were the only owner.

Pretty easy to reproduce.  Create a group then add someone else to it with any permissions except Owner.  Notice you will not be able to remove them.

This PR is into master, will open another for 6-6-stable if desired.
