### PR TITLE
Start development Key seed id from 1 to prevent `Couldn't find Key with id=0` crash on MySQL.

### DIFF
--- a/db/fixtures/development/11_keys.rb
+++ b/db/fixtures/development/11_keys.rb
@@ -2,7 +2,7 @@ Gitlab::Seeder.quiet do
   User.first(30).each_with_index do |user, i|
     Key.seed(:id, [
       {
-        id: i,
+        id: i + 1,
         title: "Sample key #{i}",
         key: "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt#{i + 100}6k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
         user_id: user.id,


### PR DESCRIPTION
If it starts from `0`, then `bundle exec rake gitlab:setup` gives:

```
== Seed from /home/git/gitlab/db/fixtures/development/11_keys.rb
Couldn't find Key with id=0
[exception trace and exit error]
```

for the **MySQL** database only.

Starting from 1 works for both MySQL and PostgreSQL.

Probably linked to the fact that `id` in MySQL is `auto_increment`, which starts from `1`?
