### PR TITLE
Add optional parameter to list merge requests

### DIFF
--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -1,15 +1,21 @@
 ## List merge requests
 
-Get all merge requests for this project. This function takes pagination parameters
-`page` and `per_page` to restrict the list of merge requests.
+Get all merge requests for this project.
+The `state` parameter can be used to get only merge requests with a
+given state (`opened`, `closed`, or `merged`) or all of them (`all`).
+The pagination parameters `page` and `per_page` can be used to restrict the
+list of merge requests.
 
 ```
 GET /projects/:id/merge_requests
+GET /projects/:id/merge_requests?state=opened
+GET /projects/:id/merge_requests?state=all
 ```
 
 Parameters:
 
 + `id` (required) - The ID of a project
++ `state` (optional) - Return `all` requests or just those that are `merged`, `opened` or `closed`
 
 ```json
 [

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -19,14 +19,24 @@ module API
       #
       # Parameters:
       #   id (required) - The ID of a project
+      #   state (optional) - Return requests "merged", "opened" or "closed"
       #
       # Example:
       #   GET /projects/:id/merge_requests
+      #   GET /projects/:id/merge_requests?state=opened
+      #   GET /projects/:id/merge_requests?state=closed
       #
       get ":id/merge_requests" do
         authorize! :read_merge_request, user_project
 
-        present paginate(user_project.merge_requests), with: Entities::MergeRequest
+        mrs = case params["state"]
+              when "opened" then user_project.merge_requests.opened
+              when "closed" then user_project.merge_requests.closed
+              when "merged" then user_project.merge_requests.merged
+              else user_project.merge_requests
+        end
+
+        present paginate(mrs), with: Entities::MergeRequest
       end
 
       # Show MR

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -7,6 +7,8 @@ describe API::API do
   let(:user) { create(:user) }
   let!(:project) {create(:project, creator_id: user.id, namespace: user.namespace) }
   let!(:merge_request) { create(:merge_request, :simple, author: user, assignee: user, source_project: project, target_project: project, title: "Test") }
+  let!(:merge_request_closed) { create(:merge_request, state: "closed", author: user, assignee: user, source_project: project, target_project: project, title: "Closed test") }
+  let!(:merge_request_merged) { create(:merge_request, state: "merged", author: user, assignee: user, source_project: project, target_project: project, title: "Merged test") }
   let!(:note) { create(:note_on_merge_request, author: user, project: project, noteable: merge_request, note: "a comment on a MR") }
   before {
     project.team << [user, :reporters]
@@ -21,11 +23,41 @@ describe API::API do
     end
 
     context "when authenticated" do
-      it "should return an array of merge_requests" do
+      it "should return an array of all merge_requests" do
         get api("/projects/#{project.id}/merge_requests", user)
         response.status.should == 200
         json_response.should be_an Array
+        json_response.length.should == 3
         json_response.first['title'].should == merge_request.title
+      end
+      it "should return an array of all merge_requests" do
+        get api("/projects/#{project.id}/merge_requests?state", user)
+        response.status.should == 200
+        json_response.should be_an Array
+        json_response.length.should == 3
+        json_response.first['title'].should == merge_request.title
+      end
+      it "should return an array of open merge_requests" do
+        get api("/projects/#{project.id}/merge_requests?state=opened", user)
+        response.status.should == 200
+        json_response.should be_an Array
+        json_response.length.should == 1
+        json_response.first['title'].should == merge_request.title
+      end
+      it "should return an array of closed merge_requests" do
+        get api("/projects/#{project.id}/merge_requests?state=closed", user)
+        response.status.should == 200
+        json_response.should be_an Array
+        json_response.length.should == 2
+        json_response.first['title'].should == merge_request_closed.title
+        json_response.second['title'].should == merge_request_merged.title
+      end
+      it "should return an array of merged merge_requests" do
+        get api("/projects/#{project.id}/merge_requests?state=merged", user)
+        response.status.should == 200
+        json_response.should be_an Array
+        json_response.length.should == 1
+        json_response.first['title'].should == merge_request_merged.title
       end
     end
   end


### PR DESCRIPTION
Add an optional parameter to list merge requests to restrict the
returned merge requests to those that are "opened", "merged" or
"closed". By default all merge requests are returned.
