### PR TITLE
fix bundle install error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,7 +644,7 @@ DEPENDENCIES
   simplecov
   sinatra
   six
-  slack-notifier (~> 0.2.0)
+  slack-notifier (~> 0.3.2)
   slim
   spinach-rails
   spring (= 1.1.1)


### PR DESCRIPTION
fix issue of bundle install error after slack-notifier upgraded. upgrade to 0.3.2
