### PR TITLE
.well-list item name spacing fix Follow up on #6643

### DIFF
--- a/app/assets/stylesheets/generic/lists.scss
+++ b/app/assets/stylesheets/generic/lists.scss
@@ -52,6 +52,12 @@
 
     .author { color: #999; }
 
+    .list-item-name {
+      float: left;
+      position: relative;
+      top: 3px;
+    }
+
     p {
       padding-top: 1px;
       margin: 0;

--- a/app/assets/stylesheets/generic/lists.scss
+++ b/app/assets/stylesheets/generic/lists.scss
@@ -13,6 +13,12 @@
     border-bottom: 1px solid #eee;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 
+    &:after {
+      content: " ";
+      display: table;
+      clear: both;
+    }
+
     &.disabled {
       color: #888;
     }

--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -113,6 +113,5 @@
   float: left;
   margin-right: 3px;
   color: #999;
-  margin-bottom: 10px;
   width: 16px;
 }

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -70,8 +70,9 @@
         - @group.users_groups.order('group_access DESC').each do |member|
           - user = member.user
           %li{class: dom_class(user)}
-            %strong
-              = link_to user.name, admin_user_path(user)
+            .list-item-name
+              %strong
+                = link_to user.name, admin_user_path(user)
             %span.pull-right.light
               = member.human_access
               = link_to group_users_group_path(@group, member), data: { confirm: remove_user_from_group_message(@group, user) }, method: :delete, remote: true, class: "btn-tiny btn btn-remove", title: 'Remove user from group' do

--- a/app/views/admin/hooks/index.html.haml
+++ b/app/views/admin/hooks/index.html.haml
@@ -28,8 +28,10 @@
     %ul.well-list
       - @hooks.each do |hook|
         %li
+          .list-item-name
+            = link_to admin_hook_path(hook) do
+              %strong= hook.url
+
           .pull-right
             = link_to 'Test Hook', admin_hook_test_path(hook), class: "btn btn-small"
             = link_to 'Remove', admin_hook_path(hook), data: { confirm: 'Are you sure?' }, method: :delete, class: "btn btn-remove btn-small"
-          = link_to admin_hook_path(hook) do
-            %strong= hook.url

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -44,9 +44,10 @@
       %ul.well-list
         - @projects.each do |project|
           %li
-            %span{ class: visibility_level_color(project.visibility_level) }
-              = visibility_level_icon(project.visibility_level)
-            = link_to project.name_with_namespace, [:admin, project]
+            .list-item-name
+              %span{ class: visibility_level_color(project.visibility_level) }
+                = visibility_level_icon(project.visibility_level)
+              = link_to project.name_with_namespace, [:admin, project]
             .pull-right
               %span.label.label-gray
                 = repository_size(project)

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -116,8 +116,9 @@
         - @project.users_projects.each do |users_project|
           - user = users_project.user
           %li.users_project
-            %strong
-              = link_to user.name, admin_user_path(user)
+            .list-item-name
+              %strong
+                = link_to user.name, admin_user_path(user)
             .pull-right
               - if users_project.owner?
                 %span.light Owner

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -36,15 +36,16 @@
       %ul.well-list
         - @users.each do |user|
           %li
-            - if user.blocked?
-              %i.icon-lock.cred
-            - else
-              %i.icon-user.cgreen
-            = link_to user.name, [:admin, user]
-            - if user.admin?
-              %strong.cred (Admin)
-            - if user == current_user
-              %span.cred It's you!
+            .list-item-name
+              - if user.blocked?
+                %i.icon-lock.cred
+              - else
+                %i.icon-user.cgreen
+              = link_to user.name, [:admin, user]
+              - if user.admin?
+                %strong.cred (Admin)
+              - if user == current_user
+                %span.cred It's you!
             .pull-right
               %span.light
                 %i.icon-envelope

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -124,7 +124,8 @@
           - @user.users_groups.each do |user_group|
             - group = user_group.group
             %li.users_group
-              %strong= link_to group.name, admin_group_path(group)
+              %span{class: ("list-item-name" unless user_group.owner?)}
+                %strong= link_to group.name, admin_group_path(group)
               .pull-right
                 %span.light= user_group.human_access
                 - unless user_group.owner?

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -73,8 +73,9 @@
           %ul.well-list
             - @group.projects.each do |project|
               %li
-                = visibility_level_icon(project.visibility_level)
-                = link_to project.name_with_namespace, project
+                .list-item-name
+                  = visibility_level_icon(project.visibility_level)
+                  = link_to project.name_with_namespace, project
                 .pull-right
                   = link_to 'Members', project_team_index_path(project), id: "edit_#{dom_id(project)}", class: "btn btn-small"
                   = link_to 'Edit', edit_project_path(project), id: "edit_#{dom_id(project)}", class: "btn btn-small"

--- a/app/views/users_groups/_users_group.html.haml
+++ b/app/views/users_groups/_users_group.html.haml
@@ -2,11 +2,12 @@
 - return unless user
 - show_roles = true if show_roles.nil?
 %li{class: "#{dom_class(member)} js-toggle-container", id: dom_id(member)}
-  = image_tag avatar_icon(user.email, 16), class: "avatar s16"
-  %strong= user.name
-  %span.cgray= user.username
-  - if user == current_user
-    %span.label.label-success It's you
+  %span{class: ("list-item-name" if show_controls)}
+    = image_tag avatar_icon(user.email, 16), class: "avatar s16"
+    %strong= user.name
+    %span.cgray= user.username
+    - if user == current_user
+      %span.label.label-success It's you
 
   - if show_roles
     %span.pull-right
@@ -22,7 +23,7 @@
           - else
             = link_to group_users_group_path(@group, member), data: { confirm: remove_user_from_group_message(@group, user) }, method: :delete, remote: true, class: "btn-tiny btn btn-remove", title: 'Remove user from group' do
               %i.icon-minus.icon-white
-  
+
     .edit-member.hide.js-toggle-content
       = form_for [@group, member], remote: true do |f|
         .alert.prepend-top-20


### PR DESCRIPTION
Follow up on #6643

The well list clearfix pull request makes some well list items bigger in height. That made it more obvious that the spacing in these list items is not equal on all sides. On the master branch the buttons are too far down. On the well list clearfix pull request version the text is higher up from the baseline thanks to the increase in height. This pull request will fix the baseline in these items as shown in the following image.

The effect of all states, left master branch, center is pull request #6643, **right one is this pull request**. (Click for a better view)

![spacing-branches](https://cloud.githubusercontent.com/assets/282402/2549026/4fe4daba-b66d-11e3-9351-f44ecd01327c.png)

The left aligned text in these list items are now wrapped in a `float: left` element (through class `.list-item-name`) which fixes the spacing to make it a generic style rather than to apply every spacing fix on their separate elements.

A different solution to this problem would be to absolute position the right aligned text `.pull-right` with `top: 10px; right: 10px;`, and apply a `padding-right: #px` to list item. However this introduces the problem of variable width of the right aligned text and thus a variable padding-right to be set for every different view. Resulting in a lot more work and a lot more code. The solution in this merge request in more flexible even though it uses floats.

Let me know what you think whether or not you prefer a different approach.

**Note: This pull request's code is dependent on pull request #6643's code. That's why it includes the same commit (I branched from that branch). Without it will just result in broken views.**
