### PR TITLE
Fix missing lines in Parallel Diff

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -116,7 +116,7 @@ module CommitsHelper
         added_lines[line_new]   = { line_code: line_code, type: type, line: line }
       end
     end
-    max_length = old_file ? old_file.sloc + added_lines.length : file.sloc
+    max_length = old_file ? [old_file.loc, file.loc].max : file.loc
 
     offset1 = 0
     offset2 = 0


### PR DESCRIPTION
A user of Gitlab here has noticed that the Parallel Diff feature chops a bunch of lines off the end of a file. This issue predates the recent changes to this feature - it affects the current version of Gitlab and can be observed on demo.gitlab.com.

We have deduced that what is happening is that a line count that removes empty lines is being used, and so  for every empty (or whitespace, I imagine) line in the file, a line off the end is not shown.

This PR seems to resolve the problem by using the loc method instead of the sloc method. It also correctly calculates the maximum length of the two files, avoiding another issue where unnecessary lines are appended to the end of the diff output if the lengths of the files differ.
