### PR TITLE
Fix syntax highlighting

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -59,7 +59,7 @@ class Dispatcher
 
   initHighlight: ->
     $('.highlight pre code').each (i, e) ->
-      hljs.highlightBlock(e)
       $(e).html($.map($(e).html().split("\n"), (line, i) ->
-        "<div class='line' id='LC" + (i + 1) + "'>" + line + "</div>"
+        "<span class='line' id='LC" + (i + 1) + "'>" + line + "</span>"
       ).join("\n"))
+      hljs.highlightBlock(e)


### PR DESCRIPTION
Don't break highlighting on multi-line spans (multi-line comments for
example).  

See #6546

Before:

![screen shot 2014-04-22 at 5 06 41 pm](https://cloud.githubusercontent.com/assets/677994/2771412/9a2ef0e0-ca6a-11e3-9f5a-c99c19a880fc.png)

After:

![screen shot 2014-04-22 at 5 02 17 pm](https://cloud.githubusercontent.com/assets/677994/2771415/a2b40b7e-ca6a-11e3-9fbe-efab8513b719.png)
