### PR TITLE
Always show merge status

### DIFF
--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -4,7 +4,10 @@
       %strong Archived projects cannot be committed to!
   - else
     .bs-callout
-      %strong You don't have permission to merge this MR
+      .automerge_widget.cannot_be_merged.hide
+        %strong This can't be merged automatically, even if it could be merged you don't have the permission to do so.
+      .automerge_widget.can_be_merged.hide
+        %strong This can be merged automatically but you don't have the permission to do so.
 
 
 - if @show_merge_controls


### PR DESCRIPTION
**What does this PR do**
It makes sure you can always see if a merge request is mergeable or not. Even if you dont have any permissions to merge the specific request 

**Are there points in the code the reviewer needs to double check?**
Maybe the text "Connot be merge - You don't have permission to merge this MR". Couldn't find a better one.

**Why was this MR needed?**
So the Merge Request Officers can better review merge requests on Gitlab.com and ask people to make mergeable again.

**What are the relevant issue numbers / Feature requests?**
http://feedback.gitlab.com/forums/176466-general/suggestions/5673321-everyone-should-be-able-to-see-a-mr-status
