### PR TITLE
Remove periods from merge request

### DIFF
--- a/app/views/projects/merge_requests/show/_mr_box.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_box.html.haml
@@ -29,13 +29,13 @@
     %span
       %i.icon-remove
       Closed by #{link_to_member(@project, @merge_request.closed_event.author)}
-      #{time_ago_with_tooltip(@merge_request.closed_event.created_at)}.
+      #{time_ago_with_tooltip(@merge_request.closed_event.created_at)}
 - if @merge_request.merged?
   .alert.alert-info
     %span
       %i.icon-ok
       Merged by #{link_to_member(@project, @merge_request.merge_event.author)}
-      #{time_ago_with_tooltip(@merge_request.merge_event.created_at)}.
+      #{time_ago_with_tooltip(@merge_request.merge_event.created_at)}
 - if !@closes_issues.empty? && @merge_request.open?
   .alert.alert-info.alert-info
     %span


### PR DESCRIPTION
The "Merged by" and "Closed by" statements end with an extra space followed by a period. This doesn't seem necessary to me and not having the extra space followed by a period looks better to me. Also, the top of the merge request doesn't have the sentence ending with a period.
