### PR TITLE
Satellites access fix

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -202,7 +202,7 @@ You can change `6-8-stable` to `master` if you want the *bleeding edge* version,
 
     # Create directory for satellites
     sudo -u git -H mkdir /home/git/gitlab-satellites
-    sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
+    sudo chmod u+rwx,g=rx,o-rwx /home/git/gitlab-satellites
 
     # Make sure GitLab can write to the tmp/pids/ and tmp/sockets/ directories
     sudo chmod -R u+rwX tmp/pids/

--- a/doc/update/6.6-to-6.7.md
+++ b/doc/update/6.6-to-6.7.md
@@ -65,7 +65,7 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 
 # Close access to gitlab-satellites for others
-sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
+sudo chmod u+rwx,g=rx,o-rwx /home/git/gitlab-satellites
 ```
 
 

--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -67,7 +67,7 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 
 # Close access to gitlab-satellites for others
-sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
+sudo chmod u+rwx,g=rx,o-rwx /home/git/gitlab-satellites
 ```
 
 ### 5. Update config files

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -458,7 +458,7 @@ namespace :gitlab do
       else
         puts "no".red
         try_fixing_it(
-          "sudo chmod u+rwx,g+rx,o-rwx #{satellites_path}",
+          "sudo chmod u+rwx,g=rx,o-rwx #{satellites_path}",
         )
         for_more_information(
           see_installation_guide_section "GitLab"


### PR DESCRIPTION
If the permissions for /home/git/gitlab-satellites are messed up the check might now be able to fix it, because the groups writeflag isn't removed.
