### PR TITLE
Fix Procfile to be usable in production.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec unicorn_rails -p $PORT -E development -c config/unicorn_development.rb
+web: bundle exec unicorn_rails -p ${PORT} -E ${RAILS_ENV} -c ${UNICORN_CONFIG:="config/unicorn.rb"}
 worker: bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,common,default,gitlab_shell


### PR DESCRIPTION
The Procfile may be used for deployment purposes (e.g. on heroku, pkgr.io, etc.), therefore any parameter should default to a production-ready one. They can then be overwritten in dev by using a proper `.env` file at the root of the project. Needed by PR #6716.
