### PR TITLE
Print Styles

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,13 @@
+/* Generic print styles */
+header, nav, nav.main-nav, nav.navbar-collapse, nav.navbar-collapse.collapse {display: none!important;}
+.profiler-results {display: none;}
+
+/* Styles targeted specifically at printing files */
+.tree-ref-holder, .tree-holder .breadcrumb, .blob-commit-info {display: none;}
+.file-title {display: none;}
+.file-holder {border: none;}
+
+.wiki h1, .wiki h2, .wiki h3, .wiki h4, .wiki h5, .wiki h6 {margin-top: 17px; }
+.wiki h1 {font-size: 30px;}
+.wiki h2 {font-size: 22px;}
+.wiki h3 {font-size: 18px; font-weight: bold; }

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -4,7 +4,8 @@
     = "#{title} | " if defined?(title)
     GitLab
   = favicon_link_tag 'favicon.ico'
-  = stylesheet_link_tag    "application"
+  = stylesheet_link_tag    "application", :media => "all"
+  = stylesheet_link_tag    "print", :media => "print"
   = javascript_include_tag "application"
   = csrf_meta_tags
   = include_gon


### PR DESCRIPTION
This change would add print styles to GitLab, so that:
- The existing styles, such as fonts, would print (currently not the case)
- The header would NOT display
- Elements seen when viewing a file, other than the file itself, would not display

This has been specifically targeted at the case of printing a file from a repository (e.g. README.md). It would probably warrant review to think about how such styles should affect other parts of the application, so (like with my other PRs) it may be more of a conversation starter than a merge-now type thing.

_See before and afters (printed to PDF):_

Before:
![gitlab_no_print_styles](https://f.cloud.github.com/assets/5344417/2508049/dede639c-b3cc-11e3-8af0-4687533a225c.png)

After:
![gitlab_print_styles](https://f.cloud.github.com/assets/5344417/2508050/e3230fe8-b3cc-11e3-9eb8-ffca32a7810a.png)
