### PR TITLE
Patch MergeRequest object with more information.

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -132,7 +132,7 @@ module API
     end
 
     class MergeRequest < ProjectEntity
-      expose :target_branch, :source_branch, :upvotes, :downvotes
+      expose :target_branch, :source_branch, :upvotes, :downvotes, :description, :milestone_id
       expose :author, :assignee, using: Entities::UserBasic
       expose :source_project_id, :target_project_id
     end


### PR DESCRIPTION
Patched the `MergeRequest` object returned by the `merge_request` API to return more information regarding the MR i.e. the `description` & the `miletstone_id`
