### PR TITLE
Do not accept merge request if contains `WIP` label

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ v 6.9.0
   - Fix wiki backup skip bug
   - Two Step MR creation process
   - Remove unwanted files from satellite working directory with git clean -fdx
+  - Do not accept merge request if contains `WIP` label
   - Accept merge request via API (sponsored by O'Reilly Media)
   - Add more access checks during API calls
   - Block SSH access for 'disabled' Active Directory users

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,7 +59,7 @@ v 6.7.0
   - Blob and tree gfm links to anchors work
   - Piwik Integration (Sebastian Winkler)
   - Show contribution guide link for new issue form (Jeroen van Baarsen)
-  - Fix CI status for merge requests from fork 
+  - Fix CI status for merge requests from fork
   - Added option to remove issue assignee on project issue page and issue edit page (Jason Blanchard)
   - New page load indicator that includes a spinner that scrolls with the page
   - Converted all the help sections into markdown
@@ -250,7 +250,7 @@ v 6.2.0
   - Store the sessions in Redis instead of the cookie store
   - Fixed relative links in markdown
   - User must confirm their email if signup enabled
-  - User must confirm changed email 
+  - User must confirm changed email
 
 v 6.1.0
   - Project specific IDs for issues, mr, milestones

--- a/app/assets/stylesheets/generic/issue_box.scss
+++ b/app/assets/stylesheets/generic/issue_box.scss
@@ -66,6 +66,19 @@
     }
   }
 
+  &.issue-box-wip {
+    border-color: #cea61b;
+    .state {
+      background-color: #fcf8e3;
+      border-color: #faebcc;
+      color: #8a6d3b;
+      .state-label {
+        background: #cea61b;
+        color: #FFF;
+      }
+    }
+  }
+
   .control-group {
     margin-bottom: 0;
   }

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -92,6 +92,8 @@ module IssuesHelper
       'issue-box-merged'
     elsif item.closed?
       'issue-box-closed'
+    elsif item.respond_to?(:wip?) && item.wip?
+      'issue-box-wip'
     else
       'issue-box-open'
     end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -320,4 +320,9 @@ class MergeRequest < ActiveRecord::Base
       source_project.repository.branch_names
     end
   end
+
+  # whether this is WIP merge request
+  def wip?
+    labels.map(&:name).any? { |label| label =~ /^wip$/i }
+  end
 end

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -49,7 +49,7 @@
           Labels
         .col-sm-10
           = f.text_field :label_list, maxlength: 2000, class: "form-control"
-          %p.hint Separate labels with commas.
+          %p.hint Separate labels with commas. If input "WIP", this merge request will not be able to accept
 
   .form-actions
     - if @merge_request.new_record?

--- a/app/views/projects/merge_requests/show/_mr_box.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_box.html.haml
@@ -5,6 +5,8 @@
         Merged
       - elsif @merge_request.closed?
         Closed
+      - elsif @merge_request.wip?
+        WIP
       - else
         Open
 

--- a/app/views/projects/merge_requests/show/_state_widget.html.haml
+++ b/app/views/projects/merge_requests/show/_state_widget.html.haml
@@ -5,7 +5,10 @@
   .panel-body
     - if @merge_request.open?
       - if @merge_request.source_branch_exists? && @merge_request.target_branch_exists?
-        = render "projects/merge_requests/show/mr_accept"
+        - if @merge_request.wip?
+          = render "projects/merge_requests/show/wip_accept"
+        - else
+          = render "projects/merge_requests/show/mr_accept"
       - else
         = render "projects/merge_requests/show/no_accept"
 

--- a/app/views/projects/merge_requests/show/_wip_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_wip_accept.html.haml
@@ -1,0 +1,4 @@
+%h4
+  This is WIP merge request
+%p
+  %strong If you want to merge this, please remove "WIP" in labels.

--- a/lib/gitlab/issues_labels.rb
+++ b/lib/gitlab/issues_labels.rb
@@ -6,7 +6,7 @@ module Gitlab
       end
 
       def warning_labels
-        %w(documentation support)
+        %w(documentation support wip)
       end
 
       def neutral_labels

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -131,4 +131,30 @@ describe MergeRequest do
     let(:backref_text) { "merge request !#{subject.iid}" }
     let(:set_mentionable_text) { ->(txt){ subject.title = txt } }
   end
+
+  describe '#wip?' do
+    subject { merge_request.wip? }
+
+    let!(:merge_request) { create(:merge_request, label_list: label_list) }
+
+    context 'contains "WIP" label' do
+      let(:label_list) { 'test, WIP' }
+      it { should be true }
+    end
+
+    context 'contains "wip" label' do
+      let(:label_list) { 'test, wip' }
+      it { should be true }
+    end
+
+    context 'contains "*WIP*" label' do
+      let(:label_list) { 'test, wipeout' }
+      it { should be false }
+    end
+
+    context 'not contains "WIP" label' do
+      let(:label_list) { 'test' }
+      it { should be false }
+    end
+  end
 end


### PR DESCRIPTION
I use the WIP MR at the beginning of the work

WIP MR should not be merged.
But I (or other) submit the accept button by mistake often.

So I hide accept button if MR title include "WIP"

![2014-04-10 1 33 47](https://cloud.githubusercontent.com/assets/608755/2658296/9bc371f6-c006-11e3-88c6-b6301012150e.png)
