### PR TITLE
Fix the merge notification email not being sent

### DIFF
--- a/app/mailers/emails/merge_requests.rb
+++ b/app/mailers/emails/merge_requests.rb
@@ -29,11 +29,11 @@ module Emails
            subject: subject("#{@merge_request.title} (!#{@merge_request.iid})"))
     end
 
-    def merged_merge_request_email(recipient_id, merge_request_id)
+    def merged_merge_request_email(recipient_id, merge_request_id, updated_by_user_id)
       @merge_request = MergeRequest.find(merge_request_id)
       @project = @merge_request.project
       @target_url = project_merge_request_url(@project, @merge_request)
-      mail(from: sender(@merge_request.author_id_of_changes),
+      mail(from: sender(updated_by_user_id),
            to: recipient(recipient_id),
            subject: subject("#{@merge_request.title} (!#{@merge_request.iid})"))
     end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -91,7 +91,7 @@ class NotificationService
     recipients = recipients.concat(project_watchers(merge_request.target_project)).uniq
 
     recipients.each do |recipient|
-      mailer.merged_merge_request_email(recipient.id, merge_request.id)
+      mailer.merged_merge_request_email(recipient.id, merge_request.id, merge_request.author_id_of_changes)
     end
   end
 

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -233,15 +233,15 @@ describe NotificationService do
         should_email(@u_watcher.id)
         should_not_email(@u_participating.id)
         should_not_email(@u_disabled.id)
-        notification.merge_mr(merge_request)
+        notification.merge_mr(merge_request, @u_disabled)
       end
 
       def should_email(user_id)
-        Notify.should_receive(:merged_merge_request_email).with(user_id, merge_request.id)
+        Notify.should_receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:merged_merge_request_email).with(user_id, merge_request.id)
+        Notify.should_not_receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
     end
   end


### PR DESCRIPTION
I broke the merge notification emails in the 6.7.\* branch.

This commit restore the email notification for merged MR. The `author_id_of_changes` attribute was always nil (as this attribute is not persisted to the database). Also there was no tests for the merge email notification — tests have been added.

Fix #6605
