### PR TITLE
Allow to parse heroku-generated database.yml config file.

### DIFF
--- a/lib/tasks/gitlab/setup.rake
+++ b/lib/tasks/gitlab/setup.rake
@@ -16,7 +16,7 @@ namespace :gitlab do
 
     Rake::Task["db:setup"].invoke
 
-    config = YAML.load_file(File.join(Rails.root,'config','database.yml'))[Rails.env]
+    config = YAML.load(ERB.new(File.read(File.join(Rails.root, "config","database.yml"))).result)
     success = case config["adapter"]
               when /^mysql/ then
                 Rake::Task["add_limits_mysql"].invoke


### PR DESCRIPTION
Better to be coherent with how config/database.yml is usually parsed, to allow for erb variables. Needed by PR #6716.
