### PR TITLE
Remove redundant signin link from signin page.

### DIFF
--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -10,7 +10,7 @@
           %p.light
             GitLab is open source software to collaborate on code.
             %br
-            #{link_to "Sign in", new_user_session_path} or browse for #{link_to "public projects", public_projects_path}.
+            Sign in or browse for #{link_to "public projects", public_projects_path}.
     %hr
     .container
       .content


### PR DESCRIPTION
The sign in link points to the page itself, and makes it seem like users have to go somewhere else to signin.

![screenshot from 2014-04-30 21 44 44](https://cloud.githubusercontent.com/assets/1429315/2846231/eb3d1184-d09f-11e3-9887-1ee3c0499b18.png)
