### PR TITLE
Show actual commit count on project dashboard

### DIFF
--- a/app/views/projects/_home_panel.html.haml
+++ b/app/views/projects/_home_panel.html.haml
@@ -25,7 +25,7 @@
     - unless empty_repo
       .col-md-4
         .project-home-links
-          = link_to pluralize(@repository.round_commit_count, 'commit'), project_commits_path(@project, @ref || @repository.root_ref)
-          = link_to pluralize(@repository.branch_names.count, 'branch'), project_branches_path(@project)
-          = link_to pluralize(@repository.tag_names.count, 'tag'), project_tags_path(@project)
+          = link_to pluralize(number_with_delimiter(@repository.commit_count), 'commit'), project_commits_path(@project, @ref || @repository.root_ref)
+          = link_to pluralize(number_with_delimiter(@repository.branch_names.count), 'branch'), project_branches_path(@project)
+          = link_to pluralize(number_with_delimiter(@repository.tag_names.count), 'tag'), project_tags_path(@project)
           %span.light.prepend-left-20= repository_size


### PR DESCRIPTION
## What does this MR do?

Instead of displaying the rounded commit count this shows the actual commit count on the project dashboard. Also added the number_with_delimiter helper to show the numbers in a nice, human-readable format.
## Why was this MR needed?

The rounded commit count is great for a quick display of the commits, such as for the public project list. However, for the dashboard it is overly simplified. When a project has between 1,000 and 5,000 commits you just see '1000+ commits'. There is no reason we shouldn't show the complete commit count here.
## Screenshots

Before:
![screen shot 2014-04-14 at 11 27 02 am](https://cloud.githubusercontent.com/assets/2394772/2697726/af1a0b86-c3f1-11e3-924f-b17d7838f448.png)

After:
![screen shot 2014-04-14 at 11 59 08 am](https://cloud.githubusercontent.com/assets/2394772/2698112/23949cd4-c3f6-11e3-9592-086c875ba494.png)
