### PR TITLE
Git hook UI management

### DIFF
--- a/app/controllers/projects/githooks_controller.rb
+++ b/app/controllers/projects/githooks_controller.rb
@@ -65,7 +65,7 @@ class Projects::GithooksController < Projects::ApplicationController
     File.symlink(File.join(githooks_path, 'hook-wrapper'), hook)
 
     # Add the hook script
-    hook = File.join(, 'hooks', "#{type}-#{name}")
+    hook = File.join(project_path, 'hooks', "#{type}-#{name}")
     File.delete(hook) if File.exists?(hook)
     File.symlink(File.join(githooks_path, name), hook)
   end

--- a/app/controllers/projects/githooks_controller.rb
+++ b/app/controllers/projects/githooks_controller.rb
@@ -1,0 +1,82 @@
+class Projects::GithooksController < Projects::ApplicationController
+  # Authorize
+  before_filter :authorize_admin_project!
+
+  respond_to :html
+
+  layout "project_settings"
+
+  def index
+    @hooks = list
+  end
+
+  def enable
+    hook = load(params[:id])
+    create_hooks(hook['hook'], hook['id'])
+    flash[:notice] = "You have successfully enbled " + hook['name']
+
+    redirect_to project_githooks_path(@project)
+  end
+
+  def disable
+    hook = load(params[:id])
+    delete_hooks(hook['hook'], hook['id'])
+    flash[:notice] = "You have successfully disabled " + hook['name']
+
+    redirect_to project_githooks_path(@project)
+  end
+
+  private
+
+  def list
+    githooks = []
+    Dir.glob(File.join(githooks_path, '*.json')) do |githook_info|
+      hook = JSON.parse(IO.read(githook_info))
+      hook['id'] = File.basename(githook_info, ".json")
+      hook['status'] = githook_status?(hook['id'])
+      githooks << hook
+    end
+    return githooks
+  end
+
+  def load(id)
+    path = File.join(githooks_path, id + '.json')
+    hook = JSON.parse(IO.read(path))
+    hook['id'] = id
+    hook['status'] = githook_status?(hook['id'])
+    return hook
+  end
+
+  def githooks_path
+    return Gitlab.config.gitlab_shell.hooks_path
+  end
+
+  def githook_status?(id)
+    path = File.join(@project.repository.path_to_repo, 'hooks', "*-#{id}")
+    !Dir.glob(path).empty?
+  end
+
+
+  def create_hooks(type, name)
+    # Add hook wrapper script
+    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}")
+    File.delete(hook) if File.exists?(hook)
+    File.symlink(File.join(githooks_path, 'hook-wrapper'), hook)
+
+    # Add the hook script
+    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-#{name}")
+    File.delete(hook) if File.exists?(hook)
+    File.symlink(File.join(githooks_path, name), hook)
+  end
+
+  def delete_hooks(type, name)
+    # Delete hook
+    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-#{name}")
+    File.delete(hook) if File.exists?(hook)
+
+    # Delete wrapper (if no more hooks are available)
+    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}")
+    path = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-*")
+    File.delete(hook) if (File.exists?(hook) && Dir.glob(path).empty?)
+  end
+end

--- a/app/controllers/projects/githooks_controller.rb
+++ b/app/controllers/projects/githooks_controller.rb
@@ -13,7 +13,7 @@ class Projects::GithooksController < Projects::ApplicationController
   def enable
     hook = load(params[:id])
     create_hooks(hook['hook'], hook['id'])
-    flash[:notice] = "You have successfully enbled " + hook['name']
+    flash[:notice] = 'You have successfully enbled ' + hook['name']
 
     redirect_to project_githooks_path(@project)
   end
@@ -21,7 +21,7 @@ class Projects::GithooksController < Projects::ApplicationController
   def disable
     hook = load(params[:id])
     delete_hooks(hook['hook'], hook['id'])
-    flash[:notice] = "You have successfully disabled " + hook['name']
+    flash[:notice] = 'You have successfully disabled ' + hook['name']
 
     redirect_to project_githooks_path(@project)
   end
@@ -32,11 +32,11 @@ class Projects::GithooksController < Projects::ApplicationController
     githooks = []
     Dir.glob(File.join(githooks_path, '*.json')) do |githook_info|
       hook = JSON.parse(IO.read(githook_info))
-      hook['id'] = File.basename(githook_info, ".json")
+      hook['id'] = File.basename(githook_info, '.json')
       hook['status'] = githook_status?(hook['id'])
       githooks << hook
     end
-    return githooks
+    githooks
   end
 
   def load(id)
@@ -44,7 +44,7 @@ class Projects::GithooksController < Projects::ApplicationController
     hook = JSON.parse(IO.read(path))
     hook['id'] = id
     hook['status'] = githook_status?(hook['id'])
-    return hook
+    hook
   end
 
   def githooks_path
@@ -56,27 +56,30 @@ class Projects::GithooksController < Projects::ApplicationController
     !Dir.glob(path).empty?
   end
 
-
   def create_hooks(type, name)
+    project_path = @project.repository.path_to_repo
+
     # Add hook wrapper script
-    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}")
+    hook = File.join(project_path, 'hooks', "#{type}")
     File.delete(hook) if File.exists?(hook)
     File.symlink(File.join(githooks_path, 'hook-wrapper'), hook)
 
     # Add the hook script
-    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-#{name}")
+    hook = File.join(, 'hooks', "#{type}-#{name}")
     File.delete(hook) if File.exists?(hook)
     File.symlink(File.join(githooks_path, name), hook)
   end
 
   def delete_hooks(type, name)
