### PR TITLE
Expose archive status of projects in API

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -43,7 +43,8 @@ GET /projects
       "owner_id": 1,
       "path": "diaspora",
       "updated_at": "2013-09-30T13: 46: 02Z"
-    }
+    },
+    "archived": false
   },
   {
     "id": 6,
@@ -78,7 +79,8 @@ GET /projects
       "owner_id": 1,
       "path": "brightbox",
       "updated_at": "2013-09-30T13:46:02Z"
-    }
+    },
+    "archived": false
   }
 ]
 ```
@@ -157,7 +159,8 @@ Parameters:
       "access_level": 50,
       "notification_level": 3
     }
-  }
+  },
+  "archived": false
 }
 ```
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -43,6 +43,7 @@ module API
     class Project < Grape::Entity
       expose :id, :description, :default_branch
       expose :public?, as: :public
+      expose :archived?, as: :archived
       expose :visibility_level, :ssh_url_to_repo, :http_url_to_repo, :web_url
       expose :owner, using: Entities::UserBasic, unless: ->(project, options) { project.group }
       expose :name, :name_with_namespace


### PR DESCRIPTION
I'd like to adapt GitLab CI to not show projects that have been both archived and never configured. But for that, GitLab needs to expose the archived flag via API.
