### PR TITLE
Added rake task to add limits back in mysql

### DIFF
--- a/lib/tasks/migrate/add_limits_mysql.rake
+++ b/lib/tasks/migrate/add_limits_mysql.rake
@@ -1,0 +1,13 @@
+desc "GITLAB | Add limits to strings in mysql database"
+task add_limits_mysql: :environment do
+  puts "Adding limits to schema.rb for mysql"
+  LimitsToMysql.new.up
+end
+
+class LimitsToMysql < ActiveRecord::Migration
+  def up
+    change_column :merge_request_diffs, :st_commits, :text, limit: 65535
+    change_column :merge_request_diffs, :st_diffs, :text, limit: 65535
+    change_column :snippets, :content, :text, limit: 65535
+  end
+end

--- a/lib/tasks/migrate/add_limits_mysql.rake
+++ b/lib/tasks/migrate/add_limits_mysql.rake
@@ -6,8 +6,8 @@ end
 
 class LimitsToMysql < ActiveRecord::Migration
   def up
-    change_column :merge_request_diffs, :st_commits, :text, limit: 65535
-    change_column :merge_request_diffs, :st_diffs, :text, limit: 65535
-    change_column :snippets, :content, :text, limit: 65535
+    change_column :merge_request_diffs, :st_commits, :text, limit: 2147483647
+    change_column :merge_request_diffs, :st_diffs, :text, limit: 2147483647
+    change_column :snippets, :content, :text, limit: 2147483647
   end
 end


### PR DESCRIPTION
This rake task will add the limits for text field back, since postgres migrations will remove it!
