### PR TITLE
Fix avatar URLs in JS-lists for relative_url_root

### DIFF
--- a/app/assets/javascripts/project_users_select.js.coffee
+++ b/app/assets/javascripts/project_users_select.js.coffee
@@ -37,7 +37,7 @@
 
   projectUserFormatResult: (user) ->
     if user.avatar_url
-      avatar = user.avatar_url
+      avatar = gon.relative_url_root + user.avatar_url
     else if gon.gravatar_enabled
       avatar = gon.gravatar_url
       avatar = avatar.replace('%{hash}', md5(user.email))

--- a/app/assets/javascripts/users_select.js.coffee
+++ b/app/assets/javascripts/users_select.js.coffee
@@ -1,7 +1,7 @@
 $ ->
   userFormatResult = (user) ->
     if user.avatar_url
-      avatar = user.avatar_url
+      avatar = gon.relative_url_root + user.avatar_url
     else if gon.gravatar_enabled
       avatar = gon.gravatar_url
       avatar = avatar.replace('%{hash}', md5(user.email))


### PR DESCRIPTION
In user lists created when entering a (partial) user name into a field, the URL to the user avatar was invalid if running with relative_url_root.

This patch is the result of:
`sed -i 's/\(= *\)\(user\.avatar_url\)/\1gon.relative_url_root + \2/' app/assets/javascripts/*.coffee`

Did not update the `CHANGELOG`, as this is after the merge window and the version number would be wrong.
