### PR TITLE
Subject of push notification email includes commit message or commits count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 6.9.0
+  - Subject of push notification email includes commit message or commits count
+
 v 6.8.0
   - Ability to at mention users that are participating in issue and merge req. discussion
   - Enabled GZip Compression for assets in example Nginx, make sure that Nginx is compiled with --with-http_gzip_static_module flag (this is default in Ubuntu)

--- a/app/mailers/emails/projects.rb
+++ b/app/mailers/emails/projects.rb
@@ -29,9 +29,14 @@ module Emails
         @target_url = project_commit_url(@project, @commits.first)
       end
 
+      subject = if @commits.size > 1
+                  "#{@commits.size} new commits"
+                else
+                  @commits.first.title
+                end
       mail(from: sender(author_id),
            to: recipient,
-           subject: subject("New push to repository"))
+           subject: subject(subject))
     end
   end
 end

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -522,7 +522,7 @@ describe Notify do
     end
 
     it 'has the correct subject' do
-      should have_subject /New push to repository/
+      should have_subject /#{commits.size} new commits/
     end
 
     it 'includes commits list' do
@@ -558,7 +558,7 @@ describe Notify do
     end
 
     it 'has the correct subject' do
-      should have_subject /New push to repository/
+      should have_subject /#{commits.first.title}/
     end
 
     it 'includes commits list' do


### PR DESCRIPTION
http://feedback.gitlab.com/forums/176466-general/suggestions/5767809-add-commit-message-to-email-on-push-subject
