### PR TITLE
Visibility traits for Project Factory

### DIFF
--- a/features/steps/project/redirects.rb
+++ b/features/steps/project/redirects.rb
@@ -4,7 +4,7 @@ class Spinach::Features::ProjectRedirects < Spinach::FeatureSteps
   include SharedProject
 
   step 'public project "Community"' do
-    create :project, name: 'Community', visibility_level: Gitlab::VisibilityLevel::PUBLIC
+    create :project, :public, name: 'Community'
   end
 
   step 'private project "Enterprise"' do

--- a/features/steps/public/projects.rb
+++ b/features/steps/public/projects.rb
@@ -4,7 +4,7 @@ class Spinach::Features::PublicProjectsFeature < Spinach::FeatureSteps
   include SharedProject
 
   step 'public empty project "Empty Public Project"' do
-    create :empty_project, name: 'Empty Public Project', visibility_level: Gitlab::VisibilityLevel::PUBLIC
+    create :empty_project, :public, name: 'Empty Public Project'
   end
 
   step 'I should see project "Empty Public Project"' do

--- a/features/steps/shared/project.rb
+++ b/features/steps/shared/project.rb
@@ -79,7 +79,7 @@ module SharedProject
   end
 
   step 'internal project "Internal"' do
-    create :project, name: 'Internal', visibility_level: Gitlab::VisibilityLevel::INTERNAL
+    create :project, :internal, name: 'Internal'
   end
 
   step 'I should see project "Internal"' do
@@ -91,7 +91,7 @@ module SharedProject
   end
 
   step 'public project "Community"' do
-    create :project, name: 'Community', visibility_level: Gitlab::VisibilityLevel::PUBLIC
+    create :project, :public, name: 'Community'
   end
 
   step 'I should see project "Community"' do
@@ -112,14 +112,14 @@ module SharedProject
   step '"John Doe" is authorized to internal project "Internal"' do
     user = user_exists("John Doe", username: "john_doe")
     project = Project.find_by(name: "Internal")
-    project ||= create :project, name: 'Internal', visibility_level: Gitlab::VisibilityLevel::INTERNAL
+    project ||= create :project, :internal, name: 'Internal'
     project.team << [user, :master]
   end
 
   step '"John Doe" is authorized to public project "Community"' do
     user = user_exists("John Doe", username: "john_doe")
     project = Project.find_by(name: "Community")
-    project ||= create :project, name: 'Community', visibility_level: Gitlab::VisibilityLevel::PUBLIC
+    project ||= create :project, :public, name: 'Community'
     project.team << [user, :master]
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -32,6 +32,18 @@ FactoryGirl.define do
     path { name.downcase.gsub(/\s/, '_') }
     namespace
     creator
+
+    trait :public do
+      visibility_level Gitlab::VisibilityLevel::PUBLIC
+    end
+
+    trait :internal do
+      visibility_level Gitlab::VisibilityLevel::INTERNAL
+    end
+
+    trait :private do
+      visibility_level Gitlab::VisibilityLevel::PRIVATE
+    end
   end
 
   # Generates a test repository from the repository stored under `spec/seed_project.tar.gz`.

--- a/spec/features/security/group/internal_group_access_spec.rb
+++ b/spec/features/security/group/internal_group_access_spec.rb
@@ -16,7 +16,7 @@ describe "Group with internal project access" do
       group.add_user(reporter, Gitlab::Access::REPORTER)
       group.add_user(guest, Gitlab::Access::GUEST)
 
-      create(:project, group: group, visibility_level: Gitlab::VisibilityLevel::INTERNAL)
+      create(:project, :internal, group: group)
     end
 
     describe "GET /groups/:path" do

--- a/spec/features/security/group/mixed_group_access_spec.rb
+++ b/spec/features/security/group/mixed_group_access_spec.rb
@@ -16,8 +16,8 @@ describe "Group access" do
       group.add_user(reporter, Gitlab::Access::REPORTER)
       group.add_user(guest, Gitlab::Access::GUEST)
 
-      create(:project, path: "internal_project", group: group, visibility_level: Gitlab::VisibilityLevel::INTERNAL)
-      create(:project, path: "public_project", group: group, visibility_level: Gitlab::VisibilityLevel::PUBLIC)
+      create(:project, :internal, path: "internal_project", group: group)
+      create(:project, :public, path: "public_project", group: group)
     end
 
     describe "GET /groups/:path" do

--- a/spec/features/security/group/public_group_access_spec.rb
+++ b/spec/features/security/group/public_group_access_spec.rb
@@ -16,7 +16,7 @@ describe "Group with public project access" do
       group.add_user(reporter, Gitlab::Access::REPORTER)
       group.add_user(guest, Gitlab::Access::GUEST)
 
-      create(:project, group: group, visibility_level: Gitlab::VisibilityLevel::PUBLIC)
+      create(:project, :public, group: group)
     end
 
     describe "GET /groups/:path" do

