### PR TITLE
Added exposing commit messages

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -102,7 +102,7 @@ module API
     end
 
     class RepoCommit < Grape::Entity
-      expose :id, :short_id, :title, :author_name, :author_email, :created_at
+      expose :id, :short_id, :title, :author_name, :author_email, :created_at, :message
     end
 
     class RepoCommitDetail < RepoCommit


### PR DESCRIPTION
Our internal tool shows commit messages and from what I see, the API lacks this parameter
