### PR TITLE
Add rake task to install or upgrade gitlab-shell installation.

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -119,30 +119,7 @@ Create a `git` user for Gitlab:
 
     sudo adduser --disabled-login --gecos 'GitLab' git
 
-
-# 4. GitLab shell
-
-GitLab Shell is an ssh access and repository management software developed specially for GitLab.
-
-    # Go to home directory
-    cd /home/git
-
-    # Clone gitlab shell
-    sudo -u git -H git clone https://gitlab.com/gitlab-org/gitlab-shell.git -b v1.9.1
-
-    cd gitlab-shell
-
-    sudo -u git -H cp config.yml.example config.yml
-
-    # Edit config and replace gitlab_url
-    # with something like 'http://domain.com/'
-    sudo -u git -H editor config.yml
-
-    # Do setup
-    sudo -u git -H ./bin/install
-
-
-# 5. Database
+# 4. Database
 
 We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](database_mysql.md).
 
@@ -165,7 +142,7 @@ We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](da
     sudo -u git -H psql -d gitlabhq_production
 
 
-# 6. GitLab
+# 5. GitLab
 
     # We'll install GitLab into home directory of the user "git"
     cd /home/git
@@ -275,6 +252,18 @@ that were [fixed](https://github.com/bundler/bundler/pull/2817) in 1.5.2.
 
     # When done you see 'Administrator account created:'
 
+## Install GitLab shell
+
+GitLab Shell is an ssh access and repository management software developed specially for GitLab.
+
+    # Go to the Gitlab installation folder:
+    cd /home/git/gitlab
+
+    # Run the installation task for gitlab-shell (replace `REDIS_URL` if needed):
+    sudo -u git -H bundle exec rake gitlab:shell:setup[v1.9.1] REDIS_URL=redis://localhost:6379
+
+    # By default, the gitlab-shell config is generated from your main gitlab config. You can review (and modify) it as follows:
+    sudo -u git -H editor /home/git/gitlab-shell/config.yml
 
 ## Install Init Script
 
@@ -314,7 +303,7 @@ Check if GitLab and its environment are configured correctly:
     sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 
 
-# 7. Nginx
+# 6. Nginx
 
 **Note:**
 Nginx is the officially supported web server for GitLab. If you cannot or do not want to use Nginx as your web server, have a look at the

--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -1,5 +1,63 @@
 namespace :gitlab do
   namespace :shell do
+    desc "GITLAB | Install or upgrade gitlab-shell"
+    task :install, [:tag, :repo] => :environment do |t, args|
+      warn_user_is_not_gitlab
+
+      args.with_defaults(tag: "v1.9.1", repo: "https://gitlab.com/gitlab-org/gitlab-shell.git")
+
+      user = Settings.gitlab.user
+      home_dir = Settings.gitlab.user_home
+      gitlab_url = Settings.gitlab.url
+      # gitlab-shell requires a / at the end of the url
+      gitlab_url += "/" unless gitlab_url.match(/\/$/)
+      target_dir = File.join(home_dir, "gitlab-shell")
+
+      # Clone if needed
+      unless File.directory?(target_dir)
+        sh "git clone '#{args.repo}' '#{target_dir}'"
+      end
+
+      # Make sure we're on the right tag
+      Dir.chdir(target_dir) do
+        sh "git fetch origin && git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"
+
+        redis_url = URI.parse(ENV['REDIS_URL'] || "redis://localhost:6379")
+
+        config = {
+          user: user,
+          gitlab_url: gitlab_url,
+          http_settings: {self_signed_cert: false},
+          repos_path: File.join(home_dir, "repositories"),
+          auth_file: File.join(home_dir, ".ssh", "authorized_keys"),
+          redis: {
+            bin: %x{which redis-cli}.chomp,
+            host: redis_url.host,
+            port: redis_url.port,
+            namespace: "resque:gitlab"
+          },
+          log_level: "INFO",
+          audit_usernames: false
+        }
+
+        # Generate config.yml based on existing gitlab settings
+        File.open("config.yml", "w+") {|f| f.puts config.to_yaml}
+
+        # Launch installation process
+        sh "bin/install"
+      end
+
+      # Required for debian packaging with PKGR: Setup .ssh/environment with
+      # the current PATH, so that the correct ruby version gets loaded
+      # Requires to set "PermitUserEnvironment yes" in sshd config (should not
+      # be an issue since it is more than likely that there are no "normal"
+      # user accounts on a gitlab server). The alternative is for the admin to
+      # install a ruby (1.9.3+) in the global path.
+      File.open(File.join(home_dir, ".ssh", "environment"), "w+") do |f|
+        f.puts "PATH=#{ENV['PATH']}"
+      end
+    end
+
     desc "GITLAB | Setup gitlab-shell"
     task setup: :environment do
       setup


### PR DESCRIPTION
I think it would be nice if Gitlab came with a rake task to streamline the gitlab-shell installation, based on the existing Gitlab configuration. This task does just that, and allows for upgrading to a newer version of gitlab-shell as well.

``` bash
rake gitlab:shell:install
# or, with specific version
rake gitlab:shell:install[v1.9.3]
```

What this does:
- fetch gitlab-shell code from github, at the given tag/branch/commit given.
- write gitlab-shell/config.yml based on the existing gitlab config
- launch the installation process of gitlab-shell
- write the current PATH to `$gitlab-shell-home/.ssh/environment`, so that the `#!/usr/bin/env ruby` shebang in gitlab-shell files returns the right ruby version (i.e. the one currently used by the gitlab app).

The last point requires a change in the sshd configuration to take effect, with potential security issues if the server is also used by normal users (http://www.openssh.org/cgi-bin/man.cgi?query=sshd_config), so if this is an issue I'm happy to remove lines 50 to 58, as it would not apply to an 'install-everything-from-source' gitlab installation anyway.
