### PR TITLE
Provide fallback for missing `name` value.

### DIFF
--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -65,7 +65,11 @@ module Gitlab
         end
 
         def name
-          auth.info.name.to_s.force_encoding("utf-8")
+          unless auth.info.name.nil?
+            auth.info.name.to_s.force_encoding("utf-8")
+          else
+            "#{auth.info.first_name} #{auth.info.last_name}".force_encoding("utf-8")
+          end
         end
 
         def username

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -65,10 +65,10 @@ module Gitlab
         end
 
         def name
-          if !auth.info.name.nil?
-            auth.info.name.to_s.force_encoding('utf-8')
-          else
+          if auth.info.name.nil?
             "#{auth.info.first_name} #{auth.info.last_name}".force_encoding('utf-8')
+          else
+            auth.info.name.to_s.force_encoding('utf-8')
           end
         end
 

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -65,10 +65,10 @@ module Gitlab
         end
 
         def name
-          unless auth.info.name.nil?
-            auth.info.name.to_s.force_encoding("utf-8")
+          if !auth.info.name.nil?
+            auth.info.name.to_s.force_encoding('utf-8')
           else
-            "#{auth.info.first_name} #{auth.info.last_name}".force_encoding("utf-8")
+            "#{auth.info.first_name} #{auth.info.last_name}".force_encoding('utf-8')
           end
         end
 


### PR DESCRIPTION
If `auth.info.name` is `nil`, then use `auth.info.first_name + auth.info.last_name`
as the value of `name`.

I would find this change useful, as I happen to have a source for first and last name, but not both.
Your call if that's worth a patch.
