### PR TITLE
Add help link to header.

### DIFF
--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -20,6 +20,10 @@
             = link_to search_path, title: "Search", class: 'has_bottom_tooltip', 'data-original-title' => 'Search area' do
               %i.icon-search
           %li
+            = link_to help_path, title: 'Help', class: 'has_bottom_tooltip',
+               'data-original-title' => 'Help'  do
+              %i.icon-question
+          %li
             = link_to public_root_path, title: "Public area", class: 'has_bottom_tooltip', 'data-original-title' => 'Public area' do
               %i.icon-globe
           %li


### PR DESCRIPTION
- people may need help from any page
- it is not obvious that help is under Dashboard:
  - when I first used GitLab, I clearly remember spending some time looking for the help.
  - the help URL is just `/help`, and not `/dashboard/projects` or `/dasboard/issues`, indicating that in the mind of the community, Help is not a part of `/dashboard`
- GitHub does it, so its probably a good design choice and GitHub users will be home

**Screenshots**

![screenshot from 2014-04-30 12 26 03](https://cloud.githubusercontent.com/assets/1429315/2840240/f8e06eba-d051-11e3-9b5a-77ecc9fc24b8.png)

![screenshot from 2014-04-30 12 26 22](https://cloud.githubusercontent.com/assets/1429315/2840242/fe0f87fe-d051-11e3-8cc7-513ea6cef9a2.png)

Hover still perceptibly changes link color on dark theme. On white theme, like before this PR link color is unchanged on hover.

![screenshot from 2014-04-30 12 26 28](https://cloud.githubusercontent.com/assets/1429315/2840243/01f5bc76-d052-11e3-990c-95be9bb2bc38.png)

**Details**
- made help bold and clear on the dark theme to make it more visible and coherent with the icons on the right
- made `header-font` used in the `.title` "Diaspora / Diaspora Title" a bit larger or else help would be more visible than it

**Questions**

If you like this, how about also adding a **Blog** link on another PR? Very important stuff, and GitHub puts it up there.
