### PR TITLE
Provide a Gitlab icon for slack messages

### DIFF
--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -54,7 +54,10 @@ class SlackService < Service
     notifier = Slack::Notifier.new(subdomain, token)
     notifier.channel = room
     notifier.username = 'GitLab'
-    notifier.ping(message.pretext, attachments: message.attachments, icon_url: 'https://www.gitlab.com/ico/apple-touch-icon-72-precomposed.png')
+
+    icon_url = 'https://www.gitlab.com/ico/apple-touch-icon-72-precomposed.png'
+    notifier.ping(message.pretext, attachments: message.attachments,
+                                   icon_url: icon_url)
   end
 
   private

--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -54,7 +54,7 @@ class SlackService < Service
     notifier = Slack::Notifier.new(subdomain, token)
     notifier.channel = room
     notifier.username = 'GitLab'
-    notifier.ping(message.pretext, attachments: message.attachments)
+    notifier.ping(message.pretext, attachments: message.attachments, icon_url: 'https://www.gitlab.com/ico/apple-touch-icon-72-precomposed.png')
   end
 
   private


### PR DESCRIPTION
Provides an icon for the slack web hook, replaces the default slack icon with Gitlab's

This would be nice to have, but not super important.
