### PR TITLE
Provide better email subject lines from email on push service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ v 7.0.0
   - Remove wall feature (no data loss - you can take it from database)
   - Dont expose user emails via API unless you are admin 
   - Detect issues closed by Merge Request description
+  - Better email subject lines from email on push service (Alex Elman)
 
 v 6.9.2
   - Revert the commit that broke the LDAP user filter

--- a/app/mailers/emails/projects.rb
+++ b/app/mailers/emails/projects.rb
@@ -25,13 +25,15 @@ module Emails
       @branch  = branch
       if @commits.length > 1
         @target_url = project_compare_url(@project, from: @commits.first, to: @commits.last)
+        @subject = "#{@commits.length} new commits pushed to repository"
       else
         @target_url = project_commit_url(@project, @commits.first)
+        @subject = @commits.first.title
       end
 
       mail(from: sender(author_id),
            cc: recipient,
-           subject: subject("New push to repository"))
+           subject: subject(@subject))
     end
   end
 end

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -537,7 +537,7 @@ describe Notify do
     end
 
     it 'has the correct subject' do
-      should have_subject /New push to repository/
+      should have_subject /#{commits.length} new commits pushed to repository/
     end
 
     it 'includes commits list' do
@@ -573,7 +573,7 @@ describe Notify do
     end
 
     it 'has the correct subject' do
-      should have_subject /New push to repository/
+      should have_subject /#{commits.first.title}/
     end
 
     it 'includes commits list' do


### PR DESCRIPTION
## Feature: Better email subject lines from email on push service

Feature request: http://feedback.gitlab.com/forums/176466-general/suggestions/5767809-add-commit-message-to-email-on-push-subject

If one commit is pushed, display the commit message in the subject
line. Otherwise display the number of commits pushed to the repository.
### Tests

I performed my tests using the Gitlab Cookbook described here https://gitlab.com/gitlab-org/cookbook-gitlab/blob/master/doc/development.md
#### Feature test

I activated Email-on-push service for one of the projects with git@localhost as the recipient. I edited the configuration for the development environment to perform deliveries and use sendmail. 

Then I installed mail-utils so I can check email. I pushed a single commit, 2 commits, and 6 commits as three separate trials. In all cases, the subject line was as I expected without introducing any regressions. I verified by checking mail with the mail command on the shell and by looking at the emails rendered in the DEBUG logs.
#### RSpec and Spinach tests

I modified two existing unit tests to account for enhanced subject lines. All tests passing.
