### PR TITLE
Fix css rules conflict between .dark & a.dark classes

### DIFF
--- a/app/assets/stylesheets/generic/typography.scss
+++ b/app/assets/stylesheets/generic/typography.scss
@@ -47,7 +47,7 @@ a {
     text-decoration: underline;
   }
 
-  &.dark {
+  &.darken {
     color: $style_color;
   }
 

--- a/app/views/projects/milestones/show.html.haml
+++ b/app/views/projects/milestones/show.html.haml
@@ -100,7 +100,7 @@
     %ul.bordered-list
       - @users.each do |user|
         %li
-          = link_to user, title: user.name, class: "dark" do
+          = link_to user, title: user.name, class: "darken" do
             = image_tag avatar_icon(user.email, 32), class: "avatar s32"
             %strong= truncate(user.name, lenght: 40)
             %br


### PR DESCRIPTION
I guess this was not intended to happen (I hope so...)
But .dark and a.dark css rules are in conflict which happend to do stuff like 

![this](http://take.ms/SjX3h)
