### PR TITLE
Return a little more information in Issue webhook

### DIFF
--- a/app/services/issues/base_service.rb
+++ b/app/services/issues/base_service.rb
@@ -1,5 +1,6 @@
 module Issues
   class BaseService < ::BaseService
+    include Rails.application.routes.url_helpers
 
     private
 
@@ -7,8 +8,13 @@ module Issues
       Note.create_assignee_change_note(issue, issue.project, current_user, issue.assignee)
     end
 
-    def execute_hooks(issue)
-      issue.project.execute_hooks(issue.to_hook_data, :issue_hooks)
+    def execute_hooks(issue, action = 'open')
+      issue_data = issue.to_hook_data
+      issue_url = project_issue_url(id: issue.iid,
+                                    project_id: issue.project,
+                                    host: Settings.gitlab['url'])
+      issue_data[:object_attributes].merge!(url: issue_url, action: action)
+      issue.project.execute_hooks(issue_data, :issue_hooks)
     end
 
     def create_milestone_note(issue)

--- a/app/services/issues/base_service.rb
+++ b/app/services/issues/base_service.rb
@@ -1,6 +1,5 @@
 module Issues
   class BaseService < ::BaseService
-    include Rails.application.routes.url_helpers
 
     private
 
@@ -10,9 +9,7 @@ module Issues
 
     def execute_hooks(issue, action = 'open')
       issue_data = issue.to_hook_data
-      issue_url = project_issue_url(id: issue.iid,
-                                    project_id: issue.project,
-                                    host: Settings.gitlab['url'])
+      issue_url = Gitlab::UrlBuilder.new(:issue).build(issue.id)
       issue_data[:object_attributes].merge!(url: issue_url, action: action)
       issue.project.execute_hooks(issue_data, :issue_hooks)
     end

--- a/app/services/issues/close_service.rb
+++ b/app/services/issues/close_service.rb
@@ -5,7 +5,7 @@ module Issues
         notification_service.close_issue(issue, current_user)
         event_service.close_issue(issue, current_user)
         create_note(issue, commit)
-        execute_hooks(issue)
+        execute_hooks(issue, 'close')
       end
 
       issue

--- a/app/services/issues/create_service.rb
+++ b/app/services/issues/create_service.rb
@@ -8,7 +8,7 @@ module Issues
         notification_service.new_issue(issue, current_user)
         event_service.open_issue(issue, current_user)
         issue.create_cross_references!(issue.project, current_user)
-        execute_hooks(issue)
+        execute_hooks(issue, 'open')
       end
 
       issue

--- a/app/services/issues/reopen_service.rb
+++ b/app/services/issues/reopen_service.rb
@@ -4,7 +4,7 @@ module Issues
       if issue.reopen
         event_service.reopen_issue(issue, current_user)
         create_note(issue)
-        execute_hooks(issue)
+        execute_hooks(issue, 'reopen')
       end
 
       issue

--- a/app/services/issues/update_service.rb
+++ b/app/services/issues/update_service.rb
@@ -23,7 +23,7 @@ module Issues
         end
 
         issue.notice_added_references(issue.project, current_user)
-        execute_hooks(issue)
+        execute_hooks(issue, 'update')
       end
 
       issue

--- a/lib/gitlab/url_builder.rb
+++ b/lib/gitlab/url_builder.rb
@@ -1,0 +1,25 @@
+module Gitlab
+  class UrlBuilder
+    include Rails.application.routes.url_helpers
+
+    def initialize(type)
+      @type = type
+    end
+
+    def build(id)
+      case @type
+      when :issue
+        issue_url(id)
+      end
+    end
+
+    private
+
+    def issue_url(id)
+      issue = Issue.find(id)
+      project_issue_url(id: issue.iid,
+                        project_id: issue.project,
+                        host: Settings.gitlab['url'])
+    end
+  end
+end

--- a/spec/lib/gitlab/url_builder_spec.rb
+++ b/spec/lib/gitlab/url_builder_spec.rb
@@ -5,7 +5,7 @@ describe Gitlab::UrlBuilder do
     it 'returns the issue url' do
       issue = create(:issue)
       url = Gitlab::UrlBuilder.new(:issue).build(issue.id)
-      expect(url).to eq "#{Settings.gitlab['url']}/namespace1/gitlabhq/issues/#{issue.iid}"
+      expect(url).to eq "#{Settings.gitlab['url']}/#{issue.project.to_param}/issues/#{issue.iid}"
     end
   end
 end

--- a/spec/lib/gitlab/url_builder_spec.rb
+++ b/spec/lib/gitlab/url_builder_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Gitlab::UrlBuilder do
+  describe 'When asking for an issue' do
+    it 'returns the issue url' do
+      issue = create(:issue)
+      url = Gitlab::UrlBuilder.new(:issue).build(issue.id)
+      expect(url).to eq "#{Settings.gitlab['url']}/namespace1/gitlabhq/issues/#{issue.iid}"
+    end
+  end
+end


### PR DESCRIPTION
**What does this MR do?**
When a webhook for issues is triggered, it should also return the
resource URL, and the action that was performed (ie: Was it reopened,
updated, opened or closed)

**Why is this MR needed?**
To make sure that services like Gitter can link to the proper issue from their UI, and also so they can show a better status.
