### PR TITLE
postgresql-9.1 isn't available on modern ubuntu

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -147,7 +147,7 @@ GitLab Shell is an ssh access and repository management software developed speci
 We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](database_mysql.md).
 
     # Install the database packages
-    sudo apt-get install -y postgresql-9.3 postgresql-client libpq-dev
+    sudo apt-get install -y postgresql postgresql-client libpq-dev
 
     # Login to PostgreSQL
     sudo -u postgres psql -d template1

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -147,7 +147,7 @@ GitLab Shell is an ssh access and repository management software developed speci
 We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](database_mysql.md).
 
     # Install the database packages
-    sudo apt-get install -y postgresql-9.1 postgresql-client libpq-dev
+    sudo apt-get install -y postgresql-9.3 postgresql-client libpq-dev
 
     # Login to PostgreSQL
     sudo -u postgres psql -d template1


### PR DESCRIPTION
This wont work on the latest ubuntu (and possibly more), so I think it's a good idea to bump the version.
