### PR TITLE
LDAP double quote fix

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -120,12 +120,12 @@ production: &base
   #   bundle exec rake gitlab:ldap:check RAILS_ENV=production
   ldap:
     enabled: false
-    host: '_your_ldap_server'
+    host: "_your_ldap_server"
     port: 636
-    uid: 'sAMAccountName'
-    method: 'ssl' # "tls" or "ssl" or "plain"
-    bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
-    password: '_the_password_of_the_bind_user'
+    uid: "sAMAccountName"
+    method: "ssl" # "tls" or "ssl" or "plain"
+    bind_dn: "_the_full_dn_of_the_user_you_will_bind_with"
+    password: "_the_password_of_the_bind_user"
     # If allow_username_or_email_login is enabled, GitLab will ignore everything
     # after the first '@' in the LDAP username submitted by the user on login.
     #
@@ -141,14 +141,14 @@ production: &base
     #
     #   Ex. ou=People,dc=gitlab,dc=example
     #
-    base: ''
+    base: ""
 
     # Filter LDAP users
     #
     #   Format: RFC 4515
     #   Ex. (employeeType=developer)
     #
-    user_filter: ''
+    user_filter: ""
 
 
   ## OmniAuth settings


### PR DESCRIPTION
According to my testings on Centos 6.5 with Gitlab 6.7 and LDAP auth all strings in LDAP configuration has to be double-quoted to be git push for LDAP users working.
