### PR TITLE
Speed up features/notes_on_merge_requests_spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color --drb
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,6 @@ group :development, :test do
   # PhantomJS driver for Capybara
   gem 'poltergeist', '~> 1.4.1'
 
-  gem 'spork', '~> 1.0rc'
   gem 'jasmine', '2.0.0.rc5'
 
   gem "spring", '1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,6 @@ GEM
       capybara (>= 2.0.0)
       railties (>= 3)
       spinach (>= 0.4)
-    spork (1.0.0rc4)
     spring (1.1.1)
     spring-commands-rspec (1.0.1)
       spring (>= 0.9.1)
@@ -654,7 +653,6 @@ DEPENDENCIES
   six
   slim
   spinach-rails
-  spork (~> 1.0rc)
   spring (= 1.1.1)
   spring-commands-rspec (= 1.0.1)
   spring-commands-spinach (= 1.0.0)

--- a/app/finders/base_finder.rb
+++ b/app/finders/base_finder.rb
@@ -47,9 +47,9 @@ class BaseFinder
         []
       end
     elsif current_user && params[:authorized_only].presence
-      klass.of_projects(current_user.authorized_projects)
+      klass.of_projects(current_user.authorized_projects).references(:project)
     else
-      klass.of_projects(Project.accessible_to(current_user))
+      klass.of_projects(Project.accessible_to(current_user)).references(:project)
     end
   end
 

--- a/app/models/merge_request_diff.rb
+++ b/app/models/merge_request_diff.rb
@@ -13,7 +13,7 @@ class MergeRequestDiff < ActiveRecord::Base
 
   delegate :target_branch, :source_branch, to: :merge_request, prefix: nil
 
-  state_machine :state, initial: :empty do
+  state_machine :state, initial: :collected do
     state :collected
     state :timeout
     state :overflow_commits_safe_size

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -146,6 +146,11 @@ FactoryGirl.define do
       state :reopened
     end
 
+    trait :simple do
+      source_branch "simple_merge_request"
+      target_branch "master"
+    end
+
     factory :closed_merge_request, traits: [:closed]
     factory :reopened_merge_request, traits: [:reopened]
     factory :merge_request_with_diffs, traits: [:with_diffs]
@@ -161,7 +166,6 @@ FactoryGirl.define do
     factory :note_on_issue, traits: [:on_issue], aliases: [:votable_note]
     factory :note_on_merge_request, traits: [:on_merge_request]
     factory :note_on_merge_request_diff, traits: [:on_merge_request, :on_diff]
-    factory :note_on_merge_request_with_attachment, traits: [:on_merge_request, :with_attachment]
 
     trait :on_commit do
       project factory: :project

--- a/spec/features/notes_on_merge_requests_spec.rb
+++ b/spec/features/notes_on_merge_requests_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
 describe "On a merge request", js: true do
-  let!(:project) { create(:project) }
-  let!(:merge_request) { create(:merge_request, source_project: project, target_project: project) }
-  let!(:note) { create(:note_on_merge_request_with_attachment,  project: project) }
+  let!(:merge_request) { create(:merge_request, :simple) }
+  let!(:project) { merge_request.source_project }
+  let!(:note) { create(:note_on_merge_request, :with_attachment, project: project) }
 
   before do
-    login_as :user
-    project.team << [@user, :master]
-
+    login_as :admin
     visit project_merge_request_path(project, merge_request)
   end
 
@@ -134,22 +132,20 @@ describe "On a merge request", js: true do
   end
 end
 
-describe "On a merge request diff", js: true, focus: true do
-  let!(:project) { create(:project) }
-  let!(:merge_request) { create(:merge_request_with_diffs, source_project: project, target_project: project) }
+describe "On a merge request diff", js: true do
+  let(:merge_request) { create(:merge_request, :with_diffs, :simple) }
+  let(:project) { merge_request.source_project }
 
   before do
-    login_as :user
-    project.team << [@user, :master]
+    login_as :admin
     visit diffs_project_merge_request_path(project, merge_request)
   end
-
 
   subject { page }
 
   describe "when adding a note" do
     before do
-      find('a[data-line-code="4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185"]').click
+      find('a[data-line-code="8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7"]').click
     end
 
     describe "the notes holder" do
@@ -160,13 +156,13 @@ describe "On a merge request diff", js: true, focus: true do
 
     describe "the note form" do
       it "shouldn't add a second form for same row" do
-        find('a[data-line-code="4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185"]').click
+        find('a[data-line-code="8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7"]').click
 
-        should have_css("tr[id='4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185'] + .js-temp-notes-holder form", count: 1)
+        should have_css("tr[id='8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7'] + .js-temp-notes-holder form", count: 1)
       end
 
       it "should be removed when canceled" do
-        within(".diff-file form[rel$='4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185']") do
+        within(".diff-file form[rel$='8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7']") do
           find(".js-close-discussion-note-form").trigger("click")
         end
 
@@ -176,12 +172,9 @@ describe "On a merge request diff", js: true, focus: true do
   end
 
   describe "with muliple note forms" do
-    let!(:project) { create(:project) }
-    let!(:merge_request) { create(:merge_request_with_diffs, source_project: project, target_project: project) }
-
     before do
-      find('a[data-line-code="4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185"]').click
-      find('a[data-line-code="342e16cbbd482ac2047dc679b2749d248cc1428f_18_17"]').click
+      find('a[data-line-code="8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7"]').click
+      find('a[data-line-code="8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_10_10"]').click
     end
 
     it { should have_css(".js-temp-notes-holder", count: 2) }
