### PR TITLE
Fix link to isue tracker integration page

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@
 + [API](api/README.md)
 + [Development](development/README.md)
 + [Install](install/README.md)
-+ [Integration](external-issue-tracker/README.md)
++ [Integration](integration/external-issue-tracker.md)
 + [Legal](legal/README.md)
 + [Markdown](markdown/markdown.md)
 + [Permissions](permissions/permissions.md)


### PR DESCRIPTION
Link to issue integegration page was wrong. This results in a 500 error on http://doc.gitlab.com

/cc @dosire
