### PR TITLE
Refactor Parallel Diff feature and add scrollbars

### DIFF
--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -62,6 +62,29 @@
         font-size: 12px;
       }
     }
+
+    .text-file-parallel div {
+      display: inline-block;
+      padding-bottom: 16px;
+    }
+    .diff-side {
+      overflow-x: scroll;
+      width: 508px;
+      height: 700px;
+    }
+    .diff-side.diff-side-left{
+      overflow-y:hidden;
+    }
+    .diff-side table, td.diff-middle table {
+      height: 700px;
+    }
+    .diff-middle {
+      width: 114px;
+      vertical-align: top;
+      height: 700px;
+      overflow: hidden
+    }
+
     .old_line, .new_line, .diff_line {
       margin: 0px;
       padding: 0px;
@@ -125,8 +148,6 @@
       }
       &.parallel {
         display: table-cell;
-        overflow: hidden;
-        width: 50%;
       }
     }
   }

--- a/app/models/diff_line.rb
+++ b/app/models/diff_line.rb
@@ -1,0 +1,3 @@
+class DiffLine
+  attr_accessor :type, :content, :num, :code
+end

--- a/app/views/projects/commits/_parallel_view.html.haml
+++ b/app/views/projects/commits/_parallel_view.html.haml
@@ -1,75 +1,55 @@
 / Side-by-side diff view
-- old_file = get_old_file(project, @commit, diff)
-- deleted_lines = {}
-- added_lines = {}
-- each_diff_line(diff, index) do |line, type, line_code, line_new, line_old, raw_line|
-  - if type == "old"
-    - deleted_lines[line_old] = { line_code: line_code, type: type, line: line }
-  - elsif type == "new"
-    - added_lines[line_new]   = { line_code: line_code, type: type, line: line }
-
-- max_length = old_file.sloc + added_lines.length if old_file
-- max_length ||= file.sloc
-- offset1 = 0
-- offset2 = 0
+- old_lines, new_lines = parallel_diff_lines(project, @commit, diff, file)
+- num_lines = old_lines.length
 
 %div.text-file-parallel
-  %table{ style: "table-layout: fixed;" }
-    - max_length.times do |line_index|
-      - line_index1 = line_index - offset1
-      - line_index2 = line_index - offset2
-      - deleted_line = deleted_lines[line_index1 + 1]
-      - added_line = added_lines[line_index2 + 1]
-      - old_line = old_file.lines[line_index1] if old_file
-      - new_line = file.lines[line_index2]
+  %div.diff-side.diff-side-left
+    %table
+      - old_lines.each do |line|
 
-      - if deleted_line && added_line
-      - elsif deleted_line
-        - new_line = nil
-        - offset2 += 1
-      - elsif added_line
-        - old_line = nil
-        - offset1 += 1
+        %tr.line_holder.parallel
+          - if line.type == :file_created
+            %td.line_content.parallel= "File was created"
+          - elsif line.type == :deleted
+            %td.line_content{class: "parallel noteable_line old #{line.code}", "line_code" => line.code }= line.content
+          - else line.type == :no_change
+            %td.line_content.parallel= line.content
 
-      %tr.line_holder.parallel
-        - if line_index == 0 && diff.new_file
-          %td.line_content.parallel= "File was created"
-          %td.old_line= ""
-        - elsif deleted_line
-          %td.line_content{class: "parallel noteable_line old #{deleted_line[:line_code]}", "line_code" => deleted_line[:line_code] }= old_line
-          %td.old_line.old
-            = line_index1 + 1
-            - if @comments_allowed
-              =# render "projects/notes/diff_note_link", line_code: deleted_line[:line_code]
-        - elsif old_line
-          %td.line_content.parallel= old_line
-          %td.old_line= line_index1 + 1
-        - else
-          %td.line_content.parallel= ""
-          %td.old_line= ""
+  %div.diff-middle
+    %table
+      - num_lines.times do |index|
+        %tr
+          - if old_lines[index].type == :deleted
+            %td.old_line.old= old_lines[index].num
+          - else
+            %td.old_line= old_lines[index].num
 
-        %td.diff_line= ""
+          %td.diff_line=""
 
-        - if diff.deleted_file && line_index == 0
-          %td.new_line= ""
-          %td.line_content.parallel= "File was deleted"
-        - elsif added_line
-          %td.new_line.new
-            = line_index2 + 1
-            - if @comments_allowed
-              =# render "projects/notes/diff_note_link", line_code: added_line[:line_code]
-          %td.line_content{class: "parallel noteable_line new #{added_line[:line_code]}", "line_code" => added_line[:line_code] }= new_line
-        - elsif new_line
-          %td.new_line= line_index2 + 1
-          %td.line_content.parallel= new_line
-        - else
-          %td.new_line= ""
-          %td.line_content.parallel= ""
+          - if new_lines[index].type == :added
+            %td.new_line.new= new_lines[index].num
+          - else
+            %td.new_line= new_lines[index].num
 
-      - if @reply_allowed
-        - comments1 = []
-        - comments2 = []
-        - comments1 = @line_notes.select { |n| n.line_code == deleted_line[:line_code] }.sort_by(&:created_at) if deleted_line
-        - comments2 = @line_notes.select { |n| n.line_code == added_line[:line_code] }.sort_by(&:created_at) if added_line
-        - unless comments1.empty? && comments2.empty?
-          = render "projects/notes/diff_notes_with_reply_parallel", notes1: comments1, notes2: comments2, line1: deleted_line, line2: added_line
+  %div.diff-side.diff-side-right
+    %table
+      - new_lines.each do |line|
+
+        %tr.line_holder.parallel
+          - if line.type == :file_deleted
+            %td.line_content.parallel= "File was deleted"
+          - elsif line.type == :added
+            %td.line_content{class: "parallel noteable_line new #{line.code}", "line_code" => line.code }= line.content
+          - else line.type == :no_change
+            %td.line_content.parallel= line.content
+
+:javascript
+  $('.diff-side-right').on('scroll', function(){
+    $('.diff-side-left, .diff-middle').scrollTop($(this).scrollTop());
+    $('.diff-side-left').scrollLeft($(this).scrollLeft());
+  });
+
+  $('.diff-side-left').on('scroll', function(){
+    $('.diff-side-right, .diff-middle').scrollTop($(this).scrollTop()); // might never be relevant
+    $('.diff-side-right').scrollLeft($(this).scrollLeft());
+  });


### PR DESCRIPTION
Currently, the Parallel Diff feature can't seem to handle lines that exceed the width of each of the two diff panes. 

![old_diff_example](https://f.cloud.github.com/assets/5344417/2505440/709925bc-b399-11e3-9347-0d46451b89df.png)

Most parallel diff implementations I have seen (e.g. in IDEs) solve this problem by allowing synchronized horizontal scrolling (i.e. both sides scroll together).

I have implemented this by moving to a three-column div layout for the feature, with each side in its own horizontally-scrolling div (I don't think it was possible to do this with the original layout, with one full line in each table row).

So that the horizontal scroll bars are accessible, I've made the diff pane a fixed height, which scrolls vertically. The result seems to work fine in recent versions of Chrome, Firefox and IE.

![new_diff_example](https://f.cloud.github.com/assets/5344417/2505442/7d6071ba-b399-11e3-8444-4a36caecdb5d.png)

In doing this change, I felt that having so much logic in the view (_parallel_view.html.haml) was constraining the layout of the page, and so it seemed appropriate to pull it out as Ruby code (which is currently, perhaps inappropriately, in the helper) and expose a data structure to the view that it could display easily in any HTML structure, removing the burden of processing from the view.

I'm interested in hearing feedback on this.
