### PR TITLE
Adds commits calendar with ajax request to user profiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,9 @@ gem "slack-notifier", "~> 0.3.2"
 # d3
 gem "d3_rails", "~> 3.1.4"
 
+#cal-heatmap
+gem "cal-heatmap-rails", "~> 0.0.1"
+
 # underscore-rails
 gem "underscore-rails", "~> 1.4.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     bootstrap-sass (3.0.3.0)
       sass (~> 3.2)
     builder (3.1.4)
+    cal-heatmap-rails (0.0.1)
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -573,6 +574,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass (~> 3.0)
+  cal-heatmap-rails (~> 0.0.1)
   capybara
   carrierwave
   coffee-rails

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -30,6 +30,7 @@
 #= require nprogress
 #= require nprogress-turbolinks
 #= require dropzone
+#= require cal-heatmap
 #= require_tree .
 
 window.slugify = (text) ->

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -1,0 +1,52 @@
+var options = {month: "short", day: "numeric"};
+function myFunction(data, date, nb)
+  {
+    $("#onClick-placeholder").hide();
+
+    $("#onClick-placeholder").html("<span class='onClicksecond'><b>" + (nb === null ? "no" : nb) + "<font color='#999'></b> commit" + ((nb!=1)?'s':'') + " " + date.toLocaleDateString("en-US",options) + "</font><hr style='padding:0px;margin:5px 0 5px 0' /></span>");
+
+    $.each(data, function (key, data) {
+      console.log(key)
+      $.each(data, function (index, data) {
+        $("#onClick-placeholder").append("Pushed <b>" + (data === null ? "no" : data) + " commit" + ((data!=1)?'s':'') +"</b> to <a href='/" + index + "'>" + index + "</a><hr style='padding:0px; margin:5px 0 5px 0' />")
+      })
+    })
+  };
+
+var cal = new CalHeatMap();
+  cal.init({
+    itemName: ["commit"],
+    data: window.timestamps,
+    start: new Date(window.timestart_year, window.timestart_month),
+    domainLabelFormat: "%b",
+    id : "cal-heatmap",
+    domain : "month",
+    subDomain : "day",
+    range : 12, 
+    tooltip: true,
+    domainDynamicDimension: false,
+    colLimit: 4,
+    label: { position: "top" },
+    domainMargin: 1,
+    legend: [0,1,4,7],
+    legendCellPadding: 3,
+    onClick: function (date, count) { 
+      $.ajax({
+        url: window.path,
+        data: {date: date},
+        dataType: 'json',
+        success: function(data) {
+          $("#loading-commits").fadeIn();
+          console.log('success')
+          console.log(data)
+          myFunction(data, date, count)
+          setTimeout(function() {$("#onClick-placeholder").fadeIn(500);}, 400);
+          setTimeout(function() {$("#loading-commits").hide();}, 400);
+        },
+        error: function(data) {
+          console.log('error')
+          console.log(data)
+        }
+      }) 
+      }
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,8 @@
  *= require nprogress
  *= require nprogress-bootstrap
  *= require dropzone/basic
+ *= require cal-heatmap
+ *= require cal-heatmap-custom
 */
 
 @import "main/*";

--- a/app/assets/stylesheets/generic/ui_box.scss
+++ b/app/assets/stylesheets/generic/ui_box.scss
@@ -30,7 +30,6 @@
   margin-bottom: 20px;
   border: 1px solid #DDD;
   word-wrap: break-word;
-
   img {
     max-width: 100%;
   }
@@ -57,7 +56,6 @@
     line-height: 40px;
     font-weight: normal;
     margin: 0;
-
     > a {
       text-shadow: 0 1px 1px #fff;
     }
@@ -96,6 +94,7 @@
 
   .body {
     padding: 10px;
+
   }
 
   &.padded {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,33 @@
 class UsersController < ApplicationController
+  include UsersHelper
   skip_before_filter :authenticate_user!, only: [:show]
   layout :determine_layout
 
   def show
     @user = User.find_by_username!(params[:username])
     @projects = @user.authorized_projects.accessible_to(current_user)
+
     if !current_user && @projects.empty?
       return authenticate_user!
     end
+
     @groups = @user.groups.accessible_to(current_user)
     @events = @user.recent_events.where(project_id: @projects.pluck(:id)).limit(20)
     @title = @user.name
+
+    user_projects = @user.authorized_projects.accessible_to(@user)
+    @user_projects = user_projects.map(&:repository)
+  end
+
+  def activities
+    @user = User.find_by_username!(params[:username])
+    user_projects = @user.authorized_projects.accessible_to(@user)
+    @user_project = user_projects.map(&:repository)
+
+    user_activities = create_timestamps_by_project(@user_project)
+    user_activities = commit_activity_match(user_activities)
+    user_activities = user_activities.to_json
+    render json: user_activities
   end
 
   def determine_layout

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,83 @@
+module UsersHelper
+  def create_timestamp(user_projects)
+    timestamps = {}
+    user_projects.each do |raw_repository|
+      if raw_repository.exists?
+        commits_log = commits_log_by_commit_date(raw_repository.graph_log)
+        commits_log.each do |k, v|
+          hash = { "#{k}" => v.count }
+          if timestamps.has_key?("#{k}")
+            timestamps.merge!(hash) { |k, v, v2| v = v.to_i + v2 }
+          else
+            timestamps.merge!(hash)
+          end
+        end
+      end
+    end
+    timestamps
+  end
+
+  def create_timestamps_by_project(user_projects)
+    projects = {}
+    project_commit = {}
+    timestamps_copy = {}
+
+    user_projects.each do |raw_repository|
+      if raw_repository.exists?
+        commits_log = commits_log_by_commit_date(raw_repository.graph_log)
+        commits_log.each do |k, v|
+          if timestamps_copy.has_key?("#{k}")
+            timestamps_copy["#{k}"].
+              merge!(raw_repository.path_with_namespace => v.count)
+          else
+            hash = { "#{k}" => { raw_repository.path_with_namespace => v.count }
+                                }
+            timestamps_copy.merge!(hash)
+          end
+        end
+        project_commit = project_commits(timestamps_copy,
+                                         raw_repository.path_with_namespace)
+        projects.merge!(timestamps_copy)
+      end
+    end
+    projects
+  end
+
+  def project_commits(timestamps, repository_name)
+    timestamps.each do |date|
+      hash = { "#{timestamps}" => repository_name }
+    end
+  end
+
+  def create_time_copy(user_projects)
+    timestamps = create_timestamp(user_projects)
+    time_copy = if timestamps.empty?
+                  DateTime.now.to_date
+                else
+                  Time.at(timestamps.first.first.to_i).to_date
+                end
+    time_copy
+  end
+
+  def timestart_year
+    create_time_copy(@user_projects).year - 1
+  end
+
+  def timestart_month
+    create_time_copy(@user_projects).month
+  end
+
+  def last_commit_date
+    create_time_copy(@user_projects).to_formatted_s(:long).to_s
+  end
+
+  def commits_log_by_commit_date(graph_log)
+    graph_log.select { |u_email| u_email[:author_email] == @user.email }.
+      map { |graph_log| Date.parse(graph_log[:date]).to_time.to_i }.
+      group_by { |commit_date| commit_date }
+  end
+
+  def commit_activity_match(user_activities)
+    user_activities.select { |x| Time.at(x.to_i) == Time.parse(params[:date]) }
+  end
+end

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -12,4 +12,3 @@
         = render "events/event/note", event: event
       - else
         = render "events/event/common", event: event
-

--- a/app/views/projects/graphs/show.js.haml
+++ b/app/views/projects/graphs/show.js.haml
@@ -2,7 +2,7 @@
   :plain
     controller = new ContributorsStatGraph
     controller.init(#{@log})
-
+ 
     $("select").change( function () {
       var field = $(this).val()
       controller.set_current_field(field)

--- a/app/views/projects/repositories/stats.html.haml
+++ b/app/views/projects/repositories/stats.html.haml
@@ -24,8 +24,7 @@
           %small.light= author.email
           .pull-right
             = author.commits
-
-
+            
 :javascript
   var labels = [#{@graph.labels.to_json}];
   var commits = [#{@graph.commits.join(', ')}];

--- a/app/views/users/_calendar.html.haml
+++ b/app/views/users/_calendar.html.haml
@@ -1,0 +1,8 @@
+#cal-heatmap
+  :javascript 
+    window.timestamps = #{create_timestamp(@user_projects).to_json};
+    window.timestart_year = #{timestart_year};
+    window.timestart_month = #{timestart_month};
+    window.path = '#{user_activities_path}';
+  = javascript_include_tag "calendar"
+= render "onclick"

--- a/app/views/users/_onclick.html.haml
+++ b/app/views/users/_onclick.html.haml
@@ -1,0 +1,24 @@
+#commitActivity
+  #onClickplaceholder
+    %span{:style => "font-size: 17px; font-weight: 500"} Commit Activity:
+
+  #loading-commits
+    %section.text-center
+      %h3
+        %i.icon-spinner.icon-spin
+
+  #onClick-placeholder
+    %span.onClicksecond
+    - if @timestamps==="{}"
+      %strong #{@user.username}
+      has no activity
+    - else
+      %strong #{@user.username}'s
+      last commit was on
+      %font{color: "#999"} #{last_commit_date}
+    
+    %hr{style: "padding:0px; margin:10px 0 5px 0"}/
+
+:javascript
+  $("#loading-commits").hide();
+  

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,10 +12,13 @@
       %span.user-show-username #{@user.username}
       %br
       %small member since #{@user.created_at.stamp("Nov 12, 2031")}
+    
     .clearfix
     %h4 Groups:
     = render 'groups', groups: @groups
     %hr
+    %h4 Calendar:
+    = render 'calendar'
     %h4 User Activity:
     = render @events
   .col-md-4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Gitlab::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
+  config.assets.precompile += %w( calendar.js )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,8 @@ Gitlab::Application.routes.draw do
   end
 
   # route for commits used by the cal-heatmap
-  match "u/:username/activities" => "users#activities", as: :user_activities, via: :get
+  match "u/:username/activities" => "users#activities", as: :user_activities, 
+                                                        via: :get
   match "/u/:username" => "users#show", as: :user, constraints: { username: /.*/ }, via: :get
 
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,8 @@ Gitlab::Application.routes.draw do
     end
   end
 
+  # route for commits used by the cal-heatmap
+  match "u/:username/activities" => "users#activities", as: :user_activities, via: :get
   match "/u/:username" => "users#show", as: :user, constraints: { username: /.*/ }, via: :get
 
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,7 @@ Gitlab::Application.routes.draw do
 
   # route for commits used by the cal-heatmap
   match "u/:username/activities" => "users#activities", as: :user_activities, 
-                                                        via: :get
+                                    via: :get
   match "/u/:username" => "users#show", as: :user, constraints: { username: /.*/ }, via: :get
 
   #

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe UsersController do
+  let(:user) { create(:user, username: 'test', name: 'Test',
+                      email: 'test@aelogica.com', password: 'test1234')
+  }
+
+  let(:project) { create(:project) }
+  let(:users_project) { create(:users_project, user: user, project: project) }
+
+  before do
+    users_project
+    sign_in(user)
+  end
+
+  describe 'GET #show' do
+    it 'renders the show template' do
+      get :show, username: user.username
+      expect(response.status).to eq(200)
+    end
+
+    context 'when there is no repository' do
+      it 'should call helper methods' do
+        timestamp = {}
+        UsersHelper.stub(:create_timestamp).with(users_project).
+        and_return(timestamp)
+        date = double(:date, year: 2014, month: 'May')
+        DateTime.stub_chain(:now, :to_date).and_return(date)
+        UsersHelper.stub(:create_timecopy).and_return(date)
+        get :show, username: user.username
+        expect(assigns(:timestamps)).to eq(timestamp.to_json)
+        expect(assigns(:time_copy)).to eq(date)
+      end
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 describe UsersController do
   let(:user) { create(:user, username: 'test', name: 'Test',
-                      email: 'test@aelogica.com', password: 'test1234')
-  }
+                             email: 'test@aelogica.com', password: 'test1234') }
 
   let(:project) { create(:project) }
   let(:users_project) { create(:users_project, user: user, project: project) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe UsersController do
   let(:user) { create(:user, username: 'test', name: 'Test',
-                             email: 'test@aelogica.com', password: 'test1234') }
+                             email: 'test@aelogica.com', password: 'test1234')
+  }
 
   let(:project) { create(:project) }
   let(:users_project) { create(:users_project, user: user, project: project) }

--- a/vendor/assets/stylesheets/cal-heatmap-custom.css
+++ b/vendor/assets/stylesheets/cal-heatmap-custom.css
@@ -1,0 +1,97 @@
+.onClicksecond {
+  font-size: 14px;
+  display: block; }
+
+#commitActivity
+{
+  padding: 5px 0 5px 0;
+}
+
+#onClickplaceholder
+{
+  padding: inherit;
+}
+
+#onClick-placeholder
+{
+  padding: 2px 0 2px 0;
+}
+
+.qi {
+  background-color: #999;
+  fill: #fff;
+}
+
+/*
+Remove comment to apply this style to date with value equal to 0
+.q0
+{
+  background-color: #fff;
+  fill: #fff;
+  stroke: #ededed
+}
+*/
+
+.q1
+{
+  background-color: #dae289;
+  fill: #ededed
+}
+
+.q2
+{
+  background-color: #cedb9c;
+  fill: #ACD5F2
+}
+
+.q3
+{
+  background-color: #b5cf6b;
+  fill: #7FA8D1
+}
+
+.q4
+{
+  background-color: #637939;
+  fill: #49729B
+}
+
+.q5
+{
+  background-color: #3b6427;
+  fill: #254E77
+}
+
+.domain-background {
+  fill: none;
+  shape-rendering: crispedges
+}
+
+.ch-tooltip {
+  position: absolute;
+  display: none;
+  margin-top: 22px;
+  margin-left: 1px;
+  font-size: 13px;
+  padding: 3px;
+  font-weight: 550;
+  background-color: #222;
+}
+.ch-tooltip span {
+  position: absolute;
+  width:200px;
+  text-align: center;
+  visibility: hidden;
+  border-radius: 10px;
+}
+.ch-tooltip span:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -8px;
+  width: 0; height: 0;
+  border-top: 8px solid #000000;
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+}


### PR DESCRIPTION
Calendar of commits in user profiles

When user has commits, it will show a calendar covering a timeframe from the year before up to his latest commit
![fdf6190a-e577-11e3-8af6-afc3f15771d8](https://cloud.githubusercontent.com/assets/6151901/3112882/ec2df25c-e6ca-11e3-868f-6969ea3f7620.gif)

When user has no commits, it will show a timeframe up to the current month
![fe7f355a-e577-11e3-9ded-ff902e828c24](https://cloud.githubusercontent.com/assets/6151901/3112883/ec2e261e-e6ca-11e3-8e31-6de01a6ff0b8.gif)

@randx this is from #6958 we added ajax request and refactored some lines
