### PR TITLE
Clearfix on .well-list

### DIFF
--- a/app/assets/stylesheets/generic/lists.scss
+++ b/app/assets/stylesheets/generic/lists.scss
@@ -13,6 +13,12 @@
     border-bottom: 1px solid #eee;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 
+    &:after {
+      content: " ";
+      display: table;
+      clear: both;
+    }
+
     &.disabled {
       color: #888;
     }


### PR DESCRIPTION
I noticed that on long issue titles, user & email combinations, group and project names elements would start to overlap.

Pages affected:
- admin/groups#show
- admin/projects#index
- admin/users#index (on small screens)
- dashboard/issues#index (on small screens)

Other pages that use the `.well-list` class don't seem to be affected by this modification.

The fix included applies a mini clearfix as described [here](http://nicolasgallagher.com/micro-clearfix-hack/).

The result would be as in the two screenshots below. Before/current left, this pull request right.

groups#show page:

![group-projects](https://f.cloud.github.com/assets/282402/2471886/2d9e4af4-b02d-11e3-9180-796592582d30.png)

Below is this is the users#index page. Although the buttons aren't aligned in the best possible way, this fix makes sure the buttons (float elements) are contained within their parent element.

![users](https://f.cloud.github.com/assets/282402/2471888/37db9f1c-b02d-11e3-900a-49fc4bc88af9.png)

Let me know what you think. I'll be happy to change things to make this merge-able.