+    project_path = @project.repository.path_to_repo
+
     # Delete hook
-    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-#{name}")
+    hook = File.join(project_path, 'hooks', "#{type}-#{name}")
     File.delete(hook) if File.exists?(hook)
 
     # Delete wrapper (if no more hooks are available)
-    hook = File.join(@project.repository.path_to_repo, 'hooks', "#{type}")
-    path = File.join(@project.repository.path_to_repo, 'hooks', "#{type}-*")
-    File.delete(hook) if (File.exists?(hook) && Dir.glob(path).empty?)
+    hook = File.join(project_path, 'hooks', "#{type}")
+    path = File.join(project_path, 'hooks', "#{type}-*")
+    File.delete(hook) if File.exists?(hook) && Dir.glob(path).empty?
   end
 end

--- a/app/controllers/projects/githooks_controller.rb
+++ b/app/controllers/projects/githooks_controller.rb
@@ -4,7 +4,7 @@ class Projects::GithooksController < Projects::ApplicationController
 
   respond_to :html
 
-  layout "project_settings"
+  layout 'project_settings'
 
   def index
     @hooks = list

--- a/app/views/projects/_settings_nav.html.haml
+++ b/app/views/projects/_settings_nav.html.haml
@@ -11,6 +11,10 @@
     = link_to project_deploy_keys_path(@project) do
       %i.icon-key
       Deploy Keys
+  = nav_link(controller: :githooks) do
+    = link_to project_githooks_path(@project) do
+      %i.icon-cogs
+      Git Hooks
   = nav_link(controller: :hooks) do
     = link_to project_hooks_path(@project) do
       %i.icon-link

--- a/app/views/projects/githooks/index.html.haml
+++ b/app/views/projects/githooks/index.html.haml
@@ -14,7 +14,7 @@
           %span.label.label-gray
             = hook['hook']
           - if hook['status']
-            = link_to 'Disable', disable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-remove", data: { confirm: 'Messaggio di conferma' }
+            = link_to 'Disable', disable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-remove", data: { confirm: "Are you sure to disable #{hook['name']} git hook?" }
           - else
-            = link_to 'Enable', enable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-success", data: { confirm: 'Messaggio di conferma' }
+            = link_to 'Enable', enable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-success", data: { confirm: "Are you sure to enable #{hook['name']} git hook?" }
       %p= hook['description']

--- a/app/views/projects/githooks/index.html.haml
+++ b/app/views/projects/githooks/index.html.haml
@@ -10,7 +10,7 @@
         = hook['name']
         .pull-right
           %span.label.label-gray
-            = 'v' + hook['version']
+            = hook['version']
           %span.label.label-gray
             = hook['hook']
           - if hook['status']

--- a/app/views/projects/githooks/index.html.haml
+++ b/app/views/projects/githooks/index.html.haml
@@ -1,0 +1,20 @@
+%h3.page-title Project git hooks
+%p.light Project git hooks allow you to integrate Git hooks in your repo.
+%hr
+
+%ul.bordered-list
+  - @hooks.each do |hook|
+    %li
+      %h4
+        = boolean_to_icon hook['status']
+        = hook['name']
+        .pull-right
+          %span.label.label-gray
+            = 'v' + hook['version']
+          %span.label.label-gray
+            = hook['hook']
+          - if hook['status']
+            = link_to 'Disable', disable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-remove", data: { confirm: 'Messaggio di conferma' }
+          - else
+            = link_to 'Enable', enable_project_githook_path(@project, hook['id']), method: :put, class: "btn btn-small btn-success", data: { confirm: 'Messaggio di conferma' }
+      %p= hook['description']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,13 @@ Gitlab::Application.routes.draw do
         end
       end
 
+      resources :githooks, constraints: { id: /[^\/]+/ } do
+        member do
+          put :enable
+          put :disable
+        end
+      end
+
       resources :deploy_keys, constraints: {id: /\d+/} do
         member do
           put :enable


### PR DESCRIPTION
This is a PoC to add a Gitlab UI to mange git hooks.
### Refs
- [selecting git repo hooks via the gitlab gui](http://feedback.gitlab.com/forums/176466-general/suggestions/4511318-selecting-git-repo-hooks-via-the-gitlab-gui)
- [allow new repositories to have default hook script](http://feedback.gitlab.com/forums/176466-general/suggestions/5496298-allow-new-repositories-to-have-default-hook-script)
### UI

![screen shot 2014-04-27 at 13 14 37](https://cloud.githubusercontent.com/assets/43941/2811032/3a2e5676-cdfe-11e3-8b15-6eb554ded922.png)
### How to use

We need to use gitlab-shell with [MR#150](https://github.com/gitlabhq/gitlab-shell/pull/150)
In gitlab-shell hooks folder create a new script (bash, ruby, python, nodejs, ...). The file name must be unique and do not need to refer to hook name (eg: `test1`).

Create a new JSON file with the same name of script (eg: `test1.json`) with hook description, like:

```
{
  "name": "Coding standard (PHP - PSR2)",
  "description": "Process php and inc files using PHP_CodeSniffer using PSR2 standard.",
  "hook": "pre-receive",
  "version": "1.0.0"
}
```

all items are required.

Go to project settings area and click on Githooks link. Enable or disable the git hooks for the repo.
### We need to
- [ ] add tests 
- [ ] move some elements (load, list, ...) in a specific model (Githook?) and include it in controller
- [ ] move "hooks container folder" as configurable directory
