### PR TITLE
Automatically generate debian package with pkgr.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,19 @@
+user: git
+group: git
+before_precompile: ./bin/pkgr_before_precompile.sh
+targets:
+  debian-7: &wheezy
+    build_dependencies:
+      - libicu-dev
+    dependencies:
+      - libicu48
+      - libpcre3
+      - git
+  ubuntu-12.04: *wheezy
+  ubuntu-14.04:
+    build_dependencies:
+      - libicu-dev
+    dependencies:
+      - libicu52
+      - libpcre3
+      - git

--- a/bin/pkgr_before_precompile.sh
+++ b/bin/pkgr_before_precompile.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -ex
+
+for file in config/*.yml.example; do
+  cp ${file} config/$(basename ${file} .example)
+done
+
+# No need for config file. Will be taken care of by REDIS_URL env variable
+rm config/resque.yml
+
+# Set default unicorn.rb file
+echo "" > config/unicorn.rb
+
+# Required for assets precompilation
+sudo service postgresql start

--- a/bin/pkgr_before_precompile.sh
+++ b/bin/pkgr_before_precompile.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 for file in config/*.yml.example; do
   cp ${file} config/$(basename ${file} .example)
 done
+
+# Allow to override the Gitlab URL from an environment variable, as this will avoid having to change the configuration file for simple deployments.
+config=$(echo '<% gitlab_url = URI(ENV["GITLAB_URL"] || "http://localhost:80") %>' | cat - config/gitlab.yml)
+echo "$config" > config/gitlab.yml
+sed -i "s/host: localhost/host: <%= gitlab_url.host %>/" config/gitlab.yml
+sed -i "s/port: 80/port: <%= gitlab_url.port %>/" config/gitlab.yml
+sed -i "s/https: false/https: <%= gitlab_url.scheme == 'https' %>/" config/gitlab.yml
 
 # No need for config file. Will be taken care of by REDIS_URL env variable
 rm config/resque.yml


### PR DESCRIPTION
Here are the changes I had to make to generate debian packages of Gitlab for Ubuntu 12.04 and Debian 7.4, using https://pkgr.io. The installation process is currently described in https://pkgr.io/apps/pkgr/gitlabhq.

In addition to the specific stuff related to packaging, I added a new `gitlab:shell:install` to streamline the installation of gitlab-shell (with auto-generation of its config.yml file), and a way to set the Gitlab configuration using environment variables. Please let me know what you think.
