### PR TITLE
Removed the Support Email setting

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -35,9 +35,6 @@ production: &base
     # Email address used in the "From" field in mails sent by GitLab
     email_from: example@example.com
 
-    # Email address of your support contact (default: same as email_from)
-    support_email: support@example.com
-
     # Email server smtp settings are in [a separate file](initializers/smtp_settings.rb.sample).
 
     ## User settings

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -79,7 +79,6 @@ Settings.gitlab['port']       ||= Settings.gitlab.https ? 443 : 80
 Settings.gitlab['relative_url_root'] ||= ENV['RAILS_RELATIVE_URL_ROOT'] || ''
 Settings.gitlab['protocol']   ||= Settings.gitlab.https ? "https" : "http"
 Settings.gitlab['email_from'] ||= "gitlab@#{Settings.gitlab.host}"
-Settings.gitlab['support_email']  ||= Settings.gitlab.email_from
 Settings.gitlab['url']        ||= Settings.send(:build_gitlab_url)
 Settings.gitlab['user']       ||= 'git'
 Settings.gitlab['user_home']  ||= begin


### PR DESCRIPTION
**What does this MR do?**
it removes the support_email param in the gitlab.yml config file

**Why was this MR needed?**
It looks like it is not used anymore so its a little cleaner not to have it around

**Anything reviewer need to watch out for?**
Well, i did a grep for support_email, and did not found any occurrences of it anymore. But please wait to see if CI will fail on anything support_email related.