--- a/spec/features/security/project/internal_access_spec.rb
+++ b/spec/features/security/project/internal_access_spec.rb
@@ -1,23 +1,18 @@
 require 'spec_helper'
 
 describe "Internal Project Access" do
-  let(:project) { create(:project) }
+  let(:project) { create(:project, :internal) }
 
   let(:master) { create(:user) }
   let(:guest) { create(:user) }
   let(:reporter) { create(:user) }
 
   before do
-    # internal project
-    project.visibility_level = Gitlab::VisibilityLevel::INTERNAL
-    project.save!
-
     # full access
     project.team << [master, :master]
 
     # readonly
     project.team << [reporter, :reporter]
-
   end
 
   describe "Project should be internal" do

--- a/spec/finders/projects_finder_spec.rb
+++ b/spec/finders/projects_finder_spec.rb
@@ -4,10 +4,10 @@ describe ProjectsFinder do
   let(:user) { create :user }
   let(:group) { create :group }
 
-  let(:project1) { create(:empty_project, group: group, visibility_level: Project::PUBLIC) }
-  let(:project2) { create(:empty_project, group: group, visibility_level: Project::INTERNAL) }
-  let(:project3) { create(:empty_project, group: group, visibility_level: Project::PRIVATE) }
-  let(:project4) { create(:empty_project, group: group, visibility_level: Project::PRIVATE) }
+  let(:project1) { create(:empty_project, :public,   group: group) }
+  let(:project2) { create(:empty_project, :internal, group: group) }
+  let(:project3) { create(:empty_project, :private,  group: group) }
+  let(:project4) { create(:empty_project, :private,  group: group) }
 
   context 'non authenticated' do
     subject { ProjectsFinder.new.execute(nil, group: group) }

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -133,7 +133,7 @@ describe API::API do
     end
 
     it "should set a project as public" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::PUBLIC })
+      project = attributes_for(:project, :public)
       post api("/projects", user), project
       json_response['public'].should be_true
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
@@ -147,21 +147,21 @@ describe API::API do
     end
 
     it "should set a project as internal" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::INTERNAL })
+      project = attributes_for(:project, :internal)
       post api("/projects", user), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
     end
 
     it "should set a project as internal overriding :public" do
-      project = attributes_for(:project, { public: true, visibility_level: Gitlab::VisibilityLevel::INTERNAL })
+      project = attributes_for(:project, :internal, { public: true })
       post api("/projects", user), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
     end
 
     it "should set a project as private" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::PRIVATE })
+      project = attributes_for(:project, :private)
       post api("/projects", user), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
@@ -215,7 +215,7 @@ describe API::API do
     end
 
     it "should set a project as public" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::PUBLIC })
+      project = attributes_for(:project, :public)
       post api("/projects/user/#{user.id}", admin), project
       json_response['public'].should be_true
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
@@ -229,21 +229,21 @@ describe API::API do
     end
 
     it "should set a project as internal" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::INTERNAL })
+      project = attributes_for(:project, :internal)
       post api("/projects/user/#{user.id}", admin), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
     end
 
     it "should set a project as internal overriding :public" do
-      project = attributes_for(:project, { public: true, visibility_level: Gitlab::VisibilityLevel::INTERNAL })
+      project = attributes_for(:project, :internal, { public: true })
       post api("/projects/user/#{user.id}", admin), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
     end
 
     it "should set a project as private" do
-      project = attributes_for(:project, { visibility_level: Gitlab::VisibilityLevel::PRIVATE })
+      project = attributes_for(:project, :private)
       post api("/projects/user/#{user.id}", admin), project
       json_response['public'].should be_false
       json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
@@ -490,10 +490,10 @@ describe API::API do
 
   describe :fork_admin do
     let(:project_fork_target) { create(:project) }
-    let(:project_fork_source) { create(:project, visibility_level: Gitlab::VisibilityLevel::PUBLIC) }
+    let(:project_fork_source) { create(:project, :public) }
 
     describe "POST /projects/:id/fork/:forked_from_id" do
-      let(:new_project_fork_source) { create(:project, visibility_level: Gitlab::VisibilityLevel::PUBLIC) }
+      let(:new_project_fork_source) { create(:project, :public) }
 
       it "shouldn't available for non admin users" do
         post api("/projects/#{project_fork_target.id}/fork/#{project_fork_source.id}", user)
@@ -562,10 +562,10 @@ describe API::API do
     let!(:post)             { create(:empty_project, name: "#{query}_post", creator_id: user.id, namespace: user.namespace) }
     let!(:pre_post)         { create(:empty_project, name: "pre_#{query}_post", creator_id: user.id, namespace: user.namespace) }
     let!(:unfound)          { create(:empty_project, name: 'unfound', creator_id: user.id, namespace: user.namespace) }
