### PR TITLE
Make sure the branch counter gets updated

### DIFF
--- a/app/controllers/projects/branches_controller.rb
+++ b/app/controllers/projects/branches_controller.rb
@@ -23,8 +23,8 @@ class Projects::BranchesController < Projects::ApplicationController
   end
 
   def destroy
-    @branch = @repository.find_branch(params[:id])
     DeleteBranchService.new.execute(project, params[:id], current_user)
+    @branch_name = params[:id]
 
     respond_to do |format|
       format.html { redirect_to project_branches_path(@project) }

--- a/app/controllers/projects/branches_controller.rb
+++ b/app/controllers/projects/branches_controller.rb
@@ -23,11 +23,12 @@ class Projects::BranchesController < Projects::ApplicationController
   end
 
   def destroy
+    @branch = @repository.find_branch(params[:id])
     DeleteBranchService.new.execute(project, params[:id], current_user)
 
     respond_to do |format|
       format.html { redirect_to project_branches_path(@project) }
-      format.js { render nothing: true }
+      format.js
     end
   end
 end

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -1,5 +1,5 @@
 - commit = @repository.commit(branch.target)
-%li
+%li(class="js-branch-#{branch.name}")
   %h4
     = link_to project_tree_path(@project, branch.name) do
       %strong= truncate(branch.name, length: 60)

--- a/app/views/projects/branches/destroy.js.haml
+++ b/app/views/projects/branches/destroy.js.haml
@@ -1,0 +1,5 @@
+:plain
+  $(".js-branch-#{@branch.name}").remove();
+  $('.js-recentbranch-count').html("#{@repository.recent_branches.count}")
+  $('.js-protectedbranch-count').html("#{@project.protected_branches.count}")
+  $('.js-totalbranch-count').html("#{@repository.branch_names.count}")

--- a/app/views/projects/branches/destroy.js.haml
+++ b/app/views/projects/branches/destroy.js.haml
@@ -1,5 +1,3 @@
 :plain
-  $(".js-branch-#{@branch.name}").remove();
-  $('.js-recentbranch-count').html("#{@repository.recent_branches.count}")
-  $('.js-protectedbranch-count').html("#{@project.protected_branches.count}")
-  $('.js-totalbranch-count').html("#{@repository.branch_names.count}")
+  $(".js-branch-#{@branch_name}").remove();
+  $('.js-totalbranch-count').html("#{@repository.branches.size}")

--- a/app/views/projects/commits/_head.html.haml
+++ b/app/views/projects/commits/_head.html.haml
@@ -9,7 +9,7 @@
   = nav_link(html_options: {class: branches_tab_class}) do
     = link_to project_branches_path(@project) do
       Branches
-      %span.badge= @repository.branches.size
+      %span.badge.js-totalbranch-count= @repository.branches.size
 
   = nav_link(controller: :tags) do
     = link_to project_tags_path(@project) do


### PR DESCRIPTION
**What does this PR do**
When you delete a branch, the counters wont get updated automaticly,
this happends because of the JS nature of the original call. I've
fixed this by responding with a JS file, and recalculate the counters.

**Relevant issue numbers**
Fixes: #6030
