### PR TITLE
Mobile UI improvements

### DIFF
--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -273,3 +273,9 @@ header {
     }
   }
 }
+
+@media (max-width: $screen-xs-max) {
+  #nprogress .spinner {
+    right: 35px !important;
+  }
+}

--- a/app/views/layouts/_public_head_panel.html.haml
+++ b/app/views/layouts/_public_head_panel.html.haml
@@ -8,11 +8,15 @@
         %span.separator
       %h1.title= title
 
-      .pull-right
+      %button.navbar-toggle{"data-target" => ".navbar-collapse", "data-toggle" => "collapse", type: "button"}
+        %span.sr-only Toggle navigation
+        %i.icon-reorder
+
+      .pull-right.hidden-xs
         = link_to "Sign in", new_session_path(:user), class: 'btn btn-sign-in btn-new'
 
-      %ul.nav.navbar-nav
-        %li
-          %a
-            %div.hide.turbolink-spinner
-              %i.icon-refresh.icon-spin
+      .navbar-collapse.collapse
+        %ul.nav.navbar-nav
+          %li.visible-xs
+            = link_to "Sign in", new_session_path(:user)
+

--- a/app/views/layouts/public_projects.html.haml
+++ b/app/views/layouts/public_projects.html.haml
@@ -4,7 +4,7 @@
   %body{class: "#{app_theme} application", :'data-page' => body_data_page}
     = render "layouts/broadcast"
     = render "layouts/public_head_panel", title: project_title(@project)
-    %nav.main-nav
+    %nav.main-nav.navbar-collapse.collapse
       .container= render 'layouts/nav/project'
     .container
       .content= yield


### PR DESCRIPTION
This PR fixes some things in the mobile UI. The biggest fix is for public pages. Previously, on public pages the navigation was expanded by default and the sign in button took up lots of space at the top (especially after we add the collapsed navigation icon). See screenshots below.

Tested on a handful of popular mobile devices - iPhone 5, Galaxy S4, Google Nexus 4. All appear as expected after the changes.

Before:
Sign in button causes top bar to be taller than expected. Also, nav has no toggle and is always visible.
![mobile-redux-1](https://f.cloud.github.com/assets/2394772/2495574/98300e40-b2fb-11e3-9fc3-e50c33d11d86.png)

After:
(Note: The light blue highlight around the nav icon is because I used Chrome emulator to take these shots and my mouse click "selected" the icon. It does not actually show on real mobile device.
![mobile-redux-2](https://f.cloud.github.com/assets/2394772/2495576/a8ba4672-b2fb-11e3-98a4-985295404683.png)
After adding the nav icon, the spinner would appear right on top of the spinner. Now, it moves just to the left, but doesn't affect long project names, as shown below.
![mobile-redux-3](https://f.cloud.github.com/assets/2394772/2495582/d2ae857e-b2fb-11e3-937e-b82f8b4c37e5.png)
