### PR TITLE
Make the db and statemachine default is the same

### DIFF
--- a/app/models/merge_request_diff.rb
+++ b/app/models/merge_request_diff.rb
@@ -26,7 +26,7 @@ class MergeRequestDiff < ActiveRecord::Base
 
   delegate :target_branch, :source_branch, to: :merge_request, prefix: nil
 
-  state_machine :state, initial: :empty do
+  state_machine :state, initial: :collected do
     state :collected
     state :timeout
     state :overflow_commits_safe_size

--- a/app/models/merge_request_diff.rb
+++ b/app/models/merge_request_diff.rb
@@ -26,7 +26,7 @@ class MergeRequestDiff < ActiveRecord::Base
 
   delegate :target_branch, :source_branch, to: :merge_request, prefix: nil
 
-  state_machine :state, initial: :collected do
+  state_machine :state, initial: :empty do
     state :collected
     state :timeout
     state :overflow_commits_safe_size

--- a/db/migrate/20140414131055_change_state_to_allow_empty_merge_request_diffs.rb
+++ b/db/migrate/20140414131055_change_state_to_allow_empty_merge_request_diffs.rb
@@ -1,0 +1,9 @@
+class ChangeStateToAllowEmptyMergeRequestDiffs < ActiveRecord::Migration
+  def up
+    change_column :merge_request_diffs, :state, :string, null: true, default: nil
+  end
+
+  def down
+    change_column :merge_request_diffs, :state, :string, null: false, default: "collected"
+  end
+end

--- a/db/migrate/20140414131055_change_state_to_allow_empty_merge_request_diffs.rb
+++ b/db/migrate/20140414131055_change_state_to_allow_empty_merge_request_diffs.rb
@@ -1,9 +1,11 @@
 class ChangeStateToAllowEmptyMergeRequestDiffs < ActiveRecord::Migration
   def up
-    change_column :merge_request_diffs, :state, :string, null: true, default: nil
+    change_column :merge_request_diffs, :state, :string, null: true,
+                  default: nil
   end
 
   def down
-    change_column :merge_request_diffs, :state, :string, null: false, default: "collected"
+    change_column :merge_request_diffs, :state, :string, null: false,
+                  default: 'collected'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140407135544) do
+ActiveRecord::Schema.define(version: 20140414131055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,10 +109,10 @@ ActiveRecord::Schema.define(version: 20140407135544) do
   add_index "keys", ["user_id"], name: "index_keys_on_user_id", using: :btree
 
   create_table "merge_request_diffs", force: true do |t|
-    t.string   "state",            default: "collected", null: false
+    t.string   "state"
     t.text     "st_commits"
     t.text     "st_diffs"
-    t.integer  "merge_request_id",                       null: false
+    t.integer  "merge_request_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
**What does this MR do?**
Remove a warning when you run the test suite:
`Both MergeRequestDiff and its :state machine have defined a different default for "state". Use only one or the other for defining defaults to avoid unexpected behaviors.`

**Are there points in the code the reviewer needs to double check?**
Maybe there was a good reason to have them different. So please wait for travis to finish its build

**Why was this MR needed?**
To remove an annoying warning.
