### PR TITLE
Correct sidekiq command line for Sidekiq 2.17.2+

### DIFF
--- a/script/background_jobs
+++ b/script/background_jobs
@@ -37,7 +37,7 @@ function start_no_deamonize
 
 function start_sidekiq
 {
-  bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,gitlab_shell,common,default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
+  bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
 }
 
 function load_ok


### PR DESCRIPTION
In Sidekiq 2.17.2+, they have explicitly removed the command line option for chaining queues in the -q option.  Either this line needs to change, or the Gemfile should require 2.17.1 or lower.

Here is the sidekiq commit removing this functionality.

https://github.com/mperham/sidekiq/commit/040eda558bc64139c846c781d3de0b79603e3035

Thanks to Matt Campbell on Gitlab.org for connecting the dots.  https://gitlab.com/u/mattrcampbell
