### PR TITLE
Support private hipchat server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,7 @@ gem "redis-rails"
 gem 'tinder', '~> 1.9.2'
 
 # HipChat integration
-gem "hipchat", "~> 0.14.0"
+gem "hipchat", "~> 1.2.0"
 
 # Flowdock integration
 gem "gitlab-flowdock-git-hook", "~> 0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,8 +232,7 @@ GEM
       railties (>= 4.0.1)
     hashie (2.0.5)
     hike (1.2.3)
-    hipchat (0.14.0)
-      httparty
+    hipchat (1.2.0)
       httparty
     http_parser.rb (0.5.3)
     httparty (0.13.0)
@@ -612,7 +611,7 @@ DEPENDENCIES
   guard-rspec
   guard-spinach
   haml-rails
-  hipchat (~> 0.14.0)
+  hipchat (~> 1.2.0)
   httparty
   jasmine (= 2.0.2)
   jquery-atwho-rails (~> 0.3.3)

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -13,12 +13,17 @@
 #  project_url :string(255)
 #  subdomain   :string(255)
 #  room        :string(255)
+#  server      :string(255)
 #  recipients  :text
 #  api_key     :string(255)
 #
 
 class HipchatService < Service
+  attr_accessible :room
+  attr_accessible :server
+
   validates :token, presence: true, if: :activated?
+  validates :room, presence: true, if: :activated?
 
   def title
     'Hipchat'
@@ -34,8 +39,9 @@ class HipchatService < Service
 
   def fields
     [
-      { type: 'text', name: 'token',     placeholder: '' },
-      { type: 'text', name: 'room',      placeholder: '' }
+      { type: 'text', name: 'token',  placeholder: '' },
+      { type: 'text', name: 'room',   placeholder: '' },
+      { type: 'text', name: 'server', placeholder: 'Leave blank to use https://hipchat.com' }
     ]
   end
 
@@ -46,7 +52,9 @@ class HipchatService < Service
   private
 
   def gate
-    @gate ||= HipChat::Client.new(token)
+    options = { api_version: 'v2' }
+    options[:server_url] = server unless server.nil?
+    @gate ||= HipChat::Client.new(token, options)
   end
 
   def create_message(push)

--- a/db/migrate/20140602230916_add_server_to_service.rb
+++ b/db/migrate/20140602230916_add_server_to_service.rb
@@ -1,0 +1,5 @@
+class AddServerToService < ActiveRecord::Migration
+  def change
+    add_column :services, :server, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140611135229) do
+ActiveRecord::Schema.define(version: 20140703230916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -252,6 +252,7 @@ ActiveRecord::Schema.define(version: 20140611135229) do
     t.string   "room"
     t.text     "recipients"
     t.string   "api_key"
+    t.string   "server"
   end
 
   add_index "services", ["project_id"], name: "index_services_on_project_id", using: :btree

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -36,6 +36,7 @@ class ProjectServices < Spinach::FeatureSteps
 
   step 'I fill hipchat settings' do
     check 'Active'
+    fill_in 'Server', with: 'http://hipchat.my.org'
     fill_in 'Room', with: 'gitlab'
     fill_in 'Token', with: 'verySecret'
     click_button 'Save'


### PR DESCRIPTION
HipChat now supports privately hosted servers.

This adds a server field to the service.
