### PR TITLE
Added the dump.rdb file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ doc/code/*
 public/uploads.*
 public/assets/
 .envrc
+dump.rdb


### PR DESCRIPTION
Whenever i'm working on GitLab I have redis running, but redis is
generating a db dump file called dump.rdb, I dont think that should be
checked in, so it should be on the gitignore list
