### PR TITLE
Webhook timeout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v 7.2.0
   - Explore page
   - Add project stars (Ciro Santilli)
+  - Add ability to configure webhook timeout via gitlab.yml
 
 v 7.1.0
   - Remove observers

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -23,7 +23,7 @@ class WebHook < ActiveRecord::Base
   default_value_for :merge_requests_events, false
 
   # HTTParty timeout
-  default_timeout 10
+  default_timeout Gitlab.config.gitlab.webhook_timeout
 
   validates :url, presence: true,
                   format: { with: URI::regexp(%w(http https)), message: "should be a valid url" }

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -67,6 +67,7 @@ production: &base
     # If a commit message matches this regular expression, all issues referenced from the matched text will be closed.
     # This happens when the commit is pushed or merged into the default branch of a project.
     # When not specified the default issue_closing_pattern as specified below will be used.
+    # Tip: you can test your closing pattern at http://rubular.com
     # issue_closing_pattern: '([Cc]lose[sd]|[Ff]ixe[sd]) #(\d+)'
 
     ## Default project features settings

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -78,6 +78,10 @@ production: &base
       snippets: false
       visibility_level: "private"  # can be "private" | "internal" | "public"
 
+    ## Webhook settings
+    # Number of seconds to wait for HTTP response after sending webhook HTTP POST request (default: 10)
+    # webhook_timeout: 10
+
     ## Repository downloads directory
     # When a user clicks e.g. 'Download zip' on a project, a temporary zip file is created in the following directory.
     # The default is 'tmp/repositories' relative to the root of the Rails app.

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -92,6 +92,7 @@ Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['issue_closing_pattern'] = '([Cc]lose[sd]|[Ff]ixe[sd]) #(\d+)' if Settings.gitlab['issue_closing_pattern'].nil?
 Settings.gitlab['default_projects_features'] ||= {}
+Settings.gitlab['webhook_timeout'] ||= 10
 Settings.gitlab.default_projects_features['issues']         = true if Settings.gitlab.default_projects_features['issues'].nil?
 Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.gitlab.default_projects_features['merge_requests'].nil?
 Settings.gitlab.default_projects_features['wiki']           = true if Settings.gitlab.default_projects_features['wiki'].nil?

--- a/doc/release/monthly.md
+++ b/doc/release/monthly.md
@@ -156,11 +156,14 @@ It is important to do this as soon as possible, so we can catch any errors befor
 
 ### **2. Prepare the blog post**
 
-- Check the changelog of CE and EE for important changes. Based on [release blog template](https://gitlab.com/gitlab-com/www-gitlab-com/blob/master/doc/release_blog_template.md) fill in the important information.
-- Create a WIP MR for the blog post and cc the team so everyone can give feedback.
+- Start with a complete copy of the [release blog template](https://gitlab.com/gitlab-com/www-gitlab-com/blob/master/doc/release_blog_template.md) and fill it out.
+- Check the changelog of CE and EE for important changes.
+- Create a WIP MR for the blog post
 - Ask Dmitriy to add screenshots to the WIP MR.
 - Decide with team who will be the MVP user.
 - Add a note if there are security fixes: This release fixes an important security issue and we advise everyone to upgrade as soon as possible.
+- Assign to one reviewer who will fix spelling issues by editing the branch (can use the online editor)
+- After the reviewer is finished the whole team will be mentioned to give their suggestions via line comments
 
 ### **3. Create a regressions issue**
 
@@ -181,7 +184,11 @@ Tweet about the RC release:
 
 # **21st - Preparation**
 
-### **1. Q&A**
+### **1. Pre QA merge**
+
+Merge CE into EE before doing the QA.
+
+### **2. QA**
 
 Create issue on dev.gitlab.org `gitlab` repository, named "GitLab X.X release" in order to keep track of the progress.
 
@@ -189,7 +196,7 @@ Use the omnibus packages of Enterprise Edition using [this guide](https://dev.gi
 
 **NOTE** Upgrader can only be tested when tags are pushed to all repositories. Do not forget to confirm it is working before releasing. Note that in the issue.
 
-### **2. Fix anything coming out of the QA**
+### **3. Fix anything coming out of the QA**
 
 Create an issue with description of a problem, if it is quick fix fix yourself otherwise contact the team for advice.
 
@@ -200,6 +207,8 @@ For GitLab EE, append `-ee` to the branches and tags.
 `x-x-stable-ee`
 
 `v.x.x.0-ee`
+
+Merge CE into EE if needed.
 
 ### **1. Create x-x-stable branch and push to the repositories**
 
@@ -212,7 +221,8 @@ git push <remote> x-x-stable
 
 ### **2. Build the Omnibus packages**
 
-[Follow this guide](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/release.md)
+Follow the [release doc in the Omnibus repository](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/release.md).
+This can happen before tagging because Omnibus uses tags in its own repo and SHA1's to refer to the GitLab codebase.
 
 ### **3. Set VERSION to x.x.x and push**
 


### PR DESCRIPTION
Our Gitlab instance needed the ability to increase the webhook_timeout used by HTTParty. It was hardcoded at 10 and I moved it to a gitlab.yaml file as a config variable

```
## Webhook settings
# webhook_timeout: 30 # default: 10 - Number of seconds to wait for HTTP response after sending webhook HTTP POST request

```

I had submitted the issue already and fixes #4954.  This is the rebase version of that commit.
