### PR TITLE
added SYSV chkconfig property so gitlab starts after MySQLd / nginx

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -12,6 +12,7 @@
 # Default-Stop:      0 1 6
 # Short-Description: GitLab git repository management
 # Description:       GitLab git repository management
+# chkconfig: - 85 14
 ### END INIT INFO
 
 


### PR DESCRIPTION
On server reboot, in RHEL distros, gitlab gets given the default chkconfig property of 50, whereas mysqld has 64.

Setting the value to 85 makes it start after mysqld, but before httpd, and nginx
