### PR TITLE
do not html encode plaintext part of emails for push notifications

### DIFF
--- a/app/views/notify/repository_push_email.text.haml
+++ b/app/views/notify/repository_push_email.text.haml
@@ -17,7 +17,7 @@ Changes:
   - else
     = diff.new_path || diff.old_path
   \=====================================
-  = diff.diff
+  != diff.diff
 \
 - if @compare.timeout
   Huge diff. To prevent performance issues it was hidden


### PR DESCRIPTION
Multipart emails from the service 'Emails on push' are html encoded, also the plaintext part, which shouldn't.
