### PR TITLE
Fix `/:username.keys` response content type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ v 6.7.0
   - Better API responses for access_levels (sponsored by O'Reilly Media)
   - Requires at least 2 unicorn workers
   - Requires gitlab-shell v1.9+
+  - Fix `/:username.keys` response content type (Dmitry Medvinsky)
 
 v 6.6.5
   - Added option to remove issue assignee on project issue page and issue edit page (Jason Blanchard)

--- a/app/controllers/profiles/keys_controller.rb
+++ b/app/controllers/profiles/keys_controller.rb
@@ -41,7 +41,7 @@ class Profiles::KeysController < ApplicationController
       begin
         user = User.find_by_username(params[:username])
         if user.present?
-          render text: user.all_ssh_keys.join("\n")
+          render text: user.all_ssh_keys.join("\n"), content_type: "text/plain"
         else
           render_404 and return
         end

--- a/spec/controllers/profile_keys_controller_spec.rb
+++ b/spec/controllers/profile_keys_controller_spec.rb
@@ -24,6 +24,11 @@ describe Profiles::KeysController do
 
         expect(response.body).to eq("")
       end
+
+      it "should respond with text/plain content type" do
+        get :get_keys, username: user.username
+        expect(response.content_type).to eq("text/plain")
+      end
     end
 
     describe "user with keys" do
@@ -43,6 +48,11 @@ describe Profiles::KeysController do
 
         expect(response.body).not_to eq("")
         expect(response.body).to eq(user.all_ssh_keys.join("\n"))
+      end
+
+      it "should respond with text/plain content type" do
+        get :get_keys, username: user.username
+        expect(response.content_type).to eq("text/plain")
       end
     end
   end


### PR DESCRIPTION
Currently this method responds with `text/html`. It is kind of unusable
if you open it in a browser. The browser thinks it is HTML and renders
it as HTML, meaning new lines are dropped. So it's very hard to
distinguish where the key starts and where it ends.

This commit changes the content type header to `text/plain`.
