### PR TITLE
Fix unclear text in broadcast message view.

### DIFF
--- a/app/views/admin/broadcast_messages/index.html.haml
+++ b/app/views/admin/broadcast_messages/index.html.haml
@@ -22,12 +22,12 @@
     = f.label :color, "Background Color", class: 'control-label'
     .col-sm-10
       = f.text_field :color, placeholder: "#AA33EE", class: "form-control"
-      .light Hex values as 3 double digit numbers, starting with a # sign.
+      .light 6 character hex values starting with a # sign.
   .form-group.js-toggle-colors-container.hide
     = f.label :font, "Font Color", class: 'control-label'
     .col-sm-10
       = f.text_field :font, placeholder: "#224466", class: "form-control"
-      .light Hex values as 3 double digit numbers, starting with a # sign.
+      .light 6 character hex values starting with a # sign.
   .form-group
     = f.label :starts_at, class: 'control-label'
     .col-sm-10.datetime-controls


### PR DESCRIPTION
### What does this MR do?

Fix weird text instructions on the broadcast message page.
### Why was this MR needed?

The existing text was extremely confusing. It read: "Hex values as 3 double digit numbers, starting with a # sign." Hex colors are not always "digits" and saying "3 double digit numbers" is extremely confusing. Just change this to say "6 character hex values starting with a # sign."
