### PR TITLE
option to enable ldap only login screen

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+  - Added support for disabling standard login (only enabled authorization methods are displayed on the sign in page)
+
 v 6.7.0
   - Increased the example Nginx client_max_body_size from 5MB to 20MB, consider updating it manually on existing installations
   - Add support for Gemnasium as a Project Service (Olivier Gonzalez)
@@ -7,7 +9,7 @@ v 6.7.0
   - Blob and tree gfm links to anchors work
   - Piwik Integration (Sebastian Winkler)
   - Show contribution guide link for new issue form (Jeroen van Baarsen)
-  - Fix CI status for merge requests from fork 
+  - Fix CI status for merge requests from fork
   - Added option to remove issue assignee on project issue page and issue edit page (Jason Blanchard)
   - New page load indicator that includes a spinner that scrolls with the page
   - Converted all the help sections into markdown

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,20 +1,29 @@
 .login-box
   %h3.page-title Sign in
-  - if ldap_enabled?
-    %ul.nav.nav-tabs
-      %li.active
-        = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
-      %li
-        = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
-    .tab-content
-      %div#tab-ldap.tab-pane.active
-        = render partial: 'devise/sessions/new_ldap'
-      %div#tab-signin.tab-pane
-        = render partial: 'devise/sessions/new_base'
+  - if ldap_enabled? or gitlab_config.signin_enabled or Gitlab.config.omniauth.enabled
+    - if ldap_enabled? and gitlab_config.signin_enabled
+      %ul.nav.nav-tabs
+        %li.active
+          = link_to 'LDAP', '#tab-ldap', 'data-toggle' => 'tab'
+        %li
+          = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
+      .tab-content
+        %div#tab-ldap.tab-pane.active
+          = render partial: 'devise/sessions/new_ldap'
+        %div#tab-signin.tab-pane
+          = render partial: 'devise/sessions/new_base'
+
+    - elsif ldap_enabled?
+      = render partial: 'devise/sessions/new_ldap'
+
+    - elsif gitlab_config.signin_enabled
+      = render partial: 'devise/sessions/new_base'
+
+    = render 'devise/sessions/oauth_providers' if devise_mapping.omniauthable?
 
   - else
-    = render partial: 'devise/sessions/new_base'
-
+    %div
+      No authentication methods configured.
 
   = render 'devise/sessions/oauth_providers' if devise_mapping.omniauthable?
   %hr

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -54,8 +54,12 @@ production: &base
 
 
     ## Users management
-    # default: false - Account passwords are not sent via the email if signup is enabled. 
+    # default: false - Account passwords are not sent via the email if signup is enabled.
     # signup_enabled: true
+
+    ## Builtin standard user login system
+    # default: true - Allow standard login even LDAP or other auth mechanisms are enabled
+    # signin_enabled: true
 
     # Restrict setting visibility levels for non-admin users.
     # The default is to allow all levels.

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -87,6 +87,7 @@ rescue ArgumentError # no user configured
   '/home/' + Settings.gitlab['user']
 end
 Settings.gitlab['signup_enabled'] ||= false
+Settings.gitlab['signin_enabled'] ||= true
 Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant_array, Gitlab::VisibilityLevel, Settings.gitlab['restricted_visibility_levels'], [])
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['issue_closing_pattern'] = '([Cc]loses|[Ff]ixes) #(\d+)' if Settings.gitlab['issue_closing_pattern'].nil?


### PR DESCRIPTION
Re feature request #605, moved [here](http://feedback.gitlab.com/forums/176466-general/suggestions/3788023-only-allow-login-via-ldap).

Pull request #5492 started to implement support for disabling the
standard login screen when other auth mechanisms were enabled. It used a
fairly confusing name for the new config option and a request to rename
it went unanswered. Eventually the PR was closed.

This should give it a much more self explanatory name and moves it to
the requested location in the configs. The original commit was rebased on master and another was added to give the setting a decent name.
