### PR TITLE
Determine label color based on lowercase name

### DIFF
--- a/app/helpers/labels_helper.rb
+++ b/app/helpers/labels_helper.rb
@@ -12,7 +12,7 @@ module LabelsHelper
   def label_css_class(name)
     klass = Gitlab::IssuesLabels
 
-    case name
+    case name.downcase
     when *klass.warning_labels
       'label-warning'
     when *klass.neutral_labels

--- a/spec/helpers/labels_helper_spec.rb
+++ b/spec/helpers/labels_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe LabelsHelper do
+  describe '#label_css_class' do
+    it 'returns label-danger when given Bug as param' do
+      expect(label_css_class('bug')).to eq('label-danger')
+    end
+
+    it 'returns label-danger when given Bug as param' do
+      expect(label_css_class('Bug')).to eq('label-danger')
+    end
+  end
+end


### PR DESCRIPTION
**What does this MR do?**
Determine the label color base on case-insensitive name

**Are there points in the code the reviewer needs to double check?**
Nothing special

**Why was this MR needed?** 
Because when you have a label "Bug" it would not get the red bug color, since it would not match. With this fix, the label name would be downcased when parsing for color detection.

**What are the relevant issue numbers / Feature requests?**
Fixes: https://github.com/gitlabhq/gitlabhq/issues/6759
