### PR TITLE
Fix url generation error on hook invalid create

### DIFF
--- a/app/controllers/projects/hooks_controller.rb
+++ b/app/controllers/projects/hooks_controller.rb
@@ -18,7 +18,7 @@ class Projects::HooksController < Projects::ApplicationController
     if @hook.valid?
       redirect_to project_hooks_path(@project)
     else
-      @hooks = @project.hooks
+      @hooks = @project.hooks.select(&:persisted?)
       render :index
     end
   end


### PR DESCRIPTION
On creating project hook with invalid url I get this error
![j90isca](https://cloud.githubusercontent.com/assets/1488195/2625621/6e20130a-bda2-11e3-8ee4-02680819d189.png)
