### PR TITLE
Fix milestones description's max length

### DIFF
--- a/app/views/projects/milestones/_form.html.haml
+++ b/app/views/projects/milestones/_form.html.haml
@@ -21,7 +21,7 @@
       .form-group
         = f.label :description, "Description", class: "control-label"
         .col-sm-10
-          = f.text_area :description, maxlength: 2000, class: "form-control", rows: 10
+          = f.text_area :description, maxlength: 65535, class: "form-control", rows: 10
           %p.hint Milestones are parsed with #{link_to "GitLab Flavored Markdown", help_markdown_path, target: '_blank'}.
     .col-md-6
       .form-group


### PR DESCRIPTION
Here a quick fix, so we can have bigger Milestones descriptions.
It's not much but I often hit the 2000 limit when I use gitlab to plan big milestone and cover all changes and stuff on the description.
So before I got bored to edit myself gitlab at every update, here I propose this change.
Thanks
