### PR TITLE
.well-list clearfix follow up

### DIFF
--- a/app/assets/stylesheets/generic/lists.scss
+++ b/app/assets/stylesheets/generic/lists.scss
@@ -13,6 +13,12 @@
     border-bottom: 1px solid #eee;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 
+    &:after {
+      content: " ";
+      display: table;
+      clear: both;
+    }
+
     &.disabled {
       color: #888;
     }

--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -113,6 +113,5 @@
   float: left;
   margin-right: 3px;
   color: #999;
-  margin-bottom: 10px;
   width: 16px;
 }


### PR DESCRIPTION
Follow up on #6577

Fixes overlap of list items in the `.well-list` lists.
Last time I overlooked the dashboard well-list and it introduced unnecessary spacing under project names. This was caused by the project visibility icon having a `margin-bottom`. I've removed that `margin-bottom` and that fixes it. I assume it was introduced to make the list item higher and apply the design.

This is the only change I made in the only commit in this pull request. (I double checked every page again and hope that I've not missed anything this time.)

Another issue I found is somewhat related, but it's is not required to be merged as well so I didn't included in this pull request. The clearfix makes it more apparent that list items don't have correct padding. They aren't vertically center aligned. It's more obvious by the changes in this pull request because some list items are now higher than previously. By this change all elements in a list item (such as option buttons) have the correct spacing around them. I have created a new pull request for this in #6644.

The effect of all states, left master branch, **center one is this pull request**, right the other pull request. (Click for a better view)

![spacing-branches](https://cloud.githubusercontent.com/assets/282402/2549026/4fe4daba-b66d-11e3-9351-f44ecd01327c.png)

If the items are now too high by these changes, the top and bottom spacing could be easily decreased to suit the rest of the design.

As again, I'll be happy to make changes to make this merge-able.
