### PR TITLE
Adds commits calendar with ajax request to user profiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,9 @@ gem "slack-notifier", "~> 0.3.2"
 # d3
 gem "d3_rails", "~> 3.1.4"
 
+#cal-heatmap
+gem "cal-heatmap-rails", "~> 0.0.1"
+
 # underscore-rails
 gem "underscore-rails", "~> 1.4.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     bootstrap-sass (3.0.3.0)
       sass (~> 3.2)
     builder (3.2.2)
+    cal-heatmap-rails (0.0.1)
     capybara (2.2.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -579,6 +580,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass (~> 3.0)
   capybara (~> 2.2.1)
+  cal-heatmap-rails (~> 0.0.1)
   carrierwave
   coffee-rails
   colored

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -30,6 +30,7 @@
 #= require nprogress
 #= require nprogress-turbolinks
 #= require dropzone
+#= require cal-heatmap
 #= require_tree .
 
 window.slugify = (text) ->

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -1,0 +1,47 @@
+var options = {month: "short", day: "numeric"};
+function calOnClick(data, date, nb)
+  {
+    $("#onClick-placeholder").hide();
+
+    $("#onClick-placeholder").html("<span class='onClicksecond'><b>" + (nb === null ? "no" : nb) + "</b><span class='commit_date'> commit" + ((nb!=1)?'s':'') + " " + date.toLocaleDateString("en-US",options) + "</span><hr class='onclick_hr'></span>");
+
+    $.each(data, function (key, data) {
+      $.each(data, function (index, data) {
+        $("#onClick-placeholder").append("Pushed <b>" + (data === null ? "no" : data) + " commit" + ((data!=1)?'s':'') +"</b> to <a href='/" + index + "'>" + index + "</a><hr class='onclick_hr'>")
+      })
+    })
+  };
+
+var cal = new CalHeatMap();
+  cal.init({
+    itemName: ["commit"],
+    data: CommitsCalendar.timestamps,
+    start: new Date(CommitsCalendar.starting_year, CommitsCalendar.starting_month),
+    domainLabelFormat: "%b",
+    id : "cal-heatmap",
+    domain : "month",
+    subDomain : "day",
+    range : 12, 
+    tooltip: true,
+    domainDynamicDimension: false,
+    colLimit: 4,
+    label: { position: "top" },
+    domainMargin: 1,
+    legend: [0,1,4,7],
+    legendCellPadding: 3,
+    onClick: function (date, count) { 
+      $.ajax({
+        url: CommitsCalendar.path,
+        data: {date: date},
+        dataType: 'json',
+        success: function(data) {
+          $("#loading-commits").fadeIn();
+          calOnClick(data, date, count)
+          setTimeout(function() {$("#onClick-placeholder").fadeIn(500);}, 400);
+          setTimeout(function() {$("#loading-commits").hide();}, 400);
+        },
+        error: function(data) {
+        }
+      }) 
+      }
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,8 @@
  *= require nprogress
  *= require nprogress-bootstrap
  *= require dropzone/basic
+ *= require cal-heatmap
+ *= require cal-heatmap-custom
 */
 
 @import "main/*";

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -138,6 +138,24 @@ class Repository
     end
   end
 
+  def graph_logs_by_user_email(user)
+    graph_log.select { |u_email| u_email[:author_email] == user.email }
+  end
+
+  def timestamps_by_user_from_graph_log(user)
+    graph_logs_by_user_email(user).
+    map { |graph_log| Date.parse(graph_log[:date]).to_time.to_i }
+  end
+
+  def commits_log_of_user_by_date(user)
+    timestamps_by_user_from_graph_log(user).
+      group_by { |commit_date| commit_date }.
+      inject({}) do |hash, (timestamp_date, commits)|
+        hash[timestamp_date] = commits.count
+        hash
+      end
+  end
+
   def cache_key(type)
     "#{type}:#{path_with_namespace}"
   end

--- a/app/views/events/_event.html.haml
+++ b/app/views/events/_event.html.haml
@@ -12,4 +12,3 @@
         = render "events/event/note", event: event
       - else
         = render "events/event/common", event: event
-

--- a/app/views/projects/graphs/show.js.haml
+++ b/app/views/projects/graphs/show.js.haml
@@ -2,7 +2,7 @@
   :plain
     controller = new ContributorsStatGraph
     controller.init(#{@log})
-
+ 
     $("select").change( function () {
       var field = $(this).val()
       controller.set_current_field(field)

--- a/app/views/projects/repositories/stats.html.haml
+++ b/app/views/projects/repositories/stats.html.haml
@@ -24,8 +24,7 @@
           %small.light= author.email
           .pull-right
             = author.commits
-
-
+            
 :javascript
   var labels = [#{@graph.labels.to_json}];
   var commits = [#{@graph.commits.join(', ')}];

--- a/app/views/users/_calendar.html.haml
+++ b/app/views/users/_calendar.html.haml
@@ -1,0 +1,9 @@
+#cal-heatmap
+  :javascript 
+    var CommitsCalendar = {}
+    CommitsCalendar.timestamps = #{@timestamps.to_json};
+    CommitsCalendar.starting_year = #{@starting_year};
+    CommitsCalendar.starting_month = #{@starting_month};
+    CommitsCalendar.path = '#{user_activities_path}';
+  = javascript_include_tag "calendar"
+= render "onclick"

--- a/app/views/users/_onclick.html.haml
+++ b/app/views/users/_onclick.html.haml
@@ -1,0 +1,26 @@
+#commit_activity
+  #onClickplaceholder
+    %h4.activity_title Commit Activity:
+
+  #loading-commits
+    %section.text-center
+      %h3
+        %i.icon-spinner.icon-spin
+
+  #onClick-placeholder
+    %span.onClicksecond
+    - if @timestamps.empty?
+      %span.activity_summary
+        %strong> #{@user.username}
+        has no activity
+    - else
+      %span.activity_summary
+        %strong> #{@user.username}
+        's last commit was on
+        %span.commit_date #{@last_commit_date}
+
+    %hr.onclick_hr
+
+:javascript
+  $("#loading-commits").hide();
+  

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,12 +12,14 @@
       %span.user-show-username #{@user.username}
       %br
       %small member since #{@user.created_at.stamp("Nov 12, 2031")}
+      
     .clearfix
-
     - if @groups.any?
       %h4 Groups:
       = render 'groups', groups: @groups
       %hr
+    %h4 Calendar:
+    = render 'calendar'
     %h4 User Activity:
     = render @events
   .col-md-4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,9 @@ Gitlab::Application.routes.draw do
     end
   end
 
+  # route for commits used by the cal-heatmap
+  match 'u/:username/activities' => 'users#activities', as: :user_activities,
+                                     via: :get
   match "/u/:username" => "users#show", as: :user, constraints: { username: /.*/ }, via: :get
 
   #

--- a/lib/gitlab/commits_calendar.rb
+++ b/lib/gitlab/commits_calendar.rb
@@ -1,0 +1,75 @@
+module Gitlab
+  class CommitsCalendar
+    def self.create_timestamp(user_projects, user, show_activity)
+      timestamps = {}
+      user_projects.each do |raw_repository|
+        if raw_repository.exists?
+          commits_log = raw_repository.commits_log_of_user_by_date(user)
+          populated_timestamps =  if show_activity
+                                    populate_timestamps_by_project(commits_log,
+                                                                   timestamps,
+                                                                   raw_repository)
+                                  else
+                                    populate_timestamps(commits_log, timestamps)
+                                  end
+          timestamps.merge!(populated_timestamps)
+        end
+      end
+      timestamps
+    end
+
+    def self.populate_timestamps(commits_log, timestamps)
+      commits_log.each do |timestamp_date, commits_count|
+        hash = { "#{timestamp_date}" => commits_count }
+        if timestamps.has_key?("#{timestamp_date}")
+          timestamps.merge!(hash) do |timestamp_date, commits_count,
+            new_commits_count| commits_count = commits_count.to_i +
+            new_commits_count
+          end
+        else
+          timestamps.merge!(hash)
+        end
+      end
+      timestamps
+    end
+
+    def self.populate_timestamps_by_project(commits_log, timestamps,
+                                            raw_repository)
+      commits_log.each do |timestamp_date, commits_count|
+        if timestamps.has_key?("#{timestamp_date}")
+          timestamps["#{timestamp_date}"].
+            merge!(raw_repository.path_with_namespace => commits_count)
+        else
+          hash = { "#{timestamp_date}" => { raw_repository.path_with_namespace =>
+                                            commits_count } }
+          timestamps.merge!(hash)
+        end
+      end
+      timestamps
+    end
+
+    def self.latest_commit_date(timestamps)
+      if timestamps.empty?
+        DateTime.now.to_date
+      else
+        Time.at(timestamps.keys.first.to_i).to_date
+      end
+    end
+
+    def self.starting_year(timestamps)
+      latest_commit_date(timestamps).year - 1
+    end
+
+    def self.starting_month(timestamps)
+      latest_commit_date(timestamps).month
+    end
+
+    def self.last_commit_date(timestamps)
+      latest_commit_date(timestamps).to_formatted_s(:long).to_s
+    end
+
+    def self.commit_activity_match(user_activities, date)
+      user_activities.select { |x| Time.at(x.to_i) == Time.parse(date) }
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe UsersController do
+  let(:user) do
+    create(:user, username: 'test', name: 'Test',
+                  email: 'test@aelogica.com', password: 'test1234')
+  end
+
+  let(:project) { create(:project) }
+  let(:users_project) { create(:users_project, user: user, project: project) }
+
+  before do
+    users_project
+    sign_in(user)
+  end
+
+  describe 'GET #show' do
+    it 'renders the show template' do
+      get :show, username: user.username
+      expect(response.status).to eq(200)
+    end
+
+    context 'when there is no repository' do
+      it 'should call helper methods' do
+        timestamp = {}
+        UsersHelper.stub(:create_timestamp).with(users_project).
+        and_return(timestamp)
+        date = double(:date, year: 2014, month: 'May')
+        DateTime.stub_chain(:now, :to_date).and_return(date)
+        UsersHelper.stub(:create_timecopy).and_return(date)
+        get :show, username: user.username
+        expect(assigns(:timestamps)).to eq(timestamp.to_json)
+        expect(assigns(:time_copy)).to eq(date)
+      end
+    end
+  end
+end

--- a/vendor/assets/stylesheets/cal-heatmap-custom.css
+++ b/vendor/assets/stylesheets/cal-heatmap-custom.css
@@ -1,0 +1,120 @@
+#onClickplaceholder
+{
+  padding: inherit;
+}
+
+#onClick-placeholder
+{
+  padding: 0 0 2px 0;
+}
+
+#commit_activity
+{
+  padding: 5px 0 0 0;
+}
+
+.onClicksecond 
+{
+  font-size: 14px;
+  display: block; 
+}
+
+.activty_title
+{ 
+  font-weight: 500
+}
+
+.onclick_hr
+{
+  padding:0px; 
+  margin:10px 0 10px 0;
+}
+
+.commit_date
+{
+  color: #999;
+}
+
+.activity_summary
+{
+  font-size: 14px;
+}
+
+.qi {
+  background-color: #999;
+  fill: #fff;
+}
+
+/*
+Remove comment to apply this style to date with value equal to 0
+.q0
+{
+  background-color: #fff;
+  fill: #fff;
+  stroke: #ededed
+}
+*/
+
+.q1
+{
+  background-color: #dae289;
+  fill: #ededed
+}
+
+.q2
+{
+  background-color: #cedb9c;
+  fill: #ACD5F2
+}
+
+.q3
+{
+  background-color: #b5cf6b;
+  fill: #7FA8D1
+}
+
+.q4
+{
+  background-color: #637939;
+  fill: #49729B
+}
+
+.q5
+{
+  background-color: #3b6427;
+  fill: #254E77
+}
+
+.domain-background {
+  fill: none;
+  shape-rendering: crispedges
+}
+
+.ch-tooltip {
+  position: absolute;
+  display: none;
+  margin-top: 22px;
+  margin-left: 1px;
+  font-size: 13px;
+  padding: 3px;
+  font-weight: 550;
+  background-color: #222;
+}
+.ch-tooltip span {
+  position: absolute;
+  width:200px;
+  text-align: center;
+  visibility: hidden;
+  border-radius: 10px;
+}
+.ch-tooltip span:after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -8px;
+  width: 0; height: 0;
+  border-top: 8px solid #000000;
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+}


### PR DESCRIPTION
Calendar of commits in user profiles

When user has commits, it will show a calendar covering a timeframe from the year before up to his latest commit
![fdf6190a-e577-11e3-8af6-afc3f15771d8](https://cloud.githubusercontent.com/assets/6151901/3113403/06598df6-e6d7-11e3-820c-2d66ce6bad58.gif)

When user has no commits, it will show a timeframe up to the current month
![fe7f355a-e577-11e3-9ded-ff902e828c24](https://cloud.githubusercontent.com/assets/6151901/3113408/1eeb686c-e6d7-11e3-9079-f63723b2d7cd.gif)

@randx this is from #6958 we, @kbleabres and I, added ajax request and edited some lines
