### PR TITLE
removed the Coverals dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'coveralls', require: false
   # gem 'rails-dev-tweaks'
   gem 'spinach-rails'
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,12 +76,6 @@ GEM
     colored (1.2)
     colorize (0.5.8)
     connection_pool (1.2.0)
-    coveralls (0.7.0)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     d3_rails (3.1.10)
@@ -409,8 +403,6 @@ GEM
       redis (>= 2.2)
     ref (1.0.5)
     require_all (1.3.2)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
     rouge (1.3.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -499,8 +491,6 @@ GEM
     state_machine (1.2.0)
     stringex (2.5.1)
     temple (0.6.7)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
     test_after_commit (0.2.2)
     therubyracer (0.12.0)
       libv8 (~> 3.16.14.0)
@@ -522,7 +512,6 @@ GEM
       mime-types (~> 1.19)
       multi_json (~> 1.7)
       twitter-stream (~> 0.1)
-    tins (0.13.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -577,7 +566,6 @@ DEPENDENCIES
   carrierwave
   coffee-rails
   colored
-  coveralls
   d3_rails (~> 3.1.4)
   database_cleaner
   default_value_for (~> 3.0.0)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,5 @@
 require 'simplecov' unless ENV['CI']
 
-if ENV['TRAVIS']
-  require 'coveralls'
-  Coveralls.wear!
-end
-
 ENV['RAILS_ENV'] = 'test'
 require './config/environment'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,6 @@ require File.expand_path("../../config/environment", __FILE__)
 
 require 'simplecov' unless ENV['CI']
 
-if ENV['TRAVIS']
-  require 'coveralls'
-  Coveralls.wear!
-end
-
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'


### PR DESCRIPTION
**What does this MR do?**
It removes the Coverals dependency from GitLab

**Why is this MR needed?**
Currently we are not using Coverals in Github or in the GitLab
interface. I think we can remove it for now, since it speeds the test
suite up a little
