### PR TITLE
Mark missing selectors as optional.

### DIFF
--- a/app/assets/stylesheets/sections/editor.scss
+++ b/app/assets/stylesheets/sections/editor.scss
@@ -27,7 +27,7 @@
     }
 
     .commit-btn {
-      @extend .save-btn;
+      @extend .save-btn !optional;
     }
     .message {
       display: inline-block;

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -54,7 +54,7 @@ ul.notes {
       .diff-file,
       .discussion-hidden,
       .notes {
-        @extend .borders;
+        @extend .borders !optional;
         background-color: #F9F9F9;
       }
       .diff-file .notes {


### PR DESCRIPTION
Fixes #2692 #3096 #4626 #5214 #5970 #6301 by marking the offending selectors as optional.

Assets precompilation now raises no concerns.
