### PR TITLE
notes pub/sub via faye

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,6 +166,9 @@ gem "gitlab_emoji", "~> 0.0.1.1"
 gem "gon", '~> 5.0.0'
 gem 'nprogress-rails'
 
+gem "private_pub"
+gem 'thin'
+
 group :development do
   gem "annotate", "~> 2.6.0.beta2"
   gem "letter_opener"
@@ -180,9 +183,6 @@ group :development do
 
   # Docs generator
   gem "sdoc"
-
-  # thin instead webrick
-  gem 'thin'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     colored (1.2)
     colorize (0.5.8)
     connection_pool (1.2.0)
+    cookiejar (0.3.2)
     coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
@@ -103,6 +104,22 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.1)
     dotenv (0.9.0)
+    elasticsearch (0.4.8)
+      elasticsearch-api (= 0.4.8)
+      elasticsearch-transport (= 0.4.8)
+    elasticsearch-api (0.4.8)
+      multi_json
+    elasticsearch-transport (0.4.8)
+      faraday
+      multi_json
+    em-http-request (1.0.3)
+      addressable (>= 2.2.3)
+      cookiejar
+      em-socksify
+      eventmachine (>= 1.0.0.beta.4)
+      http_parser.rb (>= 0.5.3)
+    em-socksify (0.3.0)
+      eventmachine (>= 1.0.0.beta.4)
     email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
@@ -127,6 +144,17 @@ GEM
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
+    faye (1.0.1)
+      cookiejar (>= 0.3.0)
+      em-http-request (>= 0.3.0)
+      eventmachine (>= 0.12.0)
+      faye-websocket (>= 0.7.0)
+      multi_json (>= 1.0.0)
+      rack (>= 1.0.0)
+      websocket-driver (>= 0.3.0)
+    faye-websocket (0.7.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.3.0)
     ffaker (1.22.1)
     ffi (1.9.3)
     fog (1.21.0)
@@ -326,6 +354,8 @@ GEM
       websocket-driver (>= 0.2.0)
     polyglot (0.3.4)
     posix-spawn (0.3.8)
+    private_pub (1.0.3)
+      faye
     protected_attributes (1.0.5)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.9.12.4)
@@ -618,6 +648,7 @@ DEPENDENCIES
   omniauth-twitter
   pg
   poltergeist (~> 1.4.1)
+  private_pub
   protected_attributes
   pry
   quiet_assets (~> 1.0.1)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec unicorn_rails -p ${PORT:="3000"} -E ${RAILS_ENV:="development"} -c ${UNICORN_CONFIG:="config/unicorn.rb"}
 worker: bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,common,default,gitlab_shell
+faye: bundle exec rackup private_pub.ru -s thin -E production

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -29,6 +29,7 @@
 #= require underscore
 #= require nprogress
 #= require nprogress-turbolinks
+#= require private_pub
 #= require_tree .
 
 window.slugify = (text) ->

--- a/app/controllers/projects/notes_controller.rb
+++ b/app/controllers/projects/notes_controller.rb
@@ -22,6 +22,9 @@ class Projects::NotesController < Projects::ApplicationController
   def create
     @note = Notes::CreateService.new(project, current_user, params).execute
 
+    channel = Gitlab::NoteHelper.channel(@note.noteable)
+    PrivatePub.publish_to(channel, note_json(@note))
+
     respond_to do |format|
       format.json { render_note_json(@note) }
       format.html { redirect_to :back }
@@ -85,9 +88,14 @@ class Projects::NotesController < Projects::ApplicationController
   end
 
   def render_note_json(note)
-    render json: {
+    render json: note_json(note)
+  end
+
+  def note_json(note)
+    {
       id: note.id,
       discussion_id: note.discussion_id,
+      line_code: note.line_code,
       html: note_to_html(note),
       discussion_html: note_to_discussion_html(note)
     }

--- a/app/views/projects/notes/_notes_with_form.html.haml
+++ b/app/views/projects/notes/_notes_with_form.html.haml
@@ -6,5 +6,7 @@
 - if can? current_user, :write_note, @project
   = render "projects/notes/form"
 
+- channel = Gitlab::NoteHelper.channel(@noteable)
+= subscribe_to channel
 :javascript
-  new Notes("#{project_notes_path(target_id: @noteable.id, target_type: @noteable.class.name.underscore)}", #{@notes.map(&:id).to_json})
+  new Notes("#{channel}", #{@notes.map(&:id).to_json})

--- a/config/private_pub.yml
+++ b/config/private_pub.yml
@@ -1,0 +1,10 @@
+development:
+  server: "http://localhost:9292/faye"
+  secret_token: "secret"
+test:
+  server: "http://localhost:9292/faye"
+  secret_token: "secret"
+production:
+  server: "http://localhost:9292/faye"
+  secret_token: "secret"
+  signature_expiration: 3600 # one hour

--- a/lib/gitlab/note_helper.rb
+++ b/lib/gitlab/note_helper.rb
@@ -1,0 +1,7 @@
+module Gitlab
+  module NoteHelper
+    def self.channel(notable)
+      "/notes/#{notable.class.name.underscore}/#{notable.id}"
+    end
+  end
+end

--- a/private_pub.ru
+++ b/private_pub.ru
@@ -1,0 +1,10 @@
+# Run with: rackup private_pub.ru -s thin -E production
+require "bundler/setup"
+require "yaml"
+require "faye"
+require "private_pub"
+
+Faye::WebSocket.load_adapter('thin')
+
+PrivatePub.load_config(File.expand_path("../config/private_pub.yml", __FILE__), ENV["RAILS_ENV"] || "development")
+run PrivatePub.faye_app


### PR DESCRIPTION
Replace notes polling to pub/sub via faye.
The main reason for that is high load which generated by polling.
At our installation 80%-90% requests are notes requests.
Also with pub/sub comments appear immediately. 
