### PR TITLE
fixes gitlab.com issue #229 - github.com issue #6976

### DIFF
--- a/app/assets/javascripts/project_users_select.js.coffee
+++ b/app/assets/javascripts/project_users_select.js.coffee
@@ -43,7 +43,7 @@
       avatar = avatar.replace('%{hash}', md5(user.email))
       avatar = avatar.replace('%{size}', '24')
     else
-      avatar = gon.relative_url_root + "/assets/no_avatar.png"
+      avatar = gon.relative_url_root + "#{image_path('no_avatar.png')}"
 
     if user.id == ''
       avatarMarkup = ''

--- a/app/assets/javascripts/users_select.js.coffee
+++ b/app/assets/javascripts/users_select.js.coffee
@@ -7,7 +7,7 @@ $ ->
       avatar = avatar.replace('%{hash}', md5(user.email))
       avatar = avatar.replace('%{size}', '24')
     else
-      avatar = gon.relative_url_root + "/assets/no_avatar.png"
+      avatar = gon.relative_url_root + "#{image_path('no_avatar.png')}"
 
     "<div class='user-result'>
        <div class='user-image'><img class='avatar s24' src='#{avatar}'></div>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
     size = 40 if size.nil? || size <= 0
 
     if !Gitlab.config.gravatar.enabled || user_email.blank?
-      '/assets/no_avatar.png'
+      image_path('no_avatar.png')
     else
       gravatar_url = request.ssl? || gitlab_config.https ? Gitlab.config.gravatar.ssl_url : Gitlab.config.gravatar.plain_url
       user_email.strip!

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -79,11 +79,11 @@ describe ApplicationHelper do
 
     it "should return a generic avatar path when Gravatar is disabled" do
       Gitlab.config.gravatar.stub(:enabled).and_return(false)
-      gravatar_icon(user_email).should == '/assets/no_avatar.png'
+      gravatar_icon(user_email).should match('no_avatar.png')
     end
 
     it "should return a generic avatar path when email is blank" do
-      gravatar_icon('').should == '/assets/no_avatar.png'
+      gravatar_icon('').should match('no_avatar.png')
     end
 
     it "should return default gravatar url" do


### PR DESCRIPTION
Changes .js.coffe files to not use a hardcoded path to
`no_avatar.png` but instead stick with the asset pipeline.

renames coffee.erb back to coffee

Please note that this PR is a copy of PR #6949 as it now targets master.
