### PR TITLE
remove duplication of notes in commit mention

### DIFF
--- a/app/models/concerns/mentionable.rb
+++ b/app/models/concerns/mentionable.rb
@@ -9,14 +9,11 @@ module Mentionable
   extend ActiveSupport::Concern
 
   module ClassMethods
+    attr_reader :mentionable_attrs
+
     # Indicate which attributes of the Mentionable to search for GFM references.
     def attr_mentionable *attrs
-      mentionable_attrs.concat(attrs.map(&:to_s))
-    end
-
-    # Accessor for attributes marked mentionable.
-    def mentionable_attrs
-      @mentionable_attrs ||= []
+      @mentionable_attrs = attrs.map(&:to_s)
     end
   end
 


### PR DESCRIPTION
after revert commit

![bug2](https://cloud.githubusercontent.com/assets/1488195/3130426/e4f8ec98-e7f7-11e3-9b8c-7c9a458c0bd6.png)

I can't reproduce it in tests, because workers executes inline.
