### PR TITLE
Add support for side-by-side inline comments

### DIFF
--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -63,23 +63,14 @@
       }
     }
 
-    .text-file-parallel div {
-      display: inline-block;
-      padding-bottom: 16px;
-    }
-    .diff-side {
-      overflow-x: scroll;
-      width: 508px;
-    }
-    .diff-side.diff-side-left{
-      overflow-y:hidden;
-    }
-    .diff-side table, td.diff-middle table {
-    }
-    .diff-middle {
-      width: 114px;
-      vertical-align: top;
-      overflow: hidden
+    tr.line_holder.parallel{
+      .old_line, .new_line, .diff_line {
+        min-width: 50px;
+      }
+
+      td.line_content.parallel{
+        width: 50%;
+      }
     }
 
     .old_line, .new_line, .diff_line {

--- a/app/assets/stylesheets/sections/notes.scss
+++ b/app/assets/stylesheets/sections/notes.scss
@@ -139,6 +139,7 @@ ul.notes {
       background-color: #fff;
       border-width: 1px 0;
       padding-top: 0;
+      vertical-align: top;
 
       li {
         padding: 5px;

--- a/app/views/projects/commits/_parallel_view.html.haml
+++ b/app/views/projects/commits/_parallel_view.html.haml
@@ -2,54 +2,37 @@
 - old_lines, new_lines = parallel_diff_lines(project, @commit, diff, file)
 - num_lines = old_lines.length
 
-%div.text-file-parallel
-  %div.diff-side.diff-side-left
-    %table
-      - old_lines.each do |line|
+%div.text-file
+  %table
+    - num_lines.times do |index|
+      - new_line = new_lines[index]
+      - old_line = old_lines[index]
+      %tr.line_holder.parallel
+        -# For old line
+        - if old_line.type == :file_created
+          %td.old_line= old_line.num
+          %td.line_content.parallel= "File was created"
+        - elsif old_line.type == :deleted
+          %td.old_line.old= old_line.num
+          %td.line_content{class: "parallel noteable_line old #{old_line.code}", "line_code" => old_line.code}= old_line.content
+        - else old_line.type == :no_change
+          %td.old_line= old_line.num
+          %td.line_content.parallel= old_line.content
 
-        %tr.line_holder.parallel
-          - if line.type == :file_created
-            %td.line_content.parallel= "File was created"
-          - elsif line.type == :deleted
-            %td.line_content{class: "parallel noteable_line old #{line.code}", "line_code" => line.code }= line.content
-          - else line.type == :no_change
-            %td.line_content.parallel= line.content
+        -# For new line
+        - if new_line.type == :file_deleted
+          %td.new_line= new_line.num
+          %td.line_content.parallel= "File was deleted"
+        - elsif new_line.type == :added
+          %td.new_line.new= new_line.num
+          %td.line_content{class: "parallel noteable_line new #{new_line.code}", "line_code" => new_line.code}= new_line.content
+        - else new_line.type == :no_change
+          %td.new_line= new_line.num
+          %td.line_content.parallel= new_line.content
 
-  %div.diff-middle
-    %table
-      - num_lines.times do |index|
-        %tr
-          - if old_lines[index].type == :deleted
-            %td.old_line.old= old_lines[index].num
-          - else
-            %td.old_line= old_lines[index].num
+      - if @reply_allowed
+        - comments1 = @line_notes.select { |n| n.line_code == old_line.code }.sort_by(&:created_at)
+        - comments2 = @line_notes.select { |n| n.line_code == new_line.code }.sort_by(&:created_at)
+        - unless comments1.empty? and comments2.empty?
+          = render "projects/notes/diff_notes_with_reply_parallel", notes1: comments1, notes2: comments2
 
-          %td.diff_line=""
-
-          - if new_lines[index].type == :added
-            %td.new_line.new= new_lines[index].num
-          - else
-            %td.new_line= new_lines[index].num
-
-  %div.diff-side.diff-side-right
-    %table
-      - new_lines.each do |line|
-
-        %tr.line_holder.parallel
-          - if line.type == :file_deleted
-            %td.line_content.parallel= "File was deleted"
-          - elsif line.type == :added
-            %td.line_content{class: "parallel noteable_line new #{line.code}", "line_code" => line.code }= line.content
-          - else line.type == :no_change
-            %td.line_content.parallel= line.content
-
-:javascript
-  $('.diff-side-right').on('scroll', function(){
-    $('.diff-side-left, .diff-middle').scrollTop($(this).scrollTop());
-    $('.diff-side-left').scrollLeft($(this).scrollLeft());
-  });
-
-  $('.diff-side-left').on('scroll', function(){
-    $('.diff-side-right, .diff-middle').scrollTop($(this).scrollTop()); // might never be relevant
-    $('.diff-side-right').scrollLeft($(this).scrollLeft());
-  });

--- a/app/views/projects/notes/_diff_notes_with_reply_parallel.html.haml
+++ b/app/views/projects/notes/_diff_notes_with_reply_parallel.html.haml
@@ -1,34 +1,33 @@
 - note1 = notes1.first # example note
 - note2 = notes2.first # example note
+-# Check if line want not changed since comment was left
+/- if !defined?(line) || line == note.diff_line
 %tr.notes_holder.js-toggle-content
-  -# Check if line want not changed since comment was left
-  /- if !defined?(line1) || line1 == note1.diff_line
   - if note1
+    %td.notes_line
+      %span.btn.disabled
+        %i.icon-comment
+        = notes1.count
     %td.notes_content
       %ul.notes{ rel: note1.discussion_id }
         = render notes1
+
       = render "projects/notes/discussion_reply_button", note: note1
-    %td.notes_line2
-      %span.btn.disabled.parallel-comment
-        %i.icon-comment
-        = notes1.count
   - else
     %td= ""
     %td= ""
 
-  %td= ""
-
-  -# Check if line want not changed since comment was left
-  /- if !defined?(line2) || line2 == note2.diff_line
   - if note2
     %td.notes_line
-      %span.btn.disabled.parallel-comment
+      %span.btn.disabled
         %i.icon-comment
         = notes2.count
     %td.notes_content
       %ul.notes{ rel: note2.discussion_id }
         = render notes2
+
       = render "projects/notes/discussion_reply_button", note: note2
   - else
     %td= ""
     %td= ""
+


### PR DESCRIPTION
- Only display inline comments for changed lines
- Support reply to existing inline comments
- **DO NOT** display inline comment for matched lines
  - Because we do not have line_code for matched lines in side-by-side mode
  - And I am not sure where should i put this comment, on the left or on the right?
  - We could support this by modifying in https://github.com/gitlabhq/gitlabhq/blob/master/app/helpers/commits_helper.rb#L108
- **DO NOT** support adding new inline comments
  - First, we also need line_code for matched lines
  - Second, it may involve more code changes. I could do it, but maybe in another pull-request.

Inline Mode
![screen shot 2014-04-24 at 8 55 49 pm](https://cloud.githubusercontent.com/assets/1321488/2789578/ccf50a50-cbaf-11e3-8be0-7035e9ebc913.png)

Side-by-side Mode
![screen shot 2014-04-24 at 8 49 00 pm](https://cloud.githubusercontent.com/assets/1321488/2789553/a12ae49e-cbaf-11e3-9e82-437b159b1294.png)
