### PR TITLE
Expose event and mergerequest timestamps in API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ v 6.8.0
   - Option to disable standard login
   - Clean old created archives from repository downloads directory
   - Fix download link for huge MR diffs
+  - Expose event and mergerequest timestamps in API
 
 v 6.7.3
   - Fix the merge notification email not being sent (Pierre de La Morinerie)

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -117,22 +117,22 @@ module API
     class ProjectEntity < Grape::Entity
       expose :id, :iid
       expose (:project_id) { |entity| entity.project.id }
+      expose :title, :description
+      expose :state, :created_at, :updated_at
     end
 
     class Milestone < ProjectEntity
-      expose :title, :description, :due_date, :state, :updated_at, :created_at
+      expose :due_date
     end
 
     class Issue < ProjectEntity
-      expose :title, :description
       expose :label_list, as: :labels
       expose :milestone, using: Entities::Milestone
       expose :assignee, :author, using: Entities::UserBasic
-      expose :state, :updated_at, :created_at
     end
 
     class MergeRequest < ProjectEntity
-      expose :target_branch, :source_branch, :title, :state, :upvotes, :downvotes, :description
+      expose :target_branch, :source_branch, :upvotes, :downvotes
       expose :author, :assignee, using: Entities::UserBasic
       expose :source_project_id, :target_project_id
     end
@@ -158,6 +158,7 @@ module API
       expose :title, :project_id, :action_name
       expose :target_id, :target_type, :author_id
       expose :data, :target_title
+      expose :created_at
     end
 
     class Namespace < Grape::Entity


### PR DESCRIPTION
# What does this MR do?
- Exposes event and mergerequest timestamps in API
- Makes code more DRY by moving title, description, state and timestamps to base class `ProjectEntity`
# Are there points in the code the reviewer needs to double check?

I have to apologize that I have no way to run the unit tests as I'm currently using a Windows machine, so I can only hope that tests don't break because of this.

However, we have been using this change for a long time in our GitLab server, so I'm quite sure it won't break any functionality.

Also, see https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/64
# Why was this merge request needed?

This merge request enables API users to create a "Changes in project since yesterday" view by filtering events by timestamp (imagine e.g. a project dasboard with GitLab widget).
More details at https://groups.google.com/forum/#!topic/gitlabhq/grWbJp8Kp78

Also, it makes `Events` and `MergeRequests` consistent with other API entities like `Issue`.
# What are the relevant feature requests?

http://feedback.gitlab.com/forums/176466-general/suggestions/5210611-gitlab-api-expose-updated-at-and-created-at-on-ev
