### PR TITLE
[WIP] Make tree new file link more visible.

### DIFF
--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -11,9 +11,11 @@
         = link_to title, '#'
   - if current_user && @repository.branch_names.include?(@ref) && current_user.can?(:push_code, @project)
     %li
-      = link_to project_new_tree_path(@project, @id), title: 'New file', id: 'new-file-link' do
+      = link_to project_new_tree_path(@project, @id), class: 'btn btn-new',
+          title: 'New file', id: 'new-file-link', style: 'padding:1px 5px;' do
         %small
-          %i.icon-plus.light
+          %i.icon-plus
+          New file
 
 %div#tree-content-holder.tree-content-holder
   %table#tree-slider{class: "table_#{@hex_path} tree-table" }


### PR DESCRIPTION
- I remember the first time I wanted to create a new file from the web UI searching for the button. It's harsh on new users.
- every time I want to create a new file I have to concentrate to find the little `+`.
- more coherent: GitLab uses "plus sign `+` text" green buttons for all "create new thing" links, including the analogous wiki "create new page" button that also adds a file to a Git repo.

![screenshot from 2014-05-01 15 50 05](https://cloud.githubusercontent.com/assets/1429315/2852618/e080c720-d137-11e3-98ec-334b3384d765.png)

This is just a mock up, I'll improve if people are for it.

Main difficulty: to look nice the button has to be as high as the branch dropdown to its left, but buttons are larger than dropdowns. I wish buttons, text fields and dropdowns all the same height. Analogous UI problem on the `/network` tab due to different heights of search field and dropdown. 
