### PR TITLE
Fixed a typo fix in the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - TASK=spec:other DB=mysql
     - TASK=jasmine:ci DB=mysql
     - TASK=spinach DB=postgresql
-    - TASK=spec:api DB=mysql
+    - TASK=spec:api DB=postgresql
     - TASK=spec:other DB=postgresql
     - TASK=jasmine:ci DB=postgresql
 before_install:


### PR DESCRIPTION
**Why is this PR needed**
Because i've splitted the tests, ive added two build options (spec:other and spec:api) but i miss typed the build option `spec:api` for postgres, so at this point, that one wont get checked. This MR fixes that.
