### PR TITLE
fix link to notes in merge request diff

### DIFF
--- a/app/views/projects/merge_requests/_show.html.haml
+++ b/app/views/projects/merge_requests/_show.html.haml
@@ -26,11 +26,11 @@
       - if @merge_request.closed?
         = link_to 'Reopen', project_merge_request_path(@project, @merge_request, merge_request: {state_event: :reopen }), method: :put, class: "btn btn-grouped btn-reopen reopen-mr-link", title: "Close merge request"
 
-  .notes.tab-content.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
-    = render "projects/notes/notes_with_form"
   .diffs.tab-content
     - if current_page?(action: 'diffs')
       = render "projects/merge_requests/show/diffs"
+  .notes.tab-content.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
+    = render "projects/notes/notes_with_form"
   .status
 
 :javascript


### PR DESCRIPTION
http://localhost:3000/gitlabhq/gitlab-ci/merge_requests/1/diffs#note_316
scroll in such links doesn't work. It happens because  on page there are 2 elements with id="note_316" in changes and discussion.
Browser takes first for scroll.
This solution works because changes loads without diffs so tag with id="note_316" just one.
Diffs loads with discussions, but in this case diff tag would be first.
It is dirty but working solution.
