### PR TITLE
Allow to specify secret token via SECRET_KEY_BASE environment variable.

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,7 +9,9 @@ require 'securerandom'
 
 def find_secure_token
   token_file = Rails.root.join('.secret')
-  if File.exist? token_file
+  if ENV.key?('SECRET_KEY_BASE')
+    ENV['SECRET_KEY_BASE']
+  elsif File.exist? token_file
     # Use the existing token.
     File.read(token_file).chomp
   else


### PR DESCRIPTION
Another important setting that should be configurable via an environment variable. Related to #6716.
