### PR TITLE
Change the notification sender username to GitLab in Slack Notifier

### DIFF
--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -52,6 +52,7 @@ class SlackService < Service
 
     notifier = Slack::Notifier.new(subdomain, token)
     notifier.channel = room
+    notifier.username = 'GitLab'
     notifier.ping(message.compose)
   end
 


### PR DESCRIPTION
Before: http://i.imgur.com/xZFVMac.png
After: http://i.imgur.com/wiMeMG7.png

I think it's a lot nicer :)
