### PR TITLE
Show link to public projects for new users.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -22,6 +22,8 @@ class DashboardController < ApplicationController
 
     @last_push = current_user.recent_push
 
+    @publicish_project_count = Project.publicish(current_user).count
+
     respond_to do |format|
       format.html
       format.json { pager_json("events/_events", @events.count) }

--- a/app/views/dashboard/_zero_authorized_projects.html.haml
+++ b/app/views/dashboard/_zero_authorized_projects.html.haml
@@ -34,3 +34,18 @@
         = link_to new_group_path, class: "btn btn-new" do
           New group »
 
+-if @publicish_project_count > 0
+  %hr
+  %div
+    .dashboard-intro-icon
+      %i.icon-globe
+    %div
+      %p.slead
+        There are
+        %strong= @publicish_project_count
+        public projects on this server.
+        %br
+        Public projects are an easy way to allow everyone to have read-only access.
+      .link_holder
+        = link_to public_projects_path, class: "btn btn-new" do
+          Browse public projects »


### PR DESCRIPTION
Fixes ACCEPTING MR at http://feedback.gitlab.com/forums/176466-general/suggestions/5486270-show-link-to-public-projects-for-new-users

UI changes absolutely identical to the proposed ones: http://feedback.gitlab.com/assets/72153275/gitlab-welcome-public.PNG

If you require tests for this I will provide them.
