### PR TITLE
Added support for Markdown formatting

### DIFF
--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -55,4 +55,4 @@
     = gfm escape_once(@commit.title)
   - if @commit.description.present?
     %pre.commit-description
-      = gfm escape_once(@commit.description)
+      = markdown escape_once(@commit.description)


### PR DESCRIPTION
- Switched from using gfm() method to markdown(), which eventually calls gfm()
  - Previous fix (pull request 6777) caused a call stack overflow on master
