### PR TITLE
Clarify that bbastov is the style of Hound CI.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,14 @@ For examples of feedback on merge requests please look at already [closed merge 
 1. It conforms to the following style guides
 
 ## Style guides
-1. [Ruby](https://github.com/bbatsov/ruby-style-guide)
-1. [Rails](https://github.com/bbatsov/rails-style-guide)
-1. [Formatting](https://github.com/thoughtbot/guides/tree/master/style#formatting)
-1. [Naming](https://github.com/thoughtbot/guides/tree/master/style#naming) 
-1. [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
-1. [CoffeeScript](https://github.com/thoughtbot/guides/tree/master/style#coffeescript)
-1. [Shell commands](doc/development/shell_commands.md)
-1. [Markdown](http://www.cirosantilli.com/markdown-styleguide)
+
+1.  [Ruby](https://github.com/bbatsov/ruby-style-guide). Important sections include [Source Code Layout](https://github.com/bbatsov/ruby-style-guide#source-code-layout) and [Naming](https://github.com/bbatsov/ruby-style-guide#naming). Use:
+    - multi-line method chaining style **Option A**: leading `.`
+    - string literal quoting style **Option A**: single quoted by default
+1.  [Rails](https://github.com/bbatsov/rails-style-guide)
+1.  [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
+1.  [CoffeeScript](https://github.com/thoughtbot/guides/tree/master/style#coffeescript)
+1.  [Shell commands](doc/development/shell_commands.md)
+1.  [Markdown](http://www.cirosantilli.com/markdown-styleguide)
+
+The above styles are used by Hound CI.


### PR DESCRIPTION
Follows discussion at: https://github.com/gitlabhq/gitlabhq/pull/6752

Since https://github.com/thoughtbot/guides/tree/master/style and bbastov's style is the same, we should link only to one of them to make things clearer.

`Source Code Layout` corresponds to the thoughtbot formatting section.

Also make it clear that Hound CI uses bbastov's style, which is not clear from their documentation.

**Questions**
1. Which "multi-line method chaining style" style are we using? Option A I imagine: dot on next line. If so I'll add that too.
2. I think Hound is an interesting option, but what policy shall we adopt for new merge requests, when existing untouched neighboring lines are in a style not accepted by Hound, specially very symmetric ones?

For example, consider that the following code exists:

```
func "a" 
func "b"
```

and that I am going modify line 2 to:

```
func 'c'
```

and use single quotes which is the correct style. But then it will look like:

```
func "a" 
func 'c'
```

which is ugly because it is not symmetric.

Shall I also modify the first line to:

```
func 'a' 
func 'c'
```

?

This is specially problematic when you are moving chunks of code around in tests, and Hound will bark a lot, so its easier to just update the entire file rather than going back and forth from your editor to your browser.

One solution to this question is that we start an effort to update all the style to the correct one. Perhaps there are tools which help with that?
