### PR TITLE
Fix can not automerge when description is too long

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ v 6.9.0
   - Improve issue and merge request mobile UI (Drew Blessing)
   - Document how to convert a backup to PostgreSQL
   - Fix locale bug in backup manager
+  - Fix can not automerge when MR description is too long
   - Fix wiki backup skip bug
 
 v 6.8.0

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -12,7 +12,7 @@
 - if @show_merge_controls
   .automerge_widget.can_be_merged.hide
     .clearfix
-      = form_for [:automerge, @project, @merge_request], remote: true, method: :get do |f|
+      = form_for [:automerge, @project, @merge_request], remote: true, method: :post do |f|
         %h4
           You can accept this request automatically.
         %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,7 +273,7 @@ Gitlab::Application.routes.draw do
       resources :merge_requests, constraints: {id: /\d+/}, except: [:destroy] do
         member do
           get :diffs
-          get :automerge
+          post :automerge
           get :automerge_check
           get :ci_status
         end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -213,7 +213,7 @@ describe Projects::RefsController, "routing" do
 end
 
 #           diffs_project_merge_request GET    /:project_id/merge_requests/:id/diffs(.:format)           projects/merge_requests#diffs
-#       automerge_project_merge_request GET    /:project_id/merge_requests/:id/automerge(.:format)       projects/merge_requests#automerge
+#       automerge_project_merge_request POST   /:project_id/merge_requests/:id/automerge(.:format)       projects/merge_requests#automerge
 # automerge_check_project_merge_request GET    /:project_id/merge_requests/:id/automerge_check(.:format) projects/merge_requests#automerge_check
 #    branch_from_project_merge_requests GET    /:project_id/merge_requests/branch_from(.:format)         projects/merge_requests#branch_from
 #      branch_to_project_merge_requests GET    /:project_id/merge_requests/branch_to(.:format)           projects/merge_requests#branch_to
@@ -230,7 +230,10 @@ describe Projects::MergeRequestsController, "routing" do
   end
 
   it "to #automerge" do
-    get("/gitlab/gitlabhq/merge_requests/1/automerge").should route_to('projects/merge_requests#automerge', project_id: 'gitlab/gitlabhq', id: '1')
+    post('/gitlab/gitlabhq/merge_requests/1/automerge').should route_to(
+      'projects/merge_requests#automerge',
+      project_id: 'gitlab/gitlabhq', id: '1'
+    )
   end
 
   it "to #automerge_check" do


### PR DESCRIPTION
When MR description is too long (ex. over 4000 characters) , can not accept.

Because 414 Error (Request-URI Too Large) may occur depending on the configuration of the server.

![mr1](https://cloud.githubusercontent.com/assets/608755/2744357/aeb33d62-c724-11e3-8c63-81c58a75c7b3.png)

![mr](https://cloud.githubusercontent.com/assets/608755/2744359/afc1e12c-c724-11e3-812d-105eebc314da.png)
