### PR TITLE
Fix typo in gitlab.yml.example

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -230,7 +230,7 @@ production: &base
   # Use the default values unless you really know what you are doing
   git:
     bin_path: /usr/bin/git
-    # The next value is the maximum memory size grit can use
+    # The next value is the maximum memory size git can use
     # Given in number of bytes per git object (e.g. a commit)
     # This value can be increased if you have very large commits
     max_size: 5242880 # 5.megabytes


### PR DESCRIPTION
Change 'grit' to 'git'