-    let!(:internal)         { create(:empty_project, name: "internal #{query}", visibility_level: Gitlab::VisibilityLevel::INTERNAL) }
-    let!(:unfound_internal) { create(:empty_project, name: 'unfound internal', visibility_level: Gitlab::VisibilityLevel::INTERNAL) }
-    let!(:public)           { create(:empty_project, name: "public #{query}", visibility_level: Gitlab::VisibilityLevel::PUBLIC) }
-    let!(:unfound_public)   { create(:empty_project, name: 'unfound public', visibility_level: Gitlab::VisibilityLevel::PUBLIC) }
+    let!(:internal)         { create(:empty_project, :internal, name: "internal #{query}") }
+    let!(:unfound_internal) { create(:empty_project, :internal, name: 'unfound internal') }
+    let!(:public)           { create(:empty_project, :public, name: "public #{query}") }
+    let!(:unfound_public)   { create(:empty_project, :public, name: 'unfound public') }
 
     context "when unauthenticated" do
       it "should return authentication error" do

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -1,28 +1,26 @@
 require 'spec_helper'
 
 describe 'Search::GlobalService' do
-  let(:found_namespace) { create(:namespace, name: 'searchable namespace', path:'another_thing') }
   let(:user) { create(:user, namespace: found_namespace) }
-  let!(:found_project) { create(:project, name: 'searchable_project', creator_id: user.id, namespace: found_namespace, visibility_level: Gitlab::VisibilityLevel::PRIVATE) }
-
-  let(:unfound_namespace) { create(:namespace, name: 'unfound namespace', path: 'yet_something_else') }
-  let!(:unfound_project) { create(:project, name: 'unfound_project', creator_id: user.id, namespace: unfound_namespace, visibility_level: Gitlab::VisibilityLevel::PRIVATE) }
-
-  let(:internal_namespace) { create(:namespace, path: 'something_internal',name: 'searchable internal namespace') }
-  let(:internal_user) { create(:user, namespace: internal_namespace) }
-  let!(:internal_project) { create(:project, name: 'searchable_internal_project', creator_id: internal_user.id, namespace: internal_namespace, visibility_level: Gitlab::VisibilityLevel::INTERNAL) }
-
-  let(:public_namespace) { create(:namespace, path: 'something_public',name: 'searchable public namespace') }
   let(:public_user) { create(:user, namespace: public_namespace) }
-  let!(:public_project) { create(:project, name: 'searchable_public_project', creator_id: public_user.id, namespace: public_namespace, visibility_level: Gitlab::VisibilityLevel::PUBLIC) }
+  let(:internal_user) { create(:user, namespace: internal_namespace) }
+
+  let(:found_namespace) { create(:namespace, name: 'searchable namespace', path:'another_thing') }
+  let(:unfound_namespace) { create(:namespace, name: 'unfound namespace', path: 'yet_something_else') }
+  let(:internal_namespace) { create(:namespace, name: 'searchable internal namespace', path: 'something_internal') }
+  let(:public_namespace) { create(:namespace, name: 'searchable public namespace', path: 'something_public') }
+
+  let!(:found_project) { create(:project, :private, name: 'searchable_project', creator_id: user.id, namespace: found_namespace) }
+  let!(:unfound_project) { create(:project, :private, name: 'unfound_project', creator_id: user.id, namespace: unfound_namespace) }
+  let!(:internal_project) { create(:project, :internal, name: 'searchable_internal_project', creator_id: internal_user.id, namespace: internal_namespace) }
+  let!(:public_project) { create(:project, :public, name: 'searchable_public_project', creator_id: public_user.id, namespace: public_namespace) }
 
   describe '#execute' do
     context 'unauthenticated' do
       it 'should return public projects only' do
         context = Search::GlobalService.new(nil, search: "searchable")
         results = context.execute
-        results[:projects].should have(1).items
-        results[:projects].should include(public_project)
+        results[:projects].should match_array [public_project]
       end
     end
 
@@ -30,24 +28,19 @@ describe 'Search::GlobalService' do
       it 'should return public, internal and private projects' do
         context = Search::GlobalService.new(user, search: "searchable")
         results = context.execute
-        results[:projects].should have(3).items
-        results[:projects].should include(public_project)
-        results[:projects].should include(found_project)
-        results[:projects].should include(internal_project)
+        results[:projects].should match_array [public_project, found_project, internal_project]
       end
 
       it 'should return only public & internal projects' do
         context = Search::GlobalService.new(internal_user, search: "searchable")
         results = context.execute
-        results[:projects].should have(2).items
-        results[:projects].should include(internal_project)
-        results[:projects].should include(public_project)
+        results[:projects].should match_array [internal_project, public_project]
       end
 
       it 'namespace name should be searchable' do
         context = Search::GlobalService.new(user, search: "searchable namespace")
         results = context.execute
-        results[:projects].should == [found_project]
+        results[:projects].should match_array [found_project]
       end
     end
   end


### PR DESCRIPTION
Adds three traits to the Project factory - public, private and internal, and
replaces all that ugly `visibility_level: Gitlab::VisibilityLevel::CONSTANT`
noise from factory creations. :grinning:
