### PR TITLE
fix for project creation: group projects don't count towards user's project limit

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -239,7 +239,7 @@ class Project < ActiveRecord::Base
   end
 
   def check_limit
-    unless creator.can_create_project?
+    unless creator.can_create_project? or namespace.kind == 'group'
       errors[:limit_reached] << ("Your project limit is #{creator.projects_limit} projects! Please contact your administrator to increase it")
     end
   rescue


### PR DESCRIPTION
fix for project creation: group projects don't count towards user's project limit

I modified method check_limit in model project to not produce an error because of project limit reached when the project will be created in a group namespace.
fixes #6126

In addition it would also make sense to show the create project button on the dashboard in the case when the user has no project limit left but owns groups (and therefore can create projects in these groups). I left it out to keep the change as small as possible.
