### PR TITLE
Split feature tests out to different build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ env:
   matrix:
     - TASK=spinach DB=mysql
     - TASK=spec:api DB=mysql
+    - TASK=spec:feature DB=mysql
     - TASK=spec:other DB=mysql
     - TASK=jasmine:ci DB=mysql
     - TASK=spinach DB=postgresql
     - TASK=spec:api DB=postgresql
+    - TASK=spec:feature DB=postgresql
     - TASK=spec:other DB=postgresql
     - TASK=jasmine:ci DB=postgresql
 before_install:

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,7 +1,7 @@
 Rake::Task["spec"].clear if Rake::Task.task_defined?('spec')
 
 namespace :spec do
-  desc 'GITLAB | Run feature specs'
+  desc 'GITLAB | Run request specs'
   task :api do
     cmds = [
       %W(rake gitlab:setup),
@@ -10,11 +10,20 @@ namespace :spec do
     run_commands(cmds)
   end
 
+  desc 'GITLAB | Run feature specs'
+  task :feature do
+    cmds = [
+      %W(rake gitlab:setup),
+      %W(rspec spec --tag @feature)
+    ]
+    run_commands(cmds)
+  end
+
   desc 'GITLAB | Run other specs'
   task :other do
     cmds = [
       %W(rake gitlab:setup),
-      %W(rspec spec --tag ~@api)
+      %W(rspec spec --tag ~@api --tag ~@feature)
     ]
     run_commands(cmds)
   end

--- a/spec/features/admin/admin_hooks_spec.rb
+++ b/spec/features/admin/admin_hooks_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Admin::Hooks" do
+describe "Admin::Hooks", feature: true do
   before do
     @project = create(:project)
     login_as :admin

--- a/spec/features/admin/admin_projects_spec.rb
+++ b/spec/features/admin/admin_projects_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Admin::Projects" do
+describe "Admin::Projects", feature: true  do
   before do
     @project = create(:project)
     login_as :admin

--- a/spec/features/admin/admin_users_spec.rb
+++ b/spec/features/admin/admin_users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Admin::Users" do
+describe "Admin::Users", feature: true  do
   before { login_as :admin }
 
   describe "GET /admin/users" do

--- a/spec/features/admin/security_spec.rb
+++ b/spec/features/admin/security_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Admin::Projects" do
+describe "Admin::Projects", feature: true  do
   describe "GET /admin/projects" do
     subject { admin_projects_path }
 

--- a/spec/features/atom/dashboard_issues_spec.rb
+++ b/spec/features/atom/dashboard_issues_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Dashboard Issues Feed" do
+describe "Dashboard Issues Feed", feature: true  do
   describe "GET /issues" do
     let!(:user)     { create(:user) }
     let!(:project1) { create(:project) }

--- a/spec/features/atom/dashboard_spec.rb
+++ b/spec/features/atom/dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Dashboard Feed" do
+describe "Dashboard Feed", feature: true  do
   describe "GET /" do
     let!(:user) { create(:user) }
 

--- a/spec/features/atom/issues_spec.rb
+++ b/spec/features/atom/issues_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Issues Feed" do
+describe "Issues Feed", feature: true  do
   describe "GET /issues" do
     let!(:user)     { create(:user) }
     let!(:project)  { create(:project) }

--- a/spec/features/gitlab_flavored_markdown_spec.rb
+++ b/spec/features/gitlab_flavored_markdown_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "GitLab Flavored Markdown", features: true do
+describe "GitLab Flavored Markdown", feature: true do
   let(:project) { create(:project) }
   let(:issue) { create(:issue, project: project) }
   let(:merge_request) { create(:merge_request, source_project: project, target_project: project) }

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Issues" do
+describe "Issues", feature: true do
   let(:project) { create(:project) }
 
   before do

--- a/spec/features/notes_on_merge_requests_spec.rb
+++ b/spec/features/notes_on_merge_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "On a merge request", js: true do
+describe "On a merge request", js: true, feature: true do
   let!(:merge_request) { create(:merge_request, :simple) }
   let!(:project) { merge_request.source_project }
   let!(:note) { create(:note_on_merge_request, :with_attachment, project: project) }

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Profile account page" do
+describe "Profile account page", feature: true do
   before(:each) { enable_observers }
   after(:each) {disable_observers}
   let(:user) { create(:user) }

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Projects" do
+describe "Projects", feature: true  do
   before(:each) { enable_observers }
   after(:each) {disable_observers}
   before { login_as :user }

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Search" do
+describe "Search", feature: true  do
   before do
     ActiveRecord::Base.observers.enable(:user_observer)
     login_as :user

--- a/spec/features/security/dashboard_access_spec.rb
+++ b/spec/features/security/dashboard_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Dashboard access" do
+describe "Dashboard access", feature: true  do
   describe "GET /dashboard" do
     subject { dashboard_path }
 

--- a/spec/features/security/group/group_access_spec.rb
+++ b/spec/features/security/group/group_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Group access" do
+describe "Group access", feature: true  do
   describe "GET /projects/new" do
     it { new_group_path.should be_allowed_for :admin }
     it { new_group_path.should be_allowed_for :user }

--- a/spec/features/security/group/internal_group_access_spec.rb
+++ b/spec/features/security/group/internal_group_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Group with internal project access" do
+describe "Group with internal project access", feature: true  do
   describe "Group" do
     let(:group) { create(:group) }
 

--- a/spec/features/security/group/mixed_group_access_spec.rb
+++ b/spec/features/security/group/mixed_group_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Group access" do
+describe "Group access", feature: true  do
   describe "Group" do
     let(:group) { create(:group) }
 

--- a/spec/features/security/group/public_group_access_spec.rb
+++ b/spec/features/security/group/public_group_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Group with public project access" do
+describe "Group with public project access", feature: true  do
   describe "Group" do
     let(:group) { create(:group) }
 

--- a/spec/features/security/profile_access_spec.rb
+++ b/spec/features/security/profile_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Users Security" do
+describe "Users Security", feature: true  do
   describe "Project" do
     before do
       @u1 = create(:user)

--- a/spec/features/security/project/internal_access_spec.rb
+++ b/spec/features/security/project/internal_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Internal Project Access" do
+describe "Internal Project Access", feature: true  do
   let(:project) { create(:project, :internal) }
 
   let(:master) { create(:user) }

--- a/spec/features/security/project/private_access_spec.rb
+++ b/spec/features/security/project/private_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Private Project Access" do
+describe "Private Project Access", feature: true  do
   let(:project) { create(:project) }
 
   let(:master)   { create(:user) }

--- a/spec/features/security/project/public_access_spec.rb
+++ b/spec/features/security/project/public_access_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Public Project Access" do
+describe "Public Project Access", feature: true  do
   let(:project) { create(:project) }
 
   let(:master) { create(:user) }

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Users' do
+describe 'Users', feature: true do
   describe "GET /users/sign_up" do
     before do
       Gitlab.config.gitlab.stub(:signup_enabled).and_return(true)


### PR DESCRIPTION
**What does this MR do?**
This MR is a follow up to: https://github.com/gitlabhq/gitlabhq/pull/6753 since it turns out that only splitting API tests out was not sufficient. At this point I've taken a look at how long the `spec/features` tests took to run on bare metal: `15 minutes`. So i think that would be a great candidate to be in a separate build job.

Also I did a line count for every type of spec we have, so maybe its a good idea to also split out the model specs. But lets see if this has any effect first:

```
Controllers: 340
Requests: 3226
Mailers: 560
Finders: 142
Services: 1440
Observers: 178
Lib: 841
Models: 3335
Features: 2232
```
