### PR TITLE
chmod satellites_path

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -458,7 +458,7 @@ namespace :gitlab do
       else
         puts "no".red
         try_fixing_it(
-          "sudo chmod u+rwx,g+rx,o-rwx #{satellites_path}",
+          "sudo chmod 750 #{satellites_path}",
         )
         for_more_information(
           see_installation_guide_section "GitLab"


### PR DESCRIPTION
my error was during the gitlab:check.
somehow the gitlab-satellites had g+w (old installation, lots of updates) which did not get removed and the error was thrown.
chmod 750 solves this
