### PR TITLE
Allow to overwrite location of gitlab.yml config file.

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -1,5 +1,5 @@
 class Settings < Settingslogic
-  source "#{Rails.root}/config/gitlab.yml"
+  source ENV.fetch('GITLAB_CONFIG') { "#{Rails.root}/config/gitlab.yml" }
   namespace Rails.env
 
   class << self


### PR DESCRIPTION
Related to #6716, it would be nice if we could point to an alternate configuration file (e.g. `/etc/gitlabhq/gitlab.yml` in the case of a debian package for instance) just by setting an environment variable.