@@ -189,12 +182,12 @@ describe "On a merge request diff", js: true, focus: true do
     describe "previewing them separately" do
       before do
         # add two separate texts and trigger previews on both
-        within("tr[id='4735dfc552ad7bf15ca468adc3cad9d05b624490_172_185'] + .js-temp-notes-holder") do
-          fill_in "note[note]", with: "One comment on line 185"
+        within("tr[id='8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_7_7'] + .js-temp-notes-holder") do
+          fill_in "note[note]", with: "One comment on line 7"
           find(".js-note-preview-button").trigger("click")
         end
-        within("tr[id='342e16cbbd482ac2047dc679b2749d248cc1428f_18_17'] + .js-temp-notes-holder") do
-          fill_in "note[note]", with: "Another comment on line 17"
+        within("tr[id='8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_10_10'] + .js-temp-notes-holder") do
+          fill_in "note[note]", with: "Another comment on line 10"
           find(".js-note-preview-button").trigger("click")
         end
       end
@@ -202,14 +195,14 @@ describe "On a merge request diff", js: true, focus: true do
 
     describe "posting a note" do
       before do
-        within("tr[id='342e16cbbd482ac2047dc679b2749d248cc1428f_18_17'] + .js-temp-notes-holder") do
-          fill_in "note[note]", with: "Another comment on line 17"
+        within("tr[id='8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_10_10'] + .js-temp-notes-holder") do
+          fill_in "note[note]", with: "Another comment on line 10"
           click_button("Add Comment")
         end
       end
 
       it 'should be added as discussion' do
-        should have_content("Another comment on line 17")
+        should have_content("Another comment on line 10")
         should have_css(".notes_holder")
         should have_css(".notes_holder .note", count: 1)
         should have_link("Reply")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,63 +1,50 @@
-require 'rubygems'
-require 'spork'
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV["RAILS_ENV"] ||= 'test'
+require File.expand_path("../../config/environment", __FILE__)
 
-Spork.prefork do
-  require 'simplecov' unless ENV['CI']
+require 'simplecov' unless ENV['CI']
 
-  if ENV['TRAVIS']
-    require 'coveralls'
-    Coveralls.wear!
-  end
-
-  # This file is copied to spec/ when you run 'rails generate rspec:install'
-  ENV["RAILS_ENV"] ||= 'test'
-  require File.expand_path("../../config/environment", __FILE__)
-  require 'rspec/rails'
-  require 'capybara/rails'
-  require 'capybara/rspec'
-  require 'webmock/rspec'
-  require 'email_spec'
-  require 'sidekiq/testing/inline'
-  require 'capybara/poltergeist'
-
-  # Loading more in this block will cause your tests to run faster. However,
-
-  # if you change any configuration or code from libraries loaded here, you'll
-  # need to restart spork for it take effect.
-  Capybara.javascript_driver = :poltergeist
-  Capybara.default_wait_time = 10
-
-  # Requires supporting ruby files with custom matchers and macros, etc,
-  # in spec/support/ and its subdirectories.
-  Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
-  WebMock.disable_net_connect!(allow_localhost: true)
-
-  RSpec.configure do |config|
-    config.mock_with :rspec
-
-    config.include LoginHelpers, type: :feature
-    config.include LoginHelpers, type: :request
-    config.include FactoryGirl::Syntax::Methods
-    config.include Devise::TestHelpers, type: :controller
-
-    config.include TestEnv
-
-    # If you're not using ActiveRecord, or you'd prefer not to run each of your
-    # examples within a transaction, remove the following line or assign false
-    # instead of true.
-    config.use_transactional_fixtures = false
-
-    config.before(:suite) do
-      TestEnv.init(observers: false, init_repos: true, repos: false)
-    end
-    config.before(:each) do
-      TestEnv.setup_stubs
-    end
-  end
+if ENV['TRAVIS']
+  require 'coveralls'
+  Coveralls.wear!
 end
 
-Spork.each_run do
-  # This code will be run each time you run your specs.
+require 'rspec/rails'
+require 'capybara/rails'
+require 'capybara/rspec'
+require 'webmock/rspec'
+require 'email_spec'
+require 'sidekiq/testing/inline'
+require 'capybara/poltergeist'
 
+Capybara.javascript_driver = :poltergeist
+Capybara.default_wait_time = 10
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+
+  config.include LoginHelpers, type: :feature
+  config.include LoginHelpers, type: :request
+  config.include FactoryGirl::Syntax::Methods
+  config.include Devise::TestHelpers, type: :controller
+
+  config.include TestEnv
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    TestEnv.init(observers: false, init_repos: true, repos: false)
+  end
+  config.before(:each) do
+    TestEnv.setup_stubs
+  end
 end


### PR DESCRIPTION
This spec featured the slowest tests in the entire suite. After some debugging,
the cause was found to be the large commit diff generated by comparing the
stable and master branches.

To fix this, the seed repository was modified to create a simple branch off of
master that consists of three simple commits and minor changes. The spec was
then updated to compare master to this branch instead of stable. The result is
a spec group that runs in under 30 seconds, down from about 90.

For a good visual, [this image](https://s3.amazonaws.com/f.cl.ly/items/3P1D2U3L301g2N1b3U1o/screenshot.png) is what was being rendered on every single
spec, and [this](https://s3.amazonaws.com/f.cl.ly/items/2H0s2F3c1J0D0J1o0M2F/screenshot2.png) is what it is now.
