### PR TITLE
project: ci_service should only catch ci services

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -330,7 +330,7 @@ class Project < ActiveRecord::Base
   end
 
   def ci_service
-    @ci_service ||= services.select(&:activated?).first
+    @ci_service ||= ci_services.select(&:activated?).first
   end
 
   # For compatibility with old code


### PR DESCRIPTION
ci_service should return true if a ci service is enabled.  Currently
it's checking for any service being enabled instead of only services in
the ci category.
