### PR TITLE
init.d script copy duplication

### DIFF
--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -62,6 +62,7 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 
 # Update init.d script
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+sudo chmod +x /etc/init.d/gitlab
 
 # Update the logrotate configuration (keep logs for 90 days instead of 52 weeks)
 sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
@@ -92,19 +93,12 @@ If you are using HTTPS, disable gzip as in [this commit](https://gitlab.com/gitl
 
 To improve performance, enable gzip asset compression as seen [in this commit](https://gitlab.com/gitlab-org/gitlab-ce/commit/8af94ed75505f0253823b9b2d44320fecea5b5fb).
 
-### 6. Update Init script
-
-```bash
-sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
-```
-
-### 7. Start application
+### 6. Start application
 
     sudo service gitlab start
     sudo service nginx restart
 
-### 8. Check application status
+### 7. Check application status
 
 Check if GitLab and its environment are configured correctly:
 


### PR DESCRIPTION
Copy init.d script twice in the 6.7 to 6.8 update guide. Deleted the second one.
