### PR TITLE
Better title format for wiki page

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -47,7 +47,11 @@ class WikiPage
 
   # The formatted title of this page.
   def title
-    @attributes[:title] || ""
+    if @attributes[:title]
+      @attributes[:title].gsub(/-+/, ' ')
+    else
+      ""
+    end
   end
 
   # Sets the title of this page.

--- a/app/views/projects/wikis/edit.html.haml
+++ b/app/views/projects/wikis/edit.html.haml
@@ -3,7 +3,7 @@
   = render 'main_links'
 %h3.page-title
   Editing -
-  %span.light #{@page.title.titleize}
+  %span.light #{@page.title}
 %hr
 = render 'form'
 

--- a/app/views/projects/wikis/history.html.haml
+++ b/app/views/projects/wikis/history.html.haml
@@ -1,7 +1,7 @@
 = render 'nav'
 %h3.page-title
   %span.light History for
-  = link_to @page.title.titleize, project_wiki_path(@project, @page)
+  = link_to @page.title, project_wiki_path(@project, @page)
 
 %table.table
   %thead

--- a/app/views/projects/wikis/pages.html.haml
+++ b/app/views/projects/wikis/pages.html.haml
@@ -5,7 +5,7 @@
   - @wiki_pages.each do |wiki_page|
     %li
       %h4
-        = link_to wiki_page.title.titleize, project_wiki_path(@project, wiki_page)
+        = link_to wiki_page.title, project_wiki_path(@project, wiki_page)
         %small (#{wiki_page.format})
         .pull-right
           %small Last edited #{time_ago_with_tooltip(wiki_page.commit.created_at)}

--- a/app/views/projects/wikis/show.html.haml
+++ b/app/views/projects/wikis/show.html.haml
@@ -1,6 +1,6 @@
 = render 'nav'
 %h3.page-title
-  = @page.title.titleize
+  = @page.title
   = render 'main_links'
 - if @page.historical?
   .warning_message

--- a/features/steps/project/wiki.rb
+++ b/features/steps/project/wiki.rb
@@ -83,7 +83,7 @@ class Spinach::Features::ProjectWiki < Spinach::FeatureSteps
 
   Then 'I should see the existing page in the pages list' do
     page.should have_content current_user.name
-    page.should have_content @page.title.titleize
+    page.should have_content @page.title
   end
 
   def wiki

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -155,4 +155,20 @@ describe WikiPage do
     end
   end
 
+  describe "#title" do
+    before do
+      create_page("Title", "content")
+      @page = wiki.find_page("Title")
+    end
+
+    after do
+      destroy_page("Title")
+    end
+
+    it "should be replace a hyphen to a space" do
+      @page.title = "Import-existing-repositories-into-GitLab"
+      @page.title.should == "Import existing repositories into GitLab"
+    end
+  end
+
 end


### PR DESCRIPTION
The title format for wiki page may be unintelligible.
For example 'GitLab' is converted to 'Git Lab', 'MySQL' is converted to 'My Sql', etc.
