### PR TITLE
Added support for markdown in gfm() function

### DIFF
--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -63,7 +63,7 @@ module Gitlab
         insert_piece($1)
       end
 
-      sanitize text.html_safe, attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class), tags: ActionView::Base.sanitized_allowed_tags + %w(table tr td th)
+      markdown(sanitize text.html_safe, attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class), tags: ActionView::Base.sanitized_allowed_tags + %w(table tr td th))
     end
 
     private

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -63,7 +63,13 @@ module Gitlab
         insert_piece($1)
       end
 
-      markdown(sanitize text.html_safe, attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class), tags: ActionView::Base.sanitized_allowed_tags + %w(table tr td th))
+      markdown(
+        sanitize(
+          text.html_safe,
+          attributes: ActionView::Base.sanitized_allowed_attributes + %w(id class),
+          tags: ActionView::Base.sanitized_allowed_tags + %w(table tr td th)
+        )
+      )
     end
 
     private


### PR DESCRIPTION
- It appears that gfm() never called the base markdown() function
- Commit messages and other items would only render the reference fields of gfm
  *\* Emojis, user names, issues, commit ID, etc
- The name Gitlab Flavored Markdown implies that base markdown syntax is supported
- Adding the call to markdown() renders all GFM text correctly
