### PR TITLE
Fix avatars in the network graph for relative-url setups.

### DIFF
--- a/app/assets/javascripts/branch-graph.js.coffee
+++ b/app/assets/javascripts/branch-graph.js.coffee
@@ -201,7 +201,7 @@ class BranchGraph
       stroke: @colors[commit.space]
       "stroke-width": 2
     )
-    r.image(commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
+    r.image(gon.relative_url_root + commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
     r.text(@offsetX + @unitSpace * @mspace + 35, y, commit.message.split("\n")[0]).attr(
       "text-anchor": "start"
       font: "14px Monaco, monospace"
@@ -274,7 +274,7 @@ class BranchGraph
 Raphael::commitTooltip = (x, y, commit) ->
   boxWidth = 300
   boxHeight = 200
-  icon = @image(commit.author.icon, x, y, 20, 20)
+  icon = @image(gon.relative_url_root + commit.author.icon, x, y, 20, 20)
   nameText = @text(x + 25, y + 10, commit.author.name)
   idText = @text(x, y + 35, commit.id)
   messageText = @text(x, y + 50, commit.message)


### PR DESCRIPTION
This fixes the avatar URL in case there is a relative URL root.
