### PR TITLE
Convert specs to RSpec 2.14.7 syntax with Transpec

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,26 +7,26 @@ describe ApplicationController do
 
     it 'should redirect if the user is over their password expiry' do
       user.password_expires_at = Time.new(2002)
-      user.ldap_user?.should be_false
-      controller.stub(:current_user).and_return(user)
-      controller.should_receive(:redirect_to)
-      controller.should_receive(:new_profile_password_path)
+      expect(user.ldap_user?).to be_false
+      allow(controller).to receive(:current_user).and_return(user)
+      expect(controller).to receive(:redirect_to)
+      expect(controller).to receive(:new_profile_password_path)
       controller.send(:check_password_expiration)
     end
 
     it 'should not redirect if the user is under their password expiry' do
       user.password_expires_at = Time.now + 20010101
-      user.ldap_user?.should be_false
-      controller.stub(:current_user).and_return(user)
-      controller.should_not_receive(:redirect_to)
+      expect(user.ldap_user?).to be_false
+      allow(controller).to receive(:current_user).and_return(user)
+      expect(controller).not_to receive(:redirect_to)
       controller.send(:check_password_expiration)
     end
 
     it 'should not redirect if the user is over their password expiry but they are an ldap user' do
       user.password_expires_at = Time.new(2002)
-      user.stub(:ldap_user?).and_return(true)
-      controller.stub(:current_user).and_return(user)
-      controller.should_not_receive(:redirect_to)
+      allow(user).to receive(:ldap_user?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(user)
+      expect(controller).not_to receive(:redirect_to)
       controller.send(:check_password_expiration)
     end
   end

--- a/spec/controllers/blob_controller_spec.rb
+++ b/spec/controllers/blob_controller_spec.rb
@@ -9,8 +9,8 @@ describe Projects::BlobController do
 
     project.team << [user, :master]
 
-    project.stub(:branches).and_return(['master', 'foo/bar/baz'])
-    project.stub(:tags).and_return(['v1.0.0', 'v2.0.0'])
+    allow(project).to receive(:branches).and_return(['master', 'foo/bar/baz'])
+    allow(project).to receive(:tags).and_return(['v1.0.0', 'v2.0.0'])
     controller.instance_variable_set(:@project, project)
   end
 

--- a/spec/controllers/commit_controller_spec.rb
+++ b/spec/controllers/commit_controller_spec.rb
@@ -19,7 +19,7 @@ describe Projects::CommitController do
       end
 
       it "should generate it" do
-        Commit.any_instance.should_receive(:"to_#{format}")
+        expect_any_instance_of(Commit).to receive(:"to_#{format}")
 
         get :show, project_id: project.to_param, id: commit.id, format: format
       end
@@ -31,7 +31,7 @@ describe Projects::CommitController do
       end
 
       it "should not escape Html" do
-        Commit.any_instance.stub(:"to_#{format}").and_return('HTML entities &<>" ')
+        allow_any_instance_of(Commit).to receive(:"to_#{format}").and_return('HTML entities &<>" ')
 
         get :show, project_id: project.to_param, id: commit.id, format: format
 

--- a/spec/controllers/commits_controller_spec.rb
+++ b/spec/controllers/commits_controller_spec.rb
@@ -13,8 +13,8 @@ describe Projects::CommitsController do
     context "as atom feed" do
       it "should render as atom" do
         get :show, project_id: project.to_param, id: "master", format: "atom"
-        response.should be_success
-        response.content_type.should == 'application/atom+xml'
+        expect(response).to be_success
+        expect(response.content_type).to eq('application/atom+xml')
       end
     end
   end

--- a/spec/controllers/merge_requests_controller_spec.rb
+++ b/spec/controllers/merge_requests_controller_spec.rb
@@ -20,7 +20,7 @@ describe Projects::MergeRequestsController do
       end
 
       it "should generate it" do
-        MergeRequest.any_instance.should_receive(:"to_#{format}")
+        expect_any_instance_of(MergeRequest).to receive(:"to_#{format}")
 
         get :show, project_id: project.to_param, id: merge_request.iid, format: format
       end
@@ -32,7 +32,7 @@ describe Projects::MergeRequestsController do
       end
 
       it "should not escape Html" do
-        MergeRequest.any_instance.stub(:"to_#{format}").and_return('HTML entities &<>" ')
+        allow_any_instance_of(MergeRequest).to receive(:"to_#{format}").and_return('HTML entities &<>" ')
 
         get :show, project_id: project.to_param, id: merge_request.iid, format: format
 

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -9,8 +9,8 @@ describe Projects::TreeController do
 
     project.team << [user, :master]
 
-    project.stub(:branches).and_return(['master', 'foo/bar/baz'])
-    project.stub(:tags).and_return(['v1.0.0', 'v2.0.0'])
+    allow(project).to receive(:branches).and_return(['master', 'foo/bar/baz'])
+    allow(project).to receive(:tags).and_return(['v1.0.0', 'v2.0.0'])
     controller.instance_variable_set(:@project, project)
   end
 

--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -9,7 +9,7 @@ FactoryGirl.factories.map(&:name).each do |factory_name|
   next if INVALID_FACTORIES.include?(factory_name)
   describe "#{factory_name} factory" do
     it 'should be valid' do
-      build(factory_name).should be_valid
+      expect(build(factory_name)).to be_valid
     end
   end
 end

--- a/spec/features/admin/admin_hooks_spec.rb
+++ b/spec/features/admin/admin_hooks_spec.rb
@@ -15,12 +15,12 @@ describe "Admin::Hooks", feature: true do
       within ".main-nav" do
         click_on "Hooks"
       end
-      current_path.should == admin_hooks_path
+      expect(current_path).to eq(admin_hooks_path)
     end
 
     it "should have hooks list" do
       visit admin_hooks_path
-      page.should have_content(@system_hook.url)
+      expect(page).to have_content(@system_hook.url)
     end
   end
 
@@ -33,8 +33,8 @@ describe "Admin::Hooks", feature: true do
     end
 
     it "should open new hook popup" do
-      page.current_path.should == admin_hooks_path
-      page.should have_content(@url)
+      expect(page.current_path).to eq(admin_hooks_path)
+      expect(page).to have_content(@url)
     end
   end
 
@@ -45,7 +45,7 @@ describe "Admin::Hooks", feature: true do
       click_link "Test Hook"
     end
 
-    it { page.current_path.should == admin_hooks_path }
+    it { expect(page.current_path).to eq(admin_hooks_path) }
   end
 
 end

--- a/spec/features/admin/admin_projects_spec.rb
+++ b/spec/features/admin/admin_projects_spec.rb
@@ -12,11 +12,11 @@ describe "Admin::Projects", feature: true  do
     end
 
     it "should be ok" do
-      current_path.should == admin_projects_path
+      expect(current_path).to eq(admin_projects_path)
     end
 
     it "should have projects list" do
-      page.should have_content(@project.name)
+      expect(page).to have_content(@project.name)
     end
   end
 
@@ -27,8 +27,8 @@ describe "Admin::Projects", feature: true  do
     end
 
     it "should have project info" do
-      page.should have_content(@project.path)
-      page.should have_content(@project.name)
+      expect(page).to have_content(@project.path)
+      expect(page).to have_content(@project.name)
     end
   end
 end

--- a/spec/features/admin/admin_users_spec.rb
+++ b/spec/features/admin/admin_users_spec.rb
@@ -9,12 +9,12 @@ describe "Admin::Users", feature: true  do
     end
 
     it "should be ok" do
-      current_path.should == admin_users_path
+      expect(current_path).to eq(admin_users_path)
     end
 
     it "should have users list" do
-      page.should have_content(@user.email)
-      page.should have_content(@user.name)
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.name)
     end
   end
 
@@ -33,19 +33,19 @@ describe "Admin::Users", feature: true  do
     it "should apply defaults to user" do
       click_button "Create user"
       user = User.last
-      user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
-      user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
+      expect(user.projects_limit).to eq(Gitlab.config.gitlab.default_projects_limit)
+      expect(user.can_create_group).to eq(Gitlab.config.gitlab.default_can_create_group)
     end
 
     it "should create user with valid data" do
       click_button "Create user"
       user = User.last
-      user.name.should ==  "Big Bang"
-      user.email.should == "bigbang@mail.com"
+      expect(user.name).to eq("Big Bang")
+      expect(user.email).to eq("bigbang@mail.com")
     end
 
     it "should call send mail" do
-      Notify.should_receive(:new_user_email)
+      expect(Notify).to receive(:new_user_email)
 
       click_button "Create user"
     end
@@ -54,9 +54,9 @@ describe "Admin::Users", feature: true  do
       click_button "Create user"
       user = User.last
       email = ActionMailer::Base.deliveries.last
-      email.subject.should have_content("Account was created")
-      email.text_part.body.should have_content(user.email)
-      email.text_part.body.should have_content('password')
+      expect(email.subject).to have_content("Account was created")
+      expect(email.text_part.body).to have_content(user.email)
+      expect(email.text_part.body).to have_content('password')
     end
   end
 
@@ -67,8 +67,8 @@ describe "Admin::Users", feature: true  do
     end
 
     it "should have user info" do
-      page.should have_content(@user.email)
-      page.should have_content(@user.name)
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.name)
     end
   end
 
@@ -80,8 +80,8 @@ describe "Admin::Users", feature: true  do
     end
 
     it "should have user edit page" do
-      page.should have_content("Name")
-      page.should have_content("Password")
+      expect(page).to have_content("Name")
+      expect(page).to have_content("Password")
     end
 
     describe "Update user" do
@@ -93,14 +93,14 @@ describe "Admin::Users", feature: true  do
       end
 
       it "should show page with  new data" do
-        page.should have_content("bigbang@mail.com")
-        page.should have_content("Big Bang")
+        expect(page).to have_content("bigbang@mail.com")
+        expect(page).to have_content("Big Bang")
       end
 
       it "should change user entry" do
         @simple_user.reload
-        @simple_user.name.should == "Big Bang"
-        @simple_user.is_admin?.should be_true
+        expect(@simple_user.name).to eq("Big Bang")
+        expect(@simple_user.is_admin?).to be_true
       end
     end
   end

--- a/spec/features/atom/dashboard_issues_spec.rb
+++ b/spec/features/atom/dashboard_issues_spec.rb
@@ -17,12 +17,12 @@ describe "Dashboard Issues Feed", feature: true  do
       it "should render atom feed via private token" do
         visit issues_dashboard_path(:atom, private_token: user.private_token)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{user.name} issues")
-        page.body.should have_selector("author email", text: issue1.author_email)
-        page.body.should have_selector("entry summary", text: issue1.title)
-        page.body.should have_selector("author email", text: issue2.author_email)
-        page.body.should have_selector("entry summary", text: issue2.title)
+        expect(page.response_headers['Content-Type']).to have_content("application/atom+xml")
+        expect(page.body).to have_selector("title", text: "#{user.name} issues")
+        expect(page.body).to have_selector("author email", text: issue1.author_email)
+        expect(page.body).to have_selector("entry summary", text: issue1.title)
+        expect(page.body).to have_selector("author email", text: issue2.author_email)
+        expect(page.body).to have_selector("entry summary", text: issue2.title)
       end
     end
   end

--- a/spec/features/atom/dashboard_spec.rb
+++ b/spec/features/atom/dashboard_spec.rb
@@ -7,7 +7,7 @@ describe "Dashboard Feed", feature: true  do
     context "projects atom feed via private token" do
       it "should render projects atom feed" do
         visit dashboard_path(:atom, private_token: user.private_token)
-        page.body.should have_selector("feed title")
+        expect(page.body).to have_selector("feed title")
       end
     end
   end

--- a/spec/features/atom/issues_spec.rb
+++ b/spec/features/atom/issues_spec.rb
@@ -13,10 +13,10 @@ describe "Issues Feed", feature: true  do
         login_with user
         visit project_issues_path(project, :atom)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{project.name} issues")
-        page.body.should have_selector("author email", text: issue.author_email)
-        page.body.should have_selector("entry summary", text: issue.title)
+        expect(page.response_headers['Content-Type']).to have_content("application/atom+xml")
+        expect(page.body).to have_selector("title", text: "#{project.name} issues")
+        expect(page.body).to have_selector("author email", text: issue.author_email)
+        expect(page.body).to have_selector("entry summary", text: issue.title)
       end
     end
 
@@ -24,10 +24,10 @@ describe "Issues Feed", feature: true  do
       it "should render atom feed" do
         visit project_issues_path(project, :atom, private_token: user.private_token)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{project.name} issues")
-        page.body.should have_selector("author email", text: issue.author_email)
-        page.body.should have_selector("entry summary", text: issue.title)
+        expect(page.response_headers['Content-Type']).to have_content("application/atom+xml")
+        expect(page.body).to have_selector("title", text: "#{project.name} issues")
+        expect(page.body).to have_selector("author email", text: issue.author_email)
+        expect(page.body).to have_selector("entry summary", text: issue.title)
       end
     end
   end

--- a/spec/features/gitlab_flavored_markdown_spec.rb
+++ b/spec/features/gitlab_flavored_markdown_spec.rb
@@ -25,25 +25,25 @@ describe "GitLab Flavored Markdown", feature: true do
     it "should render title in commits#index" do
       visit project_commits_path(project, 'master', limit: 1)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
 
     it "should render title in commits#show" do
       visit project_commit_path(project, commit)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
 
     it "should render description in commits#show" do
       visit project_commit_path(project, commit)
 
-      page.should have_link("@#{fred.username}")
+      expect(page).to have_link("@#{fred.username}")
     end
 
     it "should render title in repositories#branches" do
       visit project_branches_path(project)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
   end
 
@@ -64,19 +64,19 @@ describe "GitLab Flavored Markdown", feature: true do
     it "should render subject in issues#index" do
       visit project_issues_path(project)
 
-      page.should have_link("##{@other_issue.iid}")
+      expect(page).to have_link("##{@other_issue.iid}")
     end
 
     it "should render subject in issues#show" do
       visit project_issue_path(project, @issue)
 
-      page.should have_link("##{@other_issue.iid}")
+      expect(page).to have_link("##{@other_issue.iid}")
     end
 
     it "should render details in issues#show" do
       visit project_issue_path(project, @issue)
 
-      page.should have_link("@#{fred.username}")
+      expect(page).to have_link("@#{fred.username}")
     end
   end
 
@@ -89,13 +89,13 @@ describe "GitLab Flavored Markdown", feature: true do
     it "should render title in merge_requests#index" do
       visit project_merge_requests_path(project)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
 
     it "should render title in merge_requests#show" do
       visit project_merge_request_path(project, @merge_request)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
   end
 
@@ -111,19 +111,19 @@ describe "GitLab Flavored Markdown", feature: true do
     it "should render title in milestones#index" do
       visit project_milestones_path(project)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
 
     it "should render title in milestones#show" do
       visit project_milestone_path(project, @milestone)
 
-      page.should have_link("##{issue.iid}")
+      expect(page).to have_link("##{issue.iid}")
     end
 
     it "should render description in milestones#show" do
       visit project_milestone_path(project, @milestone)
 
-      page.should have_link("@#{fred.username}")
+      expect(page).to have_link("@#{fred.username}")
     end
   end
 end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -24,7 +24,7 @@ describe "Issues", feature: true do
     end
 
     it "should open new issue popup" do
-      page.should have_content("Issue ##{issue.iid}")
+      expect(page).to have_content("Issue ##{issue.iid}")
     end
 
     describe "fill in" do
@@ -38,9 +38,9 @@ describe "Issues", feature: true do
       it "should update issue fields" do
         click_button "Save changes"
 
-        page.should have_content @user.name
-        page.should have_content "bug 345"
-        page.should have_content project.name
+        expect(page).to have_content @user.name
+        expect(page).to have_content "bug 345"
+        expect(page).to have_content project.name
       end
     end
 
@@ -57,7 +57,7 @@ describe "Issues", feature: true do
     it 'allows user to select unasigned', :js => true do
       visit edit_project_issue_path(project, issue)
 
-      page.should have_content "Assign to #{@user.name}"
+      expect(page).to have_content "Assign to #{@user.name}"
 
       page.first('#s2id_issue_assignee_id').click
       sleep 2 # wait for ajax stuff to complete
@@ -65,8 +65,8 @@ describe "Issues", feature: true do
 
       click_button "Save changes"
 
-      page.should have_content "Assignee: Select assignee"
-      issue.reload.assignee.should be_nil
+      expect(page).to have_content "Assignee: Select assignee"
+      expect(issue.reload.assignee).to be_nil
     end
   end
 
@@ -91,33 +91,33 @@ describe "Issues", feature: true do
     it "should allow filtering by issues with no specified milestone" do
       visit project_issues_path(project, milestone_id: '0')
 
-      page.should_not have_content 'foobar'
-      page.should have_content 'barbaz'
-      page.should have_content 'gitlab'
+      expect(page).not_to have_content 'foobar'
+      expect(page).to have_content 'barbaz'
+      expect(page).to have_content 'gitlab'
     end
 
     it "should allow filtering by a specified milestone" do
       visit project_issues_path(project, milestone_id: issue.milestone.id)
 
-      page.should have_content 'foobar'
-      page.should_not have_content 'barbaz'
-      page.should_not have_content 'gitlab'
+      expect(page).to have_content 'foobar'
+      expect(page).not_to have_content 'barbaz'
+      expect(page).not_to have_content 'gitlab'
     end
 
     it "should allow filtering by issues with no specified assignee" do
       visit project_issues_path(project, assignee_id: '0')
 
-      page.should have_content 'foobar'
-      page.should_not have_content 'barbaz'
-      page.should_not have_content 'gitlab'
+      expect(page).to have_content 'foobar'
+      expect(page).not_to have_content 'barbaz'
+      expect(page).not_to have_content 'gitlab'
     end
 
     it "should allow filtering by a specified assignee" do
       visit project_issues_path(project, assignee_id: @user.id)
 
-      page.should_not have_content 'foobar'
-      page.should have_content 'barbaz'
-      page.should have_content 'gitlab'
+      expect(page).not_to have_content 'foobar'
+      expect(page).to have_content 'barbaz'
+      expect(page).to have_content 'gitlab'
     end
   end
 
@@ -132,15 +132,15 @@ describe "Issues", feature: true do
     it 'sorts by newest' do
       visit project_issues_path(project, sort: 'newest')
 
-      first_issue.should include("foo")
-      last_issue.should include("baz")
+      expect(first_issue).to include("foo")
+      expect(last_issue).to include("baz")
     end
 
     it 'sorts by oldest' do
       visit project_issues_path(project, sort: 'oldest')
 
-      first_issue.should include("baz")
-      last_issue.should include("foo")
+      expect(first_issue).to include("baz")
+      expect(last_issue).to include("foo")
     end
 
     it 'sorts by most recently updated' do
@@ -148,7 +148,7 @@ describe "Issues", feature: true do
       baz.save
       visit project_issues_path(project, sort: 'recently_updated')
 
-      first_issue.should include("baz")
+      expect(first_issue).to include("baz")
     end
 
     it 'sorts by least recently updated' do
@@ -156,7 +156,7 @@ describe "Issues", feature: true do
       baz.save
       visit project_issues_path(project, sort: 'last_updated')
 
-      first_issue.should include("baz")
+      expect(first_issue).to include("baz")
     end
 
     describe 'sorting by milestone' do
@@ -170,13 +170,13 @@ describe "Issues", feature: true do
       it 'sorts by recently due milestone' do
         visit project_issues_path(project, sort: 'milestone_due_soon')
 
-        first_issue.should include("foo")
+        expect(first_issue).to include("foo")
       end
 
       it 'sorts by least recently due milestone' do
         visit project_issues_path(project, sort: 'milestone_due_later')
 
-        first_issue.should include("bar")
+        expect(first_issue).to include("bar")
       end
     end
 
@@ -193,9 +193,9 @@ describe "Issues", feature: true do
       it 'sorts with a filter applied' do
         visit project_issues_path(project, sort: 'oldest', assignee_id: user2.id)
 
-        first_issue.should include("bar")
-        last_issue.should include("foo")
-        page.should_not have_content 'baz'
+        expect(first_issue).to include("bar")
+        expect(last_issue).to include("foo")
+        expect(page).not_to have_content 'baz'
       end
     end
   end
@@ -211,7 +211,7 @@ describe "Issues", feature: true do
         find('.edit-issue.inline-update #issue_assignee_id').set project.team.members.first.id
         click_button 'Update Issue'
 
-        page.should have_content "Assignee:"
+        expect(page).to have_content "Assignee:"
         page.has_select?('issue_assignee_id', :selected => project.team.members.first.name)
       end
     end
@@ -231,7 +231,7 @@ describe "Issues", feature: true do
         login_with guest
 
         visit project_issue_path(project, issue)
-        page.should have_content issue.assignee.name
+        expect(page).to have_content issue.assignee.name
       end
     end
   end
@@ -248,7 +248,7 @@ describe "Issues", feature: true do
         find('.edit-issue.inline-update').select(milestone.title, from: 'issue_milestone_id')
         click_button 'Update Issue'
 
-        page.should have_content "Milestone changed to #{milestone.title}"
+        expect(page).to have_content "Milestone changed to #{milestone.title}"
         page.has_select?('issue_assignee_id', :selected => milestone.title)
       end
     end
@@ -267,7 +267,7 @@ describe "Issues", feature: true do
         login_with guest
 
         visit project_issue_path(project, issue)
-        page.should have_content milestone.title
+        expect(page).to have_content milestone.title
       end
     end
 
@@ -281,15 +281,15 @@ describe "Issues", feature: true do
 
       it 'allows user to remove assignee', :js => true do
         visit project_issue_path(project, issue)
-        page.should have_content "Assignee: #{user2.name}"
+        expect(page).to have_content "Assignee: #{user2.name}"
 
         page.first('#s2id_issue_assignee_id').click
         sleep 2 # wait for ajax stuff to complete
         page.first('.user-result').click
 
-        page.should have_content "Assignee: Unassigned"
+        expect(page).to have_content "Assignee: Unassigned"
         sleep 2 # wait for ajax stuff to complete
-        issue.reload.assignee.should be_nil
+        expect(issue.reload.assignee).to be_nil
       end
     end
   end

--- a/spec/features/notes_on_merge_requests_spec.rb
+++ b/spec/features/notes_on_merge_requests_spec.rb
@@ -15,7 +15,7 @@ describe "On a merge request", js: true, feature: true do
   describe "the note form" do
     it 'should be valid' do
       should have_css(".js-main-target-form", visible: true, count: 1)
-      find(".js-main-target-form input[type=submit]").value.should == "Add Comment"
+      expect(find(".js-main-target-form input[type=submit]").value).to eq("Add Comment")
       within(".js-main-target-form") { should_not have_link("Cancel") }
       within(".js-main-target-form") { should have_css(".js-note-preview-button", visible: false) }
     end
@@ -64,8 +64,8 @@ describe "On a merge request", js: true, feature: true do
 
       it "should show the note edit form and hide the note body" do
         within("#note_#{note.id}") do
-          find(".note-edit-form", visible: true).should be_visible
-          find(".note-text", visible: false).should_not be_visible
+          expect(find(".note-edit-form", visible: true)).to be_visible
+          expect(find(".note-text", visible: false)).not_to be_visible
         end
       end
 
@@ -76,7 +76,7 @@ describe "On a merge request", js: true, feature: true do
         within(".note-edit-form") do
           fill_in "note[note]", with: "Some new content"
           find(".btn-cancel").click
-          find(".js-note-text", visible: false).text.should == note.note
+          expect(find(".js-note-text", visible: false).text).to eq(note.note)
         end
       end
 
@@ -91,7 +91,7 @@ describe "On a merge request", js: true, feature: true do
 
         within("#note_#{note.id}") do
           should have_css(".note-last-update small")
-          find(".note-last-update small").text.should match(/Edited less than a minute ago/)
+          expect(find(".note-last-update small").text).to match(/Edited less than a minute ago/)
         end
       end
     end
@@ -111,7 +111,7 @@ describe "On a merge request", js: true, feature: true do
       it "removes the attachment div and resets the edit form" do
         find(".js-note-attachment-delete").click
         should_not have_css(".note-attachment")
-        find(".note-edit-form", visible: false).should_not be_visible
+        expect(find(".note-edit-form", visible: false)).not_to be_visible
       end
     end
   end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -9,27 +9,27 @@ describe "Profile account page", feature: true do
 
   describe "when signup is enabled" do
     before do
-      Gitlab.config.gitlab.stub(:signup_enabled).and_return(true)
+      allow(Gitlab.config.gitlab).to receive(:signup_enabled).and_return(true)
       visit profile_account_path
     end
 
-    it { page.should have_content("Remove account") }
+    it { expect(page).to have_content("Remove account") }
 
     it "should delete the account" do
       expect { click_link "Delete account" }.to change {User.count}.by(-1)
-      current_path.should == new_user_session_path
+      expect(current_path).to eq(new_user_session_path)
     end
   end
 
   describe "when signup is disabled" do
     before do
-      Gitlab.config.gitlab.stub(:signup_enabled).and_return(false)
+      allow(Gitlab.config.gitlab).to receive(:signup_enabled).and_return(false)
       visit profile_account_path
     end
 
     it "should not have option to remove account" do
-      page.should_not have_content("Remove account")
-      current_path.should == profile_account_path
+      expect(page).not_to have_content("Remove account")
+      expect(current_path).to eq(profile_account_path)
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -14,7 +14,7 @@ describe "Search", feature: true  do
   end
 
   it "should show project in search results" do
-    page.should have_content @project.name
+    expect(page).to have_content @project.name
   end
 end
 

--- a/spec/features/security/dashboard_access_spec.rb
+++ b/spec/features/security/dashboard_access_spec.rb
@@ -42,14 +42,14 @@ describe "Dashboard access", feature: true  do
   end
 
   describe "GET /projects/new" do
-    it { new_project_path.should be_allowed_for :admin }
-    it { new_project_path.should be_allowed_for :user }
-    it { new_project_path.should be_denied_for :visitor }
+    it { expect(new_project_path).to be_allowed_for :admin }
+    it { expect(new_project_path).to be_allowed_for :user }
+    it { expect(new_project_path).to be_denied_for :visitor }
   end
 
   describe "GET /groups/new" do
-    it { new_group_path.should be_allowed_for :admin }
-    it { new_group_path.should be_allowed_for :user }
-    it { new_group_path.should be_denied_for :visitor }
+    it { expect(new_group_path).to be_allowed_for :admin }
+    it { expect(new_group_path).to be_allowed_for :user }
+    it { expect(new_group_path).to be_denied_for :visitor }
   end
 end

--- a/spec/features/security/group/group_access_spec.rb
+++ b/spec/features/security/group/group_access_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe "Group access", feature: true  do
   describe "GET /projects/new" do
-    it { new_group_path.should be_allowed_for :admin }
-    it { new_group_path.should be_allowed_for :user }
-    it { new_group_path.should be_denied_for :visitor }
+    it { expect(new_group_path).to be_allowed_for :admin }
+    it { expect(new_group_path).to be_allowed_for :user }
+    it { expect(new_group_path).to be_denied_for :visitor }
   end
 
   describe "Group" do

--- a/spec/features/security/profile_access_spec.rb
+++ b/spec/features/security/profile_access_spec.rb
@@ -7,7 +7,7 @@ describe "Users Security", feature: true  do
     end
 
     describe "GET /login" do
-      it { new_user_session_path.should_not be_404_for :visitor }
+      it { expect(new_user_session_path).not_to be_404_for :visitor }
     end
 
     describe "GET /profile/keys" do

--- a/spec/features/security/project/internal_access_spec.rb
+++ b/spec/features/security/project/internal_access_spec.rb
@@ -18,7 +18,10 @@ describe "Internal Project Access", feature: true  do
   describe "Project should be internal" do
     subject { project }
 
-    its(:internal?) { should be_true }
+    describe '#internal?' do
+      subject { super().internal? }
+      it { should be_true }
+    end
   end
 
   describe "GET /:project_path" do
@@ -94,12 +97,12 @@ describe "Internal Project Access", feature: true  do
       @blob_path = project_blob_path(project, File.join(commit.id, path))
     end
 
-    it { @blob_path.should be_allowed_for master }
-    it { @blob_path.should be_allowed_for reporter }
-    it { @blob_path.should be_allowed_for :admin }
-    it { @blob_path.should be_allowed_for guest }
-    it { @blob_path.should be_allowed_for :user }
-    it { @blob_path.should be_denied_for :visitor }
+    it { expect(@blob_path).to be_allowed_for master }
+    it { expect(@blob_path).to be_allowed_for reporter }
+    it { expect(@blob_path).to be_allowed_for :admin }
+    it { expect(@blob_path).to be_allowed_for guest }
+    it { expect(@blob_path).to be_allowed_for :user }
+    it { expect(@blob_path).to be_denied_for :visitor }
   end
 
   describe "GET /:project_path/edit" do
@@ -184,7 +187,7 @@ describe "Internal Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:branches).and_return([])
+      allow_any_instance_of(Project).to receive(:branches).and_return([])
     end
 
     it { should be_allowed_for master }
@@ -200,7 +203,7 @@ describe "Internal Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:tags).and_return([])
+      allow_any_instance_of(Project).to receive(:tags).and_return([])
     end
 
     it { should be_allowed_for master }

--- a/spec/features/security/project/private_access_spec.rb
+++ b/spec/features/security/project/private_access_spec.rb
@@ -18,7 +18,10 @@ describe "Private Project Access", feature: true  do
   describe "Project should be private" do
     subject { project }
 
-    its(:private?) { should be_true }
+    describe '#private?' do
+      subject { super().private? }
+      it { should be_true }
+    end
   end
 
   describe "GET /:project_path" do
@@ -94,12 +97,12 @@ describe "Private Project Access", feature: true  do
       @blob_path = project_blob_path(project, File.join(commit.id, path))
     end
 
-    it { @blob_path.should be_allowed_for master }
-    it { @blob_path.should be_allowed_for reporter }
-    it { @blob_path.should be_allowed_for :admin }
-    it { @blob_path.should be_denied_for guest }
-    it { @blob_path.should be_denied_for :user }
-    it { @blob_path.should be_denied_for :visitor }
+    it { expect(@blob_path).to be_allowed_for master }
+    it { expect(@blob_path).to be_allowed_for reporter }
+    it { expect(@blob_path).to be_allowed_for :admin }
+    it { expect(@blob_path).to be_denied_for guest }
+    it { expect(@blob_path).to be_denied_for :user }
+    it { expect(@blob_path).to be_denied_for :visitor }
   end
 
   describe "GET /:project_path/edit" do
@@ -162,7 +165,7 @@ describe "Private Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:branches).and_return([])
+      allow_any_instance_of(Project).to receive(:branches).and_return([])
     end
 
     it { should be_allowed_for master }
@@ -178,7 +181,7 @@ describe "Private Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:tags).and_return([])
+      allow_any_instance_of(Project).to receive(:tags).and_return([])
     end
 
     it { should be_allowed_for master }

--- a/spec/features/security/project/public_access_spec.rb
+++ b/spec/features/security/project/public_access_spec.rb
@@ -23,7 +23,10 @@ describe "Public Project Access", feature: true  do
   describe "Project should be public" do
     subject { project }
 
-    its(:public?) { should be_true }
+    describe '#public?' do
+      subject { super().public? }
+      it { should be_true }
+    end
   end
 
   describe "GET /:project_path" do
@@ -99,12 +102,12 @@ describe "Public Project Access", feature: true  do
       @blob_path = project_blob_path(project, File.join(commit.id, path))
     end
 
-    it { @blob_path.should be_allowed_for master }
-    it { @blob_path.should be_allowed_for reporter }
-    it { @blob_path.should be_allowed_for :admin }
-    it { @blob_path.should be_allowed_for guest }
-    it { @blob_path.should be_allowed_for :user }
-    it { @blob_path.should be_allowed_for :visitor }
+    it { expect(@blob_path).to be_allowed_for master }
+    it { expect(@blob_path).to be_allowed_for reporter }
+    it { expect(@blob_path).to be_allowed_for :admin }
+    it { expect(@blob_path).to be_allowed_for guest }
+    it { expect(@blob_path).to be_allowed_for :user }
+    it { expect(@blob_path).to be_allowed_for :visitor }
   end
 
   describe "GET /:project_path/edit" do
@@ -189,7 +192,7 @@ describe "Public Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:branches).and_return([])
+      allow_any_instance_of(Project).to receive(:branches).and_return([])
     end
 
     it { should be_allowed_for master }
@@ -205,7 +208,7 @@ describe "Public Project Access", feature: true  do
 
     before do
       # Speed increase
-      Project.any_instance.stub(:tags).and_return([])
+      allow_any_instance_of(Project).to receive(:tags).and_return([])
     end
 
     it { should be_allowed_for master }

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Users', feature: true do
   describe "GET /users/sign_up" do
     before do
-      Gitlab.config.gitlab.stub(:signup_enabled).and_return(true)
+      allow(Gitlab.config.gitlab).to receive(:signup_enabled).and_return(true)
     end
 
     it "should create a new user account" do

--- a/spec/finders/issues_finder_spec.rb
+++ b/spec/finders/issues_finder_spec.rb
@@ -25,34 +25,34 @@ describe IssuesFinder do
     it 'should filter by all' do
       params = { scope: "all", state: 'opened' }
       issues = IssuesFinder.new.execute(user, params)
-      issues.size.should == 3
+      expect(issues.size).to eq(3)
     end
 
     it 'should filter by assignee' do
       params = { scope: "assigned-to-me", state: 'opened' }
       issues = IssuesFinder.new.execute(user, params)
-      issues.size.should == 2
+      expect(issues.size).to eq(2)
     end
 
     it 'should filter by project' do
       params = { scope: "assigned-to-me", state: 'opened', project_id: project1.id }
       issues = IssuesFinder.new.execute(user, params)
-      issues.size.should == 1
+      expect(issues.size).to eq(1)
     end
 
     it 'should be empty for unauthorized user' do
       params = { scope: "all", state: 'opened' }
       issues = IssuesFinder.new.execute(nil, params)
-      issues.size.should be_zero
+      expect(issues.size).to be_zero
     end
 
     it 'should not include unauthorized issues' do
       params = { scope: "all", state: 'opened' }
       issues = IssuesFinder.new.execute(user2, params)
-      issues.size.should == 2
-      issues.should_not include(issue1)
-      issues.should include(issue2)
-      issues.should include(issue3)
+      expect(issues.size).to eq(2)
+      expect(issues).not_to include(issue1)
+      expect(issues).to include(issue2)
+      expect(issues).to include(issue3)
     end
   end
 end

--- a/spec/finders/merge_requests_finder_spec.rb
+++ b/spec/finders/merge_requests_finder_spec.rb
@@ -21,13 +21,13 @@ describe MergeRequestsFinder do
     it 'should filter by scope' do
       params = { scope: 'authored', state: 'opened' }
       merge_requests = MergeRequestsFinder.new.execute(user, params)
-      merge_requests.size.should == 2
+      expect(merge_requests.size).to eq(2)
     end
 
     it 'should filter by project' do
       params = { project_id: project1.id, scope: 'authored', state: 'opened' }
       merge_requests = MergeRequestsFinder.new.execute(user, params)
-      merge_requests.size.should == 1
+      expect(merge_requests.size).to eq(1)
     end
   end
 end

--- a/spec/finders/notes_finder_spec.rb
+++ b/spec/finders/notes_finder_spec.rb
@@ -21,7 +21,7 @@ describe NotesFinder do
 
     it 'should find all notes' do
       notes = NotesFinder.new.execute(project, user, params)
-      notes.size.should eq(2)
+      expect(notes.size).to eq(2)
     end
 
     it 'should raise an exception for an invalid target_type' do
@@ -32,7 +32,7 @@ describe NotesFinder do
     it 'filters out old notes' do
       note2.update_attribute(:updated_at, 2.hours.ago)
       notes = NotesFinder.new.execute(project, user, params)
-      notes.should eq([note1])
+      expect(notes).to eq([note1])
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 describe ApplicationHelper do
   describe 'current_controller?' do
     before do
-      controller.stub(:controller_name).and_return('foo')
+      allow(controller).to receive(:controller_name).and_return('foo')
     end
 
     it "returns true when controller matches argument" do
-      current_controller?(:foo).should be_true
+      expect(current_controller?(:foo)).to be_true
     end
 
     it "returns false when controller does not match argument" do
-      current_controller?(:bar).should_not be_true
+      expect(current_controller?(:bar)).not_to be_true
     end
 
     it "should take any number of arguments" do
-      current_controller?(:baz, :bar).should_not be_true
-      current_controller?(:baz, :bar, :foo).should be_true
+      expect(current_controller?(:baz, :bar)).not_to be_true
+      expect(current_controller?(:baz, :bar, :foo)).to be_true
     end
   end
 
@@ -26,16 +26,16 @@ describe ApplicationHelper do
     end
 
     it "returns true when action matches argument" do
-      current_action?(:foo).should be_true
+      expect(current_action?(:foo)).to be_true
     end
 
     it "returns false when action does not match argument" do
-      current_action?(:bar).should_not be_true
+      expect(current_action?(:bar)).not_to be_true
     end
 
     it "should take any number of arguments" do
-      current_action?(:baz, :bar).should_not be_true
-      current_action?(:baz, :bar, :foo).should be_true
+      expect(current_action?(:baz, :bar)).not_to be_true
+      expect(current_action?(:baz, :bar, :foo)).to be_true
     end
   end
 
@@ -46,13 +46,13 @@ describe ApplicationHelper do
       group = create(:group)
       group.avatar = File.open(avatar_file_path)
       group.save!
-      group_icon(group.path).to_s.should match("/uploads/group/avatar/#{ group.id }/gitlab_logo.png")
+      expect(group_icon(group.path).to_s).to match("/uploads/group/avatar/#{ group.id }/gitlab_logo.png")
     end
 
     it "should give default avatar_icon when no avatar is present" do
       group = create(:group)
       group.save!
-      group_icon(group.path).should match("group_avatar.png")
+      expect(group_icon(group.path)).to match("group_avatar.png")
     end
   end
 
@@ -63,13 +63,13 @@ describe ApplicationHelper do
       user = create(:user)
       user.avatar = File.open(avatar_file_path)
       user.save!
-      avatar_icon(user.email).to_s.should match("/uploads/user/avatar/#{ user.id }/gitlab_logo.png")
+      expect(avatar_icon(user.email).to_s).to match("/uploads/user/avatar/#{ user.id }/gitlab_logo.png")
     end
 
     it "should call gravatar_icon when no avatar is present" do
       user = create(:user, email: 'test@example.com')
       user.save!
-      avatar_icon(user.email).to_s.should == "http://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=40&d=identicon"
+      expect(avatar_icon(user.email).to_s).to eq("http://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=40&d=identicon")
     end
   end
 
@@ -77,43 +77,43 @@ describe ApplicationHelper do
     let(:user_email) { 'user@email.com' }
 
     it "should return a generic avatar path when Gravatar is disabled" do
-      Gitlab.config.gravatar.stub(:enabled).and_return(false)
-      gravatar_icon(user_email).should match('no_avatar.png')
+      allow(Gitlab.config.gravatar).to receive(:enabled).and_return(false)
+      expect(gravatar_icon(user_email)).to match('no_avatar.png')
     end
 
     it "should return a generic avatar path when email is blank" do
-      gravatar_icon('').should match('no_avatar.png')
+      expect(gravatar_icon('')).to match('no_avatar.png')
     end
 
     it "should return default gravatar url" do
       Gitlab.config.gitlab.stub(https: false)
-      gravatar_icon(user_email).should match('http://www.gravatar.com/avatar/b58c6f14d292556214bd64909bcdb118')
+      expect(gravatar_icon(user_email)).to match('http://www.gravatar.com/avatar/b58c6f14d292556214bd64909bcdb118')
     end
 
     it "should use SSL when appropriate" do
       Gitlab.config.gitlab.stub(https: true)
-      gravatar_icon(user_email).should match('https://secure.gravatar.com')
+      expect(gravatar_icon(user_email)).to match('https://secure.gravatar.com')
     end
 
     it "should return custom gravatar path when gravatar_url is set" do
       allow(self).to receive(:request).and_return(double(:ssl? => false))
-      Gitlab.config.gravatar.stub(:plain_url).and_return('http://example.local/?s=%{size}&hash=%{hash}')
-      gravatar_icon(user_email, 20).should == 'http://example.local/?s=20&hash=b58c6f14d292556214bd64909bcdb118'
+      allow(Gitlab.config.gravatar).to receive(:plain_url).and_return('http://example.local/?s=%{size}&hash=%{hash}')
+      expect(gravatar_icon(user_email, 20)).to eq('http://example.local/?s=20&hash=b58c6f14d292556214bd64909bcdb118')
     end
 
     it "should accept a custom size" do
       allow(self).to receive(:request).and_return(double(:ssl? => false))
-      gravatar_icon(user_email, 64).should match(/\?s=64/)
+      expect(gravatar_icon(user_email, 64)).to match(/\?s=64/)
     end
 
     it "should use default size when size is wrong" do
       allow(self).to receive(:request).and_return(double(:ssl? => false))
-      gravatar_icon(user_email, nil).should match(/\?s=40/)
+      expect(gravatar_icon(user_email, nil)).to match(/\?s=40/)
     end
 
     it "should be case insensitive" do
       allow(self).to receive(:request).and_return(double(:ssl? => false))
-      gravatar_icon(user_email).should == gravatar_icon(user_email.upcase + " ")
+      expect(gravatar_icon(user_email)).to eq(gravatar_icon(user_email.upcase + " "))
     end
   end
 
@@ -131,28 +131,28 @@ describe ApplicationHelper do
     end
 
     it "includes a list of branch names" do
-      options[0][0].should == 'Branches'
-      options[0][1].should include('master', 'stable')
+      expect(options[0][0]).to eq('Branches')
+      expect(options[0][1]).to include('master', 'stable')
     end
 
     it "includes a list of tag names" do
-      options[1][0].should == 'Tags'
-      options[1][1].should include('v0.9.4','v1.2.0')
+      expect(options[1][0]).to eq('Tags')
+      expect(options[1][1]).to include('v0.9.4','v1.2.0')
     end
 
     it "includes a specific commit ref if defined" do
       # Must be an instance variable
       @ref = '2ed06dc41dbb5936af845b87d79e05bbf24c73b8'
 
-      options[2][0].should == 'Commit'
-      options[2][1].should == [@ref]
+      expect(options[2][0]).to eq('Commit')
+      expect(options[2][1]).to eq([@ref])
     end
 
     it "sorts tags in a natural order" do
       # Stub repository.tag_names to make sure we get some valid testing data
       expect(@project.repository).to receive(:tag_names).and_return(["v1.0.9", "v1.0.10", "v2.0", "v3.1.4.2", "v1.0.9a"])
 
-      options[1][1].should == ["v3.1.4.2", "v2.0", "v1.0.10", "v1.0.9a", "v1.0.9"]
+      expect(options[1][1]).to eq(["v3.1.4.2", "v2.0", "v1.0.10", "v1.0.9a", "v1.0.9"])
     end
   end
 
@@ -160,7 +160,7 @@ describe ApplicationHelper do
     context "with current_user is nil" do
       it "should return a string" do
         allow(self).to receive(:current_user).and_return(nil)
-        user_color_scheme_class.should be_kind_of(String)
+        expect(user_color_scheme_class).to be_kind_of(String)
       end
     end
 
@@ -170,7 +170,7 @@ describe ApplicationHelper do
           it "should return a string" do
             current_user = double(:color_scheme_id => color_scheme_id)
             allow(self).to receive(:current_user).and_return(current_user)
-            user_color_scheme_class.should be_kind_of(String)
+            expect(user_color_scheme_class).to be_kind_of(String)
           end
         end
       end
@@ -181,17 +181,17 @@ describe ApplicationHelper do
     let(:a_tag) { '<a href="#">Foo</a>' }
 
     it "allows the a tag" do
-      simple_sanitize(a_tag).should == a_tag
+      expect(simple_sanitize(a_tag)).to eq(a_tag)
     end
 
     it "allows the span tag" do
       input = '<span class="foo">Bar</span>'
-      simple_sanitize(input).should == input
+      expect(simple_sanitize(input)).to eq(input)
     end
 
     it "disallows other tags" do
       input = "<strike><b>#{a_tag}</b></strike>"
-      simple_sanitize(input).should == a_tag
+      expect(simple_sanitize(input)).to eq(a_tag)
     end
   end
 

--- a/spec/helpers/broadcast_messages_helper_spec.rb
+++ b/spec/helpers/broadcast_messages_helper_spec.rb
@@ -6,7 +6,7 @@ describe BroadcastMessagesHelper do
 
     context "default style" do
       it "should have no style" do
-        broadcast_styling(broadcast_message).should match('')
+        expect(broadcast_styling(broadcast_message)).to match('')
       end
     end
 
@@ -14,7 +14,7 @@ describe BroadcastMessagesHelper do
       before { broadcast_message.stub(color: "#f2dede", font: "#b94a48") }
 
       it "should have a customized style" do
-        broadcast_styling(broadcast_message).should match('background-color:#f2dede;color:#b94a48')
+        expect(broadcast_styling(broadcast_message)).to match('background-color:#f2dede;color:#b94a48')
       end
     end
   end

--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -24,26 +24,26 @@ describe GitlabMarkdownHelper do
     it "should return unaltered text if project is nil" do
       actual = "Testing references: ##{issue.iid}"
 
-      gfm(actual).should_not == actual
+      expect(gfm(actual)).not_to eq(actual)
 
       @project = nil
-      gfm(actual).should == actual
+      expect(gfm(actual)).to eq(actual)
     end
 
     it "should not alter non-references" do
       actual = expected = "_Please_ *stop* 'helping' and all the other b*$#%' you do."
-      gfm(actual).should == expected
+      expect(gfm(actual)).to eq(expected)
     end
 
     it "should not touch HTML entities" do
-      @project.issues.stub(:where).with(id: '39').and_return([issue])
+      allow(@project.issues).to receive(:where).with(id: '39').and_return([issue])
       actual = expected = "We&#39;ll accept good pull requests."
-      gfm(actual).should == expected
+      expect(gfm(actual)).to eq(expected)
     end
 
     it "should forward HTML options to links" do
-      gfm("Fixed in #{commit.id}", @project, class: 'foo').
-          should have_selector('a.gfm.foo')
+      expect(gfm("Fixed in #{commit.id}", @project, class: 'foo')).
+          to have_selector('a.gfm.foo')
     end
 
     describe "referencing a commit" do
@@ -51,38 +51,38 @@ describe GitlabMarkdownHelper do
 
       it "should link using a full id" do
         actual = "Reverts #{commit.id}"
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link using a short id" do
         actual = "Backported from #{commit.short_id(6)}"
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link with adjacent text" do
         actual = "Reverted (see #{commit.id})"
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should keep whitespace intact" do
         actual   = "Changes #{commit.id} dramatically"
         expected = /Changes <a.+>#{commit.id}<\/a> dramatically/
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should not link with an invalid id" do
         actual = expected = "What happened in #{commit.id.reverse}"
-        gfm(actual).should == expected
+        expect(gfm(actual)).to eq(expected)
       end
 
       it "should include a title attribute" do
         actual = "Reverts #{commit.id}"
-        gfm(actual).should match(/title="#{commit.link_title}"/)
+        expect(gfm(actual)).to match(/title="#{commit.link_title}"/)
       end
 
       it "should include standard gfm classes" do
         actual = "Reverts #{commit.id}"
-        gfm(actual).should match(/class="\s?gfm gfm-commit\s?"/)
+        expect(gfm(actual)).to match(/class="\s?gfm gfm-commit\s?"/)
       end
     end
 
@@ -95,37 +95,37 @@ describe GitlabMarkdownHelper do
       end
 
       it "should link using a simple name" do
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link using a name with dots" do
         user.update_attributes(name: "alphA.Beta")
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link using name with underscores" do
         user.update_attributes(name: "ping_pong_king")
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link with adjacent text" do
         actual = "Mail the admin (@#{user.username})"
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should keep whitespace intact" do
         actual   = "Yes, @#{user.username} is right."
         expected = /Yes, <a.+>@#{user.username}<\/a> is right/
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should not link with an invalid id" do
         actual = expected = "@#{user.username.reverse} you are right."
-        gfm(actual).should == expected
+        expect(gfm(actual)).to eq(expected)
       end
 
       it "should include standard gfm classes" do
-        gfm(actual).should match(/class="\s?gfm gfm-team_member\s?"/)
+        expect(gfm(actual)).to match(/class="\s?gfm gfm-team_member\s?"/)
       end
     end
 
@@ -142,37 +142,37 @@ describe GitlabMarkdownHelper do
       let(:expected) { polymorphic_path([project, object]) }
 
       it "should link using a valid id" do
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link with adjacent text" do
         # Wrap the reference in parenthesis
-        gfm(actual.gsub(reference, "(#{reference})")).should match(expected)
+        expect(gfm(actual.gsub(reference, "(#{reference})"))).to match(expected)
 
         # Append some text to the end of the reference
-        gfm(actual.gsub(reference, "#{reference}, right?")).should match(expected)
+        expect(gfm(actual.gsub(reference, "#{reference}, right?"))).to match(expected)
       end
 
       it "should keep whitespace intact" do
         actual   = "Referenced #{reference} already."
         expected = /Referenced <a.+>[^\s]+<\/a> already/
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should not link with an invalid id" do
         # Modify the reference string so it's still parsed, but is invalid
         reference.gsub!(/^(.)(\d+)$/, '\1' + ('\2' * 2))
-        gfm(actual).should == actual
+        expect(gfm(actual)).to eq(actual)
       end
 
       it "should include a title attribute" do
         title = "#{object.class.to_s.titlecase}: #{object.title}"
-        gfm(actual).should match(/title="#{title}"/)
+        expect(gfm(actual)).to match(/title="#{title}"/)
       end
 
       it "should include standard gfm classes" do
         css = object.class.to_s.underscore
-        gfm(actual).should match(/class="\s?gfm gfm-#{css}\s?"/)
+        expect(gfm(actual)).to match(/class="\s?gfm gfm-#{css}\s?"/)
       end
     end
 
@@ -190,42 +190,42 @@ describe GitlabMarkdownHelper do
 
       before do
         issue_tracker_config = { "jira" => { "title" => "JIRA tracker", "issues_url" => "http://jira.example/browse/:id" } }
-        Gitlab.config.stub(:issues_tracker).and_return(issue_tracker_config)
-        @project.stub(:issues_tracker).and_return("jira")
-        @project.stub(:issues_tracker_id).and_return("JIRA")
+        allow(Gitlab.config).to receive(:issues_tracker).and_return(issue_tracker_config)
+        allow(@project).to receive(:issues_tracker).and_return("jira")
+        allow(@project).to receive(:issues_tracker_id).and_return("JIRA")
       end
 
       it "should link using a valid id" do
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link with adjacent text" do
         # Wrap the reference in parenthesis
-        gfm(actual.gsub(reference, "(#{reference})")).should match(expected)
+        expect(gfm(actual.gsub(reference, "(#{reference})"))).to match(expected)
 
         # Append some text to the end of the reference
-        gfm(actual.gsub(reference, "#{reference}, right?")).should match(expected)
+        expect(gfm(actual.gsub(reference, "#{reference}, right?"))).to match(expected)
       end
 
       it "should keep whitespace intact" do
         actual   = "Referenced #{reference} already."
         expected = /Referenced <a.+>[^\s]+<\/a> already/
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should not link with an invalid id" do
         # Modify the reference string so it's still parsed, but is invalid
         invalid_reference = actual.gsub(/(\d+)$/, "r45")
-        gfm(invalid_reference).should == invalid_reference
+        expect(gfm(invalid_reference)).to eq(invalid_reference)
       end
 
       it "should include a title attribute" do
         title = "Issue in JIRA tracker"
-        gfm(actual).should match(/title="#{title}"/)
+        expect(gfm(actual)).to match(/title="#{title}"/)
       end
 
       it "should include standard gfm classes" do
-        gfm(actual).should match(/class="\s?gfm gfm-issue\s?"/)
+        expect(gfm(actual)).to match(/class="\s?gfm gfm-issue\s?"/)
       end
     end
 
@@ -243,37 +243,37 @@ describe GitlabMarkdownHelper do
       let(:expected) { project_snippet_path(project, object) }
 
       it "should link using a valid id" do
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link with adjacent text" do
         # Wrap the reference in parenthesis
-        gfm(actual.gsub(reference, "(#{reference})")).should match(expected)
+        expect(gfm(actual.gsub(reference, "(#{reference})"))).to match(expected)
 
         # Append some text to the end of the reference
-        gfm(actual.gsub(reference, "#{reference}, right?")).should match(expected)
+        expect(gfm(actual.gsub(reference, "#{reference}, right?"))).to match(expected)
       end
 
       it "should keep whitespace intact" do
         actual   = "Referenced #{reference} already."
         expected = /Referenced <a.+>[^\s]+<\/a> already/
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should not link with an invalid id" do
         # Modify the reference string so it's still parsed, but is invalid
         reference.gsub!(/^(.)(\d+)$/, '\1' + ('\2' * 2))
-        gfm(actual).should == actual
+        expect(gfm(actual)).to eq(actual)
       end
 
       it "should include a title attribute" do
         title = "Snippet: #{object.title}"
-        gfm(actual).should match(/title="#{title}"/)
+        expect(gfm(actual)).to match(/title="#{title}"/)
       end
 
       it "should include standard gfm classes" do
         css = object.class.to_s.underscore
-        gfm(actual).should match(/class="\s?gfm gfm-snippet\s?"/)
+        expect(gfm(actual)).to match(/class="\s?gfm gfm-snippet\s?"/)
       end
 
     end
@@ -283,62 +283,62 @@ describe GitlabMarkdownHelper do
 
       it "should link to the merge request" do
         expected = project_merge_request_path(project, merge_request)
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link to the commit" do
         expected = project_commit_path(project, commit)
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
 
       it "should link to the issue" do
         expected = project_issue_path(project, issue)
-        gfm(actual).should match(expected)
+        expect(gfm(actual)).to match(expected)
       end
     end
 
     describe "emoji" do
       it "matches at the start of a string" do
-        gfm(":+1:").should match(/<img/)
+        expect(gfm(":+1:")).to match(/<img/)
       end
 
       it "matches at the end of a string" do
-        gfm("This gets a :-1:").should match(/<img/)
+        expect(gfm("This gets a :-1:")).to match(/<img/)
       end
 
       it "matches with adjacent text" do
-        gfm("+1 (:+1:)").should match(/<img/)
+        expect(gfm("+1 (:+1:)")).to match(/<img/)
       end
 
       it "has a title attribute" do
-        gfm(":-1:").should match(/title=":-1:"/)
+        expect(gfm(":-1:")).to match(/title=":-1:"/)
       end
 
       it "has an alt attribute" do
-        gfm(":-1:").should match(/alt=":-1:"/)
+        expect(gfm(":-1:")).to match(/alt=":-1:"/)
       end
 
       it "has an emoji class" do
-        gfm(":+1:").should match('class="emoji"')
+        expect(gfm(":+1:")).to match('class="emoji"')
       end
 
       it "sets height and width" do
         actual = gfm(":+1:")
-        actual.should match(/width="20"/)
-        actual.should match(/height="20"/)
+        expect(actual).to match(/width="20"/)
+        expect(actual).to match(/height="20"/)
       end
 
       it "keeps whitespace intact" do
-        gfm("This deserves a :+1: big time.").should match(/deserves a <img.+\/> big time/)
+        expect(gfm("This deserves a :+1: big time.")).to match(/deserves a <img.+\/> big time/)
       end
 
       it "ignores invalid emoji" do
-        gfm(":invalid-emoji:").should_not match(/<img/)
+        expect(gfm(":invalid-emoji:")).not_to match(/<img/)
       end
 
       it "should work independent of reference links (i.e. without @project being set)" do
         @project = nil
-        gfm(":+1:").should match(/<img/)
+        expect(gfm(":+1:")).to match(/<img/)
       end
     end
   end
@@ -355,34 +355,34 @@ describe GitlabMarkdownHelper do
       groups = actual.split("</a>")
 
       # Leading commit link
-      groups[0].should match(/href="#{commit_path}"/)
-      groups[0].should match(/This should finally fix $/)
+      expect(groups[0]).to match(/href="#{commit_path}"/)
+      expect(groups[0]).to match(/This should finally fix $/)
 
       # First issue link
-      groups[1].should match(/href="#{project_issue_url(project, issues[0])}"/)
-      groups[1].should match(/##{issues[0].iid}$/)
+      expect(groups[1]).to match(/href="#{project_issue_url(project, issues[0])}"/)
+      expect(groups[1]).to match(/##{issues[0].iid}$/)
 
       # Internal commit link
-      groups[2].should match(/href="#{commit_path}"/)
-      groups[2].should match(/ and /)
+      expect(groups[2]).to match(/href="#{commit_path}"/)
+      expect(groups[2]).to match(/ and /)
 
       # Second issue link
-      groups[3].should match(/href="#{project_issue_url(project, issues[1])}"/)
-      groups[3].should match(/##{issues[1].iid}$/)
+      expect(groups[3]).to match(/href="#{project_issue_url(project, issues[1])}"/)
+      expect(groups[3]).to match(/##{issues[1].iid}$/)
 
       # Trailing commit link
-      groups[4].should match(/href="#{commit_path}"/)
-      groups[4].should match(/ for real$/)
+      expect(groups[4]).to match(/href="#{commit_path}"/)
+      expect(groups[4]).to match(/ for real$/)
     end
 
     it "should forward HTML options" do
       actual = link_to_gfm("Fixed in #{commit.id}", commit_path, class: 'foo')
-      actual.should have_selector 'a.gfm.gfm-commit.foo'
+      expect(actual).to have_selector 'a.gfm.gfm-commit.foo'
     end
 
     it "escapes HTML passed in as the body" do
       actual = "This is a <h1>test</h1> - see ##{issues[0].iid}"
-      link_to_gfm(actual, commit_path).should match('&lt;h1&gt;test&lt;/h1&gt;')
+      expect(link_to_gfm(actual, commit_path)).to match('&lt;h1&gt;test&lt;/h1&gt;')
     end
   end
 
@@ -390,25 +390,25 @@ describe GitlabMarkdownHelper do
     it "should handle references in paragraphs" do
       actual = "\n\nLorem ipsum dolor sit amet. #{commit.id} Nam pulvinar sapien eget.\n"
       expected = project_commit_path(project, commit)
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
     it "should handle references in headers" do
       actual = "\n# Working around ##{issue.iid}\n## Apply !#{merge_request.iid}"
 
-      markdown(actual, {no_header_anchors:true}).should match(%r{<h1[^<]*>Working around <a.+>##{issue.iid}</a></h1>})
-      markdown(actual, {no_header_anchors:true}).should match(%r{<h2[^<]*>Apply <a.+>!#{merge_request.iid}</a></h2>})
+      expect(markdown(actual, {no_header_anchors:true})).to match(%r{<h1[^<]*>Working around <a.+>##{issue.iid}</a></h1>})
+      expect(markdown(actual, {no_header_anchors:true})).to match(%r{<h2[^<]*>Apply <a.+>!#{merge_request.iid}</a></h2>})
     end
 
     it "should add ids and links to headers" do
       # Test every rule except nested tags.
       text = '..Ab_c-d. e..'
       id = 'ab_c-d-e'
-      markdown("# #{text}").should match(%r{<h1 id="#{id}">#{text}<a href="[^"]*##{id}"></a></h1>})
-      markdown("# #{text}", {no_header_anchors:true}).should == "<h1>#{text}</h1>"
+      expect(markdown("# #{text}")).to match(%r{<h1 id="#{id}">#{text}<a href="[^"]*##{id}"></a></h1>})
+      expect(markdown("# #{text}", {no_header_anchors:true})).to eq("<h1>#{text}</h1>")
 
       id = 'link-text'
-      markdown("# [link text](url) ![img alt](url)").should match(
+      expect(markdown("# [link text](url) ![img alt](url)")).to match(
         %r{<h1 id="#{id}"><a href="[^"]*url">link text</a> <img[^>]*><a href="[^"]*##{id}"></a></h1>}
       )
     end
@@ -418,14 +418,14 @@ describe GitlabMarkdownHelper do
 
       actual = "\n* dark: ##{issue.iid}\n* light by @#{member.user.username}"
 
-      markdown(actual).should match(%r{<li>dark: <a.+>##{issue.iid}</a></li>})
-      markdown(actual).should match(%r{<li>light by <a.+>@#{member.user.username}</a></li>})
+      expect(markdown(actual)).to match(%r{<li>dark: <a.+>##{issue.iid}</a></li>})
+      expect(markdown(actual)).to match(%r{<li>light by <a.+>@#{member.user.username}</a></li>})
     end
 
     it "should handle references in <em>" do
       actual = "Apply _!#{merge_request.iid}_ ASAP"
 
-      markdown(actual).should match(%r{Apply <em><a.+>!#{merge_request.iid}</a></em>})
+      expect(markdown(actual)).to match(%r{Apply <em><a.+>!#{merge_request.iid}</a></em>})
     end
 
     it "should handle tables" do
@@ -434,76 +434,76 @@ describe GitlabMarkdownHelper do
 | cell 1   | cell 2   |
 | cell 3   | cell 4   |}
 
-      markdown(actual).should match(/\A<table/)
+      expect(markdown(actual)).to match(/\A<table/)
     end
 
     it "should leave code blocks untouched" do
-      helper.stub(:user_color_scheme_class).and_return(:white)
+      allow(helper).to receive(:user_color_scheme_class).and_return(:white)
 
       target_html = "\n<div class=\"highlighted-data white\">\n  <div class=\"highlight\">\n    <pre><code class=\"\">some code from $#{snippet.id}\nhere too\n</code></pre>\n  </div>\n</div>\n\n"
 
-      helper.markdown("\n    some code from $#{snippet.id}\n    here too\n").should == target_html
-      helper.markdown("\n```\nsome code from $#{snippet.id}\nhere too\n```\n").should == target_html
+      expect(helper.markdown("\n    some code from $#{snippet.id}\n    here too\n")).to eq(target_html)
+      expect(helper.markdown("\n```\nsome code from $#{snippet.id}\nhere too\n```\n")).to eq(target_html)
     end
 
     it "should leave inline code untouched" do
-      markdown("\nDon't use `$#{snippet.id}` here.\n").should == "<p>Don&#39;t use <code>$#{snippet.id}</code> here.</p>\n"
+      expect(markdown("\nDon't use `$#{snippet.id}` here.\n")).to eq("<p>Don&#39;t use <code>$#{snippet.id}</code> here.</p>\n")
     end
 
     it "should leave ref-like autolinks untouched" do
-      markdown("look at http://example.tld/#!#{merge_request.iid}").should == "<p>look at <a href=\"http://example.tld/#!#{merge_request.iid}\">http://example.tld/#!#{merge_request.iid}</a></p>\n"
+      expect(markdown("look at http://example.tld/#!#{merge_request.iid}")).to eq("<p>look at <a href=\"http://example.tld/#!#{merge_request.iid}\">http://example.tld/#!#{merge_request.iid}</a></p>\n")
     end
 
     it "should leave ref-like href of 'manual' links untouched" do
-      markdown("why not [inspect !#{merge_request.iid}](http://example.tld/#!#{merge_request.iid})").should == "<p>why not <a href=\"http://example.tld/#!#{merge_request.iid}\">inspect </a><a class=\"gfm gfm-merge_request \" href=\"#{project_merge_request_url(project, merge_request)}\" title=\"Merge Request: #{merge_request.title}\">!#{merge_request.iid}</a><a href=\"http://example.tld/#!#{merge_request.iid}\"></a></p>\n"
+      expect(markdown("why not [inspect !#{merge_request.iid}](http://example.tld/#!#{merge_request.iid})")).to eq("<p>why not <a href=\"http://example.tld/#!#{merge_request.iid}\">inspect </a><a class=\"gfm gfm-merge_request \" href=\"#{project_merge_request_url(project, merge_request)}\" title=\"Merge Request: #{merge_request.title}\">!#{merge_request.iid}</a><a href=\"http://example.tld/#!#{merge_request.iid}\"></a></p>\n")
     end
 
     it "should leave ref-like src of images untouched" do
-      markdown("screen shot: ![some image](http://example.tld/#!#{merge_request.iid})").should == "<p>screen shot: <img src=\"http://example.tld/#!#{merge_request.iid}\" alt=\"some image\"></p>\n"
+      expect(markdown("screen shot: ![some image](http://example.tld/#!#{merge_request.iid})")).to eq("<p>screen shot: <img src=\"http://example.tld/#!#{merge_request.iid}\" alt=\"some image\"></p>\n")
     end
 
     it "should generate absolute urls for refs" do
-      markdown("##{issue.iid}").should include(project_issue_url(project, issue))
+      expect(markdown("##{issue.iid}")).to include(project_issue_url(project, issue))
     end
 
     it "should generate absolute urls for emoji" do
-      markdown(":smile:").should include("src=\"#{url_to_image("emoji/smile")}")
+      expect(markdown(":smile:")).to include("src=\"#{url_to_image("emoji/smile")}")
     end
 
     it "should handle relative urls for a file in master" do
       actual = "[GitLab API doc](doc/api/README.md)\n"
       expected = "<p><a href=\"/#{project.path_with_namespace}/blob/master/doc/api/README.md\">GitLab API doc</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
     it "should handle relative urls for a directory in master" do
       actual = "[GitLab API doc](doc/api)\n"
       expected = "<p><a href=\"/#{project.path_with_namespace}/tree/master/doc/api\">GitLab API doc</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
     it "should handle absolute urls" do
       actual = "[GitLab](https://www.gitlab.com)\n"
       expected = "<p><a href=\"https://www.gitlab.com\">GitLab</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
     it "should handle relative urls in reference links for a file in master" do
       actual = "[GitLab API doc][GitLab readme]\n [GitLab readme]: doc/api/README.md\n"
       expected = "<p><a href=\"/#{project.path_with_namespace}/blob/master/doc/api/README.md\">GitLab API doc</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
     it "should handle relative urls in reference links for a directory in master" do
       actual = "[GitLab API doc directory][GitLab readmes]\n [GitLab readmes]: doc/api/\n"
       expected = "<p><a href=\"/#{project.path_with_namespace}/tree/master/doc/api\">GitLab API doc directory</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
 
      it "should not handle malformed relative urls in reference links for a file in master" do
       actual = "[GitLab readme]: doc/api/README.md\n"
       expected = ""
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
   end
 
@@ -516,29 +516,29 @@ describe GitlabMarkdownHelper do
     it "should not touch relative urls" do
       actual = "[GitLab API doc][GitLab readme]\n [GitLab readme]: doc/api/README.md\n"
       expected = "<p><a href=\"doc/api/README.md\">GitLab API doc</a></p>\n"
-      markdown(actual).should match(expected)
+      expect(markdown(actual)).to match(expected)
     end
   end
 
   describe "#render_wiki_content" do
     before do
       @wiki = double('WikiPage')
-      @wiki.stub(:content).and_return('wiki content')
+      allow(@wiki).to receive(:content).and_return('wiki content')
     end
 
     it "should use GitLab Flavored Markdown for markdown files" do
-      @wiki.stub(:format).and_return(:markdown)
+      allow(@wiki).to receive(:format).and_return(:markdown)
 
-      helper.should_receive(:markdown).with('wiki content')
+      expect(helper).to receive(:markdown).with('wiki content')
 
       helper.render_wiki_content(@wiki)
     end
 
     it "should use the Gollum renderer for all other file types" do
-      @wiki.stub(:format).and_return(:rdoc)
+      allow(@wiki).to receive(:format).and_return(:rdoc)
       formatted_content_stub = double('formatted_content')
-      formatted_content_stub.should_receive(:html_safe)
-      @wiki.stub(:formatted_content).and_return(formatted_content_stub)
+      expect(formatted_content_stub).to receive(:html_safe)
+      allow(@wiki).to receive(:formatted_content).and_return(formatted_content_stub)
 
       helper.render_wiki_content(@wiki)
     end

--- a/spec/helpers/issues_helper_spec.rb
+++ b/spec/helpers/issues_helper_spec.rb
@@ -8,18 +8,18 @@ describe IssuesHelper do
   describe :title_for_issue do
     it "should return issue title if used internal tracker" do
       @project = project
-      title_for_issue(issue.iid).should eq issue.title
+      expect(title_for_issue(issue.iid)).to eq issue.title
     end
 
     it "should always return empty string if used external tracker" do
       @project = ext_project
-      title_for_issue(rand(100)).should eq ""
+      expect(title_for_issue(rand(100))).to eq ""
     end
 
     it "should always return empty string if project nil" do
       @project = nil
 
-      title_for_issue(rand(100)).should eq ""
+      expect(title_for_issue(rand(100))).to eq ""
     end
   end
 
@@ -33,29 +33,29 @@ describe IssuesHelper do
 
     it "should return internal path if used internal tracker" do
       @project = project
-      url_for_project_issues.should match(int_expected)
+      expect(url_for_project_issues).to match(int_expected)
     end
 
     it "should return path to external tracker" do
       @project = ext_project
 
-      url_for_project_issues.should match(ext_expected)
+      expect(url_for_project_issues).to match(ext_expected)
     end
 
     it "should return empty string if project nil" do
       @project = nil
 
-      url_for_project_issues.should eq ""
+      expect(url_for_project_issues).to eq ""
     end
 
     describe "when external tracker was enabled and then config removed" do
       before do
         @project = ext_project
-        Gitlab.config.stub(:issues_tracker).and_return(nil)
+        allow(Gitlab.config).to receive(:issues_tracker).and_return(nil)
       end
 
       it "should return path to internal tracker" do
-        url_for_project_issues.should match(polymorphic_path([@project]))
+        expect(url_for_project_issues).to match(polymorphic_path([@project]))
       end
     end
   end
@@ -72,29 +72,29 @@ describe IssuesHelper do
 
     it "should return internal path if used internal tracker" do
       @project = project
-      url_for_issue(issue.iid).should match(int_expected)
+      expect(url_for_issue(issue.iid)).to match(int_expected)
     end
 
     it "should return path to external tracker" do
       @project = ext_project
 
-      url_for_issue(issue_id).should match(ext_expected)
+      expect(url_for_issue(issue_id)).to match(ext_expected)
     end
 
     it "should return empty string if project nil" do
       @project = nil
 
-      url_for_issue(issue.iid).should eq ""
+      expect(url_for_issue(issue.iid)).to eq ""
     end
 
     describe "when external tracker was enabled and then config removed" do
       before do
         @project = ext_project
-        Gitlab.config.stub(:issues_tracker).and_return(nil)
+        allow(Gitlab.config).to receive(:issues_tracker).and_return(nil)
       end
 
       it "should return internal path" do
-        url_for_issue(issue.iid).should match(polymorphic_path([@project, issue]))
+        expect(url_for_issue(issue.iid)).to match(polymorphic_path([@project, issue]))
       end
     end
   end
@@ -109,29 +109,29 @@ describe IssuesHelper do
 
     it "should return internal path if used internal tracker" do
       @project = project
-      url_for_new_issue.should match(int_expected)
+      expect(url_for_new_issue).to match(int_expected)
     end
 
     it "should return path to external tracker" do
       @project = ext_project
 
-      url_for_new_issue.should match(ext_expected)
+      expect(url_for_new_issue).to match(ext_expected)
     end
 
     it "should return empty string if project nil" do
       @project = nil
 
-      url_for_new_issue.should eq ""
+      expect(url_for_new_issue).to eq ""
     end
 
     describe "when external tracker was enabled and then config removed" do
       before do
         @project = ext_project
-        Gitlab.config.stub(:issues_tracker).and_return(nil)
+        allow(Gitlab.config).to receive(:issues_tracker).and_return(nil)
       end
 
       it "should return internal path" do
-        url_for_new_issue.should match(new_project_issue_path(@project))
+        expect(url_for_new_issue).to match(new_project_issue_path(@project))
       end
     end
   end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -8,7 +8,7 @@ describe NotificationsHelper do
       before { notification.stub(disabled?: true) }
 
       it "has a red icon" do
-        notification_icon(notification).should match('class="icon-volume-off ns-mute"')
+        expect(notification_icon(notification)).to match('class="icon-volume-off ns-mute"')
       end
     end
 
@@ -16,7 +16,7 @@ describe NotificationsHelper do
       before { notification.stub(participating?: true) }
 
       it "has a blue icon" do
-        notification_icon(notification).should match('class="icon-volume-down ns-part"')
+        expect(notification_icon(notification)).to match('class="icon-volume-down ns-part"')
       end
     end
 
@@ -24,12 +24,12 @@ describe NotificationsHelper do
       before { notification.stub(watch?: true) }
 
       it "has a green icon" do
-        notification_icon(notification).should match('class="icon-volume-up ns-watch"')
+        expect(notification_icon(notification)).to match('class="icon-volume-up ns-watch"')
       end
     end
 
     it "has a blue icon" do
-      notification_icon(notification).should match('class="icon-circle-blank ns-default"')
+      expect(notification_icon(notification)).to match('class="icon-circle-blank ns-default"')
     end
   end
 end

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -3,21 +3,24 @@ require 'spec_helper'
 describe ProjectsHelper do
   describe '#project_issues_trackers' do
     it "returns the correct issues trackers available" do
-      project_issues_trackers.should ==
+      expect(project_issues_trackers).to eq(
           "<option value=\"redmine\">Redmine</option>\n" \
           "<option value=\"gitlab\">GitLab</option>"
+      )
     end
 
     it "returns the correct issues trackers available with current tracker 'gitlab' selected" do
-      project_issues_trackers('gitlab').should ==
+      expect(project_issues_trackers('gitlab')).to eq(
           "<option value=\"redmine\">Redmine</option>\n" \
           "<option selected=\"selected\" value=\"gitlab\">GitLab</option>"
+      )
     end
 
     it "returns the correct issues trackers available with current tracker 'redmine' selected" do
-      project_issues_trackers('redmine').should ==
+      expect(project_issues_trackers('redmine')).to eq(
           "<option selected=\"selected\" value=\"redmine\">Redmine</option>\n" \
           "<option value=\"gitlab\">GitLab</option>"
+      )
     end
   end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -13,7 +13,7 @@ describe SearchHelper do
       end
 
       it "it returns nil" do
-        search_autocomplete_opts("q").should be_nil
+        expect(search_autocomplete_opts("q")).to be_nil
       end
     end
 
@@ -25,29 +25,29 @@ describe SearchHelper do
       end
 
       it "includes Help sections" do
-        search_autocomplete_opts("hel").size.should == 9
+        expect(search_autocomplete_opts("hel").size).to eq(9)
       end
 
       it "includes default sections" do
-        search_autocomplete_opts("adm").size.should == 1
+        expect(search_autocomplete_opts("adm").size).to eq(1)
       end
 
       it "includes the user's groups" do
         create(:group).add_owner(user)
-        search_autocomplete_opts("gro").size.should == 1
+        expect(search_autocomplete_opts("gro").size).to eq(1)
       end
 
       it "includes the user's projects" do
         project = create(:project, namespace: create(:namespace, owner: user))
-        search_autocomplete_opts(project.name).size.should == 1
+        expect(search_autocomplete_opts(project.name).size).to eq(1)
       end
 
       context "with a current project" do
         before { @project = create(:project) }
 
         it "includes project-specific sections" do
-          search_autocomplete_opts("Files").size.should == 1
-          search_autocomplete_opts("Commits").size.should == 1
+          expect(search_autocomplete_opts("Files").size).to eq(1)
+          expect(search_autocomplete_opts("Commits").size).to eq(1)
         end
       end
     end

--- a/spec/helpers/submodule_helper_spec.rb
+++ b/spec/helpers/submodule_helper_spec.rb
@@ -19,28 +19,28 @@ describe SubmoduleHelper do
         Gitlab.config.gitlab_shell.stub(ssh_port: 22) # set this just to be sure
         Gitlab.config.gitlab_shell.stub(ssh_path_prefix: Settings.send(:build_gitlab_shell_ssh_path_prefix))
         stub_url([ config.user, '@', config.host, ':gitlab-org/gitlab-ce.git' ].join(''))
-        submodule_links(submodule_item).should == [ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ]
+        expect(submodule_links(submodule_item)).to eq([ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ])
       end
 
       it 'should detect ssh on non-standard port' do
         Gitlab.config.gitlab_shell.stub(ssh_port: 2222)
         Gitlab.config.gitlab_shell.stub(ssh_path_prefix: Settings.send(:build_gitlab_shell_ssh_path_prefix))
         stub_url([ 'ssh://', config.user, '@', config.host, ':2222/gitlab-org/gitlab-ce.git' ].join(''))
-        submodule_links(submodule_item).should == [ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ]
+        expect(submodule_links(submodule_item)).to eq([ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ])
       end
 
       it 'should detect http on standard port' do
         Gitlab.config.gitlab.stub(port: 80)
         Gitlab.config.gitlab.stub(url: Settings.send(:build_gitlab_url))
         stub_url([ 'http://', config.host, '/gitlab-org/gitlab-ce.git' ].join(''))
-        submodule_links(submodule_item).should == [ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ]
+        expect(submodule_links(submodule_item)).to eq([ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ])
       end
 
       it 'should detect http on non-standard port' do
         Gitlab.config.gitlab.stub(port: 3000)
         Gitlab.config.gitlab.stub(url: Settings.send(:build_gitlab_url))
         stub_url([ 'http://', config.host, ':3000/gitlab-org/gitlab-ce.git' ].join(''))
-        submodule_links(submodule_item).should == [ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ]
+        expect(submodule_links(submodule_item)).to eq([ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ])
       end
 
       it 'should work with relative_url_root' do
@@ -48,67 +48,67 @@ describe SubmoduleHelper do
         Gitlab.config.gitlab.stub(relative_url_root: '/gitlab/root')
         Gitlab.config.gitlab.stub(url: Settings.send(:build_gitlab_url))
         stub_url([ 'http://', config.host, '/gitlab/root/gitlab-org/gitlab-ce.git' ].join(''))
-        submodule_links(submodule_item).should == [ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ]
+        expect(submodule_links(submodule_item)).to eq([ project_path('gitlab-org/gitlab-ce'), project_tree_path('gitlab-org/gitlab-ce', 'hash') ])
       end
     end
 
     context 'submodule on github.com' do
       it 'should detect ssh' do
         stub_url('git@github.com:gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should detect http' do
         stub_url('http://github.com/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should detect https' do
         stub_url('https://github.com/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://github.com/gitlab-org/gitlab-ce', 'https://github.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should return original with non-standard url' do
         stub_url('http://github.com/gitlab-org/gitlab-ce')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
 
         stub_url('http://github.com/another/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
       end
     end
 
     context 'submodule on gitlab.com' do
       it 'should detect ssh' do
         stub_url('git@gitlab.com:gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should detect http' do
         stub_url('http://gitlab.com/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should detect https' do
         stub_url('https://gitlab.com/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ]
+        expect(submodule_links(submodule_item)).to eq([ 'https://gitlab.com/gitlab-org/gitlab-ce', 'https://gitlab.com/gitlab-org/gitlab-ce/tree/hash' ])
       end
 
       it 'should return original with non-standard url' do
         stub_url('http://gitlab.com/gitlab-org/gitlab-ce')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
 
         stub_url('http://gitlab.com/another/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
       end
     end
 
     context 'submodule on unsupported' do
       it 'should return original' do
         stub_url('http://mygitserver.com/gitlab-org/gitlab-ce')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
 
         stub_url('http://mygitserver.com/gitlab-org/gitlab-ce.git')
-        submodule_links(submodule_item).should == [ repo.submodule_url_for, nil ]
+        expect(submodule_links(submodule_item)).to eq([ repo.submodule_url_for, nil ])
       end
     end
   end

--- a/spec/helpers/tab_helper_spec.rb
+++ b/spec/helpers/tab_helper_spec.rb
@@ -5,40 +5,40 @@ describe TabHelper do
 
   describe 'nav_link' do
     before do
-      controller.stub(:controller_name).and_return('foo')
+      allow(controller).to receive(:controller_name).and_return('foo')
       allow(self).to receive(:action_name).and_return('foo')
     end
 
     it "captures block output" do
-      nav_link { "Testing Blocks" }.should match(/Testing Blocks/)
+      expect(nav_link { "Testing Blocks" }).to match(/Testing Blocks/)
     end
 
     it "performs checks on the current controller" do
-      nav_link(controller: :foo).should match(/<li class="active">/)
-      nav_link(controller: :bar).should_not match(/active/)
-      nav_link(controller: [:foo, :bar]).should match(/active/)
+      expect(nav_link(controller: :foo)).to match(/<li class="active">/)
+      expect(nav_link(controller: :bar)).not_to match(/active/)
+      expect(nav_link(controller: [:foo, :bar])).to match(/active/)
     end
 
     it "performs checks on the current action" do
-      nav_link(action: :foo).should match(/<li class="active">/)
-      nav_link(action: :bar).should_not match(/active/)
-      nav_link(action: [:foo, :bar]).should match(/active/)
+      expect(nav_link(action: :foo)).to match(/<li class="active">/)
+      expect(nav_link(action: :bar)).not_to match(/active/)
+      expect(nav_link(action: [:foo, :bar])).to match(/active/)
     end
 
     it "performs checks on both controller and action when both are present" do
-      nav_link(controller: :bar, action: :foo).should_not match(/active/)
-      nav_link(controller: :foo, action: :bar).should_not match(/active/)
-      nav_link(controller: :foo, action: :foo).should match(/active/)
+      expect(nav_link(controller: :bar, action: :foo)).not_to match(/active/)
+      expect(nav_link(controller: :foo, action: :bar)).not_to match(/active/)
+      expect(nav_link(controller: :foo, action: :foo)).to match(/active/)
     end
 
     it "accepts a path shorthand" do
-      nav_link(path: 'foo#bar').should_not match(/active/)
-      nav_link(path: 'foo#foo').should match(/active/)
+      expect(nav_link(path: 'foo#bar')).not_to match(/active/)
+      expect(nav_link(path: 'foo#foo')).to match(/active/)
     end
 
     it "passes extra html options to the list element" do
-      nav_link(action: :foo, html_options: {class: 'home'}).should match(/<li class="home active">/)
-      nav_link(html_options: {class: 'active'}).should match(/<li class="active">/)
+      expect(nav_link(action: :foo, html_options: {class: 'home'})).to match(/<li class="home active">/)
+      expect(nav_link(html_options: {class: 'active'})).to match(/<li class="active">/)
     end
   end
 end

--- a/spec/helpers/tree_helper_spec.rb
+++ b/spec/helpers/tree_helper_spec.rb
@@ -4,12 +4,12 @@ describe TreeHelper do
   describe '#markup?' do
     %w(textile rdoc org creole mediawiki rst asciidoc pod).each do |type|
       it "returns true for #{type} files" do
-        markup?("README.#{type}").should be_true
+        expect(markup?("README.#{type}")).to be_true
       end
     end
 
     it "returns false when given a non-markup filename" do
-      markup?('README.rb').should_not be_true
+      expect(markup?('README.rb')).not_to be_true
     end
   end
 end

--- a/spec/lib/auth_spec.rb
+++ b/spec/lib/auth_spec.rb
@@ -14,15 +14,15 @@ describe Gitlab::Auth do
     end
 
     it "should find user by valid login/password" do
-      gl_auth.find('john', '88877711').should == @user
+      expect(gl_auth.find('john', '88877711')).to eq(@user)
     end
 
     it "should not find user with invalid password" do
-      gl_auth.find('john', 'invalid11').should_not == @user
+      expect(gl_auth.find('john', 'invalid11')).not_to eq(@user)
     end
 
     it "should not find user with invalid login and password" do
-      gl_auth.find('jon', 'invalid11').should_not == @user
+      expect(gl_auth.find('jon', 'invalid11')).not_to eq(@user)
     end
   end
 end

--- a/spec/lib/extracts_path_spec.rb
+++ b/spec/lib/extracts_path_spec.rb
@@ -14,44 +14,46 @@ describe ExtractsPath do
   describe '#extract_ref' do
     it "returns an empty pair when no @project is set" do
       @project = nil
-      extract_ref('master/CHANGELOG').should == ['', '']
+      expect(extract_ref('master/CHANGELOG')).to eq(['', ''])
     end
 
     context "without a path" do
       it "extracts a valid branch" do
-        extract_ref('master').should == ['master', '']
+        expect(extract_ref('master')).to eq(['master', ''])
       end
 
       it "extracts a valid tag" do
-        extract_ref('v2.0.0').should == ['v2.0.0', '']
+        expect(extract_ref('v2.0.0')).to eq(['v2.0.0', ''])
       end
 
       it "extracts a valid commit ref without a path" do
-        extract_ref('f4b14494ef6abf3d144c28e4af0c20143383e062').should ==
+        expect(extract_ref('f4b14494ef6abf3d144c28e4af0c20143383e062')).to eq(
           ['f4b14494ef6abf3d144c28e4af0c20143383e062', '']
+        )
       end
 
       it "falls back to a primitive split for an invalid ref" do
-        extract_ref('stable').should == ['stable', '']
+        expect(extract_ref('stable')).to eq(['stable', ''])
       end
     end
 
     context "with a path" do
       it "extracts a valid branch" do
-        extract_ref('foo/bar/baz/CHANGELOG').should == ['foo/bar/baz', 'CHANGELOG']
+        expect(extract_ref('foo/bar/baz/CHANGELOG')).to eq(['foo/bar/baz', 'CHANGELOG'])
       end
 
       it "extracts a valid tag" do
-        extract_ref('v2.0.0/CHANGELOG').should == ['v2.0.0', 'CHANGELOG']
+        expect(extract_ref('v2.0.0/CHANGELOG')).to eq(['v2.0.0', 'CHANGELOG'])
       end
 
       it "extracts a valid commit SHA" do
-        extract_ref('f4b14494ef6abf3d144c28e4af0c20143383e062/CHANGELOG').should ==
+        expect(extract_ref('f4b14494ef6abf3d144c28e4af0c20143383e062/CHANGELOG')).to eq(
           ['f4b14494ef6abf3d144c28e4af0c20143383e062', 'CHANGELOG']
+        )
       end
 
       it "falls back to a primitive split for an invalid ref" do
-        extract_ref('stable/CHANGELOG').should == ['stable', 'CHANGELOG']
+        expect(extract_ref('stable/CHANGELOG')).to eq(['stable', 'CHANGELOG'])
       end
     end
   end

--- a/spec/lib/gitlab/backend/shell_spec.rb
+++ b/spec/lib/gitlab/backend/shell_spec.rb
@@ -14,5 +14,5 @@ describe Gitlab::Shell do
   it { should respond_to :remove_repository }
   it { should respond_to :fork_repository }
 
-  it { gitlab_shell.url_to_repo('diaspora').should == Gitlab.config.gitlab_shell.ssh_path_prefix + "diaspora.git" }
+  it { expect(gitlab_shell.url_to_repo('diaspora')).to eq(Gitlab.config.gitlab_shell.ssh_path_prefix + "diaspora.git") }
 end

--- a/spec/lib/gitlab/ldap/ldap_user_auth_spec.rb
+++ b/spec/lib/gitlab/ldap/ldap_user_auth_spec.rb
@@ -26,8 +26,8 @@ describe Gitlab::LDAP do
     it "should update credentials by email if missing uid" do
       user = double('User')
       User.stub find_by_extern_uid_and_provider: nil
-      User.stub(:find_by).with(hash_including(email: anything())) { user }
-      user.should_receive :update_attributes
+      allow(User).to receive(:find_by).with(hash_including(email: anything())) { user }
+      expect(user).to receive :update_attributes
       gl_auth.find_or_create(@auth)
     end
 
@@ -36,9 +36,9 @@ describe Gitlab::LDAP do
       value = Gitlab.config.ldap.allow_username_or_email_login
       Gitlab.config.ldap['allow_username_or_email_login'] = true
       User.stub find_by_extern_uid_and_provider: nil
-      User.stub(:find_by).with(hash_including(email: anything())) { nil }
-      User.stub(:find_by).with(hash_including(username: anything())) { user }
-      user.should_receive :update_attributes
+      allow(User).to receive(:find_by).with(hash_including(email: anything())) { nil }
+      allow(User).to receive(:find_by).with(hash_including(username: anything())) { user }
+      expect(user).to receive :update_attributes
       gl_auth.find_or_create(@auth)
       Gitlab.config.ldap['allow_username_or_email_login'] = value
     end
@@ -48,9 +48,9 @@ describe Gitlab::LDAP do
       value = Gitlab.config.ldap.allow_username_or_email_login
       Gitlab.config.ldap['allow_username_or_email_login'] = false
       User.stub find_by_extern_uid_and_provider: nil
-      User.stub(:find_by).with(hash_including(email: anything())) { nil }
-      User.stub(:find_by).with(hash_including(username: anything())) { user }
-      user.should_not_receive :update_attributes
+      allow(User).to receive(:find_by).with(hash_including(email: anything())) { nil }
+      allow(User).to receive(:find_by).with(hash_including(username: anything())) { user }
+      expect(user).not_to receive :update_attributes
       gl_auth.find_or_create(@auth)
       Gitlab.config.ldap['allow_username_or_email_login'] = value
     end

--- a/spec/lib/gitlab/popen_spec.rb
+++ b/spec/lib/gitlab/popen_spec.rb
@@ -13,8 +13,8 @@ describe 'Gitlab::Popen', no_db: true do
       @output, @status = @klass.new.popen(%W(ls), path)
     end
 
-    it { @status.should be_zero }
-    it { @output.should include('cache') }
+    it { expect(@status).to be_zero }
+    it { expect(@output).to include('cache') }
   end
 
   context 'non-zero status' do
@@ -22,8 +22,8 @@ describe 'Gitlab::Popen', no_db: true do
       @output, @status = @klass.new.popen(%W(cat NOTHING), path)
     end
 
-    it { @status.should == 1 }
-    it { @output.should include('No such file or directory') }
+    it { expect(@status).to eq(1) }
+    it { expect(@output).to include('No such file or directory') }
   end
 
   context 'unsafe string command' do
@@ -37,8 +37,8 @@ describe 'Gitlab::Popen', no_db: true do
       @output, @status = @klass.new.popen(%W(ls))
     end
 
-    it { @status.should be_zero }
-    it { @output.should include('spec') }
+    it { expect(@status).to be_zero }
+    it { expect(@output).to include('spec') }
   end
 
 end

--- a/spec/lib/gitlab/satellite/action_spec.rb
+++ b/spec/lib/gitlab/satellite/action_spec.rb
@@ -12,22 +12,22 @@ describe 'Gitlab::Satellite::Action' do
       #now lets dirty it up
 
       starting_remote_count = repo.git.list_remotes.size
-      starting_remote_count.should >= 1
+      expect(starting_remote_count).to be >= 1
       #kind of hookey way to add a second remote
       origin_uri = repo.git.remote({v: true}).split(" ")[1]
     begin
       repo.git.remote({raise: true}, 'add', 'another-remote', origin_uri)
       repo.git.branch({raise: true}, 'a-new-branch')
 
-      repo.heads.size.should > (starting_remote_count)
-      repo.git.remote().split(" ").size.should > (starting_remote_count)
+      expect(repo.heads.size).to be > (starting_remote_count)
+      expect(repo.git.remote().split(" ").size).to be > (starting_remote_count)
     rescue
     end
 
       repo.git.config({}, "user.name", "#{user.name} -- foo")
       repo.git.config({}, "user.email", "#{user.email} -- foo")
-      repo.config['user.name'].should =="#{user.name} -- foo"
-      repo.config['user.email'].should =="#{user.email} -- foo"
+      expect(repo.config['user.name']).to eq("#{user.name} -- foo")
+      expect(repo.config['user.email']).to eq("#{user.email} -- foo")
 
 
       #These must happen in the context of the satellite directory...
@@ -39,13 +39,13 @@ describe 'Gitlab::Satellite::Action' do
 
       #verify it's clean
       heads = repo.heads.map(&:name)
-      heads.size.should == 1
-      heads.include?(Gitlab::Satellite::Satellite::PARKING_BRANCH).should == true
+      expect(heads.size).to eq(1)
+      expect(heads.include?(Gitlab::Satellite::Satellite::PARKING_BRANCH)).to eq(true)
       remotes = repo.git.remote().split(' ')
-      remotes.size.should == 1
-      remotes.include?('origin').should == true
-      repo.config['user.name'].should ==user.name
-      repo.config['user.email'].should ==user.email
+      expect(remotes.size).to eq(1)
+      expect(remotes.include?('origin')).to eq(true)
+      expect(repo.config['user.name']).to eq(user.name)
+      expect(repo.config['user.email']).to eq(user.email)
     end
   end
 
@@ -58,16 +58,16 @@ describe 'Gitlab::Satellite::Action' do
       #set assumptions
       File.rm(project.satellite.lock_file) unless !File.exists? project.satellite.lock_file
 
-      File.exists?(project.satellite.lock_file).should be_false
+      expect(File.exists?(project.satellite.lock_file)).to be_false
 
       satellite_action = Gitlab::Satellite::Action.new(user, project)
       satellite_action.send(:in_locked_and_timed_satellite) do |sat_repo|
-        repo.should == sat_repo
-        (File.exists? project.satellite.lock_file).should be_true
+        expect(repo).to eq(sat_repo)
+        expect(File.exists? project.satellite.lock_file).to be_true
         called = true
       end
 
-      called.should be_true
+      expect(called).to be_true
 
     end
 
@@ -77,19 +77,19 @@ describe 'Gitlab::Satellite::Action' do
 
       # Set base assumptions
       if File.exists? project.satellite.lock_file
-        FileLockStatusChecker.new(project.satellite.lock_file).flocked?.should be_false
+        expect(FileLockStatusChecker.new(project.satellite.lock_file).flocked?).to be_false
       end
 
       satellite_action = Gitlab::Satellite::Action.new(user, project)
       satellite_action.send(:in_locked_and_timed_satellite) do |sat_repo|
         called = true
-        repo.should == sat_repo
-        (File.exists? project.satellite.lock_file).should be_true
-        FileLockStatusChecker.new(project.satellite.lock_file).flocked?.should be_true
+        expect(repo).to eq(sat_repo)
+        expect(File.exists? project.satellite.lock_file).to be_true
+        expect(FileLockStatusChecker.new(project.satellite.lock_file).flocked?).to be_true
       end
 
-      called.should be_true
-      FileLockStatusChecker.new(project.satellite.lock_file).flocked?.should be_false
+      expect(called).to be_true
+      expect(FileLockStatusChecker.new(project.satellite.lock_file).flocked?).to be_false
 
     end
 

--- a/spec/lib/gitlab/satellite/merge_action_spec.rb
+++ b/spec/lib/gitlab/satellite/merge_action_spec.rb
@@ -19,9 +19,9 @@ describe 'Gitlab::Satellite::MergeAction' do
 
   describe '#commits_between' do
     def verify_commits(commits, first_commit_sha, last_commit_sha)
-      commits.each { |commit| commit.class.should == Gitlab::Git::Commit }
-      commits.first.id.should == first_commit_sha
-      commits.last.id.should == last_commit_sha
+      commits.each { |commit| expect(commit.class).to eq(Gitlab::Git::Commit) }
+      expect(commits.first.id).to eq(first_commit_sha)
+      expect(commits.last.id).to eq(last_commit_sha)
     end
 
     context 'on fork' do
@@ -56,15 +56,15 @@ describe 'Gitlab::Satellite::MergeAction' do
     let(:source_commit) {['metior', '313d96e42b313a0af5ab50fa233bf43e27118b3f']}
 
     def verify_content(patch)
-      (patch.include? source_commit[1]).should be_true
-      (patch.include? '635d3e09b72232b6e92a38de6cc184147e5bcb41').should be_true
-      (patch.include? '2bb2dee057327c81978ed0aa99904bd7ff5e6105').should be_true
-      (patch.include? '2e83de1924ad3429b812d17498b009a8b924795d').should be_true
-      (patch.include? 'ee45a49c57a362305431cbf004e4590b713c910e').should be_true
-      (patch.include? 'a6870dd08f8f274d9a6b899f638c0c26fefaa690').should be_true
+      expect(patch.include? source_commit[1]).to be_true
+      expect(patch.include? '635d3e09b72232b6e92a38de6cc184147e5bcb41').to be_true
+      expect(patch.include? '2bb2dee057327c81978ed0aa99904bd7ff5e6105').to be_true
+      expect(patch.include? '2e83de1924ad3429b812d17498b009a8b924795d').to be_true
+      expect(patch.include? 'ee45a49c57a362305431cbf004e4590b713c910e').to be_true
+      expect(patch.include? 'a6870dd08f8f274d9a6b899f638c0c26fefaa690').to be_true
 
-      (patch.include? 'e74fae147abc7d2ffbf93d363dbbe45b87751f6f').should be_false
-      (patch.include? '86f76b11c670425bbab465087f25172378d76147').should be_false
+      expect(patch.include? 'e74fae147abc7d2ffbf93d363dbbe45b87751f6f').to be_false
+      expect(patch.include? '86f76b11c670425bbab465087f25172378d76147').to be_false
     end
 
     context 'on fork' do
@@ -90,11 +90,11 @@ describe 'Gitlab::Satellite::MergeAction' do
 
     def is_a_matching_diff(diff, diffs)
       diff_count = diff.scan('diff --git').size
-      diff_count.should >= 1
-      diffs.size.should == diff_count
+      expect(diff_count).to be >= 1
+      expect(diffs.size).to eq(diff_count)
       diffs.each do |a_diff|
-        a_diff.class.should == Gitlab::Git::Diff
-        (diff.include? a_diff.diff).should be_true
+        expect(a_diff.class).to eq(Gitlab::Git::Diff)
+        expect(diff.include? a_diff.diff).to be_true
       end
     end
 
@@ -126,11 +126,11 @@ describe 'Gitlab::Satellite::MergeAction' do
       it 'return true or false depending on if something is mergable' do
         merge_request_fork.target_branch = @one_after_stable[0]
         merge_request_fork.source_branch = @master[0]
-        Gitlab::Satellite::MergeAction.new(merge_request_fork.author, merge_request_fork).can_be_merged?.should be_true
+        expect(Gitlab::Satellite::MergeAction.new(merge_request_fork.author, merge_request_fork).can_be_merged?).to be_true
 
         merge_request_fork.target_branch = @conflicting_metior[0]
         merge_request_fork.source_branch = @wiki_branch[0]
-        Gitlab::Satellite::MergeAction.new(merge_request_fork.author, merge_request_fork).can_be_merged?.should be_false
+        expect(Gitlab::Satellite::MergeAction.new(merge_request_fork.author, merge_request_fork).can_be_merged?).to be_false
       end
     end
 
@@ -138,11 +138,11 @@ describe 'Gitlab::Satellite::MergeAction' do
       it 'return true or false depending on if something is mergable' do
         merge_request.target_branch = @one_after_stable[0]
         merge_request.source_branch = @master[0]
-        Gitlab::Satellite::MergeAction.new(merge_request.author, merge_request).can_be_merged?.should be_true
+        expect(Gitlab::Satellite::MergeAction.new(merge_request.author, merge_request).can_be_merged?).to be_true
 
         merge_request.target_branch = @conflicting_metior[0]
         merge_request.source_branch = @wiki_branch[0]
-        Gitlab::Satellite::MergeAction.new(merge_request.author, merge_request).can_be_merged?.should be_false
+        expect(Gitlab::Satellite::MergeAction.new(merge_request.author, merge_request).can_be_merged?).to be_false
       end
     end
   end

--- a/spec/lib/gitlab/upgrader_spec.rb
+++ b/spec/lib/gitlab/upgrader_spec.rb
@@ -5,20 +5,20 @@ describe Gitlab::Upgrader do
   let(:current_version) { Gitlab::VERSION }
 
   describe 'current_version_raw' do
-    it { upgrader.current_version_raw.should == current_version }
+    it { expect(upgrader.current_version_raw).to eq(current_version) }
   end
 
   describe 'latest_version?' do
     it 'should be true if newest version' do
       upgrader.stub(latest_version_raw: current_version)
-      upgrader.latest_version?.should be_true
+      expect(upgrader.latest_version?).to be_true
     end
   end
 
   describe 'latest_version_raw' do
     it 'should be latest version for GitLab 5' do
       upgrader.stub(current_version_raw: "5.3.0")
-      upgrader.latest_version_raw.should == "v5.4.2"
+      expect(upgrader.latest_version_raw).to eq("v5.4.2")
     end
   end
 end

--- a/spec/lib/gitlab/version_info_spec.rb
+++ b/spec/lib/gitlab/version_info_spec.rb
@@ -12,58 +12,58 @@ describe 'Gitlab::VersionInfo', no_db: true do
   end
 
   context '>' do
-    it { @v2_0_0.should > @v1_1_0 }
-    it { @v1_1_0.should > @v1_0_1 }
-    it { @v1_0_1.should > @v1_0_0 }
-    it { @v1_0_0.should > @v0_1_0 }
-    it { @v0_1_0.should > @v0_0_1 }
+    it { expect(@v2_0_0).to be > @v1_1_0 }
+    it { expect(@v1_1_0).to be > @v1_0_1 }
+    it { expect(@v1_0_1).to be > @v1_0_0 }
+    it { expect(@v1_0_0).to be > @v0_1_0 }
+    it { expect(@v0_1_0).to be > @v0_0_1 }
   end
 
   context '>=' do
-    it { @v2_0_0.should >= Gitlab::VersionInfo.new(2, 0, 0) }
-    it { @v2_0_0.should >= @v1_1_0 }
+    it { expect(@v2_0_0).to be >= Gitlab::VersionInfo.new(2, 0, 0) }
+    it { expect(@v2_0_0).to be >= @v1_1_0 }
   end
 
   context '<' do
-    it { @v0_0_1.should < @v0_1_0 }
-    it { @v0_1_0.should < @v1_0_0 }
-    it { @v1_0_0.should < @v1_0_1 }
-    it { @v1_0_1.should < @v1_1_0 }
-    it { @v1_1_0.should < @v2_0_0 }
+    it { expect(@v0_0_1).to be < @v0_1_0 }
+    it { expect(@v0_1_0).to be < @v1_0_0 }
+    it { expect(@v1_0_0).to be < @v1_0_1 }
+    it { expect(@v1_0_1).to be < @v1_1_0 }
+    it { expect(@v1_1_0).to be < @v2_0_0 }
   end
 
   context '<=' do
-    it { @v0_0_1.should <= Gitlab::VersionInfo.new(0, 0, 1) }
-    it { @v0_0_1.should <= @v0_1_0 }
+    it { expect(@v0_0_1).to be <= Gitlab::VersionInfo.new(0, 0, 1) }
+    it { expect(@v0_0_1).to be <= @v0_1_0 }
   end
 
   context '==' do
-    it { @v0_0_1.should == Gitlab::VersionInfo.new(0, 0, 1) }
-    it { @v0_1_0.should == Gitlab::VersionInfo.new(0, 1, 0) }
-    it { @v1_0_0.should == Gitlab::VersionInfo.new(1, 0, 0) }
+    it { expect(@v0_0_1).to eq(Gitlab::VersionInfo.new(0, 0, 1)) }
+    it { expect(@v0_1_0).to eq(Gitlab::VersionInfo.new(0, 1, 0)) }
+    it { expect(@v1_0_0).to eq(Gitlab::VersionInfo.new(1, 0, 0)) }
   end
 
   context '!=' do
-    it { @v0_0_1.should_not == @v0_1_0 }
+    it { expect(@v0_0_1).not_to eq(@v0_1_0) }
   end
 
   context 'unknown' do
-    it { @unknown.should_not be @v0_0_1 }
-    it { @unknown.should_not be Gitlab::VersionInfo.new }
+    it { expect(@unknown).not_to be @v0_0_1 }
+    it { expect(@unknown).not_to be Gitlab::VersionInfo.new }
     it { expect{@unknown > @v0_0_1}.to raise_error(ArgumentError) }
     it { expect{@unknown < @v0_0_1}.to raise_error(ArgumentError) }
   end
 
   context 'parse' do
-    it { Gitlab::VersionInfo.parse("1.0.0").should == @v1_0_0 }
-    it { Gitlab::VersionInfo.parse("1.0.0.1").should == @v1_0_0 }
-    it { Gitlab::VersionInfo.parse("git 1.0.0b1").should == @v1_0_0 }
-    it { Gitlab::VersionInfo.parse("git 1.0b1").should_not be_valid }
+    it { expect(Gitlab::VersionInfo.parse("1.0.0")).to eq(@v1_0_0) }
+    it { expect(Gitlab::VersionInfo.parse("1.0.0.1")).to eq(@v1_0_0) }
+    it { expect(Gitlab::VersionInfo.parse("git 1.0.0b1")).to eq(@v1_0_0) }
+    it { expect(Gitlab::VersionInfo.parse("git 1.0b1")).not_to be_valid }
   end
 
   context 'to_s' do
-    it { @v1_0_0.to_s.should == "1.0.0" }
-    it { @unknown.to_s.should == "Unknown" }
+    it { expect(@v1_0_0.to_s).to eq("1.0.0") }
+    it { expect(@unknown.to_s).to eq("Unknown") }
   end
 end
 

--- a/spec/lib/oauth_spec.rb
+++ b/spec/lib/oauth_spec.rb
@@ -19,27 +19,27 @@ describe Gitlab::OAuth::User do
       @auth = double(info: @info, provider: 'ldap')
       user = gl_auth.create(@auth)
 
-      user.should be_valid
-      user.extern_uid.should == @info.uid
-      user.provider.should == 'ldap'
+      expect(user).to be_valid
+      expect(user.extern_uid).to eq(@info.uid)
+      expect(user.provider).to eq('ldap')
     end
 
     it "should create user from Omniauth" do
       @auth = double(info: @info, provider: 'twitter')
       user = gl_auth.create(@auth)
 
-      user.should be_valid
-      user.extern_uid.should == @info.uid
-      user.provider.should == 'twitter'
+      expect(user).to be_valid
+      expect(user.extern_uid).to eq(@info.uid)
+      expect(user.provider).to eq('twitter')
     end
 
     it "should apply defaults to user" do
       @auth = double(info: @info, provider: 'ldap')
       user = gl_auth.create(@auth)
 
-      user.should be_valid
-      user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
-      user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
+      expect(user).to be_valid
+      expect(user.projects_limit).to eq(Gitlab.config.gitlab.default_projects_limit)
+      expect(user.can_create_group).to eq(Gitlab.config.gitlab.default_can_create_group)
     end
   end
 end

--- a/spec/lib/votes_spec.rb
+++ b/spec/lib/votes_spec.rb
@@ -5,95 +5,95 @@ describe Issue, 'Votes' do
 
   describe "#upvotes" do
     it "with no notes has a 0/0 score" do
-      issue.upvotes.should == 0
+      expect(issue.upvotes).to eq(0)
     end
 
     it "should recognize non-+1 notes" do
       add_note "No +1 here"
-      issue.should have(1).note
-      issue.notes.first.upvote?.should be_false
-      issue.upvotes.should == 0
+      expect(issue.size).to eq(1)
+      expect(issue.notes.first.upvote?).to be_false
+      expect(issue.upvotes).to eq(0)
     end
 
     it "should recognize a single +1 note" do
       add_note "+1 This is awesome"
-      issue.upvotes.should == 1
+      expect(issue.upvotes).to eq(1)
     end
 
     it "should recognize multiple +1 notes" do
       add_note "+1 This is awesome"
       add_note "+1 I want this"
-      issue.upvotes.should == 2
+      expect(issue.upvotes).to eq(2)
     end
   end
 
   describe "#downvotes" do
     it "with no notes has a 0/0 score" do
-      issue.downvotes.should == 0
+      expect(issue.downvotes).to eq(0)
     end
 
     it "should recognize non--1 notes" do
       add_note "Almost got a -1"
-      issue.should have(1).note
-      issue.notes.first.downvote?.should be_false
-      issue.downvotes.should == 0
+      expect(issue.size).to eq(1)
+      expect(issue.notes.first.downvote?).to be_false
+      expect(issue.downvotes).to eq(0)
     end
 
     it "should recognize a single -1 note" do
       add_note "-1 This is bad"
-      issue.downvotes.should == 1
+      expect(issue.downvotes).to eq(1)
     end
 
     it "should recognize multiple -1 notes" do
       add_note "-1 This is bad"
       add_note "-1 Away with this"
-      issue.downvotes.should == 2
+      expect(issue.downvotes).to eq(2)
     end
   end
 
   describe "#votes_count" do
     it "with no notes has a 0/0 score" do
-      issue.votes_count.should == 0
+      expect(issue.votes_count).to eq(0)
     end
 
     it "should recognize non notes" do
       add_note "No +1 here"
-      issue.should have(1).note
-      issue.votes_count.should == 0
+      expect(issue.size).to eq(1)
+      expect(issue.votes_count).to eq(0)
     end
 
     it "should recognize a single +1 note" do
       add_note "+1 This is awesome"
-      issue.votes_count.should == 1
+      expect(issue.votes_count).to eq(1)
     end
 
     it "should recognize a single -1 note" do
       add_note "-1 This is bad"
-      issue.votes_count.should == 1
+      expect(issue.votes_count).to eq(1)
     end
 
     it "should recognize multiple notes" do
       add_note "+1 This is awesome"
       add_note "-1 This is bad"
       add_note "+1 I want this"
-      issue.votes_count.should == 3
+      expect(issue.votes_count).to eq(3)
     end
   end
 
   describe "#upvotes_in_percent" do
     it "with no notes has a 0% score" do
-      issue.upvotes_in_percent.should == 0
+      expect(issue.upvotes_in_percent).to eq(0)
     end
 
     it "should count a single 1 note as 100%" do
       add_note "+1 This is awesome"
-      issue.upvotes_in_percent.should == 100
+      expect(issue.upvotes_in_percent).to eq(100)
     end
 
     it "should count multiple +1 notes as 100%" do
       add_note "+1 This is awesome"
       add_note "+1 I want this"
-      issue.upvotes_in_percent.should == 100
+      expect(issue.upvotes_in_percent).to eq(100)
     end
 
     it "should count fractions for multiple +1 and -1 notes correctly" do
@@ -101,24 +101,24 @@ describe Issue, 'Votes' do
       add_note "+1 I want this"
       add_note "-1 This is bad"
       add_note "+1 me too"
-      issue.upvotes_in_percent.should == 75
+      expect(issue.upvotes_in_percent).to eq(75)
     end
   end
 
   describe "#downvotes_in_percent" do
     it "with no notes has a 0% score" do
-      issue.downvotes_in_percent.should == 0
+      expect(issue.downvotes_in_percent).to eq(0)
     end
 
     it "should count a single -1 note as 100%" do
       add_note "-1 This is bad"
-      issue.downvotes_in_percent.should == 100
+      expect(issue.downvotes_in_percent).to eq(100)
     end
 
     it "should count multiple -1 notes as 100%" do
       add_note "-1 This is bad"
       add_note "-1 Away with this"
-      issue.downvotes_in_percent.should == 100
+      expect(issue.downvotes_in_percent).to eq(100)
     end
 
     it "should count fractions for multiple +1 and -1 notes correctly" do
@@ -126,7 +126,7 @@ describe Issue, 'Votes' do
       add_note "+1 I want this"
       add_note "-1 This is bad"
       add_note "+1 me too"
-      issue.downvotes_in_percent.should == 25
+      expect(issue.downvotes_in_percent).to eq(25)
     end
   end
 

--- a/spec/mailers/notify_spec.rb
+++ b/spec/mailers/notify_spec.rb
@@ -17,8 +17,8 @@ describe Notify do
   shared_examples 'an email sent from GitLab' do
     it 'is sent from GitLab' do
       sender = subject.header[:from].addrs[0]
-      sender.display_name.should eq('GitLab')
-      sender.address.should eq(gitlab_sender)
+      expect(sender.display_name).to eq('GitLab')
+      expect(sender.address).to eq(gitlab_sender)
     end
   end
 
@@ -136,8 +136,8 @@ describe Notify do
       shared_examples 'an assignee email' do
         it 'is sent as the author' do
           sender = subject.header[:from].addrs[0]
-          sender.display_name.should eq(current_user.name)
-          sender.address.should eq(gitlab_sender)
+          expect(sender.display_name).to eq(current_user.name)
+          expect(sender.address).to eq(gitlab_sender)
         end
 
         it 'is sent to the assignee' do
@@ -182,8 +182,8 @@ describe Notify do
 
           it 'is sent as the author' do
             sender = subject.header[:from].addrs[0]
-            sender.display_name.should eq(current_user.name)
-            sender.address.should eq(gitlab_sender)
+            expect(sender.display_name).to eq(current_user.name)
+            expect(sender.address).to eq(gitlab_sender)
           end
 
           it 'has the correct subject' do
@@ -213,8 +213,8 @@ describe Notify do
 
           it 'is sent as the author' do
             sender = subject.header[:from].addrs[0]
-            sender.display_name.should eq(current_user.name)
-            sender.address.should eq(gitlab_sender)
+            expect(sender.display_name).to eq(current_user.name)
+            expect(sender.address).to eq(gitlab_sender)
           end
 
           it 'has the correct subject' do
@@ -286,8 +286,8 @@ describe Notify do
 
           it 'is sent as the author' do
             sender = subject.header[:from].addrs[0]
-            sender.display_name.should eq(current_user.name)
-            sender.address.should eq(gitlab_sender)
+            expect(sender.display_name).to eq(current_user.name)
+            expect(sender.address).to eq(gitlab_sender)
           end
 
           it 'has the correct subject' do
@@ -314,8 +314,8 @@ describe Notify do
 
           it 'is sent as the merge author' do
             sender = subject.header[:from].addrs[0]
-            sender.display_name.should eq(merge_author.name)
-            sender.address.should eq(gitlab_sender)
+            expect(sender.display_name).to eq(merge_author.name)
+            expect(sender.address).to eq(gitlab_sender)
           end
 
           it 'has the correct subject' do
@@ -383,14 +383,14 @@ describe Notify do
       let(:note) { create(:note, project: project, author: note_author) }
 
       before :each do
-        Note.stub(:find).with(note.id).and_return(note)
+        allow(Note).to receive(:find).with(note.id).and_return(note)
       end
 
       shared_examples 'a note email' do
         it 'is sent as the author' do
           sender = subject.header[:from].addrs[0]
-          sender.display_name.should eq(note_author.name)
-          sender.address.should eq(gitlab_sender)
+          expect(sender.display_name).to eq(note_author.name)
+          expect(sender.address).to eq(gitlab_sender)
         end
 
         it 'is sent to the given recipient' do
@@ -405,7 +405,7 @@ describe Notify do
       describe 'on a commit' do
         let(:commit) { project.repository.commit }
 
-        before(:each) { note.stub(:noteable).and_return(commit) }
+        before(:each) { allow(note).to receive(:noteable).and_return(commit) }
 
         subject { Notify.note_commit_email(recipient.id, note.id) }
 
@@ -423,7 +423,7 @@ describe Notify do
       describe 'on a merge request' do
         let(:merge_request) { create(:merge_request, source_project: project, target_project: project) }
         let(:note_on_merge_request_path) { project_merge_request_path(project, merge_request, anchor: "note_#{note.id}") }
-        before(:each) { note.stub(:noteable).and_return(merge_request) }
+        before(:each) { allow(note).to receive(:noteable).and_return(merge_request) }
 
         subject { Notify.note_merge_request_email(recipient.id, note.id) }
 
@@ -441,7 +441,7 @@ describe Notify do
       describe 'on an issue' do
         let(:issue) { create(:issue, project: project) }
         let(:note_on_issue_path) { project_issue_path(project, issue, anchor: "note_#{note.id}") }
-        before(:each) { note.stub(:noteable).and_return(issue) }
+        before(:each) { allow(note).to receive(:noteable).and_return(issue) }
 
         subject { Notify.note_issue_email(recipient.id, note.id) }
 
@@ -517,8 +517,8 @@ describe Notify do
 
     it 'is sent as the author' do
       sender = subject.header[:from].addrs[0]
-      sender.display_name.should eq(user.name)
-      sender.address.should eq(gitlab_sender)
+      expect(sender.display_name).to eq(user.name)
+      expect(sender.address).to eq(gitlab_sender)
     end
 
     it 'is sent to recipient' do
@@ -553,8 +553,8 @@ describe Notify do
 
     it 'is sent as the author' do
       sender = subject.header[:from].addrs[0]
-      sender.display_name.should eq(user.name)
-      sender.address.should eq(gitlab_sender)
+      expect(sender.display_name).to eq(user.name)
+      expect(sender.address).to eq(gitlab_sender)
     end
 
     it 'is sent to recipient' do

--- a/spec/models/assembla_service_spec.rb
+++ b/spec/models/assembla_service_spec.rb
@@ -45,7 +45,7 @@ describe AssemblaService, models: true do
 
     it "should call Assembla API" do
       @assembla_service.execute(@sample_data)
-      WebMock.should have_requested(:post, @api_url).with(
+      expect(WebMock).to have_requested(:post, @api_url).with(
         body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/
       ).once
     end

--- a/spec/models/broadcast_message_spec.rb
+++ b/spec/models/broadcast_message_spec.rb
@@ -23,17 +23,17 @@ describe BroadcastMessage do
   describe :current do
     it "should return last message if time match" do
       broadcast_message = create(:broadcast_message, starts_at: Time.now.yesterday, ends_at: Time.now.tomorrow)
-      BroadcastMessage.current.should == broadcast_message
+      expect(BroadcastMessage.current).to eq(broadcast_message)
     end
 
     it "should return nil if time not come" do
       broadcast_message = create(:broadcast_message, starts_at: Time.now.tomorrow, ends_at: Time.now + 2.days)
-      BroadcastMessage.current.should be_nil
+      expect(BroadcastMessage.current).to be_nil
     end
 
     it "should return nil if time has passed" do
       broadcast_message = create(:broadcast_message, starts_at: Time.now - 2.days, ends_at: Time.now.yesterday)
-      BroadcastMessage.current.should be_nil
+      expect(BroadcastMessage.current).to be_nil
     end
   end
 end

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -6,29 +6,29 @@ describe Commit do
 
   describe '#title' do
     it "returns no_commit_message when safe_message is blank" do
-      commit.stub(:safe_message).and_return('')
-      commit.title.should == "--no commit message"
+      allow(commit).to receive(:safe_message).and_return('')
+      expect(commit.title).to eq("--no commit message")
     end
 
     it "truncates a message without a newline at 80 characters" do
       message = commit.safe_message * 10
 
-      commit.stub(:safe_message).and_return(message)
-      commit.title.should == "#{message[0..79]}&hellip;"
+      allow(commit).to receive(:safe_message).and_return(message)
+      expect(commit.title).to eq("#{message[0..79]}&hellip;")
     end
 
     it "truncates a message with a newline before 80 characters at the newline" do
       message = commit.safe_message.split(" ").first
 
-      commit.stub(:safe_message).and_return(message + "\n" + message)
-      commit.title.should == message
+      allow(commit).to receive(:safe_message).and_return(message + "\n" + message)
+      expect(commit.title).to eq(message)
     end
 
     it "truncates a message with a newline after 80 characters at 70 characters" do
       message = (commit.safe_message * 10) + "\n"
 
-      commit.stub(:safe_message).and_return(message)
-      commit.title.should == "#{message[0..79]}&hellip;"
+      allow(commit).to receive(:safe_message).and_return(message)
+      expect(commit.title).to eq("#{message[0..79]}&hellip;")
     end
   end
 
@@ -53,7 +53,7 @@ describe Commit do
 
     it 'detects issues that this commit is marked as closing' do
       commit.stub(issue_closing_regex: /^([Cc]loses|[Ff]ixes) #\d+/, safe_message: "Fixes ##{issue.iid}")
-      commit.closes_issues(project).should == [issue]
+      expect(commit.closes_issues(project)).to eq([issue])
     end
   end
 

--- a/spec/models/concerns/issuable_spec.rb
+++ b/spec/models/concerns/issuable_spec.rb
@@ -20,47 +20,47 @@ describe Issue, "Issuable" do
   end
 
   describe "Scope" do
-    it { described_class.should respond_to(:opened) }
-    it { described_class.should respond_to(:closed) }
-    it { described_class.should respond_to(:assigned) }
+    it { expect(described_class).to respond_to(:opened) }
+    it { expect(described_class).to respond_to(:closed) }
+    it { expect(described_class).to respond_to(:assigned) }
   end
 
   describe ".search" do
     let!(:searchable_issue) { create(:issue, title: "Searchable issue") }
 
     it "matches by title" do
-      described_class.search('able').should == [searchable_issue]
+      expect(described_class.search('able')).to eq([searchable_issue])
     end
   end
 
   describe "#today?" do
     it "returns true when created today" do
       # Avoid timezone differences and just return exactly what we want
-      Date.stub(:today).and_return(issue.created_at.to_date)
-      issue.today?.should be_true
+      allow(Date).to receive(:today).and_return(issue.created_at.to_date)
+      expect(issue.today?).to be_true
     end
 
     it "returns false when not created today" do
-      Date.stub(:today).and_return(Date.yesterday)
-      issue.today?.should be_false
+      allow(Date).to receive(:today).and_return(Date.yesterday)
+      expect(issue.today?).to be_false
     end
   end
 
   describe "#new?" do
     it "returns true when created today and record hasn't been updated" do
-      issue.stub(:today?).and_return(true)
-      issue.new?.should be_true
+      allow(issue).to receive(:today?).and_return(true)
+      expect(issue.new?).to be_true
     end
 
     it "returns false when not created today" do
-      issue.stub(:today?).and_return(false)
-      issue.new?.should be_false
+      allow(issue).to receive(:today?).and_return(false)
+      expect(issue.new?).to be_false
     end
 
     it "returns false when record has been updated" do
-      issue.stub(:today?).and_return(true)
+      allow(issue).to receive(:today?).and_return(true)
       issue.touch
-      issue.new?.should be_false
+      expect(issue.new?).to be_false
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -58,11 +58,11 @@ describe Event do
       )
     end
 
-    it { @event.push?.should be_true }
-    it { @event.proper?.should be_true }
-    it { @event.new_branch?.should be_true }
-    it { @event.tag?.should be_false }
-    it { @event.branch_name.should == "master" }
-    it { @event.author.should == @user }
+    it { expect(@event.push?).to be_true }
+    it { expect(@event.proper?).to be_true }
+    it { expect(@event.new_branch?).to be_true }
+    it { expect(@event.tag?).to be_false }
+    it { expect(@event.branch_name).to eq("master") }
+    it { expect(@event.author).to eq(@user) }
   end
 end

--- a/spec/models/flowdock_service_spec.rb
+++ b/spec/models/flowdock_service_spec.rb
@@ -44,7 +44,7 @@ describe FlowdockService do
 
     it "should call FlowDock API" do
       @flowdock_service.execute(@sample_data)
-      WebMock.should have_requested(:post, @api_url).with(
+      expect(WebMock).to have_requested(:post, @api_url).with(
         body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/
       ).once
     end

--- a/spec/models/forked_project_link_spec.rb
+++ b/spec/models/forked_project_link_spec.rb
@@ -21,11 +21,11 @@ describe ForkedProjectLink, "add link on fork" do
   end
 
   it "project_to should know it is forked" do
-    @project_to.forked?.should be_true
+    expect(@project_to.forked?).to be_true
   end
 
   it "project should know who it is forked from" do
-    @project_to.forked_from_project.should == project_from
+    expect(@project_to.forked_from_project).to eq(project_from)
   end
 end
 
@@ -43,15 +43,15 @@ describe :forked_from_project do
 
 
   it "project_to should know it is forked" do
-    project_to.forked?.should be_true
+    expect(project_to.forked?).to be_true
   end
 
   it "project_from should not be forked" do
-    project_from.forked?.should be_false
+    expect(project_from.forked?).to be_false
   end
 
   it "project_to.destroy should destroy fork_link" do
-    forked_project_link.should_receive(:destroy)
+    expect(forked_project_link).to receive(:destroy)
     project_to.destroy
   end
 

--- a/spec/models/gemnasium_service_spec.rb
+++ b/spec/models/gemnasium_service_spec.rb
@@ -41,7 +41,7 @@ describe GemnasiumService do
       @sample_data = GitPushService.new.sample_data(project, user)
     end
     it "should call Gemnasium service" do
-      Gemnasium::GitlabService.should_receive(:execute).with(an_instance_of(Hash)).once
+      expect(Gemnasium::GitlabService).to receive(:execute).with(an_instance_of(Hash)).once
       @gemnasium_service.execute(@sample_data)
     end
   end

--- a/spec/models/gitlab_ci_service_spec.rb
+++ b/spec/models/gitlab_ci_service_spec.rb
@@ -40,11 +40,11 @@ describe GitlabCiService do
     end
 
     describe :commit_status_path do
-      it { @service.commit_status_path("2ab7834c").should == "http://ci.gitlab.org/projects/2/builds/2ab7834c/status.json?token=verySecret"}
+      it { expect(@service.commit_status_path("2ab7834c")).to eq("http://ci.gitlab.org/projects/2/builds/2ab7834c/status.json?token=verySecret")}
     end
 
     describe :build_page do
-      it { @service.build_page("2ab7834c").should == "http://ci.gitlab.org/projects/2/builds/2ab7834c"}
+      it { expect(@service.build_page("2ab7834c")).to eq("http://ci.gitlab.org/projects/2/builds/2ab7834c")}
     end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -30,18 +30,18 @@ describe Group do
   it { should_not validate_presence_of :owner }
 
   describe :users do
-    it { group.users.should == group.owners }
+    it { expect(group.users).to eq(group.owners) }
   end
 
   describe :human_name do
-    it { group.human_name.should == group.name }
+    it { expect(group.human_name).to eq(group.name) }
   end
 
   describe :add_users do
     let(:user) { create(:user) }
     before { group.add_user(user, UsersGroup::MASTER) }
 
-    it { group.users_groups.masters.map(&:user).should include(user) }
+    it { expect(group.users_groups.masters.map(&:user)).to include(user) }
   end
 
   describe :add_users do
@@ -49,10 +49,10 @@ describe Group do
     before { group.add_users([user.id], UsersGroup::GUEST) }
 
     it "should update the group permission" do
-      group.users_groups.guests.map(&:user).should include(user)
+      expect(group.users_groups.guests.map(&:user)).to include(user)
       group.add_users([user.id], UsersGroup::DEVELOPER)
-      group.users_groups.developers.map(&:user).should include(user)
-      group.users_groups.guests.map(&:user).should_not include(user)
+      expect(group.users_groups.developers.map(&:user)).to include(user)
+      expect(group.users_groups.guests.map(&:user)).not_to include(user)
     end
   end
 
@@ -62,12 +62,12 @@ describe Group do
 
     it "should be true if avatar is image" do
       group.update_attribute(:avatar, 'uploads/avatar.png')
-      group.avatar_type.should be_true
+      expect(group.avatar_type).to be_true
     end
 
     it "should be false if avatar is html page" do
       group.update_attribute(:avatar, 'uploads/avatar.html')
-      group.avatar_type.should == ["only images allowed"]
+      expect(group.avatar_type).to eq(["only images allowed"])
     end
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -38,10 +38,10 @@ describe Issue do
   describe '#is_being_reassigned?' do
     it 'returns true if the issue assignee has changed' do
       subject.assignee = create(:user)
-      subject.is_being_reassigned?.should be_true
+      expect(subject.is_being_reassigned?).to be_true
     end
     it 'returns false if the issue assignee has not changed' do
-      subject.is_being_reassigned?.should be_false
+      expect(subject.is_being_reassigned?).to be_false
     end
   end
 
@@ -53,7 +53,7 @@ describe Issue do
         issue = create :issue, assignee: user
       end
 
-      Issue.open_for(user).count.should eq 2
+      expect(Issue.open_for(user).count).to eq 2
     end
   end
 

--- a/spec/models/key_spec.rb
+++ b/spec/models/key_spec.rb
@@ -39,46 +39,46 @@ describe Key do
     let(:user) { create(:user) }
 
     it "accepts the key once" do
-      build(:key, user: user).should be_valid
+      expect(build(:key, user: user)).to be_valid
     end
 
     it "does not accept the exact same key twice" do
       create(:key, user: user)
-      build(:key, user: user).should_not be_valid
+      expect(build(:key, user: user)).not_to be_valid
     end
 
     it "does not accept a duplicate key with a different comment" do
       create(:key, user: user)
       duplicate = build(:key, user: user)
       duplicate.key << ' extra comment'
-      duplicate.should_not be_valid
+      expect(duplicate).not_to be_valid
     end
   end
 
   context "validate it is a fingerprintable key" do
     it "accepts the fingerprintable key" do
-      build(:key).should be_valid
+      expect(build(:key)).to be_valid
     end
 
     it "rejects the unfingerprintable key (contains space in middle)" do
-      build(:key_with_a_space_in_the_middle).should_not be_valid
+      expect(build(:key_with_a_space_in_the_middle)).not_to be_valid
     end
 
     it "rejects the unfingerprintable key (not a key)" do
-      build(:invalid_key).should_not be_valid
+      expect(build(:invalid_key)).not_to be_valid
     end
   end
 
   context 'callbacks' do
     it 'should add new key to authorized_file' do
       @key = build(:personal_key, id: 7)
-      GitlabShellWorker.should_receive(:perform_async).with(:add_key, @key.shell_id, @key.key)
+      expect(GitlabShellWorker).to receive(:perform_async).with(:add_key, @key.shell_id, @key.key)
       @key.save
     end
 
     it 'should remove key from authorized_file' do
       @key = create(:personal_key)
-      GitlabShellWorker.should_receive(:perform_async).with(:remove_key, @key.shell_id, @key.key)
+      expect(GitlabShellWorker).to receive(:perform_async).with(:remove_key, @key.shell_id, @key.key)
       @key.destroy
     end
   end

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -46,14 +46,14 @@ describe MergeRequest do
     let!(:merge_request) { create(:merge_request) }
 
     before do
-      merge_request.stub(:commits) { [merge_request.source_project.repository.commit] }
+      allow(merge_request).to receive(:commits) { [merge_request.source_project.repository.commit] }
       create(:note, commit_id: merge_request.commits.first.id, noteable_type: 'Commit', project: merge_request.project)
       create(:note, noteable: merge_request, project: merge_request.project)
     end
 
     it "should include notes for commits" do
-      merge_request.commits.should_not be_empty
-      merge_request.mr_and_commit_notes.count.should == 2
+      expect(merge_request.commits).not_to be_empty
+      expect(merge_request.mr_and_commit_notes.count).to eq(2)
     end
   end
 
@@ -62,10 +62,10 @@ describe MergeRequest do
   describe '#is_being_reassigned?' do
     it 'returns true if the merge_request assignee has changed' do
       subject.assignee = create(:user)
-      subject.is_being_reassigned?.should be_true
+      expect(subject.is_being_reassigned?).to be_true
     end
     it 'returns false if the merge request assignee has not changed' do
-      subject.is_being_reassigned?.should be_false
+      expect(subject.is_being_reassigned?).to be_false
     end
   end
 
@@ -74,11 +74,11 @@ describe MergeRequest do
       subject.source_project = create(:project, namespace: create(:group))
       subject.target_project = create(:project, namespace: create(:group))
 
-      subject.for_fork?.should be_true
+      expect(subject.for_fork?).to be_true
     end
 
     it 'returns false if is not for a fork' do
-      subject.for_fork?.should be_false
+      expect(subject.for_fork?).to be_false
     end
   end
 
@@ -96,14 +96,14 @@ describe MergeRequest do
     it 'accesses the set of issues that will be closed on acceptance' do
       subject.project.stub(default_branch: subject.target_branch)
 
-      subject.closes_issues.should == [issue0, issue1].sort_by(&:id)
+      expect(subject.closes_issues).to eq([issue0, issue1].sort_by(&:id))
     end
 
     it 'only lists issues as to be closed if it targets the default branch' do
       subject.project.stub(default_branch: 'master')
       subject.target_branch = 'something-else'
 
-      subject.closes_issues.should be_empty
+      expect(subject.closes_issues).to be_empty
     end
 
     it 'detects issues mentioned in the description' do
@@ -111,7 +111,7 @@ describe MergeRequest do
       subject.description = "Closes ##{issue2.iid}"
       subject.project.stub(default_branch: subject.target_branch)
 
-      subject.closes_issues.should include(issue2)
+      expect(subject.closes_issues).to include(issue2)
     end
   end
 

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -37,30 +37,30 @@ describe Milestone do
   describe "#percent_complete" do
     it "should not count open issues" do
       milestone.issues << issue
-      milestone.percent_complete.should == 0
+      expect(milestone.percent_complete).to eq(0)
     end
 
     it "should count closed issues" do
       issue.close
       milestone.issues << issue
-      milestone.percent_complete.should == 100
+      expect(milestone.percent_complete).to eq(100)
     end
 
     it "should recover from dividing by zero" do
-      milestone.issues.should_receive(:count).and_return(0)
-      milestone.percent_complete.should == 100
+      expect(milestone.issues).to receive(:count).and_return(0)
+      expect(milestone.percent_complete).to eq(100)
     end
   end
 
   describe "#expires_at" do
     it "should be nil when due_date is unset" do
       milestone.update_attributes(due_date: nil)
-      milestone.expires_at.should be_nil
+      expect(milestone.expires_at).to be_nil
     end
 
     it "should not be nil when due_date is set" do
       milestone.update_attributes(due_date: Date.tomorrow)
-      milestone.expires_at.should be_present
+      expect(milestone.expires_at).to be_present
     end
   end
 
@@ -70,7 +70,7 @@ describe Milestone do
         milestone.stub(due_date: Date.today.prev_year)
       end
 
-      it { milestone.expired?.should be_true }
+      it { expect(milestone.expired?).to be_true }
     end
 
     context "not expired" do
@@ -78,7 +78,7 @@ describe Milestone do
         milestone.stub(due_date: Date.today.next_year)
       end
 
-      it { milestone.expired?.should be_false }
+      it { expect(milestone.expired?).to be_false }
     end
   end
 
@@ -90,7 +90,7 @@ describe Milestone do
       )
     end
 
-    it { milestone.percent_complete.should == 75 }
+    it { expect(milestone.percent_complete).to eq(75) }
   end
 
   describe :items_count do
@@ -100,14 +100,14 @@ describe Milestone do
       milestone.merge_requests << create(:merge_request)
     end
 
-    it { milestone.closed_items_count.should == 1 }
-    it { milestone.open_items_count.should == 2 }
-    it { milestone.total_items_count.should == 3 }
-    it { milestone.is_empty?.should be_false }
+    it { expect(milestone.closed_items_count).to eq(1) }
+    it { expect(milestone.open_items_count).to eq(2) }
+    it { expect(milestone.total_items_count).to eq(3) }
+    it { expect(milestone.is_empty?).to be_false }
   end
 
   describe :can_be_closed? do
-    it { milestone.can_be_closed?.should be_true }
+    it { expect(milestone.can_be_closed?).to be_true }
   end
 
   describe :is_empty? do
@@ -117,7 +117,7 @@ describe Milestone do
     end
 
     it 'Should return total count of issues and merge requests assigned to milestone' do
-      milestone.total_items_count.should eq 2
+      expect(milestone.total_items_count).to eq 2
     end
   end
 
@@ -130,14 +130,14 @@ describe Milestone do
     end
 
     it 'should be true if milestone active and all nested issues closed' do
-      milestone.can_be_closed?.should be_true
+      expect(milestone.can_be_closed?).to be_true
     end
 
     it 'should be false if milestone active and not all nested issues closed' do
       issue.milestone = milestone
       issue.save
 
-      milestone.can_be_closed?.should be_false
+      expect(milestone.can_be_closed?).to be_false
     end
   end
 

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -35,14 +35,14 @@ describe Namespace do
     it { should respond_to(:to_param) }
   end
 
-  it { Namespace.global_id.should == 'GLN' }
+  it { expect(Namespace.global_id).to eq('GLN') }
 
   describe :to_param do
-    it { namespace.to_param.should == namespace.path }
+    it { expect(namespace.to_param).to eq(namespace.path) }
   end
 
   describe :human_name do
-    it { namespace.human_name.should == namespace.owner_name }
+    it { expect(namespace.human_name).to eq(namespace.owner_name) }
   end
 
   describe :search do
@@ -50,8 +50,8 @@ describe Namespace do
       @namespace = create :namespace
     end
 
-    it { Namespace.search(@namespace.path).should == [@namespace] }
-    it { Namespace.search('unknown').should == [] }
+    it { expect(Namespace.search(@namespace.path)).to eq([@namespace]) }
+    it { expect(Namespace.search('unknown')).to eq([]) }
   end
 
   describe :move_dir do
@@ -68,13 +68,13 @@ describe Namespace do
       new_path = @namespace.path + "_new"
       @namespace.stub(path_was: @namespace.path)
       @namespace.stub(path: new_path)
-      @namespace.move_dir.should be_true
+      expect(@namespace.move_dir).to be_true
     end
   end
 
   describe :rm_dir do
     it "should remove dir" do
-      namespace.rm_dir.should be_true
+      expect(namespace.rm_dir).to be_true
     end
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -41,44 +41,44 @@ describe Note do
 
     it "recognizes a neutral note" do
       note = create(:votable_note, note: "This is not a +1 note")
-      note.should_not be_upvote
-      note.should_not be_downvote
+      expect(note).not_to be_upvote
+      expect(note).not_to be_downvote
     end
 
     it "recognizes a neutral emoji note" do
       note = build(:votable_note, note: "I would :+1: this, but I don't want to")
-      note.should_not be_upvote
-      note.should_not be_downvote
+      expect(note).not_to be_upvote
+      expect(note).not_to be_downvote
     end
 
     it "recognizes a +1 note" do
       note = create(:votable_note, note: "+1 for this")
-      note.should be_upvote
+      expect(note).to be_upvote
     end
 
     it "recognizes a +1 emoji as a vote" do
       note = build(:votable_note, note: ":+1: for this")
-      note.should be_upvote
+      expect(note).to be_upvote
     end
 
     it "recognizes a thumbsup emoji as a vote" do
       note = build(:votable_note, note: ":thumbsup: for this")
-      note.should be_upvote
+      expect(note).to be_upvote
     end
 
     it "recognizes a -1 note" do
       note = create(:votable_note, note: "-1 for this")
-      note.should be_downvote
+      expect(note).to be_downvote
     end
 
     it "recognizes a -1 emoji as a vote" do
       note = build(:votable_note, note: ":-1: for this")
-      note.should be_downvote
+      expect(note).to be_downvote
     end
 
     it "recognizes a thumbsdown emoji as a vote" do
       note = build(:votable_note, note: ":thumbsdown: for this")
-      note.should be_downvote
+      expect(note).to be_downvote
     end
   end
 
@@ -89,22 +89,22 @@ describe Note do
     let!(:commit) { note.noteable }
 
     it "should be accessible through #noteable" do
-      note.commit_id.should == commit.id
-      note.noteable.should be_a(Commit)
-      note.noteable.should == commit
+      expect(note.commit_id).to eq(commit.id)
+      expect(note.noteable).to be_a(Commit)
+      expect(note.noteable).to eq(commit)
     end
 
     it "should save a valid note" do
-      note.commit_id.should == commit.id
+      expect(note.commit_id).to eq(commit.id)
       note.noteable == commit
     end
 
     it "should be recognized by #for_commit?" do
-      note.should be_for_commit
+      expect(note).to be_for_commit
     end
 
     it "should not be votable" do
-      note.should_not be_votable
+      expect(note).not_to be_votable
     end
   end
 
@@ -113,20 +113,20 @@ describe Note do
     let!(:commit) { note.noteable }
 
     it "should save a valid note" do
-      note.commit_id.should == commit.id
-      note.noteable.id.should == commit.id
+      expect(note.commit_id).to eq(commit.id)
+      expect(note.noteable.id).to eq(commit.id)
     end
 
     it "should be recognized by #for_diff_line?" do
-      note.should be_for_diff_line
+      expect(note).to be_for_diff_line
     end
 
     it "should be recognized by #for_commit_diff_line?" do
-      note.should be_for_commit_diff_line
+      expect(note).to be_for_commit_diff_line
     end
 
     it "should not be votable" do
-      note.should_not be_votable
+      expect(note).not_to be_votable
     end
   end
 
@@ -134,7 +134,7 @@ describe Note do
     let!(:note) { create(:note_on_issue, note: "+1 from me") }
 
     it "should not be votable" do
-      note.should be_votable
+      expect(note).to be_votable
     end
   end
 
@@ -142,7 +142,7 @@ describe Note do
     let!(:note) { create(:note_on_merge_request, note: "+1 from me") }
 
     it "should be votable" do
-      note.should be_votable
+      expect(note).to be_votable
     end
   end
 
@@ -150,7 +150,7 @@ describe Note do
     let!(:note) { create(:note_on_merge_request_diff, note: "+1 from me") }
 
     it "should not be votable" do
-      note.should_not be_votable
+      expect(note).not_to be_votable
     end
   end
 
@@ -164,19 +164,34 @@ describe Note do
 
     it 'creates and saves a Note' do
       should be_a Note
-      subject.id.should_not be_nil
+      expect(subject.id).not_to be_nil
     end
 
-    its(:noteable) { should == thing }
-    its(:project) { should == thing.project }
-    its(:author) { should == author }
-    its(:note) { should =~ /Status changed to #{status}/ }
+    describe '#noteable' do
+      subject { super().noteable }
+      it { should == thing }
+    end
+
+    describe '#project' do
+      subject { super().project }
+      it { should == thing.project }
+    end
+
+    describe '#author' do
+      subject { super().author }
+      it { should == author }
+    end
+
+    describe '#note' do
+      subject { super().note }
+      it { should =~ /Status changed to #{status}/ }
+    end
 
     it 'appends a back-reference if a closing mentionable is supplied' do
       commit = double('commit', gfm_reference: 'commit 123456')
       n = Note.create_status_change_note(thing, project, author, status, commit)
 
-      n.note.should =~ /Status changed to #{status} by commit 123456/
+      expect(n.note).to match(/Status changed to #{status} by commit 123456/)
     end
   end
 
@@ -190,18 +205,40 @@ describe Note do
 
     context 'creates and saves a Note' do
       it { should be_a Note }
-      its(:id) { should_not be_nil }
+
+      describe '#id' do
+        subject { super().id }
+        it { should_not be_nil }
+      end
     end
 
-    its(:noteable) { should == thing }
-    its(:project) { should == thing.project }
-    its(:author) { should == author }
-    its(:note) { should =~ /Reassigned to @#{assignee.username}/ }
+    describe '#noteable' do
+      subject { super().noteable }
+      it { should == thing }
+    end
+
+    describe '#project' do
+      subject { super().project }
+      it { should == thing.project }
+    end
+
+    describe '#author' do
+      subject { super().author }
+      it { should == author }
+    end
+
+    describe '#note' do
+      subject { super().note }
+      it { should =~ /Reassigned to @#{assignee.username}/ }
+    end
 
     context 'assignee is removed' do
       let(:assignee) { nil }
 
-      its(:note) { should =~ /Assignee removed/ }
+      describe '#note' do
+        subject { super().note }
+        it { should =~ /Assignee removed/ }
+      end
     end
   end
 
@@ -219,46 +256,110 @@ describe Note do
       subject { Note.create_cross_reference_note(issue, mergereq, author, project) }
 
       it { should be_valid }
-      its(:noteable) { should == issue }
-      its(:project)  { should == issue.project }
-      its(:author)   { should == author }
-      its(:note) { should == "_mentioned in merge request !#{mergereq.iid}_" }
+
+      describe '#noteable' do
+        subject { super().noteable }
+        it { should == issue }
+      end
+
+      describe '#project' do
+        subject { super().project }
+        it { should == issue.project }
+      end
+
+      describe '#author' do
+        subject { super().author }
+        it { should == author }
+      end
+
+      describe '#note' do
+        subject { super().note }
+        it { should == "_mentioned in merge request !#{mergereq.iid}_" }
+      end
     end
 
     context 'issue from a commit' do
       subject { Note.create_cross_reference_note(issue, commit, author, project) }
 
       it { should be_valid }
-      its(:noteable) { should == issue }
-      its(:note) { should == "_mentioned in commit #{commit.sha[0..5]}_" }
+
+      describe '#noteable' do
+        subject { super().noteable }
+        it { should == issue }
+      end
+
+      describe '#note' do
+        subject { super().note }
+        it { should == "_mentioned in commit #{commit.sha[0..5]}_" }
+      end
     end
 
     context 'merge request from an issue' do
       subject { Note.create_cross_reference_note(mergereq, issue, author, project) }
 
       it { should be_valid }
-      its(:noteable) { should == mergereq }
-      its(:project) { should == mergereq.project }
-      its(:note) { should == "_mentioned in issue ##{issue.iid}_" }
+
+      describe '#noteable' do
+        subject { super().noteable }
+        it { should == mergereq }
+      end
+
+      describe '#project' do
+        subject { super().project }
+        it { should == mergereq.project }
+      end
+
+      describe '#note' do
+        subject { super().note }
+        it { should == "_mentioned in issue ##{issue.iid}_" }
+      end
     end
 
     context 'commit from a merge request' do
       subject { Note.create_cross_reference_note(commit, mergereq, author, project) }
 
       it { should be_valid }
-      its(:noteable) { should == commit }
-      its(:project) { should == project }
-      its(:note) { should == "_mentioned in merge request !#{mergereq.iid}_" }
+
+      describe '#noteable' do
+        subject { super().noteable }
+        it { should == commit }
+      end
+
+      describe '#project' do
+        subject { super().project }
+        it { should == project }
+      end
+
+      describe '#note' do
+        subject { super().note }
+        it { should == "_mentioned in merge request !#{mergereq.iid}_" }
+      end
     end
 
     context 'commit from issue' do
       subject { Note.create_cross_reference_note(commit, issue, author, project) }
 
       it { should be_valid }
-      its(:noteable_type) { should == "Commit" }
-      its(:noteable_id) { should be_nil }
-      its(:commit_id) { should == commit.id }
-      its(:note) { should == "_mentioned in issue ##{issue.iid}_" }
+
+      describe '#noteable_type' do
+        subject { super().noteable_type }
+        it { should == "Commit" }
+      end
+
+      describe '#noteable_id' do
+        subject { super().noteable_id }
+        it { should be_nil }
+      end
+
+      describe '#commit_id' do
+        subject { super().commit_id }
+        it { should == commit.id }
+      end
+
+      describe '#note' do
+        subject { super().note }
+        it { should == "_mentioned in issue ##{issue.iid}_" }
+      end
     end
   end
 
@@ -274,11 +375,11 @@ describe Note do
     end
 
     it 'detects if a mentionable has already been mentioned' do
-      Note.cross_reference_exists?(issue, commit0).should be_true
+      expect(Note.cross_reference_exists?(issue, commit0)).to be_true
     end
 
     it 'detects if a mentionable has not already been mentioned' do
-      Note.cross_reference_exists?(issue, commit1).should be_false
+      expect(Note.cross_reference_exists?(issue, commit1)).to be_false
     end
   end
 
@@ -291,22 +392,22 @@ describe Note do
 
     it 'should recognize user-supplied notes as non-system' do
       @note = create(:note_on_issue)
-      @note.should_not be_system
+      expect(@note).not_to be_system
     end
 
     it 'should identify status-change notes as system notes' do
       @note = Note.create_status_change_note(issue, project, author, 'closed', nil)
-      @note.should be_system
+      expect(@note).to be_system
     end
 
     it 'should identify cross-reference notes as system notes' do
       @note = Note.create_cross_reference_note(issue, other, author, project)
-      @note.should be_system
+      expect(@note).to be_system
     end
 
     it 'should identify assignee-change notes as system notes' do
       @note = Note.create_assignee_change_note(issue, project, author, assignee)
-      @note.should be_system
+      expect(@note).to be_system
     end
   end
 
@@ -327,9 +428,9 @@ describe Note do
         @p2.users_projects.create(user: @u3, project_access: UsersProject::GUEST)
       end
 
-      it { @abilities.allowed?(@u1, :read_note, @p1).should be_false }
-      it { @abilities.allowed?(@u2, :read_note, @p1).should be_true }
-      it { @abilities.allowed?(@u3, :read_note, @p1).should be_false }
+      it { expect(@abilities.allowed?(@u1, :read_note, @p1)).to be_false }
+      it { expect(@abilities.allowed?(@u2, :read_note, @p1)).to be_true }
+      it { expect(@abilities.allowed?(@u3, :read_note, @p1)).to be_false }
     end
 
     describe :write do
@@ -338,9 +439,9 @@ describe Note do
         @p2.users_projects.create(user: @u3, project_access: UsersProject::DEVELOPER)
       end
 
-      it { @abilities.allowed?(@u1, :write_note, @p1).should be_false }
-      it { @abilities.allowed?(@u2, :write_note, @p1).should be_true }
-      it { @abilities.allowed?(@u3, :write_note, @p1).should be_false }
+      it { expect(@abilities.allowed?(@u1, :write_note, @p1)).to be_false }
+      it { expect(@abilities.allowed?(@u2, :write_note, @p1)).to be_true }
+      it { expect(@abilities.allowed?(@u3, :write_note, @p1)).to be_false }
     end
 
     describe :admin do
@@ -350,9 +451,9 @@ describe Note do
         @p2.users_projects.create(user: @u3, project_access: UsersProject::MASTER)
       end
 
-      it { @abilities.allowed?(@u1, :admin_note, @p1).should be_false }
-      it { @abilities.allowed?(@u2, :admin_note, @p1).should be_true }
-      it { @abilities.allowed?(@u3, :admin_note, @p1).should be_false }
+      it { expect(@abilities.allowed?(@u1, :admin_note, @p1)).to be_false }
+      it { expect(@abilities.allowed?(@u2, :admin_note, @p1)).to be_true }
+      it { expect(@abilities.allowed?(@u3, :admin_note, @p1)).to be_false }
     end
   end
 

--- a/spec/models/project_security_spec.rb
+++ b/spec/models/project_security_spec.rb
@@ -23,7 +23,7 @@ describe Project do
     describe "Non member rules" do
       it "should deny for non-project users any actions" do
         admin_actions.each do |action|
-          @abilities.allowed?(@u1, action, @p1).should be_false
+          expect(@abilities.allowed?(@u1, action, @p1)).to be_false
         end
       end
     end
@@ -35,7 +35,7 @@ describe Project do
 
       it "should allow for project user any guest actions" do
         guest_actions.each do |action|
-          @abilities.allowed?(@u2, action, @p1).should be_true
+          expect(@abilities.allowed?(@u2, action, @p1)).to be_true
         end
       end
     end
@@ -47,7 +47,7 @@ describe Project do
 
       it "should allow for project user any report actions" do
         report_actions.each do |action|
-          @abilities.allowed?(@u2, action, @p1).should be_true
+          expect(@abilities.allowed?(@u2, action, @p1)).to be_true
         end
       end
     end
@@ -60,13 +60,13 @@ describe Project do
 
       it "should deny for developer master-specific actions" do
         [dev_actions - report_actions].each do |action|
-          @abilities.allowed?(@u2, action, @p1).should be_false
+          expect(@abilities.allowed?(@u2, action, @p1)).to be_false
         end
       end
 
       it "should allow for project user any dev actions" do
         dev_actions.each do |action|
-          @abilities.allowed?(@u3, action, @p1).should be_true
+          expect(@abilities.allowed?(@u3, action, @p1)).to be_true
         end
       end
     end
@@ -79,13 +79,13 @@ describe Project do
 
       it "should deny for developer master-specific actions" do
         [master_actions - dev_actions].each do |action|
-          @abilities.allowed?(@u2, action, @p1).should be_false
+          expect(@abilities.allowed?(@u2, action, @p1)).to be_false
         end
       end
 
       it "should allow for project user any master actions" do
         master_actions.each do |action|
-          @abilities.allowed?(@u3, action, @p1).should be_true
+          expect(@abilities.allowed?(@u3, action, @p1)).to be_true
         end
       end
     end
@@ -98,13 +98,13 @@ describe Project do
 
       it "should deny for masters admin-specific actions" do
         [admin_actions - master_actions].each do |action|
-          @abilities.allowed?(@u2, action, @p1).should be_false
+          expect(@abilities.allowed?(@u2, action, @p1)).to be_false
         end
       end
 
       it "should allow for project owner any admin actions" do
         admin_actions.each do |action|
-          @abilities.allowed?(@u4, action, @p1).should be_true
+          expect(@abilities.allowed?(@u4, action, @p1)).to be_true
         end
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -69,9 +69,9 @@ describe Project do
 
     it "should not allow new projects beyond user limits" do
       project2 = build(:project)
-      project2.stub(:creator).and_return(double(can_create_project?: false, projects_limit: 0).as_null_object)
-      project2.should_not be_valid
-      project2.errors[:limit_reached].first.should match(/Your project limit is 0/)
+      allow(project2).to receive(:creator).and_return(double(can_create_project?: false, projects_limit: 0).as_null_object)
+      expect(project2).not_to be_valid
+      expect(project2.errors[:limit_reached].first).to match(/Your project limit is 0/)
     end
   end
 
@@ -88,17 +88,17 @@ describe Project do
 
   it "should return valid url to repo" do
     project = Project.new(path: "somewhere")
-    project.url_to_repo.should == Gitlab.config.gitlab_shell.ssh_path_prefix + "somewhere.git"
+    expect(project.url_to_repo).to eq(Gitlab.config.gitlab_shell.ssh_path_prefix + "somewhere.git")
   end
 
   it "returns the full web URL for this repo" do
     project = Project.new(path: "somewhere")
-    project.web_url.should == "#{Gitlab.config.gitlab.url}/somewhere"
+    expect(project.web_url).to eq("#{Gitlab.config.gitlab.url}/somewhere")
   end
 
   it "returns the web URL without the protocol for this repo" do
     project = Project.new(path: "somewhere")
-    project.web_url_without_protocol.should == "#{Gitlab.config.gitlab.url.split("://")[1]}/somewhere"
+    expect(project.web_url_without_protocol).to eq("#{Gitlab.config.gitlab.url.split("://")[1]}/somewhere")
   end
 
   describe "last_activity methods" do
@@ -108,18 +108,18 @@ describe Project do
     describe "last_activity" do
       it "should alias last_activity to last_event" do
         project.stub(last_event: last_event)
-        project.last_activity.should == last_event
+        expect(project.last_activity).to eq(last_event)
       end
     end
 
     describe 'last_activity_date' do
       it 'returns the creation date of the project\'s last event if present' do
         last_activity_event = create(:event, project: project)
-        project.last_activity_at.to_i.should == last_event.created_at.to_i
+        expect(project.last_activity_at.to_i).to eq(last_event.created_at.to_i)
       end
 
       it 'returns the project\'s last update date if it has no events' do
-        project.last_activity_date.should == project.updated_at
+        expect(project.last_activity_date).to eq(project.updated_at)
       end
     end
   end
@@ -134,16 +134,16 @@ describe Project do
 
     it "should close merge request if last commit from source branch was pushed to target branch" do
       @merge_request.reload_code
-      @merge_request.last_commit.id.should == "69b34b7e9ad9f496f0ad10250be37d6265a03bba"
+      expect(@merge_request.last_commit.id).to eq("69b34b7e9ad9f496f0ad10250be37d6265a03bba")
       project.update_merge_requests("8716fc78f3c65bbf7bcf7b574febd583bc5d2812", "69b34b7e9ad9f496f0ad10250be37d6265a03bba", "refs/heads/stable", @key.user)
       @merge_request.reload
-      @merge_request.merged?.should be_true
+      expect(@merge_request.merged?).to be_true
     end
 
     it "should update merge request commits with new one if pushed to source branch" do
       project.update_merge_requests("8716fc78f3c65bbf7bcf7b574febd583bc5d2812", "69b34b7e9ad9f496f0ad10250be37d6265a03bba", "refs/heads/master", @key.user)
       @merge_request.reload
-      @merge_request.last_commit.id.should == "69b34b7e9ad9f496f0ad10250be37d6265a03bba"
+      expect(@merge_request.last_commit.id).to eq("69b34b7e9ad9f496f0ad10250be37d6265a03bba")
     end
   end
 
@@ -155,8 +155,8 @@ describe Project do
         @project = create(:project, name: 'gitlabhq', namespace: @group)
       end
 
-      it { Project.find_with_namespace('gitlab/gitlabhq').should == @project }
-      it { Project.find_with_namespace('gitlab-ci').should be_nil }
+      it { expect(Project.find_with_namespace('gitlab/gitlabhq')).to eq(@project) }
+      it { expect(Project.find_with_namespace('gitlab-ci')).to be_nil }
     end
   end
 
@@ -167,7 +167,7 @@ describe Project do
         @project = create(:project, name: 'gitlabhq', namespace: @group)
       end
 
-      it { @project.to_param.should == "gitlab/gitlabhq" }
+      it { expect(@project.to_param).to eq("gitlab/gitlabhq") }
     end
   end
 
@@ -175,7 +175,7 @@ describe Project do
     let(:project) { create(:project) }
 
     it "should return valid repo" do
-      project.repository.should be_kind_of(Repository)
+      expect(project.repository).to be_kind_of(Repository)
     end
   end
 
@@ -186,15 +186,15 @@ describe Project do
     let(:ext_project) { create(:redmine_project) }
 
     it "should be true or if used internal tracker and issue exists" do
-      project.issue_exists?(existed_issue.iid).should be_true
+      expect(project.issue_exists?(existed_issue.iid)).to be_true
     end
 
     it "should be false or if used internal tracker and issue not exists" do
-      project.issue_exists?(not_existed_issue.iid).should be_false
+      expect(project.issue_exists?(not_existed_issue.iid)).to be_false
     end
 
     it "should always be true if used other tracker" do
-      ext_project.issue_exists?(rand(100)).should be_true
+      expect(ext_project.issue_exists?(rand(100))).to be_true
     end
   end
 
@@ -203,11 +203,11 @@ describe Project do
     let(:ext_project) { create(:redmine_project) }
 
     it "should be true if used internal tracker" do
-      project.used_default_issues_tracker?.should be_true
+      expect(project.used_default_issues_tracker?).to be_true
     end
 
     it "should be false if used other tracker" do
-      ext_project.used_default_issues_tracker?.should be_false
+      expect(ext_project.used_default_issues_tracker?).to be_false
     end
   end
 
@@ -216,19 +216,19 @@ describe Project do
     let(:ext_project) { create(:redmine_project) }
 
     it "should be true for projects with external issues tracker if issues enabled" do
-      ext_project.can_have_issues_tracker_id?.should be_true
+      expect(ext_project.can_have_issues_tracker_id?).to be_true
     end
 
     it "should be false for projects with internal issue tracker if issues enabled" do
-      project.can_have_issues_tracker_id?.should be_false
+      expect(project.can_have_issues_tracker_id?).to be_false
     end
 
     it "should be always false if issues disabled" do
       project.issues_enabled = false
       ext_project.issues_enabled = false
 
-      project.can_have_issues_tracker_id?.should be_false
-      ext_project.can_have_issues_tracker_id?.should be_false
+      expect(project.can_have_issues_tracker_id?).to be_false
+      expect(ext_project.can_have_issues_tracker_id?).to be_false
     end
   end
 
@@ -239,7 +239,7 @@ describe Project do
       project.protected_branches.create(name: 'master')
     end
 
-    it { project.open_branches.map(&:name).should include('bootstrap') }
-    it { project.open_branches.map(&:name).should_not include('master') }
+    it { expect(project.open_branches.map(&:name)).to include('bootstrap') }
+    it { expect(project.open_branches.map(&:name)).not_to include('master') }
   end
 end

--- a/spec/models/project_team_spec.rb
+++ b/spec/models/project_team_spec.rb
@@ -16,17 +16,17 @@ describe ProjectTeam do
     end
 
     describe 'members collection' do
-      it { project.team.masters.should include(master) }
-      it { project.team.masters.should_not include(guest) }
-      it { project.team.masters.should_not include(reporter) }
-      it { project.team.masters.should_not include(nonmember) }
+      it { expect(project.team.masters).to include(master) }
+      it { expect(project.team.masters).not_to include(guest) }
+      it { expect(project.team.masters).not_to include(reporter) }
+      it { expect(project.team.masters).not_to include(nonmember) }
     end
 
     describe 'access methods' do
-      it { project.team.master?(master).should be_true }
-      it { project.team.master?(guest).should be_false }
-      it { project.team.master?(reporter).should be_false }
-      it { project.team.master?(nonmember).should be_false }
+      it { expect(project.team.master?(master)).to be_true }
+      it { expect(project.team.master?(guest)).to be_false }
+      it { expect(project.team.master?(reporter)).to be_false }
+      it { expect(project.team.master?(nonmember)).to be_false }
     end
   end
 
@@ -47,19 +47,19 @@ describe ProjectTeam do
     end
 
     describe 'members collection' do
-      it { project.team.reporters.should include(reporter) }
-      it { project.team.masters.should include(master) }
-      it { project.team.masters.should include(guest) }
-      it { project.team.masters.should_not include(reporter) }
-      it { project.team.masters.should_not include(nonmember) }
+      it { expect(project.team.reporters).to include(reporter) }
+      it { expect(project.team.masters).to include(master) }
+      it { expect(project.team.masters).to include(guest) }
+      it { expect(project.team.masters).not_to include(reporter) }
+      it { expect(project.team.masters).not_to include(nonmember) }
     end
 
     describe 'access methods' do
-      it { project.team.reporter?(reporter).should be_true }
-      it { project.team.master?(master).should be_true }
-      it { project.team.master?(guest).should be_true }
-      it { project.team.master?(reporter).should be_false }
-      it { project.team.master?(nonmember).should be_false }
+      it { expect(project.team.reporter?(reporter)).to be_true }
+      it { expect(project.team.master?(master)).to be_true }
+      it { expect(project.team.master?(guest)).to be_true }
+      it { expect(project.team.master?(reporter)).to be_false }
+      it { expect(project.team.master?(nonmember)).to be_false }
     end
   end
 end

--- a/spec/models/project_wiki_spec.rb
+++ b/spec/models/project_wiki_spec.rb
@@ -31,19 +31,19 @@ describe ProjectWiki do
 
   describe "#path_with_namespace" do
     it "returns the project path with namespace with the .wiki extension" do
-      subject.path_with_namespace.should == project.path_with_namespace + ".wiki"
+      expect(subject.path_with_namespace).to eq(project.path_with_namespace + ".wiki")
     end
   end
 
   describe "#url_to_repo" do
     it "returns the correct ssh url to the repo" do
-      subject.url_to_repo.should == gitlab_shell.url_to_repo(subject.path_with_namespace)
+      expect(subject.url_to_repo).to eq(gitlab_shell.url_to_repo(subject.path_with_namespace))
     end
   end
 
   describe "#ssh_url_to_repo" do
     it "equals #url_to_repo" do
-      subject.ssh_url_to_repo.should == subject.url_to_repo
+      expect(subject.ssh_url_to_repo).to eq(subject.url_to_repo)
     end
   end
 
@@ -51,31 +51,31 @@ describe ProjectWiki do
     it "provides the full http url to the repo" do
       gitlab_url = Gitlab.config.gitlab.url
       repo_http_url = "#{gitlab_url}/#{subject.path_with_namespace}.git"
-      subject.http_url_to_repo.should == repo_http_url
+      expect(subject.http_url_to_repo).to eq(repo_http_url)
     end
   end
 
   describe "#wiki" do
     it "contains a Gollum::Wiki instance" do
-      subject.wiki.should be_a Gollum::Wiki
+      expect(subject.wiki).to be_a Gollum::Wiki
     end
 
     before do
-      Gitlab::Shell.any_instance.stub(:add_repository) do
+      allow_any_instance_of(Gitlab::Shell).to receive(:add_repository) do
         create_temp_repo("#{Rails.root}/tmp/test-git-base-path/non-existant.wiki.git")
       end
-      project.stub(:path_with_namespace).and_return("non-existant")
+      allow(project).to receive(:path_with_namespace).and_return("non-existant")
     end
 
     it "creates a new wiki repo if one does not yet exist" do
       wiki = ProjectWiki.new(project, user)
-      wiki.create_page("index", "test content").should_not == false
+      expect(wiki.create_page("index", "test content")).not_to eq(false)
 
       FileUtils.rm_rf wiki.send(:path_to_repo)
     end
 
     it "raises CouldNotCreateWikiError if it can't create the wiki repository" do
-      ProjectWiki.any_instance.stub(:init_repo).and_return(false)
+      allow_any_instance_of(ProjectWiki).to receive(:init_repo).and_return(false)
       expect { ProjectWiki.new(project, user).wiki }.to raise_exception(ProjectWiki::CouldNotCreateWikiError)
     end
   end
@@ -83,13 +83,16 @@ describe ProjectWiki do
   describe "#empty?" do
     context "when the wiki repository is empty" do
       before do
-        Gitlab::Shell.any_instance.stub(:add_repository) do
+        allow_any_instance_of(Gitlab::Shell).to receive(:add_repository) do
           create_temp_repo("#{Rails.root}/tmp/test-git-base-path/non-existant.wiki.git")
         end
-        project.stub(:path_with_namespace).and_return("non-existant")
+        allow(project).to receive(:path_with_namespace).and_return("non-existant")
       end
 
-      its(:empty?) { should be_true }
+      describe '#empty?' do
+        subject { super().empty? }
+        it { should be_true }
+      end
     end
 
     context "when the wiki has pages" do
@@ -97,7 +100,10 @@ describe ProjectWiki do
         create_page("index", "This is an awesome new Gollum Wiki")
       end
 
-      its(:empty?) { should be_false }
+      describe '#empty?' do
+        subject { super().empty? }
+        it { should be_false }
+      end
     end
   end
 
@@ -112,11 +118,11 @@ describe ProjectWiki do
     end
 
     it "returns an array of WikiPage instances" do
-      @pages.first.should be_a WikiPage
+      expect(@pages.first).to be_a WikiPage
     end
 
     it "returns the correct number of pages" do
-      @pages.count.should == 1
+      expect(@pages.count).to eq(1)
     end
   end
 
@@ -131,21 +137,21 @@ describe ProjectWiki do
 
     it "returns the latest version of the page if it exists" do
       page = subject.find_page("index page")
-      page.title.should == "index page"
+      expect(page.title).to eq("index page")
     end
 
     it "returns nil if the page does not exist" do
-      subject.find_page("non-existant").should == nil
+      expect(subject.find_page("non-existant")).to eq(nil)
     end
 
     it "can find a page by slug" do
       page = subject.find_page("index-page")
-      page.title.should == "index page"
+      expect(page.title).to eq("index page")
     end
 
     it "returns a WikiPage instance" do
       page = subject.find_page("index page")
-      page.should be_a WikiPage
+      expect(page).to be_a WikiPage
     end
   end
 
@@ -155,23 +161,23 @@ describe ProjectWiki do
     end
 
     it "creates a new wiki page" do
-      subject.create_page("test page", "this is content").should_not == false
-      subject.pages.count.should == 1
+      expect(subject.create_page("test page", "this is content")).not_to eq(false)
+      expect(subject.pages.count).to eq(1)
     end
 
     it "returns false when a duplicate page exists" do
       subject.create_page("test page", "content")
-      subject.create_page("test page", "content").should == false
+      expect(subject.create_page("test page", "content")).to eq(false)
     end
 
     it "stores an error message when a duplicate page exists" do
       2.times { subject.create_page("test page", "content") }
-      subject.error_message.should =~ /Duplicate page:/
+      expect(subject.error_message).to match(/Duplicate page:/)
     end
 
     it "sets the correct commit message" do
       subject.create_page("test page", "some content", :markdown, "commit message")
-      subject.pages.first.page.version.message.should == "commit message"
+      expect(subject.pages.first.page.version.message).to eq("commit message")
     end
   end
 
@@ -188,11 +194,11 @@ describe ProjectWiki do
     end
 
     it "updates the content of the page" do
-      @page.raw_data.should == "some other content"
+      expect(@page.raw_data).to eq("some other content")
     end
 
     it "sets the correct commit message" do
-      @page.version.message.should == "updated page"
+      expect(@page.version.message).to eq("updated page")
     end
   end
 
@@ -204,7 +210,7 @@ describe ProjectWiki do
 
     it "deletes the page" do
       subject.delete_page(@page)
-      subject.pages.count.should == 0
+      expect(subject.pages.count).to eq(0)
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -46,7 +46,7 @@ describe Service do
       end
 
       describe :can_test do
-        it { @testable.should == true }
+        it { expect(@testable).to eq(true) }
       end
     end
 
@@ -61,7 +61,7 @@ describe Service do
       end
 
       describe :can_test do
-        it { @testable.should == true }
+        it { expect(@testable).to eq(true) }
       end
     end
   end

--- a/spec/models/slack_message_spec.rb
+++ b/spec/models/slack_message_spec.rb
@@ -25,16 +25,17 @@ describe SlackMessage do
     end
 
     it 'returns a message regarding pushes' do
-      subject.pretext.should ==
+      expect(subject.pretext).to eq(
         'user_name pushed to branch <url/commits/master|master> of ' <<
         '<url|project_name> (<url/compare/before...after|Compare changes>)'
-      subject.attachments.should == [
+      )
+      expect(subject.attachments).to eq([
         {
           text: "<url1|abcdefghi>: message1 - author1\n" <<
                 "<url2|123456789>: message2 - author2",
           color: color,
         }
-      ]
+      ])
     end
   end
 
@@ -44,10 +45,11 @@ describe SlackMessage do
     end
 
     it 'returns a message regarding a new branch' do
-      subject.pretext.should ==
+      expect(subject.pretext).to eq(
         'user_name pushed new branch <url/commits/master|master> to ' <<
         '<url|project_name>'
-      subject.attachments.should be_empty
+      )
+      expect(subject.attachments).to be_empty
     end
   end
 
@@ -57,9 +59,10 @@ describe SlackMessage do
     end
 
     it 'returns a message regarding a removed branch' do
-      subject.pretext.should ==
+      expect(subject.pretext).to eq(
         'user_name removed branch master from <url|project_name>'
-      subject.attachments.should be_empty
+      )
+      expect(subject.attachments).to be_empty
     end
   end
 end

--- a/spec/models/slack_service_spec.rb
+++ b/spec/models/slack_service_spec.rb
@@ -64,7 +64,7 @@ describe SlackService do
     it "should call Slack API" do
       slack.execute(sample_data)
 
-      WebMock.should have_requested(:post, api_url).once
+      expect(WebMock).to have_requested(:post, api_url).once
     end
   end
 end

--- a/spec/models/system_hook_spec.rb
+++ b/spec/models/system_hook_spec.rb
@@ -26,32 +26,32 @@ describe SystemHook do
 
     it "project_create hook" do
       Projects::CreateService.new(create(:user), name: 'empty').execute
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /project_create/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /project_create/).once
     end
 
     it "project_destroy hook" do
       user = create(:user)
       project = create(:empty_project, namespace: user.namespace)
       Projects::DestroyService.new(project, user, {}).execute
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /project_destroy/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /project_destroy/).once
     end
 
     it "user_create hook" do
       create(:user)
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /user_create/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /user_create/).once
     end
 
     it "user_destroy hook" do
       user = create(:user)
       user.destroy
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /user_destroy/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /user_destroy/).once
     end
 
     it "project_create hook" do
       user = create(:user)
       project = create(:project)
       project.team << [user, :master]
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /user_add_to_team/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /user_add_to_team/).once
     end
 
     it "project_destroy hook" do
@@ -59,7 +59,7 @@ describe SystemHook do
       project = create(:project)
       project.team << [user, :master]
       project.users_projects.destroy_all
-      WebMock.should have_requested(:post, @system_hook.url).with(body: /user_remove_from_team/).once
+      expect(WebMock).to have_requested(:post, @system_hook.url).with(body: /user_remove_from_team/).once
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -120,26 +120,26 @@ describe User do
   describe '#generate_password' do
     it "should execute callback when force_random_password specified" do
       user = build(:user, force_random_password: true)
-      user.should_receive(:generate_password)
+      expect(user).to receive(:generate_password)
       user.save
     end
 
     it "should not generate password by default" do
       user = create(:user, password: 'abcdefghe')
-      user.password.should == 'abcdefghe'
+      expect(user.password).to eq('abcdefghe')
     end
 
     it "should generate password when forcing random password" do
-      Devise.stub(:friendly_token).and_return('123456789')
+      allow(Devise).to receive(:friendly_token).and_return('123456789')
       user = create(:user, password: 'abcdefg', force_random_password: true)
-      user.password.should == '12345678'
+      expect(user.password).to eq('12345678')
     end
   end
 
   describe 'authentication token' do
     it "should have authentication token" do
       user = create(:user)
-      user.authentication_token.should_not be_blank
+      expect(user.authentication_token).not_to be_blank
     end
   end
 
@@ -154,15 +154,15 @@ describe User do
       @project_3.team << [@user, :developer]
     end
 
-    it { @user.authorized_projects.should include(@project) }
-    it { @user.authorized_projects.should include(@project_2) }
-    it { @user.authorized_projects.should include(@project_3) }
-    it { @user.owned_projects.should include(@project) }
-    it { @user.owned_projects.should_not include(@project_2) }
-    it { @user.owned_projects.should_not include(@project_3) }
-    it { @user.personal_projects.should include(@project) }
-    it { @user.personal_projects.should_not include(@project_2) }
-    it { @user.personal_projects.should_not include(@project_3) }
+    it { expect(@user.authorized_projects).to include(@project) }
+    it { expect(@user.authorized_projects).to include(@project_2) }
+    it { expect(@user.authorized_projects).to include(@project_3) }
+    it { expect(@user.owned_projects).to include(@project) }
+    it { expect(@user.owned_projects).not_to include(@project_2) }
+    it { expect(@user.owned_projects).not_to include(@project_3) }
+    it { expect(@user.personal_projects).to include(@project) }
+    it { expect(@user.personal_projects).not_to include(@project_2) }
+    it { expect(@user.personal_projects).not_to include(@project_3) }
   end
 
   describe 'groups' do
@@ -172,9 +172,9 @@ describe User do
       @group.add_owner(@user)
     end
 
-    it { @user.several_namespaces?.should be_true }
-    it { @user.authorized_groups.should == [@group] }
-    it { @user.owned_groups.should == [@group] }
+    it { expect(@user.several_namespaces?).to be_true }
+    it { expect(@user.authorized_groups).to eq([@group]) }
+    it { expect(@user.owned_groups).to eq([@group]) }
   end
 
   describe 'group multiple owners' do
@@ -187,7 +187,7 @@ describe User do
       @group.add_user(@user2, UsersGroup::OWNER)
     end
 
-    it { @user2.several_namespaces?.should be_true }
+    it { expect(@user2.several_namespaces?).to be_true }
   end
 
   describe 'namespaced' do
@@ -196,7 +196,7 @@ describe User do
       @project = create :project, namespace: @user.namespace
     end
 
-    it { @user.several_namespaces?.should be_false }
+    it { expect(@user.several_namespaces?).to be_false }
   end
 
   describe 'blocking user' do
@@ -204,7 +204,7 @@ describe User do
 
     it "should block user" do
       user.block
-      user.blocked?.should be_true
+      expect(user.blocked?).to be_true
     end
   end
 
@@ -216,10 +216,10 @@ describe User do
       @blocked = create :user, state: :blocked
     end
 
-    it { User.filter("admins").should == [@admin] }
-    it { User.filter("blocked").should == [@blocked] }
-    it { User.filter("wop").should include(@user, @admin, @blocked) }
-    it { User.filter(nil).should include(@user, @admin) }
+    it { expect(User.filter("admins")).to eq([@admin]) }
+    it { expect(User.filter("blocked")).to eq([@blocked]) }
+    it { expect(User.filter("wop")).to include(@user, @admin, @blocked) }
+    it { expect(User.filter(nil)).to include(@user, @admin) }
   end
 
   describe :not_in_project do
@@ -229,27 +229,27 @@ describe User do
       @project = create :project
     end
 
-    it { User.not_in_project(@project).should include(@user, @project.owner) }
+    it { expect(User.not_in_project(@project)).to include(@user, @project.owner) }
   end
 
   describe 'user creation' do
     describe 'normal user' do
       let(:user) { create(:user, name: 'John Smith') }
 
-      it { user.is_admin?.should be_false }
-      it { user.require_ssh_key?.should be_true }
-      it { user.can_create_group?.should be_true }
-      it { user.can_create_project?.should be_true }
-      it { user.first_name.should == 'John' }
+      it { expect(user.is_admin?).to be_false }
+      it { expect(user.require_ssh_key?).to be_true }
+      it { expect(user.can_create_group?).to be_true }
+      it { expect(user.can_create_project?).to be_true }
+      it { expect(user.first_name).to eq('John') }
     end
 
     describe 'without defaults' do
       let(:user) { User.new }
 
       it "should not apply defaults to user" do
-        user.projects_limit.should == 10
-        user.can_create_group.should be_true
-        user.theme_id.should == Gitlab::Theme::BASIC
+        expect(user.projects_limit).to eq(10)
+        expect(user.can_create_group).to be_true
+        expect(user.theme_id).to eq(Gitlab::Theme::BASIC)
       end
     end
     context 'as admin' do
@@ -257,9 +257,9 @@ describe User do
         let(:user) { User.build_user({}, as: :admin) }
 
         it "should apply defaults to user" do
-          user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
-          user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
-          user.theme_id.should == Gitlab.config.gitlab.default_theme
+          expect(user.projects_limit).to eq(Gitlab.config.gitlab.default_projects_limit)
+          expect(user.can_create_group).to eq(Gitlab.config.gitlab.default_can_create_group)
+          expect(user.theme_id).to eq(Gitlab.config.gitlab.default_theme)
         end
       end
 
@@ -267,12 +267,12 @@ describe User do
         let(:user) { User.build_user({projects_limit: 123, can_create_group: true, can_create_team: true, theme_id: Gitlab::Theme::BASIC}, as: :admin) }
 
         it "should apply defaults to user" do
-          Gitlab.config.gitlab.default_projects_limit.should_not == 123
-          Gitlab.config.gitlab.default_can_create_group.should_not be_true
-          Gitlab.config.gitlab.default_theme.should_not == Gitlab::Theme::BASIC
-          user.projects_limit.should == 123
-          user.can_create_group.should be_true
-          user.theme_id.should == Gitlab::Theme::BASIC
+          expect(Gitlab.config.gitlab.default_projects_limit).not_to eq(123)
+          expect(Gitlab.config.gitlab.default_can_create_group).not_to be_true
+          expect(Gitlab.config.gitlab.default_theme).not_to eq(Gitlab::Theme::BASIC)
+          expect(user.projects_limit).to eq(123)
+          expect(user.can_create_group).to be_true
+          expect(user.theme_id).to eq(Gitlab::Theme::BASIC)
         end
       end
     end
@@ -282,9 +282,9 @@ describe User do
         let(:user) { User.build_user }
 
         it "should apply defaults to user" do
-          user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
-          user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
-          user.theme_id.should == Gitlab.config.gitlab.default_theme
+          expect(user.projects_limit).to eq(Gitlab.config.gitlab.default_projects_limit)
+          expect(user.can_create_group).to eq(Gitlab.config.gitlab.default_can_create_group)
+          expect(user.theme_id).to eq(Gitlab.config.gitlab.default_theme)
         end
       end
 
@@ -292,9 +292,9 @@ describe User do
         let(:user) { User.build_user(projects_limit: 123, can_create_group: true, theme_id: Gitlab::Theme::BASIC) }
 
         it "should apply defaults to user" do
-          user.projects_limit.should == Gitlab.config.gitlab.default_projects_limit
-          user.can_create_group.should == Gitlab.config.gitlab.default_can_create_group
-          user.theme_id.should == Gitlab.config.gitlab.default_theme
+          expect(user.projects_limit).to eq(Gitlab.config.gitlab.default_projects_limit)
+          expect(user.can_create_group).to eq(Gitlab.config.gitlab.default_can_create_group)
+          expect(user.theme_id).to eq(Gitlab.config.gitlab.default_theme)
         end
       end
     end
@@ -305,12 +305,12 @@ describe User do
     let(:user2) { create(:user, username: 'jameson', email: 'jameson@example.com') }
 
     it "should be case insensitive" do
-      User.search(user1.username.upcase).to_a.should == [user1]
-      User.search(user1.username.downcase).to_a.should == [user1]
-      User.search(user2.username.upcase).to_a.should == [user2]
-      User.search(user2.username.downcase).to_a.should == [user2]
-      User.search(user1.username.downcase).to_a.count.should == 2
-      User.search(user2.username.downcase).to_a.count.should == 1
+      expect(User.search(user1.username.upcase).to_a).to eq([user1])
+      expect(User.search(user1.username.downcase).to_a).to eq([user1])
+      expect(User.search(user2.username.upcase).to_a).to eq([user2])
+      expect(User.search(user2.username.downcase).to_a).to eq([user2])
+      expect(User.search(user1.username.downcase).to_a.count).to eq(2)
+      expect(User.search(user2.username.downcase).to_a.count).to eq(1)
     end
   end
 
@@ -318,10 +318,10 @@ describe User do
     let(:user1) { create(:user, username: 'foo') }
 
     it "should get the correct user" do
-      User.by_username_or_id(user1.id).should == user1
-      User.by_username_or_id('foo').should == user1
-      User.by_username_or_id(-1).should be_nil
-      User.by_username_or_id('bar').should be_nil
+      expect(User.by_username_or_id(user1.id)).to eq(user1)
+      expect(User.by_username_or_id('foo')).to eq(user1)
+      expect(User.by_username_or_id(-1)).to be_nil
+      expect(User.by_username_or_id('bar')).to be_nil
     end
   end
 
@@ -332,7 +332,7 @@ describe User do
       user = create :user
       key = create :key, key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD33bWLBxu48Sev9Fert1yzEO4WGcWglWF7K/AwblIUFselOt/QdOL9DSjpQGxLagO1s9wl53STIO8qGS4Ms0EJZyIXOEFMjFJ5xmjSy+S37By4sG7SsltQEHMxtbtFOaW5LV2wCrX+rUsRNqLMamZjgjcPO0/EgGCXIGMAYW4O7cwGZdXWYIhQ1Vwy+CsVMDdPkPgBXqK7nR/ey8KMs8ho5fMNgB5hBw/AL9fNGhRw3QTD6Q12Nkhl4VZES2EsZqlpNnJttnPdp847DUsT6yuLRlfiQfz5Cn9ysHFdXObMN5VYIiPFwHeYCZp1X2S4fDZooRE8uOLTfxWHPXwrhqSH", user_id: user.id
 
-      user.all_ssh_keys.should include(key.key)
+      expect(user.all_ssh_keys).to include(key.key)
     end
   end
 
@@ -341,12 +341,12 @@ describe User do
 
     it "should be true if avatar is image" do
       user.update_attribute(:avatar, 'uploads/avatar.png')
-      user.avatar_type.should be_true
+      expect(user.avatar_type).to be_true
     end
 
     it "should be false if avatar is html page" do
       user.update_attribute(:avatar, 'uploads/avatar.html')
-      user.avatar_type.should == ["only images allowed"]
+      expect(user.avatar_type).to eq(["only images allowed"])
     end
   end
 

--- a/spec/models/users_group_spec.rb
+++ b/spec/models/users_group_spec.rb
@@ -43,7 +43,7 @@ describe UsersGroup do
       it "should send email to user" do
         membership = build(:users_group)
         membership.stub(notification_service: double('NotificationService').as_null_object)
-        membership.should_receive(:notification_service)
+        expect(membership).to receive(:notification_service)
         membership.save
       end
     end
@@ -55,12 +55,12 @@ describe UsersGroup do
       end
 
       it "should send email to user" do
-        @membership.should_receive(:notification_service)
+        expect(@membership).to receive(:notification_service)
         @membership.update_attribute(:group_access, UsersGroup::MASTER)
       end
 
       it "does not send an email when the access level has not changed" do
-        @membership.should_not_receive(:notification_service)
+        expect(@membership).not_to receive(:notification_service)
         @membership.update_attribute(:group_access, UsersGroup::OWNER)
       end
     end

--- a/spec/models/users_project_spec.rb
+++ b/spec/models/users_project_spec.rb
@@ -55,19 +55,19 @@ describe UsersProject do
       @status = @project_2.team.import(@project_1)
     end
 
-    it { @status.should be_true }
+    it { expect(@status).to be_true }
 
     describe 'project 2 should get user 1 as developer. user_2 should not be changed' do
-      it { @project_2.users.should include(@user_1) }
-      it { @project_2.users.should include(@user_2) }
+      it { expect(@project_2.users).to include(@user_1) }
+      it { expect(@project_2.users).to include(@user_2) }
 
-      it { @abilities.allowed?(@user_1, :write_project, @project_2).should be_true }
-      it { @abilities.allowed?(@user_2, :read_project, @project_2).should be_true }
+      it { expect(@abilities.allowed?(@user_1, :write_project, @project_2)).to be_true }
+      it { expect(@abilities.allowed?(@user_2, :read_project, @project_2)).to be_true }
     end
 
     describe 'project 1 should not be changed' do
-      it { @project_1.users.should include(@user_1) }
-      it { @project_1.users.should_not include(@user_2) }
+      it { expect(@project_1.users).to include(@user_1) }
+      it { expect(@project_1.users).not_to include(@user_2) }
     end
   end
 
@@ -86,12 +86,12 @@ describe UsersProject do
       )
     end
 
-    it { @project_1.users.should include(@user_1) }
-    it { @project_1.users.should include(@user_2) }
+    it { expect(@project_1.users).to include(@user_1) }
+    it { expect(@project_1.users).to include(@user_2) }
 
 
-    it { @project_2.users.should include(@user_1) }
-    it { @project_2.users.should include(@user_2) }
+    it { expect(@project_2.users).to include(@user_1) }
+    it { expect(@project_2.users).to include(@user_2) }
   end
 
   describe :truncate_teams do
@@ -108,7 +108,7 @@ describe UsersProject do
       UsersProject.truncate_teams([@project_1.id, @project_2.id])
     end
 
-    it { @project_1.users.should be_empty }
-    it { @project_2.users.should be_empty }
+    it { expect(@project_1.users).to be_empty }
+    it { expect(@project_2.users).to be_empty }
   end
 end

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -54,22 +54,22 @@ describe ProjectHook do
 
     it "POSTs to the web hook URL" do
       @project_hook.execute(@data)
-      WebMock.should have_requested(:post, @project_hook.url).once
+      expect(WebMock).to have_requested(:post, @project_hook.url).once
     end
 
     it "POSTs the data as JSON" do
       json = @data.to_json
 
       @project_hook.execute(@data)
-      WebMock.should have_requested(:post, @project_hook.url).with(body: json).once
+      expect(WebMock).to have_requested(:post, @project_hook.url).with(body: json).once
     end
 
     it "catches exceptions" do
-      WebHook.should_receive(:post).and_raise("Some HTTP Post error")
+      expect(WebHook).to receive(:post).and_raise("Some HTTP Post error")
 
-      lambda {
+      expect {
         @project_hook.execute(@data)
-      }.should raise_error
+      }.to raise_error
     end
   end
 end

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -39,27 +39,27 @@ describe WikiPage do
       end
 
       it "sets the slug attribute" do
-        @wiki_page.slug.should == "test-page"
+        expect(@wiki_page.slug).to eq("test-page")
       end
 
       it "sets the title attribute" do
-        @wiki_page.title.should == "test page"
+        expect(@wiki_page.title).to eq("test page")
       end
 
       it "sets the formatted content attribute" do
-        @wiki_page.content.should == "test content"
+        expect(@wiki_page.content).to eq("test content")
       end
 
       it "sets the format attribute" do
-        @wiki_page.format.should == :markdown
+        expect(@wiki_page.format).to eq(:markdown)
       end
 
       it "sets the message attribute" do
-        @wiki_page.message.should == "test commit"
+        expect(@wiki_page.message).to eq("test commit")
       end
 
       it "sets the version attribute" do
-        @wiki_page.version.should be_a Commit
+        expect(@wiki_page.version).to be_a Commit
       end
     end
   end
@@ -71,12 +71,12 @@ describe WikiPage do
 
     it "validates presence of title" do
       subject.attributes.delete(:title)
-      subject.valid?.should be_false
+      expect(subject.valid?).to be_false
     end
 
     it "validates presence of content" do
       subject.attributes.delete(:content)
-      subject.valid?.should be_false
+      expect(subject.valid?).to be_false
     end
   end
 
@@ -92,11 +92,11 @@ describe WikiPage do
     context "with valid attributes" do
       it "saves the wiki page" do
         subject.create(@wiki_attr)
-        wiki.find_page("Index").should_not be_nil
+        expect(wiki.find_page("Index")).not_to be_nil
       end
 
       it "returns true" do
-        subject.create(@wiki_attr).should == true
+        expect(subject.create(@wiki_attr)).to eq(true)
       end
     end
   end
@@ -118,7 +118,7 @@ describe WikiPage do
       end
 
       it "returns true" do
-        @page.update("more content").should be_true
+        expect(@page.update("more content")).to be_true
       end
     end
   end
@@ -131,11 +131,11 @@ describe WikiPage do
 
     it "should delete the page" do
       @page.delete
-      wiki.pages.should be_empty
+      expect(wiki.pages).to be_empty
     end
 
     it "should return true" do
-      @page.delete.should == true
+      expect(@page.delete).to eq(true)
     end
   end
 
@@ -151,7 +151,7 @@ describe WikiPage do
 
     it "returns an array of all commits for the page" do
       3.times { |i| @page.update("content #{i}") }
-      @page.versions.count.should == 4
+      expect(@page.versions.count).to eq(4)
     end
   end
 
@@ -167,7 +167,7 @@ describe WikiPage do
 
     it "should be replace a hyphen to a space" do
       @page.title = "Import-existing-repositories-into-GitLab"
-      @page.title.should == "Import existing repositories into GitLab"
+      expect(@page.title).to eq("Import existing repositories into GitLab")
     end
   end
 

--- a/spec/requests/api/api_helpers_spec.rb
+++ b/spec/requests/api/api_helpers_spec.rb
@@ -41,32 +41,32 @@ describe API, api: true do
   describe ".current_user" do
     it "should return nil for an invalid token" do
       env[API::APIHelpers::PRIVATE_TOKEN_HEADER] = 'invalid token'
-      current_user.should be_nil
+      expect(current_user).to be_nil
     end
 
     it "should return nil for a user without access" do
       env[API::APIHelpers::PRIVATE_TOKEN_HEADER] = user.private_token
       Gitlab::UserAccess.stub(allowed?: false)
-      current_user.should be_nil
+      expect(current_user).to be_nil
     end
 
     it "should leave user as is when sudo not specified" do
       env[API::APIHelpers::PRIVATE_TOKEN_HEADER] = user.private_token
-      current_user.should == user
+      expect(current_user).to eq(user)
       clear_env
       params[API::APIHelpers::PRIVATE_TOKEN_PARAM] = user.private_token
-      current_user.should == user
+      expect(current_user).to eq(user)
     end
 
     it "should change current user to sudo when admin" do
       set_env(admin, user.id)
-      current_user.should == user
+      expect(current_user).to eq(user)
       set_param(admin, user.id)
-      current_user.should == user
+      expect(current_user).to eq(user)
       set_env(admin, user.username)
-      current_user.should == user
+      expect(current_user).to eq(user)
       set_param(admin, user.username)
-      current_user.should == user
+      expect(current_user).to eq(user)
     end
 
     it "should throw an error when the current user is not an admin and attempting to sudo" do
@@ -82,8 +82,8 @@ describe API, api: true do
 
     it "should throw an error when the user cannot be found for a given id" do
       id = user.id + admin.id
-      user.id.should_not == id
-      admin.id.should_not == id
+      expect(user.id).not_to eq(id)
+      expect(admin.id).not_to eq(id)
       set_env(admin, id)
       expect { current_user }.to raise_error
 
@@ -93,8 +93,8 @@ describe API, api: true do
 
     it "should throw an error when the user cannot be found for a given username" do
       username = "#{user.username}#{admin.username}"
-      user.username.should_not == username
-      admin.username.should_not == username
+      expect(user.username).not_to eq(username)
+      expect(admin.username).not_to eq(username)
       set_env(admin, username)
       expect { current_user }.to raise_error
 
@@ -104,69 +104,69 @@ describe API, api: true do
 
     it "should handle sudo's to oneself" do
       set_env(admin, admin.id)
-      current_user.should == admin
+      expect(current_user).to eq(admin)
       set_param(admin, admin.id)
-      current_user.should == admin
+      expect(current_user).to eq(admin)
       set_env(admin, admin.username)
-      current_user.should == admin
+      expect(current_user).to eq(admin)
       set_param(admin, admin.username)
-      current_user.should == admin
+      expect(current_user).to eq(admin)
     end
 
     it "should handle multiple sudo's to oneself" do
       set_env(admin, user.id)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
       set_env(admin, user.username)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
 
       set_param(admin, user.id)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
       set_param(admin, user.username)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
     end
 
     it "should handle multiple sudo's to oneself using string ids" do
       set_env(admin, user.id.to_s)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
 
       set_param(admin, user.id.to_s)
-      current_user.should == user
-      current_user.should == user
+      expect(current_user).to eq(user)
+      expect(current_user).to eq(user)
     end
   end
 
   describe '.sudo_identifier' do
     it "should return integers when input is an int" do
       set_env(admin, '123')
-      sudo_identifier.should == 123
+      expect(sudo_identifier).to eq(123)
       set_env(admin, '0001234567890')
-      sudo_identifier.should == 1234567890
+      expect(sudo_identifier).to eq(1234567890)
 
       set_param(admin, '123')
-      sudo_identifier.should == 123
+      expect(sudo_identifier).to eq(123)
       set_param(admin, '0001234567890')
-      sudo_identifier.should == 1234567890
+      expect(sudo_identifier).to eq(1234567890)
     end
 
     it "should return string when input is an is not an int" do
       set_env(admin, '12.30')
-      sudo_identifier.should == "12.30"
+      expect(sudo_identifier).to eq("12.30")
       set_env(admin, 'hello')
-      sudo_identifier.should == 'hello'
+      expect(sudo_identifier).to eq('hello')
       set_env(admin, ' 123')
-      sudo_identifier.should == ' 123'
+      expect(sudo_identifier).to eq(' 123')
 
       set_param(admin, '12.30')
-      sudo_identifier.should == "12.30"
+      expect(sudo_identifier).to eq("12.30")
       set_param(admin, 'hello')
-      sudo_identifier.should == 'hello'
+      expect(sudo_identifier).to eq('hello')
       set_param(admin, ' 123')
-      sudo_identifier.should == ' 123'
+      expect(sudo_identifier).to eq(' 123')
     end
   end
 end

--- a/spec/requests/api/branches_spec.rb
+++ b/spec/requests/api/branches_spec.rb
@@ -13,79 +13,79 @@ describe API::API, api: true  do
   describe "GET /projects/:id/repository/branches" do
     it "should return an array of project branches" do
       get api("/projects/#{project.id}/repository/branches", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.first['name'].should == project.repo.heads.sort_by(&:name).first.name
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.first['name']).to eq(project.repo.heads.sort_by(&:name).first.name)
     end
   end
 
   describe "GET /projects/:id/repository/branches/:branch" do
     it "should return the branch information for a single branch" do
       get api("/projects/#{project.id}/repository/branches/new_design", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['name'].should == 'new_design'
-      json_response['commit']['id'].should == '621491c677087aa243f165eab467bfdfbee00be1'
-      json_response['protected'].should == false
+      expect(json_response['name']).to eq('new_design')
+      expect(json_response['commit']['id']).to eq('621491c677087aa243f165eab467bfdfbee00be1')
+      expect(json_response['protected']).to eq(false)
     end
 
     it "should return a 403 error if guest" do
       get api("/projects/#{project.id}/repository/branches", user2)
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     it "should return a 404 error if branch is not available" do
       get api("/projects/#{project.id}/repository/branches/unknown", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
   describe "PUT /projects/:id/repository/branches/:branch/protect" do
     it "should protect a single branch" do
       put api("/projects/#{project.id}/repository/branches/new_design/protect", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['name'].should == 'new_design'
-      json_response['commit']['id'].should == '621491c677087aa243f165eab467bfdfbee00be1'
-      json_response['protected'].should == true
+      expect(json_response['name']).to eq('new_design')
+      expect(json_response['commit']['id']).to eq('621491c677087aa243f165eab467bfdfbee00be1')
+      expect(json_response['protected']).to eq(true)
     end
 
     it "should return a 404 error if branch not found" do
       put api("/projects/#{project.id}/repository/branches/unknown/protect", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return a 403 error if guest" do
       put api("/projects/#{project.id}/repository/branches/new_design/protect", user2)
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     it "should return success when protect branch again" do
       put api("/projects/#{project.id}/repository/branches/new_design/protect", user)
       put api("/projects/#{project.id}/repository/branches/new_design/protect", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 
   describe "PUT /projects/:id/repository/branches/:branch/unprotect" do
     it "should unprotect a single branch" do
       put api("/projects/#{project.id}/repository/branches/new_design/unprotect", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['name'].should == 'new_design'
-      json_response['commit']['id'].should == '621491c677087aa243f165eab467bfdfbee00be1'
-      json_response['protected'].should == false
+      expect(json_response['name']).to eq('new_design')
+      expect(json_response['commit']['id']).to eq('621491c677087aa243f165eab467bfdfbee00be1')
+      expect(json_response['protected']).to eq(false)
     end
 
     it "should return success when unprotect branch" do
       put api("/projects/#{project.id}/repository/branches/unknown/unprotect", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return success when unprotect branch again" do
       put api("/projects/#{project.id}/repository/branches/new_design/unprotect", user)
       put api("/projects/#{project.id}/repository/branches/new_design/unprotect", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 
@@ -95,10 +95,10 @@ describe API::API, api: true  do
         branch_name: 'new_design',
         ref: '621491c677087aa243f165eab467bfdfbee00be1'
 
-      response.status.should == 201
+      expect(response.status).to eq(201)
 
-      json_response['name'].should == 'new_design'
-      json_response['commit']['id'].should == '621491c677087aa243f165eab467bfdfbee00be1'
+      expect(json_response['name']).to eq('new_design')
+      expect(json_response['commit']['id']).to eq('621491c677087aa243f165eab467bfdfbee00be1')
     end
 
     it "should deny for user without push access" do
@@ -106,7 +106,7 @@ describe API::API, api: true  do
         branch_name: 'new_design',
         ref: '621491c677087aa243f165eab467bfdfbee00be1'
 
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
   end
 
@@ -115,20 +115,20 @@ describe API::API, api: true  do
 
     it "should remove branch" do
       delete api("/projects/#{project.id}/repository/branches/new_design", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should remove protected branch" do
       project.protected_branches.create(name: 'new_design')
       delete api("/projects/#{project.id}/repository/branches/new_design", user)
-      response.status.should == 405
-      json_response['message'].should == 'Protected branch cant be removed'
+      expect(response.status).to eq(405)
+      expect(json_response['message']).to eq('Protected branch cant be removed')
     end
 
     it "should not remove HEAD branch" do
       delete api("/projects/#{project.id}/repository/branches/master", user)
-      response.status.should == 405
-      json_response['message'].should == 'Cannot remove HEAD branch'
+      expect(response.status).to eq(405)
+      expect(json_response['message']).to eq('Cannot remove HEAD branch')
     end
   end
 end

--- a/spec/requests/api/commits_spec.rb
+++ b/spec/requests/api/commits_spec.rb
@@ -17,17 +17,17 @@ describe API::API, api: true  do
 
       it "should return project commits" do
         get api("/projects/#{project.id}/repository/commits", user)
-        response.status.should == 200
+        expect(response.status).to eq(200)
 
-        json_response.should be_an Array
-        json_response.first['id'].should == project.repository.commit.id
+        expect(json_response).to be_an Array
+        expect(json_response.first['id']).to eq(project.repository.commit.id)
       end
     end
 
     context "unauthorized user" do
       it "should not return project commits" do
         get api("/projects/#{project.id}/repository/commits")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
   end
@@ -36,21 +36,21 @@ describe API::API, api: true  do
     context "authorized user" do
       it "should return a commit by sha" do
         get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}", user)
-        response.status.should == 200
-        json_response['id'].should == project.repository.commit.id
-        json_response['title'].should == project.repository.commit.title
+        expect(response.status).to eq(200)
+        expect(json_response['id']).to eq(project.repository.commit.id)
+        expect(json_response['title']).to eq(project.repository.commit.title)
       end
 
       it "should return a 404 error if not found" do
         get api("/projects/#{project.id}/repository/commits/invalid_sha", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "unauthorized user" do
       it "should not return the selected commit" do
         get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
   end
@@ -61,23 +61,23 @@ describe API::API, api: true  do
 
       it "should return the diff of the selected commit" do
         get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}/diff", user)
-        response.status.should == 200
+        expect(response.status).to eq(200)
 
-        json_response.should be_an Array
-        json_response.length.should >= 1
-        json_response.first.keys.should include "diff"
+        expect(json_response).to be_an Array
+        expect(json_response.length).to be >= 1
+        expect(json_response.first.keys).to include "diff"
       end
 
       it "should return a 404 error if invalid commit" do
         get api("/projects/#{project.id}/repository/commits/invalid_sha/diff", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "unauthorized user" do
       it "should not return the diff of the selected commit" do
         get api("/projects/#{project.id}/repository/commits/#{project.repository.commit.id}/diff")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
   end

--- a/spec/requests/api/files_spec.rb
+++ b/spec/requests/api/files_spec.rb
@@ -14,15 +14,15 @@ describe API::API, api: true  do
       }
 
       get api("/projects/#{project.id}/repository/files", user), params
-      response.status.should == 200
-      json_response['file_path'].should == 'app/models/key.rb'
-      json_response['file_name'].should == 'key.rb'
-      Base64.decode64(json_response['content']).lines.first.should == "class Key < ActiveRecord::Base\n"
+      expect(response.status).to eq(200)
+      expect(json_response['file_path']).to eq('app/models/key.rb')
+      expect(json_response['file_name']).to eq('key.rb')
+      expect(Base64.decode64(json_response['content']).lines.first).to eq("class Key < ActiveRecord::Base\n")
     end
 
     it "should return a 400 bad request if no params given" do
       get api("/projects/#{project.id}/repository/files", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 404 if such file does not exist" do
@@ -32,7 +32,7 @@ describe API::API, api: true  do
       }
 
       get api("/projects/#{project.id}/repository/files", user), params
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -52,13 +52,13 @@ describe API::API, api: true  do
       )
 
       post api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 201
-      json_response['file_path'].should == 'newfile.rb'
+      expect(response.status).to eq(201)
+      expect(json_response['file_path']).to eq('newfile.rb')
     end
 
     it "should return a 400 bad request if no params given" do
       post api("/projects/#{project.id}/repository/files", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 if satellite fails to create file" do
@@ -67,7 +67,7 @@ describe API::API, api: true  do
       )
 
       post api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -87,13 +87,13 @@ describe API::API, api: true  do
       )
 
       put api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 200
-      json_response['file_path'].should == 'spec/spec_helper.rb'
+      expect(response.status).to eq(200)
+      expect(json_response['file_path']).to eq('spec/spec_helper.rb')
     end
 
     it "should return a 400 bad request if no params given" do
       put api("/projects/#{project.id}/repository/files", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 if satellite fails to create file" do
@@ -102,7 +102,7 @@ describe API::API, api: true  do
       )
 
       put api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -121,13 +121,13 @@ describe API::API, api: true  do
       )
 
       delete api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 200
-      json_response['file_path'].should == 'spec/spec_helper.rb'
+      expect(response.status).to eq(200)
+      expect(json_response['file_path']).to eq('spec/spec_helper.rb')
     end
 
     it "should return a 400 bad request if no params given" do
       delete api("/projects/#{project.id}/repository/files", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 if satellite fails to create file" do
@@ -136,7 +136,7 @@ describe API::API, api: true  do
       )
 
       delete api("/projects/#{project.id}/repository/files", user), valid_params
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 end

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -18,26 +18,26 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/groups")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated as user" do
       it "normal user: should return an array of groups of user1" do
         get api("/groups", user1)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 1
-        json_response.first['name'].should == group1.name
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(1)
+        expect(json_response.first['name']).to eq(group1.name)
       end
     end
 
     context "when authenticated as  admin" do
       it "admin: should return an array of all groups" do
         get api("/groups", admin)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 2
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(2)
       end
     end
   end
@@ -46,31 +46,31 @@ describe API::API, api: true  do
     context "when authenticated as user" do
       it "should return one of user1's groups" do
         get api("/groups/#{group1.id}", user1)
-        response.status.should == 200
+        expect(response.status).to eq(200)
         json_response['name'] == group1.name
       end
 
       it "should not return a non existing group" do
         get api("/groups/1328", user1)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should not return a group not attached to user1" do
         get api("/groups/#{group2.id}", user1)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should return any existing group" do
         get api("/groups/#{group2.id}", admin)
-        response.status.should == 200
+        expect(response.status).to eq(200)
         json_response['name'] == group2.name
       end
 
       it "should not return a non existing group" do
         get api("/groups/1328", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -79,29 +79,29 @@ describe API::API, api: true  do
     context "when authenticated as user" do
       it "should not create group" do
         post api("/groups", user1), attributes_for(:group)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should create group" do
         post api("/groups", admin), attributes_for(:group)
-        response.status.should == 201
+        expect(response.status).to eq(201)
       end
 
       it "should not create group, duplicate" do
         post api("/groups", admin), {name: "Duplicate Test", path: group2.path}
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should return 400 bad request error if name not given" do
         post api("/groups", admin), {path: group2.path}
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 400 bad request error if path not given" do
         post api("/groups", admin), { name: 'test' }
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
     end
   end
@@ -110,36 +110,36 @@ describe API::API, api: true  do
     context "when authenticated as user" do
       it "should remove group" do
         delete api("/groups/#{group1.id}", user1)
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it "should not remove a group if not an owner" do
         user3 = create(:user)
         group1.add_user(user3, Gitlab::Access::MASTER)
         delete api("/groups/#{group1.id}", user3)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
 
       it "should not remove a non existing group" do
         delete api("/groups/1328", user1)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should not remove a group not attached to user1" do
         delete api("/groups/#{group2.id}", user1)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should remove any existing group" do
         delete api("/groups/#{group2.id}", admin)
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it "should not remove a non existing group" do
         delete api("/groups/1328", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -148,20 +148,20 @@ describe API::API, api: true  do
     let(:project) { create(:project) }
     before(:each) do
       Projects::TransferService.any_instance.stub(execute: true)
-      Project.stub(:find).and_return(project)
+      allow(Project).to receive(:find).and_return(project)
     end
 
     context "when authenticated as user" do
       it "should not transfer project to group" do
         post api("/groups/#{group1.id}/projects/#{project.id}", user2)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should transfer project to group" do
         post api("/groups/#{group1.id}/projects/#{project.id}", admin)
-        response.status.should == 201
+        expect(response.status).to eq(201)
       end
     end
   end
@@ -192,20 +192,20 @@ describe API::API, api: true  do
         it "each user: should return an array of members groups of group3" do
           [owner, master, developer, reporter, guest].each do |user|
             get api("/groups/#{group_with_members.id}/members", user)
-            response.status.should == 200
-            json_response.should be_an Array
-            json_response.size.should == 5
-            json_response.find { |e| e['id']==owner.id }['access_level'].should == UsersGroup::OWNER
-            json_response.find { |e| e['id']==reporter.id }['access_level'].should == UsersGroup::REPORTER
-            json_response.find { |e| e['id']==developer.id }['access_level'].should == UsersGroup::DEVELOPER
-            json_response.find { |e| e['id']==master.id }['access_level'].should == UsersGroup::MASTER
-            json_response.find { |e| e['id']==guest.id }['access_level'].should == UsersGroup::GUEST
+            expect(response.status).to eq(200)
+            expect(json_response).to be_an Array
+            expect(json_response.size).to eq(5)
+            expect(json_response.find { |e| e['id']==owner.id }['access_level']).to eq(UsersGroup::OWNER)
+            expect(json_response.find { |e| e['id']==reporter.id }['access_level']).to eq(UsersGroup::REPORTER)
+            expect(json_response.find { |e| e['id']==developer.id }['access_level']).to eq(UsersGroup::DEVELOPER)
+            expect(json_response.find { |e| e['id']==master.id }['access_level']).to eq(UsersGroup::MASTER)
+            expect(json_response.find { |e| e['id']==guest.id }['access_level']).to eq(UsersGroup::GUEST)
           end
         end
 
         it "users not part of the group should get access error" do
           get api("/groups/#{group_with_members.id}/members", user1)
-          response.status.should == 403
+          expect(response.status).to eq(403)
         end
       end
     end
@@ -214,7 +214,7 @@ describe API::API, api: true  do
       context "when not a member of the group" do
         it "should not add guest as member of group_no_members when adding being done by person outside the group" do
           post api("/groups/#{group_no_members.id}/members", reporter), user_id: guest.id, access_level: UsersGroup::MASTER
-          response.status.should == 403
+          expect(response.status).to eq(403)
         end
       end
 
@@ -223,30 +223,30 @@ describe API::API, api: true  do
           count_before=group_no_members.users_groups.count
           new_user = create(:user)
           post api("/groups/#{group_no_members.id}/members", owner), user_id: new_user.id, access_level: UsersGroup::MASTER
-          response.status.should == 201
-          json_response['name'].should == new_user.name
-          json_response['access_level'].should == UsersGroup::MASTER
-          group_no_members.users_groups.count.should == count_before + 1
+          expect(response.status).to eq(201)
+          expect(json_response['name']).to eq(new_user.name)
+          expect(json_response['access_level']).to eq(UsersGroup::MASTER)
+          expect(group_no_members.users_groups.count).to eq(count_before + 1)
         end
 
         it "should return error if member already exists" do
           post api("/groups/#{group_with_members.id}/members", owner), user_id: master.id, access_level: UsersGroup::MASTER
-          response.status.should == 409
+          expect(response.status).to eq(409)
         end
 
         it "should return a 400 error when user id is not given" do
           post api("/groups/#{group_no_members.id}/members", owner), access_level: UsersGroup::MASTER
-          response.status.should == 400
+          expect(response.status).to eq(400)
         end
 
         it "should return a 400 error when access level is not given" do
           post api("/groups/#{group_no_members.id}/members", owner), user_id: master.id
-          response.status.should == 400
+          expect(response.status).to eq(400)
         end
 
         it "should return a 422 error when access level is not known" do
           post api("/groups/#{group_no_members.id}/members", owner), user_id: master.id, access_level: 1234
-          response.status.should == 422
+          expect(response.status).to eq(422)
         end
       end
     end
@@ -256,7 +256,7 @@ describe API::API, api: true  do
         it "should not delete guest's membership of group_with_members" do
           random_user = create(:user)
           delete api("/groups/#{group_with_members.id}/members/#{owner.id}", random_user)
-          response.status.should == 403
+          expect(response.status).to eq(403)
         end
       end
 
@@ -264,13 +264,13 @@ describe API::API, api: true  do
         it "should delete guest's membership of group" do
           count_before=group_with_members.users_groups.count
           delete api("/groups/#{group_with_members.id}/members/#{guest.id}", owner)
-          response.status.should == 200
-          group_with_members.users_groups.count.should == count_before - 1
+          expect(response.status).to eq(200)
+          expect(group_with_members.users_groups.count).to eq(count_before - 1)
         end
 
         it "should return a 404 error when user id is not known" do
           delete api("/groups/#{group_with_members.id}/members/1328", owner)
-          response.status.should == 404
+          expect(response.status).to eq(404)
         end
       end
     end

--- a/spec/requests/api/internal_spec.rb
+++ b/spec/requests/api/internal_spec.rb
@@ -10,8 +10,8 @@ describe API::API, api: true  do
     it do
       get api("/internal/check")
 
-      response.status.should == 200
-      json_response['api_version'].should == API::API.version
+      expect(response.status).to eq(200)
+      expect(json_response['api_version']).to eq(API::API.version)
     end
   end
 
@@ -19,9 +19,9 @@ describe API::API, api: true  do
     it do
       get(api("/internal/discover"), key_id: key.id)
 
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['name'].should == user.name
+      expect(json_response['name']).to eq(user.name)
     end
   end
 
@@ -35,8 +35,8 @@ describe API::API, api: true  do
         it do
           pull(key, project)
 
-          response.status.should == 200
-          response.body.should == 'true'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('true')
         end
       end
 
@@ -44,8 +44,8 @@ describe API::API, api: true  do
         it do
           push(key, project)
 
-          response.status.should == 200
-          response.body.should == 'true'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('true')
         end
       end
     end
@@ -59,8 +59,8 @@ describe API::API, api: true  do
         it do
           pull(key, project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
 
@@ -68,8 +68,8 @@ describe API::API, api: true  do
         it do
           push(key, project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
     end
@@ -85,8 +85,8 @@ describe API::API, api: true  do
         it do
           pull(key, personal_project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
 
@@ -94,8 +94,8 @@ describe API::API, api: true  do
         it do
           push(key, personal_project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
     end
@@ -112,8 +112,8 @@ describe API::API, api: true  do
         it do
           pull(key, project)
 
-          response.status.should == 200
-          response.body.should == 'true'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('true')
         end
       end
 
@@ -121,8 +121,8 @@ describe API::API, api: true  do
         it do
           push(key, project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
     end
@@ -138,8 +138,8 @@ describe API::API, api: true  do
         it do
           archive(key, project)
 
-          response.status.should == 200
-          response.body.should == 'true'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('true')
         end
       end
 
@@ -147,8 +147,8 @@ describe API::API, api: true  do
         it do
           archive(key, project)
 
-          response.status.should == 200
-          response.body.should == 'false'
+          expect(response.status).to eq(200)
+          expect(response.body).to eq('false')
         end
       end
     end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -11,22 +11,23 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/issues")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated" do
       it "should return an array of issues" do
         get api("/issues", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['title'].should == issue.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['title']).to eq(issue.title)
       end
 
       it "should add pagination headers" do
         get api("/issues?per_page=3", user)
-        response.headers['Link'].should ==
+        expect(response.headers['Link']).to eq(
           '<http://www.example.com/api/v3/issues?page=1&per_page=3>; rel="first", <http://www.example.com/api/v3/issues?page=1&per_page=3>; rel="last"'
+        )
       end
     end
   end
@@ -34,23 +35,23 @@ describe API::API, api: true  do
   describe "GET /projects/:id/issues" do
     it "should return project issues" do
       get api("/projects/#{project.id}/issues", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.first['title'].should == issue.title
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.first['title']).to eq(issue.title)
     end
   end
 
   describe "GET /projects/:id/issues/:issue_id" do
     it "should return a project issue by id" do
       get api("/projects/#{project.id}/issues/#{issue.id}", user)
-      response.status.should == 200
-      json_response['title'].should == issue.title
-      json_response['iid'].should == issue.iid
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq(issue.title)
+      expect(json_response['iid']).to eq(issue.iid)
     end
 
     it "should return 404 if issue id not found" do
       get api("/projects/#{project.id}/issues/54321", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -58,15 +59,15 @@ describe API::API, api: true  do
     it "should create a new project issue" do
       post api("/projects/#{project.id}/issues", user),
         title: 'new issue', labels: 'label, label2'
-      response.status.should == 201
-      json_response['title'].should == 'new issue'
-      json_response['description'].should be_nil
-      json_response['labels'].should == ['label', 'label2']
+      expect(response.status).to eq(201)
+      expect(json_response['title']).to eq('new issue')
+      expect(json_response['description']).to be_nil
+      expect(json_response['labels']).to eq(['label', 'label2'])
     end
 
     it "should return a 400 bad request if title not given" do
       post api("/projects/#{project.id}/issues", user), labels: 'label, label2'
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -74,15 +75,15 @@ describe API::API, api: true  do
     it "should update a project issue" do
       put api("/projects/#{project.id}/issues/#{issue.id}", user),
         title: 'updated title'
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['title'].should == 'updated title'
+      expect(json_response['title']).to eq('updated title')
     end
 
     it "should return 404 error if issue id not found" do
       put api("/projects/#{project.id}/issues/44444", user),
         title: 'updated title'
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -90,17 +91,17 @@ describe API::API, api: true  do
     it "should update a project issue" do
       put api("/projects/#{project.id}/issues/#{issue.id}", user),
         labels: 'label2', state_event: "close"
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['labels'].should == ['label2']
-      json_response['state'].should eq "closed"
+      expect(json_response['labels']).to eq(['label2'])
+      expect(json_response['state']).to eq "closed"
     end
   end
 
   describe "DELETE /projects/:id/issues/:issue_id" do
     it "should delete a project issue" do
       delete api("/projects/#{project.id}/issues/#{issue.id}", user)
-      response.status.should == 405
+      expect(response.status).to eq(405)
     end
   end
 end

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -16,46 +16,46 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/projects/#{project.id}/merge_requests")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated" do
       it "should return an array of all merge_requests" do
         get api("/projects/#{project.id}/merge_requests", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 3
-        json_response.first['title'].should == merge_request.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(3)
+        expect(json_response.first['title']).to eq(merge_request.title)
       end
       it "should return an array of all merge_requests" do
         get api("/projects/#{project.id}/merge_requests?state", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 3
-        json_response.first['title'].should == merge_request.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(3)
+        expect(json_response.first['title']).to eq(merge_request.title)
       end
       it "should return an array of open merge_requests" do
         get api("/projects/#{project.id}/merge_requests?state=opened", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 1
-        json_response.first['title'].should == merge_request.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(1)
+        expect(json_response.first['title']).to eq(merge_request.title)
       end
       it "should return an array of closed merge_requests" do
         get api("/projects/#{project.id}/merge_requests?state=closed", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 2
-        json_response.first['title'].should == merge_request_closed.title
-        json_response.second['title'].should == merge_request_merged.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(2)
+        expect(json_response.first['title']).to eq(merge_request_closed.title)
+        expect(json_response.second['title']).to eq(merge_request_merged.title)
       end
       it "should return an array of merged merge_requests" do
         get api("/projects/#{project.id}/merge_requests?state=merged", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.length.should == 1
-        json_response.first['title'].should == merge_request_merged.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.length).to eq(1)
+        expect(json_response.first['title']).to eq(merge_request_merged.title)
       end
     end
   end
@@ -63,14 +63,14 @@ describe API::API, api: true  do
   describe "GET /projects/:id/merge_request/:merge_request_id" do
     it "should return merge_request" do
       get api("/projects/#{project.id}/merge_request/#{merge_request.id}", user)
-      response.status.should == 200
-      json_response['title'].should == merge_request.title
-      json_response['iid'].should == merge_request.iid
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq(merge_request.title)
+      expect(json_response['iid']).to eq(merge_request.iid)
     end
 
     it "should return a 404 error if merge_request_id not found" do
       get api("/projects/#{project.id}/merge_request/999", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -79,32 +79,32 @@ describe API::API, api: true  do
       it "should return merge_request" do
         post api("/projects/#{project.id}/merge_requests", user),
         title: 'Test merge_request', source_branch: "stable", target_branch: "master", author: user
-        response.status.should == 201
-        json_response['title'].should == 'Test merge_request'
+        expect(response.status).to eq(201)
+        expect(json_response['title']).to eq('Test merge_request')
       end
 
       it "should return 422 when source_branch equals target_branch" do
         post api("/projects/#{project.id}/merge_requests", user),
         title: "Test merge_request", source_branch: "master", target_branch: "master", author: user
-        response.status.should == 422
+        expect(response.status).to eq(422)
       end
 
       it "should return 400 when source_branch is missing" do
         post api("/projects/#{project.id}/merge_requests", user),
         title: "Test merge_request", target_branch: "master", author: user
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 400 when target_branch is missing" do
         post api("/projects/#{project.id}/merge_requests", user),
         title: "Test merge_request", source_branch: "stable", author: user
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 400 when title is missing" do
         post api("/projects/#{project.id}/merge_requests", user),
         target_branch: 'master', source_branch: 'stable'
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
     end
 
@@ -120,55 +120,55 @@ describe API::API, api: true  do
       it "should return merge_request" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', source_branch: "stable", target_branch: "master", author: user2, target_project_id: project.id, description: 'Test description for Test merge_request'
-        response.status.should == 201
-        json_response['title'].should == 'Test merge_request'
-        json_response['description'].should == 'Test description for Test merge_request'
+        expect(response.status).to eq(201)
+        expect(json_response['title']).to eq('Test merge_request')
+        expect(json_response['description']).to eq('Test description for Test merge_request')
       end
 
       it "should not return 422 when source_branch equals target_branch" do
-        project.id.should_not == fork_project.id
-        fork_project.forked?.should be_true
-        fork_project.forked_from_project.should == project
+        expect(project.id).not_to eq(fork_project.id)
+        expect(fork_project.forked?).to be_true
+        expect(fork_project.forked_from_project).to eq(project)
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', source_branch: "master", target_branch: "master", author: user2, target_project_id: project.id
-        response.status.should == 201
-        json_response['title'].should == 'Test merge_request'
+        expect(response.status).to eq(201)
+        expect(json_response['title']).to eq('Test merge_request')
       end
 
       it "should return 400 when source_branch is missing" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', target_branch: "master", author: user2, target_project_id: project.id
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 400 when target_branch is missing" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', target_branch: "master", author: user2, target_project_id: project.id
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 400 when title is missing" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         target_branch: 'master', source_branch: 'stable', author: user2, target_project_id: project.id
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return 404 when target_branch is specified and not a forked project" do
         post api("/projects/#{project.id}/merge_requests", user),
         title: 'Test merge_request', target_branch: 'master', source_branch: 'stable', author: user, target_project_id: fork_project.id
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should return 404 when target_branch is specified and for a different fork" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', target_branch: 'master', source_branch: 'stable', author: user2, target_project_id: unrelated_project.id
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should return 201 when target_branch is specified and for the same project" do
         post api("/projects/#{fork_project.id}/merge_requests", user2),
         title: 'Test merge_request', target_branch: 'master', source_branch: 'stable', author: user2, target_project_id: fork_project.id
-        response.status.should == 201
+        expect(response.status).to eq(201)
       end
     end
   end
@@ -176,8 +176,8 @@ describe API::API, api: true  do
   describe "PUT /projects/:id/merge_request/:merge_request_id to close MR" do
     it "should return merge_request" do
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}", user), state_event: "close"
-      response.status.should == 200
-      json_response['state'].should == 'closed'
+      expect(response.status).to eq(200)
+      expect(json_response['state']).to eq('closed')
     end
   end
 
@@ -185,89 +185,89 @@ describe API::API, api: true  do
     it "should return merge_request in case of success" do
       MergeRequest.any_instance.stub(can_be_merged?: true, automerge!: true)
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}/merge", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return 405 if branch can't be merged" do
       MergeRequest.any_instance.stub(can_be_merged?: false)
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}/merge", user)
-      response.status.should == 405
-      json_response['message'].should == 'Branch cannot be merged'
+      expect(response.status).to eq(405)
+      expect(json_response['message']).to eq('Branch cannot be merged')
     end
 
     it "should return 405 if merge_request is not open" do
       merge_request.close
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}/merge", user)
-      response.status.should == 405
-      json_response['message'].should == 'Method Not Allowed'
+      expect(response.status).to eq(405)
+      expect(json_response['message']).to eq('Method Not Allowed')
     end
 
     it "should return 401 if user has no permissions to merge" do
       user2 = create(:user)
       project.team << [user2, :reporter]
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}/merge", user2)
-      response.status.should == 401
-      json_response['message'].should == '401 Unauthorized'
+      expect(response.status).to eq(401)
+      expect(json_response['message']).to eq('401 Unauthorized')
     end
   end
 
   describe "PUT /projects/:id/merge_request/:merge_request_id" do
     it "should return merge_request" do
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}", user), title: "New title"
-      response.status.should == 200
-      json_response['title'].should == 'New title'
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq('New title')
     end
 
     it "should return merge_request" do
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}", user), description: "New description"
-      response.status.should == 200
-      json_response['description'].should == 'New description'
+      expect(response.status).to eq(200)
+      expect(json_response['description']).to eq('New description')
     end
 
     it "should return 422 when source_branch and target_branch are renamed the same" do
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}", user),
       source_branch: "master", target_branch: "master"
-      response.status.should == 422
+      expect(response.status).to eq(422)
     end
 
     it "should return merge_request with renamed target_branch" do
       put api("/projects/#{project.id}/merge_request/#{merge_request.id}", user), target_branch: "wiki"
-      response.status.should == 200
-      json_response['target_branch'].should == 'wiki'
+      expect(response.status).to eq(200)
+      expect(json_response['target_branch']).to eq('wiki')
     end
   end
 
   describe "POST /projects/:id/merge_request/:merge_request_id/comments" do
     it "should return comment" do
       post api("/projects/#{project.id}/merge_request/#{merge_request.id}/comments", user), note: "My comment"
-      response.status.should == 201
-      json_response['note'].should == 'My comment'
+      expect(response.status).to eq(201)
+      expect(json_response['note']).to eq('My comment')
     end
 
     it "should return 400 if note is missing" do
       post api("/projects/#{project.id}/merge_request/#{merge_request.id}/comments", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return 404 if note is attached to non existent merge request" do
       post api("/projects/#{project.id}/merge_request/111/comments", user), note: "My comment"
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
   describe "GET :id/merge_request/:merge_request_id/comments" do
     it "should return merge_request comments" do
       get api("/projects/#{project.id}/merge_request/#{merge_request.id}/comments", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.length.should == 1
-      json_response.first['note'].should == "a comment on a MR"
-      json_response.first['author']['id'].should == user.id
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.length).to eq(1)
+      expect(json_response.first['note']).to eq("a comment on a MR")
+      expect(json_response.first['author']['id']).to eq(user.id)
     end
 
     it "should return a 404 error if merge_request_id not found" do
       get api("/projects/#{project.id}/merge_request/999/comments", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 end

--- a/spec/requests/api/milestones_spec.rb
+++ b/spec/requests/api/milestones_spec.rb
@@ -11,55 +11,55 @@ describe API::API, api: true  do
   describe "GET /projects/:id/milestones" do
     it "should return project milestones" do
       get api("/projects/#{project.id}/milestones", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.first['title'].should == milestone.title
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.first['title']).to eq(milestone.title)
     end
 
     it "should return a 401 error if user not authenticated" do
       get api("/projects/#{project.id}/milestones")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
   end
 
   describe "GET /projects/:id/milestones/:milestone_id" do
     it "should return a project milestone by id" do
       get api("/projects/#{project.id}/milestones/#{milestone.id}", user)
-      response.status.should == 200
-      json_response['title'].should == milestone.title
-      json_response['iid'].should == milestone.iid
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq(milestone.title)
+      expect(json_response['iid']).to eq(milestone.iid)
     end
 
     it "should return 401 error if user not authenticated" do
       get api("/projects/#{project.id}/milestones/#{milestone.id}")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
 
     it "should return a 404 error if milestone id not found" do
       get api("/projects/#{project.id}/milestones/1234", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
   describe "POST /projects/:id/milestones" do
     it "should create a new project milestone" do
       post api("/projects/#{project.id}/milestones", user), title: 'new milestone'
-      response.status.should == 201
-      json_response['title'].should == 'new milestone'
-      json_response['description'].should be_nil
+      expect(response.status).to eq(201)
+      expect(json_response['title']).to eq('new milestone')
+      expect(json_response['description']).to be_nil
     end
 
     it "should create a new project milestone with description and due date" do
       post api("/projects/#{project.id}/milestones", user),
         title: 'new milestone', description: 'release', due_date: '2013-03-02'
-      response.status.should == 201
-      json_response['description'].should == 'release'
-      json_response['due_date'].should == '2013-03-02'
+      expect(response.status).to eq(201)
+      expect(json_response['description']).to eq('release')
+      expect(json_response['due_date']).to eq('2013-03-02')
     end
 
     it "should return a 400 error if title is missing" do
       post api("/projects/#{project.id}/milestones", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -67,14 +67,14 @@ describe API::API, api: true  do
     it "should update a project milestone" do
       put api("/projects/#{project.id}/milestones/#{milestone.id}", user),
         title: 'updated title'
-      response.status.should == 200
-      json_response['title'].should == 'updated title'
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq('updated title')
     end
 
     it "should return a 404 error if milestone id not found" do
       put api("/projects/#{project.id}/milestones/1234", user),
         title: 'updated title'
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -82,15 +82,15 @@ describe API::API, api: true  do
     it "should update a project milestone" do
       put api("/projects/#{project.id}/milestones/#{milestone.id}", user),
         state_event: 'close'
-      response.status.should == 200
+      expect(response.status).to eq(200)
 
-      json_response['state'].should == 'closed'
+      expect(json_response['state']).to eq('closed')
     end
   end
 
   describe "PUT /projects/:id/milestones/:milestone_id to test observer on close" do
     it "should create an activity event when an milestone is closed" do
-      Event.should_receive(:create)
+      expect(Event).to receive(:create)
 
       put api("/projects/#{project.id}/milestones/#{milestone.id}", user),
           state_event: 'close'

--- a/spec/requests/api/namespaces_spec.rb
+++ b/spec/requests/api/namespaces_spec.rb
@@ -10,18 +10,18 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/namespaces")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated as  admin" do
       it "admin: should return an array of all namespaces" do
         get api("/namespaces", admin)
-        response.status.should == 200
-        json_response.should be_an Array
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
 
         # Admin namespace + 2 group namespaces
-        json_response.length.should == 3
+        expect(json_response.length).to eq(3)
       end
     end
   end

--- a/spec/requests/api/notes_spec.rb
+++ b/spec/requests/api/notes_spec.rb
@@ -16,42 +16,42 @@ describe API::API, api: true  do
     context "when noteable is an Issue" do
       it "should return an array of issue notes" do
         get api("/projects/#{project.id}/issues/#{issue.id}/notes", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['body'].should == issue_note.note
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['body']).to eq(issue_note.note)
       end
 
       it "should return a 404 error when issue id not found" do
         get api("/projects/#{project.id}/issues/123/notes", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "when noteable is a Snippet" do
       it "should return an array of snippet notes" do
         get api("/projects/#{project.id}/snippets/#{snippet.id}/notes", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['body'].should == snippet_note.note
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['body']).to eq(snippet_note.note)
       end
 
       it "should return a 404 error when snippet id not found" do
         get api("/projects/#{project.id}/snippets/42/notes", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "when noteable is a Merge Request" do
       it "should return an array of merge_requests notes" do
         get api("/projects/#{project.id}/merge_requests/#{merge_request.id}/notes", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['body'].should == merge_request_note.note
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['body']).to eq(merge_request_note.note)
       end
 
       it "should return a 404 error if merge request id not found" do
         get api("/projects/#{project.id}/merge_requests/4444/notes", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -60,26 +60,26 @@ describe API::API, api: true  do
     context "when noteable is an Issue" do
       it "should return an issue note by id" do
         get api("/projects/#{project.id}/issues/#{issue.id}/notes/#{issue_note.id}", user)
-        response.status.should == 200
-        json_response['body'].should == issue_note.note
+        expect(response.status).to eq(200)
+        expect(json_response['body']).to eq(issue_note.note)
       end
 
       it "should return a 404 error if issue note not found" do
         get api("/projects/#{project.id}/issues/#{issue.id}/notes/123", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "when noteable is a Snippet" do
       it "should return a snippet note by id" do
         get api("/projects/#{project.id}/snippets/#{snippet.id}/notes/#{snippet_note.id}", user)
-        response.status.should == 200
-        json_response['body'].should == snippet_note.note
+        expect(response.status).to eq(200)
+        expect(json_response['body']).to eq(snippet_note.note)
       end
 
       it "should return a 404 error if snippet note not found" do
         get api("/projects/#{project.id}/snippets/#{snippet.id}/notes/123", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -88,45 +88,45 @@ describe API::API, api: true  do
     context "when noteable is an Issue" do
       it "should create a new issue note" do
         post api("/projects/#{project.id}/issues/#{issue.id}/notes", user), body: 'hi!'
-        response.status.should == 201
-        json_response['body'].should == 'hi!'
-        json_response['author']['username'].should == user.username
+        expect(response.status).to eq(201)
+        expect(json_response['body']).to eq('hi!')
+        expect(json_response['author']['username']).to eq(user.username)
       end
 
       it "should return a 400 bad request error if body not given" do
         post api("/projects/#{project.id}/issues/#{issue.id}/notes", user)
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return a 401 unauthorized error if user not authenticated" do
         post api("/projects/#{project.id}/issues/#{issue.id}/notes"), body: 'hi!'
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when noteable is a Snippet" do
       it "should create a new snippet note" do
         post api("/projects/#{project.id}/snippets/#{snippet.id}/notes", user), body: 'hi!'
-        response.status.should == 201
-        json_response['body'].should == 'hi!'
-        json_response['author']['username'].should == user.username
+        expect(response.status).to eq(201)
+        expect(json_response['body']).to eq('hi!')
+        expect(json_response['author']['username']).to eq(user.username)
       end
 
       it "should return a 400 bad request error if body not given" do
         post api("/projects/#{project.id}/snippets/#{snippet.id}/notes", user)
-        response.status.should == 400
+        expect(response.status).to eq(400)
       end
 
       it "should return a 401 unauthorized error if user not authenticated" do
         post api("/projects/#{project.id}/snippets/#{snippet.id}/notes"), body: 'hi!'
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
   end
 
   describe "POST /projects/:id/noteable/:noteable_id/notes to test observer on create" do
     it "should create an activity event when an issue note is created" do
-      Event.should_receive(:create)
+      expect(Event).to receive(:create)
 
       post api("/projects/#{project.id}/issues/#{issue.id}/notes", user), body: 'hi!'
     end

--- a/spec/requests/api/project_hooks_spec.rb
+++ b/spec/requests/api/project_hooks_spec.rb
@@ -16,18 +16,18 @@ describe API::API, 'ProjectHooks', api: true  do
     context "authorized user" do
       it "should return project hooks" do
         get api("/projects/#{project.id}/hooks", user)
-        response.status.should == 200
+        expect(response.status).to eq(200)
 
-        json_response.should be_an Array
-        json_response.count.should == 1
-        json_response.first['url'].should == "http://example.com"
+        expect(json_response).to be_an Array
+        expect(json_response.count).to eq(1)
+        expect(json_response.first['url']).to eq("http://example.com")
       end
     end
 
     context "unauthorized user" do
       it "should not access project hooks" do
         get api("/projects/#{project.id}/hooks", user3)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
   end
@@ -36,26 +36,26 @@ describe API::API, 'ProjectHooks', api: true  do
     context "authorized user" do
       it "should return a project hook" do
         get api("/projects/#{project.id}/hooks/#{hook.id}", user)
-        response.status.should == 200
-        json_response['url'].should == hook.url
+        expect(response.status).to eq(200)
+        expect(json_response['url']).to eq(hook.url)
       end
 
       it "should return a 404 error if hook id is not available" do
         get api("/projects/#{project.id}/hooks/1234", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "unauthorized user" do
       it "should not access an existing hook" do
         get api("/projects/#{project.id}/hooks/#{hook.id}", user3)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     it "should return a 404 error if hook id is not available" do
       get api("/projects/#{project.id}/hooks/1234", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -65,17 +65,17 @@ describe API::API, 'ProjectHooks', api: true  do
         post api("/projects/#{project.id}/hooks", user),
           url: "http://example.com", issues_events: true
       }.to change {project.hooks.count}.by(1)
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "should return a 400 error if url not given" do
       post api("/projects/#{project.id}/hooks", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 422 error if url not valid" do
       post api("/projects/#{project.id}/hooks", user), "url" => "ftp://example.com"
-      response.status.should == 422
+      expect(response.status).to eq(422)
     end
   end
 
@@ -83,23 +83,23 @@ describe API::API, 'ProjectHooks', api: true  do
     it "should update an existing project hook" do
       put api("/projects/#{project.id}/hooks/#{hook.id}", user),
         url: 'http://example.org', push_events: false
-      response.status.should == 200
-      json_response['url'].should == 'http://example.org'
+      expect(response.status).to eq(200)
+      expect(json_response['url']).to eq('http://example.org')
     end
 
     it "should return 404 error if hook id not found" do
       put api("/projects/#{project.id}/hooks/1234", user), url: 'http://example.org'
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return 400 error if url is not given" do
       put api("/projects/#{project.id}/hooks/#{hook.id}", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 422 error if url is not valid" do
       put api("/projects/#{project.id}/hooks/#{hook.id}", user), url: 'ftp://example.com'
-      response.status.should == 422
+      expect(response.status).to eq(422)
     end
   end
 
@@ -108,22 +108,22 @@ describe API::API, 'ProjectHooks', api: true  do
       expect {
         delete api("/projects/#{project.id}/hooks/#{hook.id}", user)
       }.to change {project.hooks.count}.by(-1)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return success when deleting hook" do
       delete api("/projects/#{project.id}/hooks/#{hook.id}", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return success when deleting non existent hook" do
       delete api("/projects/#{project.id}/hooks/42", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return a 405 error if hook id not given" do
       delete api("/projects/#{project.id}/hooks", user)
-      response.status.should == 405
+      expect(response.status).to eq(405)
     end
   end
 end

--- a/spec/requests/api/project_members_spec.rb
+++ b/spec/requests/api/project_members_spec.rb
@@ -15,23 +15,23 @@ describe API::API, api: true  do
 
     it "should return project team members" do
       get api("/projects/#{project.id}/members", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.count.should == 2
-      json_response.map { |u| u['username'] }.should include user.username
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.count).to eq(2)
+      expect(json_response.map { |u| u['username'] }).to include user.username
     end
 
     it "finds team members with query string" do
       get api("/projects/#{project.id}/members", user), query: user.username
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.count.should == 1
-      json_response.first['username'].should == user.username
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.count).to eq(1)
+      expect(json_response.first['username']).to eq(user.username)
     end
 
     it "should return a 404 error if id not found" do
       get api("/projects/9999/members", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -40,14 +40,14 @@ describe API::API, api: true  do
 
     it "should return project team member" do
       get api("/projects/#{project.id}/members/#{user.id}", user)
-      response.status.should == 200
-      json_response['username'].should == user.username
-      json_response['access_level'].should == UsersProject::MASTER
+      expect(response.status).to eq(200)
+      expect(json_response['username']).to eq(user.username)
+      expect(json_response['access_level']).to eq(UsersProject::MASTER)
     end
 
     it "should return a 404 error if user id not found" do
       get api("/projects/#{project.id}/members/1234", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -58,9 +58,9 @@ describe API::API, api: true  do
           access_level: UsersProject::DEVELOPER
       }.to change { UsersProject.count }.by(1)
 
-      response.status.should == 201
-      json_response['username'].should == user2.username
-      json_response['access_level'].should == UsersProject::DEVELOPER
+      expect(response.status).to eq(201)
+      expect(json_response['username']).to eq(user2.username)
+      expect(json_response['access_level']).to eq(UsersProject::DEVELOPER)
     end
 
     it "should return a 201 status if user is already project member" do
@@ -71,24 +71,24 @@ describe API::API, api: true  do
           access_level: UsersProject::DEVELOPER
       }.not_to change { UsersProject.count }.by(1)
 
-      response.status.should == 201
-      json_response['username'].should == user2.username
-      json_response['access_level'].should == UsersProject::DEVELOPER
+      expect(response.status).to eq(201)
+      expect(json_response['username']).to eq(user2.username)
+      expect(json_response['access_level']).to eq(UsersProject::DEVELOPER)
     end
 
     it "should return a 400 error when user id is not given" do
       post api("/projects/#{project.id}/members", user), access_level: UsersProject::MASTER
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 error when access level is not given" do
       post api("/projects/#{project.id}/members", user), user_id: user2.id
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 422 error when access level is not known" do
       post api("/projects/#{project.id}/members", user), user_id: user2.id, access_level: 1234
-      response.status.should == 422
+      expect(response.status).to eq(422)
     end
   end
 
@@ -97,24 +97,24 @@ describe API::API, api: true  do
 
     it "should update project team member" do
       put api("/projects/#{project.id}/members/#{user3.id}", user), access_level: UsersProject::MASTER
-      response.status.should == 200
-      json_response['username'].should == user3.username
-      json_response['access_level'].should == UsersProject::MASTER
+      expect(response.status).to eq(200)
+      expect(json_response['username']).to eq(user3.username)
+      expect(json_response['access_level']).to eq(UsersProject::MASTER)
     end
 
     it "should return a 404 error if user_id is not found" do
       put api("/projects/#{project.id}/members/1234", user), access_level: UsersProject::MASTER
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return a 400 error when access level is not given" do
       put api("/projects/#{project.id}/members/#{user3.id}", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 422 error when access level is not known" do
       put api("/projects/#{project.id}/members/#{user3.id}", user), access_level: 123
-      response.status.should == 422
+      expect(response.status).to eq(422)
     end
   end
 
@@ -138,16 +138,16 @@ describe API::API, api: true  do
     it "should return 200 if team member already removed" do
       delete api("/projects/#{project.id}/members/#{user3.id}", user)
       delete api("/projects/#{project.id}/members/#{user3.id}", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return 200 OK when the user was not member" do
       expect {
         delete api("/projects/#{project.id}/members/1000000", user)
       }.to change { UsersProject.count }.by(0)
-      response.status.should == 200
-      json_response['message'].should == "Access revoked"
-      json_response['id'].should == 1000000
+      expect(response.status).to eq(200)
+      expect(json_response['message']).to eq("Access revoked")
+      expect(json_response['id']).to eq(1000000)
     end
   end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -24,17 +24,17 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/projects")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated" do
       it "should return an array of projects" do
         get api("/projects", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['name'].should == project.name
-        json_response.first['owner']['username'].should == user.username
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['name']).to eq(project.name)
+        expect(json_response.first['owner']['username']).to eq(user.username)
       end
     end
   end
@@ -45,24 +45,24 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/projects/all")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated as regular user" do
       it "should return authentication error" do
         get api("/projects/all", user)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should return an array of all projects" do
         get api("/projects/all", admin)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['name'].should == project.name
-        json_response.first['owner']['username'].should == user.username
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['name']).to eq(project.name)
+        expect(json_response.first['owner']['username']).to eq(user.username)
       end
     end
   end
@@ -92,23 +92,23 @@ describe API::API, api: true  do
 
     it "should return a 400 error if name not given" do
       post api("/projects", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should create last project before reaching project limit" do
       (1..user2.projects_limit-1).each { |p| post api("/projects", user2), name: "foo#{p}" }
       post api("/projects", user2), name: "foo"
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "should respond with 201 on success" do
       post api("/projects", user), name: 'foo'
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "should respond with 400 if name is not given" do
       post api("/projects", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 403 error if project limit reached" do
@@ -116,7 +116,7 @@ describe API::API, api: true  do
         post api("/projects", user), name: "foo#{p}"
       end
       post api("/projects", user), name: 'bar'
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     it "should assign attributes to project" do
@@ -131,50 +131,50 @@ describe API::API, api: true  do
 
       project.each_pair do |k,v|
         next if k == :path
-        json_response[k.to_s].should == v
+        expect(json_response[k.to_s]).to eq(v)
       end
     end
 
     it "should set a project as public" do
       project = attributes_for(:project, :public)
       post api("/projects", user), project
-      json_response['public'].should be_true
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
+      expect(json_response['public']).to be_true
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PUBLIC)
     end
 
     it "should set a project as public using :public" do
       project = attributes_for(:project, { public: true })
       post api("/projects", user), project
-      json_response['public'].should be_true
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
+      expect(json_response['public']).to be_true
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PUBLIC)
     end
 
     it "should set a project as internal" do
       project = attributes_for(:project, :internal)
       post api("/projects", user), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::INTERNAL)
     end
 
     it "should set a project as internal overriding :public" do
       project = attributes_for(:project, :internal, { public: true })
       post api("/projects", user), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::INTERNAL)
     end
 
     it "should set a project as private" do
       project = attributes_for(:project, :private)
       post api("/projects", user), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PRIVATE)
     end
 
     it "should set a project as private using :public" do
       project = attributes_for(:project, { public: false })
       post api("/projects", user), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PRIVATE)
     end
   end
 
@@ -192,12 +192,12 @@ describe API::API, api: true  do
 
     it "should respond with 201 on success" do
       post api("/projects/user/#{user.id}", admin), name: 'foo'
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "should respond with 404 on failure" do
       post api("/projects/user/#{user.id}", admin)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should assign attributes to project" do
@@ -212,50 +212,50 @@ describe API::API, api: true  do
 
       project.each_pair do |k,v|
         next if k == :path
-        json_response[k.to_s].should == v
+        expect(json_response[k.to_s]).to eq(v)
       end
     end
 
     it "should set a project as public" do
       project = attributes_for(:project, :public)
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_true
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
+      expect(json_response['public']).to be_true
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PUBLIC)
     end
 
     it "should set a project as public using :public" do
       project = attributes_for(:project, { public: true })
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_true
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PUBLIC
+      expect(json_response['public']).to be_true
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PUBLIC)
     end
 
     it "should set a project as internal" do
       project = attributes_for(:project, :internal)
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::INTERNAL)
     end
 
     it "should set a project as internal overriding :public" do
       project = attributes_for(:project, :internal, { public: true })
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::INTERNAL
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::INTERNAL)
     end
 
     it "should set a project as private" do
       project = attributes_for(:project, :private)
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PRIVATE)
     end
 
     it "should set a project as private using :public" do
       project = attributes_for(:project, { public: false })
       post api("/projects/user/#{user.id}", admin), project
-      json_response['public'].should be_false
-      json_response['visibility_level'].should == Gitlab::VisibilityLevel::PRIVATE
+      expect(json_response['public']).to be_false
+      expect(json_response['visibility_level']).to eq(Gitlab::VisibilityLevel::PRIVATE)
     end
   end
 
@@ -265,36 +265,36 @@ describe API::API, api: true  do
 
     it "should return a project by id" do
       get api("/projects/#{project.id}", user)
-      response.status.should == 200
-      json_response['name'].should == project.name
-      json_response['owner']['username'].should == user.username
+      expect(response.status).to eq(200)
+      expect(json_response['name']).to eq(project.name)
+      expect(json_response['owner']['username']).to eq(user.username)
     end
 
     it "should return a project by path name" do
       get api("/projects/#{project.id}", user)
-      response.status.should == 200
-      json_response['name'].should == project.name
+      expect(response.status).to eq(200)
+      expect(json_response['name']).to eq(project.name)
     end
 
     it "should return a 404 error if not found" do
       get api("/projects/42", user)
-      response.status.should == 404
-      json_response['message'].should == '404 Not Found'
+      expect(response.status).to eq(404)
+      expect(json_response['message']).to eq('404 Not Found')
     end
 
     it "should return a 404 error if user is not a member" do
       other_user = create(:user)
       get api("/projects/#{project.id}", other_user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     describe 'permissions' do
       context 'personal project' do
         before { get api("/projects/#{project.id}", user) }
 
-        it { response.status.should == 200 }
-        it { json_response['permissions']["project_access"]["access_level"].should == Gitlab::Access::MASTER }
-        it { json_response['permissions']["group_access"].should be_nil }
+        it { expect(response.status).to eq(200) }
+        it { expect(json_response['permissions']["project_access"]["access_level"]).to eq(Gitlab::Access::MASTER) }
+        it { expect(json_response['permissions']["group_access"]).to be_nil }
       end
 
       context 'group project' do
@@ -304,9 +304,9 @@ describe API::API, api: true  do
           get api("/projects/#{project2.id}", user)
         end
 
-        it { response.status.should == 200 }
-        it { json_response['permissions']["project_access"].should be_nil }
-        it { json_response['permissions']["group_access"]["access_level"].should == Gitlab::Access::OWNER }
+        it { expect(response.status).to eq(200) }
+        it { expect(json_response['permissions']["project_access"]).to be_nil }
+        it { expect(json_response['permissions']["group_access"]["access_level"]).to eq(Gitlab::Access::OWNER) }
       end
     end
   end
@@ -316,23 +316,23 @@ describe API::API, api: true  do
 
     it "should return a project events" do
       get api("/projects/#{project.id}/events", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
       json_event = json_response.first
 
-      json_event['action_name'].should == 'joined'
-      json_event['project_id'].to_i.should == project.id
+      expect(json_event['action_name']).to eq('joined')
+      expect(json_event['project_id'].to_i).to eq(project.id)
     end
 
     it "should return a 404 error if not found" do
       get api("/projects/42/events", user)
-      response.status.should == 404
-      json_response['message'].should == '404 Not Found'
+      expect(response.status).to eq(404)
+      expect(json_response['message']).to eq('404 Not Found')
     end
 
     it "should return a 404 error if user is not a member" do
       other_user = create(:user)
       get api("/projects/#{project.id}/events", other_user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -341,22 +341,22 @@ describe API::API, api: true  do
 
     it "should return an array of project snippets" do
       get api("/projects/#{project.id}/snippets", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.first['title'].should == snippet.title
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.first['title']).to eq(snippet.title)
     end
   end
 
   describe "GET /projects/:id/snippets/:snippet_id" do
     it "should return a project snippet" do
       get api("/projects/#{project.id}/snippets/#{snippet.id}", user)
-      response.status.should == 200
-      json_response['title'].should == snippet.title
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq(snippet.title)
     end
 
     it "should return a 404 error if snippet id not found" do
       get api("/projects/#{project.id}/snippets/1234", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -364,26 +364,26 @@ describe API::API, api: true  do
     it "should create a new project snippet" do
       post api("/projects/#{project.id}/snippets", user),
         title: 'api test', file_name: 'sample.rb', code: 'test'
-      response.status.should == 201
-      json_response['title'].should == 'api test'
+      expect(response.status).to eq(201)
+      expect(json_response['title']).to eq('api test')
     end
 
     it "should return a 400 error if title is not given" do
       post api("/projects/#{project.id}/snippets", user),
         file_name: 'sample.rb', code: 'test'
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 error if file_name not given" do
       post api("/projects/#{project.id}/snippets", user),
         title: 'api test', code: 'test'
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return a 400 error if code not given" do
       post api("/projects/#{project.id}/snippets", user),
         title: 'api test', file_name: 'sample.rb'
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -391,16 +391,16 @@ describe API::API, api: true  do
     it "should update an existing project snippet" do
       put api("/projects/#{project.id}/snippets/#{snippet.id}", user),
         code: 'updated code'
-      response.status.should == 200
-      json_response['title'].should == 'example'
-      snippet.reload.content.should == 'updated code'
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq('example')
+      expect(snippet.reload.content).to eq('updated code')
     end
 
     it "should update an existing project snippet with new title" do
       put api("/projects/#{project.id}/snippets/#{snippet.id}", user),
         title: 'other api test'
-      response.status.should == 200
-      json_response['title'].should == 'other api test'
+      expect(response.status).to eq(200)
+      expect(json_response['title']).to eq('other api test')
     end
   end
 
@@ -411,24 +411,24 @@ describe API::API, api: true  do
       expect {
         delete api("/projects/#{project.id}/snippets/#{snippet.id}", user)
       }.to change { Snippet.count }.by(-1)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return success when deleting unknown snippet id" do
       delete api("/projects/#{project.id}/snippets/1234", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 
   describe "GET /projects/:id/snippets/:snippet_id/raw" do
     it "should get a raw project snippet" do
       get api("/projects/#{project.id}/snippets/#{snippet.id}/raw", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return a 404 error if raw project snippet not found" do
       get api("/projects/#{project.id}/snippets/5555/raw", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -441,29 +441,29 @@ describe API::API, api: true  do
 
       it "should return array of ssh keys" do
         get api("/projects/#{project.id}/keys", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['title'].should == deploy_key.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['title']).to eq(deploy_key.title)
       end
     end
 
     describe "GET /projects/:id/keys/:key_id" do
       it "should return a single key" do
         get api("/projects/#{project.id}/keys/#{deploy_key.id}", user)
-        response.status.should == 200
-        json_response['title'].should == deploy_key.title
+        expect(response.status).to eq(200)
+        expect(json_response['title']).to eq(deploy_key.title)
       end
 
       it "should return 404 Not Found with invalid ID" do
         get api("/projects/#{project.id}/keys/404", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     describe "POST /projects/:id/keys" do
       it "should not create an invalid ssh key" do
         post api("/projects/#{project.id}/keys", user), { title: "invalid key" }
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should create new ssh key" do
@@ -485,7 +485,7 @@ describe API::API, api: true  do
 
       it "should return 404 Not Found with invalid ID" do
         delete api("/projects/#{project.id}/keys/404", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -499,33 +499,33 @@ describe API::API, api: true  do
 
       it "shouldn't available for non admin users" do
         post api("/projects/#{project_fork_target.id}/fork/#{project_fork_source.id}", user)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
 
       it "should allow project to be forked from an existing project" do
-        project_fork_target.forked?.should_not be_true
+        expect(project_fork_target.forked?).not_to be_true
         post api("/projects/#{project_fork_target.id}/fork/#{project_fork_source.id}", admin)
-        response.status.should == 201
+        expect(response.status).to eq(201)
         project_fork_target.reload
-        project_fork_target.forked_from_project.id.should == project_fork_source.id
-        project_fork_target.forked_project_link.should_not be_nil
-        project_fork_target.forked?.should be_true
+        expect(project_fork_target.forked_from_project.id).to eq(project_fork_source.id)
+        expect(project_fork_target.forked_project_link).not_to be_nil
+        expect(project_fork_target.forked?).to be_true
       end
 
       it "should fail if forked_from project which does not exist" do
         post api("/projects/#{project_fork_target.id}/fork/9999", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should fail with 409 if already forked" do
         post api("/projects/#{project_fork_target.id}/fork/#{project_fork_source.id}", admin)
         project_fork_target.reload
-        project_fork_target.forked_from_project.id.should == project_fork_source.id
+        expect(project_fork_target.forked_from_project.id).to eq(project_fork_source.id)
         post api("/projects/#{project_fork_target.id}/fork/#{new_project_fork_source.id}", admin)
-        response.status.should == 409
+        expect(response.status).to eq(409)
         project_fork_target.reload
-        project_fork_target.forked_from_project.id.should == project_fork_source.id
-        project_fork_target.forked?.should be_true
+        expect(project_fork_target.forked_from_project.id).to eq(project_fork_source.id)
+        expect(project_fork_target.forked?).to be_true
       end
     end
 
@@ -533,26 +533,26 @@ describe API::API, api: true  do
 
       it "shouldn't available for non admin users" do
         delete api("/projects/#{project_fork_target.id}/fork", user)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
 
       it "should make forked project unforked" do
         post api("/projects/#{project_fork_target.id}/fork/#{project_fork_source.id}", admin)
         project_fork_target.reload
-        project_fork_target.forked_from_project.should_not be_nil
-        project_fork_target.forked?.should be_true
+        expect(project_fork_target.forked_from_project).not_to be_nil
+        expect(project_fork_target.forked?).to be_true
         delete api("/projects/#{project_fork_target.id}/fork", admin)
-        response.status.should == 200
+        expect(response.status).to eq(200)
         project_fork_target.reload
-        project_fork_target.forked_from_project.should be_nil
-        project_fork_target.forked?.should_not be_true
+        expect(project_fork_target.forked_from_project).to be_nil
+        expect(project_fork_target.forked?).not_to be_true
       end
 
       it "should be idempotent if not forked" do
-        project_fork_target.forked_from_project.should be_nil
+        expect(project_fork_target.forked_from_project).to be_nil
         delete api("/projects/#{project_fork_target.id}/fork", admin)
-        response.status.should == 200
-        project_fork_target.reload.forked_from_project.should be_nil
+        expect(response.status).to eq(200)
+        expect(project_fork_target.reload.forked_from_project).to be_nil
       end
     end
   end
@@ -572,27 +572,27 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/projects/search/#{query}")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated" do
       it "should return an array of projects" do
         get api("/projects/search/#{query}",user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.size.should == 6
-        json_response.each {|project| project['name'].should =~ /.*query.*/}
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.size).to eq(6)
+        json_response.each {|project| expect(project['name']).to match(/.*query.*/)}
       end
     end
 
     context "when authenticated as a different user" do
       it "should return matching public projects" do
         get api("/projects/search/#{query}", user2)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.size.should == 2
-        json_response.each {|project| project['name'].should =~ /(internal|public) query/}
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.size).to eq(2)
+        json_response.each {|project| expect(project['name']).to match(/(internal|public) query/)}
       end
     end
   end
@@ -601,36 +601,36 @@ describe API::API, api: true  do
     context "when authenticated as user" do
       it "should remove project" do
         delete api("/projects/#{project.id}", user)
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it "should not remove a project if not an owner" do
         user3 = create(:user)
         project.team << [user3, :developer]
         delete api("/projects/#{project.id}", user3)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
 
       it "should not remove a non existing project" do
         delete api("/projects/1328", user)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it "should not remove a project not attached to user" do
         delete api("/projects/#{project.id}", user2)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
 
     context "when authenticated as admin" do
       it "should remove any existing project" do
         delete api("/projects/#{project.id}", admin)
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it "should not remove a non existing project" do
         delete api("/projects/1328", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -641,10 +641,10 @@ describe API::API, api: true  do
 
       it 'should return project labels' do
         get api("/projects/#{project.id}/labels", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['name'].should == issue_with_labels.labels.first.name
-        json_response.last['name'].should == issue_with_labels.labels.last.name
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['name']).to eq(issue_with_labels.labels.first.name)
+        expect(json_response.last['name']).to eq(issue_with_labels.labels.last.name)
       end
     end
 
@@ -653,10 +653,10 @@ describe API::API, api: true  do
 
       it 'should return project labels' do
         get api("/projects/#{project.id}/labels", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['name'].should == merge_request_with_labels.labels.first.name
-        json_response.last['name'].should == merge_request_with_labels.labels.last.name
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['name']).to eq(merge_request_with_labels.labels.first.name)
+        expect(json_response.last['name']).to eq(merge_request_with_labels.labels.last.name)
       end
     end
 
@@ -668,11 +668,11 @@ describe API::API, api: true  do
 
       it 'should return project labels from both' do
         get api("/projects/#{project.id}/labels", user)
-        response.status.should == 200
-        json_response.should be_an Array
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
         all_labels = issue_with_labels.labels.map(&:name).to_a
                        .concat(merge_request_with_labels.labels.map(&:name).to_a)
-        json_response.map { |e| e['name'] }.should =~ all_labels
+        expect(json_response.map { |e| e['name'] }).to match(all_labels)
       end
     end
   end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -14,9 +14,9 @@ describe API::API, api: true  do
   describe "GET /projects/:id/repository/tags" do
     it "should return an array of project tags" do
       get api("/projects/#{project.id}/repository/tags", user)
-      response.status.should == 200
-      json_response.should be_an Array
-      json_response.first['name'].should == project.repo.tags.sort_by(&:name).reverse.first.name
+      expect(response.status).to eq(200)
+      expect(json_response).to be_an Array
+      expect(json_response.first['name']).to eq(project.repo.tags.sort_by(&:name).reverse.first.name)
     end
   end
 
@@ -26,15 +26,15 @@ describe API::API, api: true  do
            tag_name: 'v1.0.0',
            ref: 'master'
 
-      response.status.should == 201
-      json_response['name'].should == 'v1.0.0'
+      expect(response.status).to eq(201)
+      expect(json_response['name']).to eq('v1.0.0')
     end
     it 'should deny for user without push access' do
       post api("/projects/#{project.id}/repository/tags", user2),
            tag_name: 'v1.0.0',
            ref: '621491c677087aa243f165eab467bfdfbee00be1'
 
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
   end
 
@@ -44,19 +44,19 @@ describe API::API, api: true  do
 
       it "should return project commits" do
         get api("/projects/#{project.id}/repository/tree", user)
-        response.status.should == 200
+        expect(response.status).to eq(200)
 
-        json_response.should be_an Array
-        json_response.first['name'].should == 'app'
-        json_response.first['type'].should == 'tree'
-        json_response.first['mode'].should == '040000'
+        expect(json_response).to be_an Array
+        expect(json_response.first['name']).to eq('app')
+        expect(json_response.first['type']).to eq('tree')
+        expect(json_response.first['mode']).to eq('040000')
       end
     end
 
     context "unauthorized user" do
       it "should not return project commits" do
         get api("/projects/#{project.id}/repository/tree")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
   end
@@ -64,36 +64,36 @@ describe API::API, api: true  do
   describe "GET /projects/:id/repository/blobs/:sha" do
     it "should get the raw file contents" do
       get api("/projects/#{project.id}/repository/blobs/master?filepath=README.md", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return 404 for invalid branch_name" do
       get api("/projects/#{project.id}/repository/blobs/invalid_branch_name?filepath=README.md", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return 404 for invalid file" do
       get api("/projects/#{project.id}/repository/blobs/master?filepath=README.invalid", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return a 400 error if filepath is missing" do
       get api("/projects/#{project.id}/repository/blobs/master", user)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
   describe "GET /projects/:id/repository/commits/:sha/blob" do
     it "should get the raw file contents" do
       get api("/projects/#{project.id}/repository/commits/master/blob?filepath=README.md", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 
   describe "GET /projects/:id/repository/raw_blobs/:sha" do
     it "should get the raw file contents" do
       get api("/projects/#{project.id}/repository/raw_blobs/d1aff2896d99d7acc4d9780fbb716b113c45ecf7", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 
@@ -101,69 +101,69 @@ describe API::API, api: true  do
     it "should get the archive" do
       get api("/projects/#{project.id}/repository/archive", user)
       repo_name = project.repository.name.gsub("\.git", "")
-      response.status.should == 200
-      response.headers['Content-Disposition'].should =~ /filename\=\"#{repo_name}\-[^\.]+\.tar.gz\"/
-      response.content_type.should == MIME::Types.type_for('file.tar.gz').first.content_type
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Disposition']).to match(/filename\=\"#{repo_name}\-[^\.]+\.tar.gz\"/)
+      expect(response.content_type).to eq(MIME::Types.type_for('file.tar.gz').first.content_type)
     end
 
     it "should get the archive.zip" do
       get api("/projects/#{project.id}/repository/archive.zip", user)
       repo_name = project.repository.name.gsub("\.git", "")
-      response.status.should == 200
-      response.headers['Content-Disposition'].should =~ /filename\=\"#{repo_name}\-[^\.]+\.zip\"/
-      response.content_type.should == MIME::Types.type_for('file.zip').first.content_type
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Disposition']).to match(/filename\=\"#{repo_name}\-[^\.]+\.zip\"/)
+      expect(response.content_type).to eq(MIME::Types.type_for('file.zip').first.content_type)
     end
 
     it "should get the archive.tar.bz2" do
       get api("/projects/#{project.id}/repository/archive.tar.bz2", user)
       repo_name = project.repository.name.gsub("\.git", "")
-      response.status.should == 200
-      response.headers['Content-Disposition'].should =~ /filename\=\"#{repo_name}\-[^\.]+\.tar.bz2\"/
-      response.content_type.should == MIME::Types.type_for('file.tar.bz2').first.content_type
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Disposition']).to match(/filename\=\"#{repo_name}\-[^\.]+\.tar.bz2\"/)
+      expect(response.content_type).to eq(MIME::Types.type_for('file.tar.bz2').first.content_type)
     end
 
     it "should return 404 for invalid sha" do
       get api("/projects/#{project.id}/repository/archive/?sha=xxx", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
   describe 'GET /GET /projects/:id/repository/compare' do
     it "should compare branches" do
       get api("/projects/#{project.id}/repository/compare", user), from: 'master', to: 'simple_merge_request'
-      response.status.should == 200
-      json_response['commits'].should be_present
-      json_response['diffs'].should be_present
+      expect(response.status).to eq(200)
+      expect(json_response['commits']).to be_present
+      expect(json_response['diffs']).to be_present
     end
 
     it "should compare tags" do
       get api("/projects/#{project.id}/repository/compare", user), from: 'v1.0.1', to: 'v1.0.2'
-      response.status.should == 200
-      json_response['commits'].should be_present
-      json_response['diffs'].should be_present
+      expect(response.status).to eq(200)
+      expect(json_response['commits']).to be_present
+      expect(json_response['diffs']).to be_present
     end
 
     it "should compare commits" do
       get api("/projects/#{project.id}/repository/compare", user), from: 'b1e6a9dbf1c85', to: '1e689bfba395'
-      response.status.should == 200
-      json_response['commits'].should be_empty
-      json_response['diffs'].should be_empty
-      json_response['compare_same_ref'].should be_false
+      expect(response.status).to eq(200)
+      expect(json_response['commits']).to be_empty
+      expect(json_response['diffs']).to be_empty
+      expect(json_response['compare_same_ref']).to be_false
     end
 
     it "should compare commits in reverse order" do
       get api("/projects/#{project.id}/repository/compare", user), from: '1e689bfba395', to: 'b1e6a9dbf1c85'
-      response.status.should == 200
-      json_response['commits'].should be_present
-      json_response['diffs'].should be_present
+      expect(response.status).to eq(200)
+      expect(json_response['commits']).to be_present
+      expect(json_response['diffs']).to be_present
     end
 
     it "should compare same refs" do
       get api("/projects/#{project.id}/repository/compare", user), from: 'master', to: 'master'
-      response.status.should == 200
-      json_response['commits'].should be_empty
-      json_response['diffs'].should be_empty
-      json_response['compare_same_ref'].should be_true
+      expect(response.status).to eq(200)
+      expect(json_response['commits']).to be_empty
+      expect(json_response['diffs']).to be_empty
+      expect(json_response['compare_same_ref']).to be_true
     end
   end
 end

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -9,13 +9,13 @@ describe API::API, api: true  do
     it "should update gitlab-ci settings" do
       put api("/projects/#{project.id}/services/gitlab-ci", user), token: 'secret-token', project_url: "http://ci.example.com/projects/1"
 
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return if required fields missing" do
       put api("/projects/#{project.id}/services/gitlab-ci", user), project_url: "http://ci.example.com/projects/1", active: true
 
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -23,8 +23,8 @@ describe API::API, api: true  do
     it "should update gitlab-ci settings" do
       delete api("/projects/#{project.id}/services/gitlab-ci", user)
 
-      response.status.should == 200
-      project.gitlab_ci_service.should be_nil
+      expect(response.status).to eq(200)
+      expect(project.gitlab_ci_service).to be_nil
     end
   end
 end

--- a/spec/requests/api/session_spec.rb
+++ b/spec/requests/api/session_spec.rb
@@ -9,43 +9,43 @@ describe API::API, api: true  do
     context "when valid password" do
       it "should return private token" do
         post api("/session"), email: user.email, password: '12345678'
-        response.status.should == 201
+        expect(response.status).to eq(201)
 
-        json_response['email'].should == user.email
-        json_response['private_token'].should == user.private_token
-        json_response['is_admin'].should == user.is_admin?
-        json_response['can_create_project'].should == user.can_create_project?
-        json_response['can_create_group'].should == user.can_create_group?
+        expect(json_response['email']).to eq(user.email)
+        expect(json_response['private_token']).to eq(user.private_token)
+        expect(json_response['is_admin']).to eq(user.is_admin?)
+        expect(json_response['can_create_project']).to eq(user.can_create_project?)
+        expect(json_response['can_create_group']).to eq(user.can_create_group?)
       end
     end
 
     context "when invalid password" do
       it "should return authentication error" do
         post api("/session"), email: user.email, password: '123'
-        response.status.should == 401
+        expect(response.status).to eq(401)
 
-        json_response['email'].should be_nil
-        json_response['private_token'].should be_nil
+        expect(json_response['email']).to be_nil
+        expect(json_response['private_token']).to be_nil
       end
     end
 
     context "when empty password" do
       it "should return authentication error" do
         post api("/session"), email: user.email
-        response.status.should == 401
+        expect(response.status).to eq(401)
 
-        json_response['email'].should be_nil
-        json_response['private_token'].should be_nil
+        expect(json_response['email']).to be_nil
+        expect(json_response['private_token']).to be_nil
       end
     end
 
     context "when empty name" do
       it "should return authentication error" do
         post api("/session"), password: user.password
-        response.status.should == 401
+        expect(response.status).to eq(401)
 
-        json_response['email'].should be_nil
-        json_response['private_token'].should be_nil
+        expect(json_response['email']).to be_nil
+        expect(json_response['private_token']).to be_nil
       end
     end
   end

--- a/spec/requests/api/system_hooks_spec.rb
+++ b/spec/requests/api/system_hooks_spec.rb
@@ -13,23 +13,23 @@ describe API::API, api: true  do
     context "when no user" do
       it "should return authentication error" do
         get api("/hooks")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when not an admin" do
       it "should return forbidden error" do
         get api("/hooks", user)
-        response.status.should == 403
+        expect(response.status).to eq(403)
       end
     end
 
     context "when authenticated as admin" do
       it "should return an array of hooks" do
         get api("/hooks", admin)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['url'].should == hook.url
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['url']).to eq(hook.url)
       end
     end
   end
@@ -43,7 +43,7 @@ describe API::API, api: true  do
 
     it "should respond with 400 if url not given" do
       post api("/hooks", admin)
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should not create new hook without url" do
@@ -56,13 +56,13 @@ describe API::API, api: true  do
   describe "GET /hooks/:id" do
     it "should return hook by id" do
       get api("/hooks/#{hook.id}", admin)
-      response.status.should == 200
-      json_response['event_name'].should == 'project_create'
+      expect(response.status).to eq(200)
+      expect(json_response['event_name']).to eq('project_create')
     end
 
     it "should return 404 on failure" do
       get api("/hooks/404", admin)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -75,7 +75,7 @@ describe API::API, api: true  do
 
     it "should return success if hook id not found" do
       delete api("/hooks/12345", admin)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -11,27 +11,27 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/users")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context "when authenticated" do
       it "should return an array of users" do
         get api("/users", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['username'].should == user.username
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['username']).to eq(user.username)
       end
     end
 
     context "when admin" do
       it "should return an array of users" do
         get api("/users", admin)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first.keys.should include 'email'
-        json_response.first.keys.should include 'extern_uid'
-        json_response.first.keys.should include 'can_create_project'
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first.keys).to include 'email'
+        expect(json_response.first.keys).to include 'extern_uid'
+        expect(json_response.first.keys).to include 'can_create_project'
       end
     end
   end
@@ -39,18 +39,18 @@ describe API::API, api: true  do
   describe "GET /users/:id" do
     it "should return a user by id" do
       get api("/users/#{user.id}", user)
-      response.status.should == 200
-      json_response['username'].should == user.username
+      expect(response.status).to eq(200)
+      expect(json_response['username']).to eq(user.username)
     end
 
     it "should return a 401 if unauthenticated" do
       get api("/users/9998")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
 
     it "should return a 404 error if user id not found" do
       get api("/users/9999", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -65,69 +65,69 @@ describe API::API, api: true  do
 
     it "should create user with correct attributes" do
       post api('/users', admin), attributes_for(:user, admin: true, can_create_group: true)
-      response.status.should == 201
+      expect(response.status).to eq(201)
       user_id = json_response['id']
       new_user = User.find(user_id)
-      new_user.should_not == nil
-      new_user.admin.should == true
-      new_user.can_create_group.should == true
+      expect(new_user).not_to eq(nil)
+      expect(new_user.admin).to eq(true)
+      expect(new_user.can_create_group).to eq(true)
     end
 
     it "should create non-admin user" do
       post api('/users', admin), attributes_for(:user, admin: false, can_create_group: false)
-      response.status.should == 201
+      expect(response.status).to eq(201)
       user_id = json_response['id']
       new_user = User.find(user_id)
-      new_user.should_not == nil
-      new_user.admin.should == false
-      new_user.can_create_group.should == false
+      expect(new_user).not_to eq(nil)
+      expect(new_user.admin).to eq(false)
+      expect(new_user.can_create_group).to eq(false)
     end
 
     it "should create non-admin users by default" do
       post api('/users', admin), attributes_for(:user)
-      response.status.should == 201
+      expect(response.status).to eq(201)
       user_id = json_response['id']
       new_user = User.find(user_id)
-      new_user.should_not == nil
-      new_user.admin.should == false
+      expect(new_user).not_to eq(nil)
+      expect(new_user.admin).to eq(false)
     end
 
     it "should return 201 Created on success" do
       post api("/users", admin), attributes_for(:user, projects_limit: 3)
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "creating a user should respect default project limit" do
       limit = 123456
-      Gitlab.config.gitlab.stub(:default_projects_limit).and_return(limit)
+      allow(Gitlab.config.gitlab).to receive(:default_projects_limit).and_return(limit)
       attr = attributes_for(:user )
       expect {
         post api("/users", admin), attr
       }.to change { User.count }.by(1)
       user = User.find_by(username: attr[:username])
-      user.projects_limit.should == limit
-      user.theme_id.should == Gitlab::Theme::MARS
-      Gitlab.config.gitlab.unstub(:default_projects_limit)
+      expect(user.projects_limit).to eq(limit)
+      expect(user.theme_id).to eq(Gitlab::Theme::MARS)
+      allow(Gitlab.config.gitlab).to receive(:default_projects_limit).and_call_original
     end
 
     it "should not create user with invalid email" do
       post api("/users", admin), { email: "invalid email", password: 'password' }
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return 400 error if password not given" do
       post api("/users", admin), { email: 'test@example.com' }
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should return 400 error if email not given" do
       post api("/users", admin), { password: 'pass1234' }
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "shouldn't available for non admin users" do
       post api("/users", user), attributes_for(:user)
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     context "with existing user" do
@@ -152,24 +152,24 @@ describe API::API, api: true  do
   describe "GET /users/sign_up" do
     context 'enabled' do
       before do
-        Gitlab.config.gitlab.stub(:signup_enabled).and_return(true)
+        allow(Gitlab.config.gitlab).to receive(:signup_enabled).and_return(true)
       end
 
       it "should return sign up page if signup is enabled" do
         get "/users/sign_up"
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
     end
 
     context 'disabled' do
       before do
-        Gitlab.config.gitlab.stub(:signup_enabled).and_return(false)
+        allow(Gitlab.config.gitlab).to receive(:signup_enabled).and_return(false)
       end
 
       it "should redirect to sign in page if signup is disabled" do
         get "/users/sign_up"
-        response.status.should == 302
-        response.should redirect_to(new_user_session_path)
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
@@ -181,40 +181,40 @@ describe API::API, api: true  do
 
     it "should update user with new bio" do
       put api("/users/#{user.id}", admin), {bio: 'new test bio'}
-      response.status.should == 200
-      json_response['bio'].should == 'new test bio'
-      user.reload.bio.should == 'new test bio'
+      expect(response.status).to eq(200)
+      expect(json_response['bio']).to eq('new test bio')
+      expect(user.reload.bio).to eq('new test bio')
     end
 
     it "should update admin status" do
       put api("/users/#{user.id}", admin), {admin: true}
-      response.status.should == 200
-      json_response['is_admin'].should == true
-      user.reload.admin.should == true
+      expect(response.status).to eq(200)
+      expect(json_response['is_admin']).to eq(true)
+      expect(user.reload.admin).to eq(true)
     end
 
     it "should not update admin status" do
       put api("/users/#{admin_user.id}", admin), {can_create_group: false}
-      response.status.should == 200
-      json_response['is_admin'].should == true
-      admin_user.reload.admin.should == true
-      admin_user.can_create_group.should == false
+      expect(response.status).to eq(200)
+      expect(json_response['is_admin']).to eq(true)
+      expect(admin_user.reload.admin).to eq(true)
+      expect(admin_user.can_create_group).to eq(false)
     end
 
     it "should not allow invalid update" do
       put api("/users/#{user.id}", admin), {email: 'invalid email'}
-      response.status.should == 404
-      user.reload.email.should_not == 'invalid email'
+      expect(response.status).to eq(404)
+      expect(user.reload.email).not_to eq('invalid email')
     end
 
     it "shouldn't available for non admin users" do
       put api("/users/#{user.id}", user), attributes_for(:user)
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     it "should return 404 for non-existing user" do
       put api("/users/999999", admin), {bio: 'update should fail'}
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     context "with existing user" do
@@ -242,7 +242,7 @@ describe API::API, api: true  do
 
     it "should not create invalid ssh key" do
       post api("/users/#{user.id}/keys", admin), { title: "invalid key" }
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should create ssh key" do
@@ -259,23 +259,23 @@ describe API::API, api: true  do
     context 'when unauthenticated' do
       it 'should return authentication error' do
         get api("/users/#{user.id}/keys")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
     context 'when authenticated' do
       it 'should return 404 for non-existing user' do
         get api('/users/999999/keys', admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it 'should return array of ssh keys' do
         user.keys << key
         user.save
         get api("/users/#{user.id}/keys", admin)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first['title'].should == key.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first['title']).to eq(key.title)
       end
     end
   end
@@ -286,7 +286,7 @@ describe API::API, api: true  do
     context 'when unauthenticated' do
       it 'should return authentication error' do
         delete api("/users/#{user.id}/keys/42")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
@@ -297,19 +297,19 @@ describe API::API, api: true  do
         expect {
           delete api("/users/#{user.id}/keys/#{key.id}", admin)
         }.to change { user.keys.count }.by(-1)
-        response.status.should == 200
+        expect(response.status).to eq(200)
       end
 
       it 'should return 404 error if user not found' do
         user.keys << key
         user.save
         delete api("/users/999999/keys/#{key.id}", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
 
       it 'should return 404 error if key not foud' do
         delete api("/users/#{user.id}/keys/42", admin)
-        response.status.should == 404
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -319,40 +319,40 @@ describe API::API, api: true  do
 
     it "should delete user" do
       delete api("/users/#{user.id}", admin)
-      response.status.should == 200
+      expect(response.status).to eq(200)
       expect { User.find(user.id) }.to raise_error ActiveRecord::RecordNotFound
-      json_response['email'].should == user.email
+      expect(json_response['email']).to eq(user.email)
     end
 
     it "should not delete for unauthenticated user" do
       delete api("/users/#{user.id}")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
 
     it "shouldn't available for non admin users" do
       delete api("/users/#{user.id}", user)
-      response.status.should == 403
+      expect(response.status).to eq(403)
     end
 
     it "should return 404 for non-existing user" do
       delete api("/users/999999", admin)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
   describe "GET /user" do
     it "should return current user" do
       get api("/user", user)
-      response.status.should == 200
-      json_response['email'].should == user.email
-      json_response['is_admin'].should == user.is_admin?
-      json_response['can_create_project'].should == user.can_create_project?
-      json_response['can_create_group'].should == user.can_create_group?
+      expect(response.status).to eq(200)
+      expect(json_response['email']).to eq(user.email)
+      expect(json_response['is_admin']).to eq(user.is_admin?)
+      expect(json_response['can_create_project']).to eq(user.can_create_project?)
+      expect(json_response['can_create_group']).to eq(user.can_create_group?)
     end
 
     it "should return 401 error if user is unauthenticated" do
       get api("/user")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
   end
 
@@ -360,7 +360,7 @@ describe API::API, api: true  do
     context "when unauthenticated" do
       it "should return authentication error" do
         get api("/user/keys")
-        response.status.should == 401
+        expect(response.status).to eq(401)
       end
     end
 
@@ -369,9 +369,9 @@ describe API::API, api: true  do
         user.keys << key
         user.save
         get api("/user/keys", user)
-        response.status.should == 200
-        json_response.should be_an Array
-        json_response.first["title"].should == key.title
+        expect(response.status).to eq(200)
+        expect(json_response).to be_an Array
+        expect(json_response.first["title"]).to eq(key.title)
       end
     end
   end
@@ -381,13 +381,13 @@ describe API::API, api: true  do
       user.keys << key
       user.save
       get api("/user/keys/#{key.id}", user)
-      response.status.should == 200
-      json_response["title"].should == key.title
+      expect(response.status).to eq(200)
+      expect(json_response["title"]).to eq(key.title)
     end
 
     it "should return 404 Not Found within invalid ID" do
       get api("/user/keys/42", user)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
 
     it "should return 404 error if admin accesses user's ssh key" do
@@ -395,7 +395,7 @@ describe API::API, api: true  do
       user.save
       admin
       get api("/user/keys/#{key.id}", admin)
-      response.status.should == 404
+      expect(response.status).to eq(404)
     end
   end
 
@@ -405,22 +405,22 @@ describe API::API, api: true  do
       expect {
         post api("/user/keys", user), key_attrs
       }.to change{ user.keys.count }.by(1)
-      response.status.should == 201
+      expect(response.status).to eq(201)
     end
 
     it "should return a 401 error if unauthorized" do
       post api("/user/keys"), title: 'some title', key: 'some key'
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
 
     it "should not create ssh key without key" do
       post api("/user/keys", user), title: 'title'
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
 
     it "should not create ssh key without title" do
       post api("/user/keys", user), key: "somekey"
-      response.status.should == 400
+      expect(response.status).to eq(400)
     end
   end
 
@@ -431,19 +431,19 @@ describe API::API, api: true  do
       expect {
         delete api("/user/keys/#{key.id}", user)
       }.to change{user.keys.count}.by(-1)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return success if key ID not found" do
       delete api("/user/keys/42", user)
-      response.status.should == 200
+      expect(response.status).to eq(200)
     end
 
     it "should return 401 error if unauthorized" do
       user.keys << key
       user.save
       delete api("/user/keys/#{key.id}")
-      response.status.should == 401
+      expect(response.status).to eq(401)
     end
   end
 end

--- a/spec/routing/admin_routing_spec.rb
+++ b/spec/routing/admin_routing_spec.rb
@@ -12,47 +12,47 @@ require 'spec_helper'
 #                        DELETE /admin/users/:id(.:format)             admin/users#destroy
 describe Admin::UsersController, "routing" do
   it "to #team_update" do
-    put("/admin/users/1/team_update").should route_to('admin/users#team_update', id: '1')
+    expect(put("/admin/users/1/team_update")).to route_to('admin/users#team_update', id: '1')
   end
 
   it "to #block" do
-    put("/admin/users/1/block").should route_to('admin/users#block', id: '1')
+    expect(put("/admin/users/1/block")).to route_to('admin/users#block', id: '1')
   end
 
   it "to #unblock" do
-    put("/admin/users/1/unblock").should route_to('admin/users#unblock', id: '1')
+    expect(put("/admin/users/1/unblock")).to route_to('admin/users#unblock', id: '1')
   end
 
   it "to #index" do
-    get("/admin/users").should route_to('admin/users#index')
+    expect(get("/admin/users")).to route_to('admin/users#index')
   end
 
   it "to #show" do
-    get("/admin/users/1").should route_to('admin/users#show', id: '1')
+    expect(get("/admin/users/1")).to route_to('admin/users#show', id: '1')
   end
 
   it "to #create" do
-    post("/admin/users").should route_to('admin/users#create')
+    expect(post("/admin/users")).to route_to('admin/users#create')
   end
 
   it "to #new" do
-    get("/admin/users/new").should route_to('admin/users#new')
+    expect(get("/admin/users/new")).to route_to('admin/users#new')
   end
 
   it "to #edit" do
-    get("/admin/users/1/edit").should route_to('admin/users#edit', id: '1')
+    expect(get("/admin/users/1/edit")).to route_to('admin/users#edit', id: '1')
   end
 
   it "to #show" do
-    get("/admin/users/1").should route_to('admin/users#show', id: '1')
+    expect(get("/admin/users/1")).to route_to('admin/users#show', id: '1')
   end
 
   it "to #update" do
-    put("/admin/users/1").should route_to('admin/users#update', id: '1')
+    expect(put("/admin/users/1")).to route_to('admin/users#update', id: '1')
   end
 
   it "to #destroy" do
-    delete("/admin/users/1").should route_to('admin/users#destroy', id: '1')
+    expect(delete("/admin/users/1")).to route_to('admin/users#destroy', id: '1')
   end
 end
 
@@ -67,11 +67,11 @@ end
 #                           DELETE /admin/projects/:id(.:format)             admin/projects#destroy {id: /[^\/]+/}
 describe Admin::ProjectsController, "routing" do
   it "to #index" do
-    get("/admin/projects").should route_to('admin/projects#index')
+    expect(get("/admin/projects")).to route_to('admin/projects#index')
   end
 
   it "to #show" do
-    get("/admin/projects/gitlab").should route_to('admin/projects#show', id: 'gitlab')
+    expect(get("/admin/projects/gitlab")).to route_to('admin/projects#show', id: 'gitlab')
   end
 end
 
@@ -81,19 +81,19 @@ end
 #      admin_hook DELETE /admin/hooks/:id(.:format)           admin/hooks#destroy
 describe Admin::HooksController, "routing" do
   it "to #test" do
-    get("/admin/hooks/1/test").should route_to('admin/hooks#test', hook_id: '1')
+    expect(get("/admin/hooks/1/test")).to route_to('admin/hooks#test', hook_id: '1')
   end
 
   it "to #index" do
-    get("/admin/hooks").should route_to('admin/hooks#index')
+    expect(get("/admin/hooks")).to route_to('admin/hooks#index')
   end
 
   it "to #create" do
-    post("/admin/hooks").should route_to('admin/hooks#create')
+    expect(post("/admin/hooks")).to route_to('admin/hooks#create')
   end
 
   it "to #destroy" do
-    delete("/admin/hooks/1").should route_to('admin/hooks#destroy', id: '1')
+    expect(delete("/admin/hooks/1")).to route_to('admin/hooks#destroy', id: '1')
   end
 
 end
@@ -101,21 +101,21 @@ end
 # admin_logs GET    /admin/logs(.:format) admin/logs#show
 describe Admin::LogsController, "routing" do
   it "to #show" do
-    get("/admin/logs").should route_to('admin/logs#show')
+    expect(get("/admin/logs")).to route_to('admin/logs#show')
   end
 end
 
 # admin_background_jobs GET    /admin/background_jobs(.:format) admin/background_jobs#show
 describe Admin::BackgroundJobsController, "routing" do
   it "to #show" do
-    get("/admin/background_jobs").should route_to('admin/background_jobs#show')
+    expect(get("/admin/background_jobs")).to route_to('admin/background_jobs#show')
   end
 end
 
 # admin_root        /admin(.:format) admin/dashboard#index
 describe Admin::DashboardController, "routing" do
   it "to #index" do
-    get("/admin").should route_to('admin/dashboard#index')
+    expect(get("/admin")).to route_to('admin/dashboard#index')
   end
 end
 

--- a/spec/routing/notifications_routing_spec.rb
+++ b/spec/routing/notifications_routing_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe Profiles::NotificationsController do
   describe "routing" do
     it "routes to #show" do
-      get("/profile/notifications").should route_to("profiles/notifications#show")
+      expect(get("/profile/notifications")).to route_to("profiles/notifications#show")
     end
 
     it "routes to #update" do
-      put("/profile/notifications").should route_to("profiles/notifications#update")
+      expect(put("/profile/notifications")).to route_to("profiles/notifications#update")
     end
   end
 end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -25,31 +25,31 @@ shared_examples "RESTful project resources" do
   let(:actions) { [:index, :create, :new, :edit, :show, :update, :destroy] }
 
   it "to #index" do
-    get("/gitlab/gitlabhq/#{controller}").should route_to("projects/#{controller}#index", project_id: 'gitlab/gitlabhq') if actions.include?(:index)
+    expect(get("/gitlab/gitlabhq/#{controller}")).to route_to("projects/#{controller}#index", project_id: 'gitlab/gitlabhq') if actions.include?(:index)
   end
 
   it "to #create" do
-    post("/gitlab/gitlabhq/#{controller}").should route_to("projects/#{controller}#create", project_id: 'gitlab/gitlabhq') if actions.include?(:create)
+    expect(post("/gitlab/gitlabhq/#{controller}")).to route_to("projects/#{controller}#create", project_id: 'gitlab/gitlabhq') if actions.include?(:create)
   end
 
   it "to #new" do
-    get("/gitlab/gitlabhq/#{controller}/new").should route_to("projects/#{controller}#new", project_id: 'gitlab/gitlabhq') if actions.include?(:new)
+    expect(get("/gitlab/gitlabhq/#{controller}/new")).to route_to("projects/#{controller}#new", project_id: 'gitlab/gitlabhq') if actions.include?(:new)
   end
 
   it "to #edit" do
-    get("/gitlab/gitlabhq/#{controller}/1/edit").should route_to("projects/#{controller}#edit", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:edit)
+    expect(get("/gitlab/gitlabhq/#{controller}/1/edit")).to route_to("projects/#{controller}#edit", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:edit)
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/#{controller}/1").should route_to("projects/#{controller}#show", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:show)
+    expect(get("/gitlab/gitlabhq/#{controller}/1")).to route_to("projects/#{controller}#show", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:show)
   end
 
   it "to #update" do
-    put("/gitlab/gitlabhq/#{controller}/1").should route_to("projects/#{controller}#update", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:update)
+    expect(put("/gitlab/gitlabhq/#{controller}/1")).to route_to("projects/#{controller}#update", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:update)
   end
 
   it "to #destroy" do
-    delete("/gitlab/gitlabhq/#{controller}/1").should route_to("projects/#{controller}#destroy", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:destroy)
+    expect(delete("/gitlab/gitlabhq/#{controller}/1")).to route_to("projects/#{controller}#destroy", project_id: 'gitlab/gitlabhq', id: '1') if actions.include?(:destroy)
   end
 end
 
@@ -63,35 +63,35 @@ end
 #               DELETE /:id(.:format)          projects#destroy
 describe ProjectsController, "routing" do
   it "to #create" do
-    post("/projects").should route_to('projects#create')
+    expect(post("/projects")).to route_to('projects#create')
   end
 
   it "to #new" do
-    get("/projects/new").should route_to('projects#new')
+    expect(get("/projects/new")).to route_to('projects#new')
   end
 
   it "to #fork" do
-    post("/gitlab/gitlabhq/fork").should route_to('projects#fork', id: 'gitlab/gitlabhq')
+    expect(post("/gitlab/gitlabhq/fork")).to route_to('projects#fork', id: 'gitlab/gitlabhq')
   end
 
   it "to #edit" do
-    get("/gitlab/gitlabhq/edit").should route_to('projects#edit', id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/edit")).to route_to('projects#edit', id: 'gitlab/gitlabhq')
   end
 
   it "to #autocomplete_sources" do
-    get('/gitlab/gitlabhq/autocomplete_sources').should route_to('projects#autocomplete_sources', id: "gitlab/gitlabhq")
+    expect(get('/gitlab/gitlabhq/autocomplete_sources')).to route_to('projects#autocomplete_sources', id: "gitlab/gitlabhq")
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq").should route_to('projects#show', id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq")).to route_to('projects#show', id: 'gitlab/gitlabhq')
   end
 
   it "to #update" do
-    put("/gitlab/gitlabhq").should route_to('projects#update', id: 'gitlab/gitlabhq')
+    expect(put("/gitlab/gitlabhq")).to route_to('projects#update', id: 'gitlab/gitlabhq')
   end
 
   it "to #destroy" do
-    delete("/gitlab/gitlabhq").should route_to('projects#destroy', id: 'gitlab/gitlabhq')
+    expect(delete("/gitlab/gitlabhq")).to route_to('projects#destroy', id: 'gitlab/gitlabhq')
   end
 end
 
@@ -103,11 +103,11 @@ end
 #                      DELETE /:project_id/wikis/:id(.:format)         projects/wikis#destroy
 describe Projects::WikisController, "routing" do
   it "to #pages" do
-    get("/gitlab/gitlabhq/wikis/pages").should route_to('projects/wikis#pages', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/wikis/pages")).to route_to('projects/wikis#pages', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #history" do
-    get("/gitlab/gitlabhq/wikis/1/history").should route_to('projects/wikis#history', project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/wikis/1/history")).to route_to('projects/wikis#history', project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it_behaves_like "RESTful project resources" do
@@ -122,43 +122,43 @@ end
 #     edit_project_repository GET    /:project_id/repository/edit(.:format)     projects/repositories#edit
 describe Projects::RepositoriesController, "routing" do
   it "to #archive" do
-    get("/gitlab/gitlabhq/repository/archive").should route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/repository/archive")).to route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #archive format:zip" do
-    get("/gitlab/gitlabhq/repository/archive.zip").should route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq', format: 'zip')
+    expect(get("/gitlab/gitlabhq/repository/archive.zip")).to route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq', format: 'zip')
   end
 
   it "to #archive format:tar.bz2" do
-    get("/gitlab/gitlabhq/repository/archive.tar.bz2").should route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq', format: 'tar.bz2')
+    expect(get("/gitlab/gitlabhq/repository/archive.tar.bz2")).to route_to('projects/repositories#archive', project_id: 'gitlab/gitlabhq', format: 'tar.bz2')
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/repository").should route_to('projects/repositories#show', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/repository")).to route_to('projects/repositories#show', project_id: 'gitlab/gitlabhq')
   end
 end
 
 describe Projects::BranchesController, "routing" do
   it "to #branches" do
-    get("/gitlab/gitlabhq/branches").should route_to('projects/branches#index', project_id: 'gitlab/gitlabhq')
-    delete("/gitlab/gitlabhq/branches/feature%2345").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45')
-    delete("/gitlab/gitlabhq/branches/feature%2B45").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45')
-    delete("/gitlab/gitlabhq/branches/feature@45").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45')
-    delete("/gitlab/gitlabhq/branches/feature%2345/foo/bar/baz").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45/foo/bar/baz')
-    delete("/gitlab/gitlabhq/branches/feature%2B45/foo/bar/baz").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45/foo/bar/baz')
-    delete("/gitlab/gitlabhq/branches/feature@45/foo/bar/baz").should route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45/foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/branches")).to route_to('projects/branches#index', project_id: 'gitlab/gitlabhq')
+    expect(delete("/gitlab/gitlabhq/branches/feature%2345")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45')
+    expect(delete("/gitlab/gitlabhq/branches/feature%2B45")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45')
+    expect(delete("/gitlab/gitlabhq/branches/feature@45")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45')
+    expect(delete("/gitlab/gitlabhq/branches/feature%2345/foo/bar/baz")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45/foo/bar/baz')
+    expect(delete("/gitlab/gitlabhq/branches/feature%2B45/foo/bar/baz")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45/foo/bar/baz')
+    expect(delete("/gitlab/gitlabhq/branches/feature@45/foo/bar/baz")).to route_to('projects/branches#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45/foo/bar/baz')
   end
 end
 
 describe Projects::TagsController, "routing" do
   it "to #tags" do
-    get("/gitlab/gitlabhq/tags").should route_to('projects/tags#index', project_id: 'gitlab/gitlabhq')
-    delete("/gitlab/gitlabhq/tags/feature%2345").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45')
-    delete("/gitlab/gitlabhq/tags/feature%2B45").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45')
-    delete("/gitlab/gitlabhq/tags/feature@45").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45')
-    delete("/gitlab/gitlabhq/tags/feature%2345/foo/bar/baz").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45/foo/bar/baz')
-    delete("/gitlab/gitlabhq/tags/feature%2B45/foo/bar/baz").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45/foo/bar/baz')
-    delete("/gitlab/gitlabhq/tags/feature@45/foo/bar/baz").should route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45/foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/tags")).to route_to('projects/tags#index', project_id: 'gitlab/gitlabhq')
+    expect(delete("/gitlab/gitlabhq/tags/feature%2345")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45')
+    expect(delete("/gitlab/gitlabhq/tags/feature%2B45")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45')
+    expect(delete("/gitlab/gitlabhq/tags/feature@45")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45')
+    expect(delete("/gitlab/gitlabhq/tags/feature%2345/foo/bar/baz")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature#45/foo/bar/baz')
+    expect(delete("/gitlab/gitlabhq/tags/feature%2B45/foo/bar/baz")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature+45/foo/bar/baz')
+    expect(delete("/gitlab/gitlabhq/tags/feature@45/foo/bar/baz")).to route_to('projects/tags#destroy', project_id: 'gitlab/gitlabhq', id: 'feature@45/foo/bar/baz')
   end
 end
 
@@ -191,19 +191,19 @@ end
 #  logs_file_project_ref GET    /:project_id/refs/:id/logs_tree/:path(.:format) refs#logs_tree
 describe Projects::RefsController, "routing" do
   it "to #switch" do
-    get("/gitlab/gitlabhq/refs/switch").should route_to('projects/refs#switch', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/refs/switch")).to route_to('projects/refs#switch', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #logs_tree" do
-    get("/gitlab/gitlabhq/refs/stable/logs_tree").should             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable')
-    get("/gitlab/gitlabhq/refs/feature%2345/logs_tree").should             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature#45')
-    get("/gitlab/gitlabhq/refs/feature%2B45/logs_tree").should             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature+45')
-    get("/gitlab/gitlabhq/refs/feature@45/logs_tree").should             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature@45')
-    get("/gitlab/gitlabhq/refs/stable/logs_tree/foo/bar/baz").should route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'foo/bar/baz')
-    get("/gitlab/gitlabhq/refs/feature%2345/logs_tree/foo/bar/baz").should route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature#45', path: 'foo/bar/baz')
-    get("/gitlab/gitlabhq/refs/feature%2B45/logs_tree/foo/bar/baz").should route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature+45', path: 'foo/bar/baz')
-    get("/gitlab/gitlabhq/refs/feature@45/logs_tree/foo/bar/baz").should route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature@45', path: 'foo/bar/baz')
-    get("/gitlab/gitlabhq/refs/stable/logs_tree/files.scss").should route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'files.scss')
+    expect(get("/gitlab/gitlabhq/refs/stable/logs_tree")).to             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable')
+    expect(get("/gitlab/gitlabhq/refs/feature%2345/logs_tree")).to             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature#45')
+    expect(get("/gitlab/gitlabhq/refs/feature%2B45/logs_tree")).to             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature+45')
+    expect(get("/gitlab/gitlabhq/refs/feature@45/logs_tree")).to             route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature@45')
+    expect(get("/gitlab/gitlabhq/refs/stable/logs_tree/foo/bar/baz")).to route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/refs/feature%2345/logs_tree/foo/bar/baz")).to route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature#45', path: 'foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/refs/feature%2B45/logs_tree/foo/bar/baz")).to route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature+45', path: 'foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/refs/feature@45/logs_tree/foo/bar/baz")).to route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'feature@45', path: 'foo/bar/baz')
+    expect(get("/gitlab/gitlabhq/refs/stable/logs_tree/files.scss")).to route_to('projects/refs#logs_tree', project_id: 'gitlab/gitlabhq', id: 'stable', path: 'files.scss')
   end
 end
 
@@ -221,31 +221,31 @@ end
 #                                       DELETE /:project_id/merge_requests/:id(.:format)                 projects/merge_requests#destroy
 describe Projects::MergeRequestsController, "routing" do
   it "to #diffs" do
-    get("/gitlab/gitlabhq/merge_requests/1/diffs").should route_to('projects/merge_requests#diffs', project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/merge_requests/1/diffs")).to route_to('projects/merge_requests#diffs', project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #automerge" do
-    post('/gitlab/gitlabhq/merge_requests/1/automerge').should route_to(
+    expect(post('/gitlab/gitlabhq/merge_requests/1/automerge')).to route_to(
       'projects/merge_requests#automerge',
       project_id: 'gitlab/gitlabhq', id: '1'
     )
   end
 
   it "to #automerge_check" do
-    get("/gitlab/gitlabhq/merge_requests/1/automerge_check").should route_to('projects/merge_requests#automerge_check', project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/merge_requests/1/automerge_check")).to route_to('projects/merge_requests#automerge_check', project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #branch_from" do
-    get("/gitlab/gitlabhq/merge_requests/branch_from").should route_to('projects/merge_requests#branch_from', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/merge_requests/branch_from")).to route_to('projects/merge_requests#branch_from', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #branch_to" do
-    get("/gitlab/gitlabhq/merge_requests/branch_to").should route_to('projects/merge_requests#branch_to', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/merge_requests/branch_to")).to route_to('projects/merge_requests#branch_to', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/merge_requests/1.diff").should route_to('projects/merge_requests#show', project_id: 'gitlab/gitlabhq', id: '1', format: 'diff')
-    get("/gitlab/gitlabhq/merge_requests/1.patch").should route_to('projects/merge_requests#show', project_id: 'gitlab/gitlabhq', id: '1', format: 'patch')
+    expect(get("/gitlab/gitlabhq/merge_requests/1.diff")).to route_to('projects/merge_requests#show', project_id: 'gitlab/gitlabhq', id: '1', format: 'diff')
+    expect(get("/gitlab/gitlabhq/merge_requests/1.patch")).to route_to('projects/merge_requests#show', project_id: 'gitlab/gitlabhq', id: '1', format: 'patch')
   end
 
   it_behaves_like "RESTful project resources" do
@@ -264,35 +264,35 @@ end
 #                      DELETE /:project_id/snippets/:id(.:format)      snippets#destroy
 describe SnippetsController, "routing" do
   it "to #raw" do
-    get("/gitlab/gitlabhq/snippets/1/raw").should route_to('projects/snippets#raw', project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/snippets/1/raw")).to route_to('projects/snippets#raw', project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #index" do
-    get("/gitlab/gitlabhq/snippets").should route_to("projects/snippets#index", project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/snippets")).to route_to("projects/snippets#index", project_id: 'gitlab/gitlabhq')
   end
 
   it "to #create" do
-    post("/gitlab/gitlabhq/snippets").should route_to("projects/snippets#create", project_id: 'gitlab/gitlabhq')
+    expect(post("/gitlab/gitlabhq/snippets")).to route_to("projects/snippets#create", project_id: 'gitlab/gitlabhq')
   end
 
   it "to #new" do
-    get("/gitlab/gitlabhq/snippets/new").should route_to("projects/snippets#new", project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/snippets/new")).to route_to("projects/snippets#new", project_id: 'gitlab/gitlabhq')
   end
 
   it "to #edit" do
-    get("/gitlab/gitlabhq/snippets/1/edit").should route_to("projects/snippets#edit", project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/snippets/1/edit")).to route_to("projects/snippets#edit", project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/snippets/1").should route_to("projects/snippets#show", project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/snippets/1")).to route_to("projects/snippets#show", project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #update" do
-    put("/gitlab/gitlabhq/snippets/1").should route_to("projects/snippets#update", project_id: 'gitlab/gitlabhq', id: '1')
+    expect(put("/gitlab/gitlabhq/snippets/1")).to route_to("projects/snippets#update", project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it "to #destroy" do
-    delete("/gitlab/gitlabhq/snippets/1").should route_to("projects/snippets#destroy", project_id: 'gitlab/gitlabhq', id: '1')
+    expect(delete("/gitlab/gitlabhq/snippets/1")).to route_to("projects/snippets#destroy", project_id: 'gitlab/gitlabhq', id: '1')
   end
 end
 
@@ -302,7 +302,7 @@ end
 #      project_hook DELETE /:project_id/hooks/:id(.:format)      hooks#destroy
 describe Projects::HooksController, "routing" do
   it "to #test" do
-    get("/gitlab/gitlabhq/hooks/1/test").should route_to('projects/hooks#test', project_id: 'gitlab/gitlabhq', id: '1')
+    expect(get("/gitlab/gitlabhq/hooks/1/test")).to route_to('projects/hooks#test', project_id: 'gitlab/gitlabhq', id: '1')
   end
 
   it_behaves_like "RESTful project resources" do
@@ -314,10 +314,10 @@ end
 # project_commit GET    /:project_id/commit/:id(.:format) commit#show {id: /[[:alnum:]]{6,40}/, project_id: /[^\/]+/}
 describe Projects::CommitController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/commit/4246fb").should route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb')
-    get("/gitlab/gitlabhq/commit/4246fb.diff").should route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb', format: 'diff')
-    get("/gitlab/gitlabhq/commit/4246fb.patch").should route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb', format: 'patch')
-    get("/gitlab/gitlabhq/commit/4246fbd13872934f72a8fd0d6fb1317b47b59cb5").should route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fbd13872934f72a8fd0d6fb1317b47b59cb5')
+    expect(get("/gitlab/gitlabhq/commit/4246fb")).to route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb')
+    expect(get("/gitlab/gitlabhq/commit/4246fb.diff")).to route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb', format: 'diff')
+    expect(get("/gitlab/gitlabhq/commit/4246fb.patch")).to route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fb', format: 'patch')
+    expect(get("/gitlab/gitlabhq/commit/4246fbd13872934f72a8fd0d6fb1317b47b59cb5")).to route_to('projects/commit#show', project_id: 'gitlab/gitlabhq', id: '4246fbd13872934f72a8fd0d6fb1317b47b59cb5')
   end
 end
 
@@ -332,7 +332,7 @@ describe Projects::CommitsController, "routing" do
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/commits/master.atom").should route_to('projects/commits#show', project_id: 'gitlab/gitlabhq', id: "master", format: "atom")
+    expect(get("/gitlab/gitlabhq/commits/master.atom")).to route_to('projects/commits#show', project_id: 'gitlab/gitlabhq', id: "master", format: "atom")
   end
 end
 
@@ -367,7 +367,7 @@ end
 # project_labels GET    /:project_id/labels(.:format) labels#index
 describe Projects::LabelsController, "routing" do
   it "to #index" do
-    get("/gitlab/gitlabhq/labels").should route_to('projects/labels#index', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/labels")).to route_to('projects/labels#index', project_id: 'gitlab/gitlabhq')
   end
 end
 
@@ -383,7 +383,7 @@ end
 #                            DELETE /:project_id/issues/:id(.:format)         issues#destroy
 describe Projects::IssuesController, "routing" do
   it "to #bulk_update" do
-    post("/gitlab/gitlabhq/issues/bulk_update").should route_to('projects/issues#bulk_update', project_id: 'gitlab/gitlabhq')
+    expect(post("/gitlab/gitlabhq/issues/bulk_update")).to route_to('projects/issues#bulk_update', project_id: 'gitlab/gitlabhq')
   end
 
   it_behaves_like "RESTful project resources" do
@@ -398,7 +398,7 @@ end
 #          project_note DELETE /:project_id/notes/:id(.:format)     notes#destroy
 describe Projects::NotesController, "routing" do
   it "to #preview" do
-    post("/gitlab/gitlabhq/notes/preview").should route_to('projects/notes#preview', project_id: 'gitlab/gitlabhq')
+    expect(post("/gitlab/gitlabhq/notes/preview")).to route_to('projects/notes#preview', project_id: 'gitlab/gitlabhq')
   end
 
   it_behaves_like "RESTful project resources" do
@@ -410,25 +410,25 @@ end
 # project_blame GET    /:project_id/blame/:id(.:format) blame#show {id: /.+/, project_id: /[^\/]+/}
 describe Projects::BlameController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/blame/master/app/models/project.rb").should route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
-    get("/gitlab/gitlabhq/blame/master/files.scss").should route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
+    expect(get("/gitlab/gitlabhq/blame/master/app/models/project.rb")).to route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
+    expect(get("/gitlab/gitlabhq/blame/master/files.scss")).to route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
   end
 end
 
 # project_blob GET    /:project_id/blob/:id(.:format) blob#show {id: /.+/, project_id: /[^\/]+/}
 describe Projects::BlobController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/blob/master/app/models/project.rb").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
-    get("/gitlab/gitlabhq/blob/master/app/models/compare.rb").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/compare.rb')
-    get("/gitlab/gitlabhq/blob/master/files.scss").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
+    expect(get("/gitlab/gitlabhq/blob/master/app/models/project.rb")).to route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
+    expect(get("/gitlab/gitlabhq/blob/master/app/models/compare.rb")).to route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/compare.rb')
+    expect(get("/gitlab/gitlabhq/blob/master/files.scss")).to route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
   end
 end
 
 # project_tree GET    /:project_id/tree/:id(.:format) tree#show {id: /.+/, project_id: /[^\/]+/}
 describe Projects::TreeController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/tree/master/app/models/project.rb").should route_to('projects/tree#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
-    get("/gitlab/gitlabhq/tree/master/files.scss").should route_to('projects/tree#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
+    expect(get("/gitlab/gitlabhq/tree/master/app/models/project.rb")).to route_to('projects/tree#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
+    expect(get("/gitlab/gitlabhq/tree/master/files.scss")).to route_to('projects/tree#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
   end
 end
 
@@ -437,28 +437,28 @@ end
 #       project_compare        /:project_id/compare/:from...:to(.:format) compare#show {from: /.+/, to: /.+/, id: /[^\/]+/, project_id: /[^\/]+/}
 describe Projects::CompareController, "routing" do
   it "to #index" do
-    get("/gitlab/gitlabhq/compare").should route_to('projects/compare#index', project_id: 'gitlab/gitlabhq')
+    expect(get("/gitlab/gitlabhq/compare")).to route_to('projects/compare#index', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #compare" do
-    post("/gitlab/gitlabhq/compare").should route_to('projects/compare#create', project_id: 'gitlab/gitlabhq')
+    expect(post("/gitlab/gitlabhq/compare")).to route_to('projects/compare#create', project_id: 'gitlab/gitlabhq')
   end
 
   it "to #show" do
-    get("/gitlab/gitlabhq/compare/master...stable").should     route_to('projects/compare#show', project_id: 'gitlab/gitlabhq', from: 'master', to: 'stable')
-    get("/gitlab/gitlabhq/compare/issue/1234...stable").should route_to('projects/compare#show', project_id: 'gitlab/gitlabhq', from: 'issue/1234', to: 'stable')
+    expect(get("/gitlab/gitlabhq/compare/master...stable")).to     route_to('projects/compare#show', project_id: 'gitlab/gitlabhq', from: 'master', to: 'stable')
+    expect(get("/gitlab/gitlabhq/compare/issue/1234...stable")).to route_to('projects/compare#show', project_id: 'gitlab/gitlabhq', from: 'issue/1234', to: 'stable')
   end
 end
 
 describe Projects::NetworkController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/network/master").should route_to('projects/network#show', project_id: 'gitlab/gitlabhq', id: 'master')
-    get("/gitlab/gitlabhq/network/master.json").should route_to('projects/network#show', project_id: 'gitlab/gitlabhq', id: 'master', format: "json")
+    expect(get("/gitlab/gitlabhq/network/master")).to route_to('projects/network#show', project_id: 'gitlab/gitlabhq', id: 'master')
+    expect(get("/gitlab/gitlabhq/network/master.json")).to route_to('projects/network#show', project_id: 'gitlab/gitlabhq', id: 'master', format: "json")
   end
 end
 
 describe Projects::GraphsController, "routing" do
   it "to #show" do
-    get("/gitlab/gitlabhq/graphs/master").should route_to('projects/graphs#show', project_id: 'gitlab/gitlabhq', id: 'master')
+    expect(get("/gitlab/gitlabhq/graphs/master")).to route_to('projects/graphs#show', project_id: 'gitlab/gitlabhq', id: 'master')
   end
 end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # search GET    /search(.:format) search#show
 describe SearchController, "routing" do
   it "to #show" do
-    get("/search").should route_to('search#show')
+    expect(get("/search")).to route_to('search#show')
   end
 end
 
@@ -11,11 +11,11 @@ end
 #            /:path       Grack
 describe "Mounted Apps", "routing" do
   it "to API" do
-    get("/api/issues").should be_routable
+    expect(get("/api/issues")).to be_routable
   end
 
   it "to Grack" do
-    get("/gitlab/gitlabhq.git").should be_routable
+    expect(get("/gitlab/gitlabhq.git")).to be_routable
   end
 end
 
@@ -28,39 +28,39 @@ end
 #          DELETE /snippets/:id(.:format)      snippets#destroy
 describe SnippetsController, "routing" do
   it "to #user_index" do
-    get("/s/User").should route_to('snippets#user_index', username: 'User')
+    expect(get("/s/User")).to route_to('snippets#user_index', username: 'User')
   end
 
   it "to #raw" do
-    get("/snippets/1/raw").should route_to('snippets#raw', id: '1')
+    expect(get("/snippets/1/raw")).to route_to('snippets#raw', id: '1')
   end
 
   it "to #index" do
-    get("/snippets").should route_to('snippets#index')
+    expect(get("/snippets")).to route_to('snippets#index')
   end
 
   it "to #create" do
-    post("/snippets").should route_to('snippets#create')
+    expect(post("/snippets")).to route_to('snippets#create')
   end
 
   it "to #new" do
-    get("/snippets/new").should route_to('snippets#new')
+    expect(get("/snippets/new")).to route_to('snippets#new')
   end
 
   it "to #edit" do
-    get("/snippets/1/edit").should route_to('snippets#edit', id: '1')
+    expect(get("/snippets/1/edit")).to route_to('snippets#edit', id: '1')
   end
 
   it "to #show" do
-    get("/snippets/1").should route_to('snippets#show', id: '1')
+    expect(get("/snippets/1")).to route_to('snippets#show', id: '1')
   end
 
   it "to #update" do
-    put("/snippets/1").should route_to('snippets#update', id: '1')
+    expect(put("/snippets/1")).to route_to('snippets#update', id: '1')
   end
 
   it "to #destroy" do
-    delete("/snippets/1").should route_to('snippets#destroy', id: '1')
+    expect(delete("/snippets/1")).to route_to('snippets#destroy', id: '1')
   end
 end
 
@@ -75,39 +75,39 @@ end
 #    help_raketasks GET    /help/raketasks(.:format)    help#raketasks
 describe HelpController, "routing" do
   it "to #index" do
-    get("/help").should route_to('help#index')
+    expect(get("/help")).to route_to('help#index')
   end
 
   it "to #permissions" do
-    get("/help/permissions/permissions").should route_to('help#show', category: "permissions", file: "permissions")
+    expect(get("/help/permissions/permissions")).to route_to('help#show', category: "permissions", file: "permissions")
   end
 
   it "to #workflow" do
-    get("/help/workflow/README").should route_to('help#show', category: "workflow", file: "README")
+    expect(get("/help/workflow/README")).to route_to('help#show', category: "workflow", file: "README")
   end
 
   it "to #api" do
-    get("/help/api/README").should route_to('help#show', category: "api", file: "README")
+    expect(get("/help/api/README")).to route_to('help#show', category: "api", file: "README")
   end
 
   it "to #web_hooks" do
-    get("/help/web_hooks/web_hooks").should route_to('help#show', category: "web_hooks", file: "web_hooks")
+    expect(get("/help/web_hooks/web_hooks")).to route_to('help#show', category: "web_hooks", file: "web_hooks")
   end
 
   it "to #system_hooks" do
-    get("/help/system_hooks/system_hooks").should route_to('help#show', category: "system_hooks", file: "system_hooks")
+    expect(get("/help/system_hooks/system_hooks")).to route_to('help#show', category: "system_hooks", file: "system_hooks")
   end
 
   it "to #markdown" do
-    get("/help/markdown/markdown").should route_to('help#show',category: "markdown", file: "markdown")
+    expect(get("/help/markdown/markdown")).to route_to('help#show',category: "markdown", file: "markdown")
   end
 
   it "to #ssh" do
-    get("/help/ssh/README").should route_to('help#show', category: "ssh", file: "README")
+    expect(get("/help/ssh/README")).to route_to('help#show', category: "ssh", file: "README")
   end
 
   it "to #raketasks" do
-    get("/help/raketasks/README").should route_to('help#show', category: "raketasks", file: "README")
+    expect(get("/help/raketasks/README")).to route_to('help#show', category: "raketasks", file: "README")
   end
 end
 
@@ -121,23 +121,23 @@ end
 #              profile_update PUT    /profile/update(.:format)              profile#update
 describe ProfilesController, "routing" do
   it "to #account" do
-    get("/profile/account").should route_to('profiles/accounts#show')
+    expect(get("/profile/account")).to route_to('profiles/accounts#show')
   end
 
   it "to #history" do
-    get("/profile/history").should route_to('profiles#history')
+    expect(get("/profile/history")).to route_to('profiles#history')
   end
 
   it "to #reset_private_token" do
-    put("/profile/reset_private_token").should route_to('profiles#reset_private_token')
+    expect(put("/profile/reset_private_token")).to route_to('profiles#reset_private_token')
   end
 
   it "to #show" do
-    get("/profile").should route_to('profiles#show')
+    expect(get("/profile")).to route_to('profiles#show')
   end
 
   it "to #design" do
-    get("/profile/design").should route_to('profiles#design')
+    expect(get("/profile/design")).to route_to('profiles#design')
   end
 end
 
@@ -150,36 +150,36 @@ end
 #          DELETE /keys/:id(.:format)      keys#destroy
 describe Profiles::KeysController, "routing" do
   it "to #index" do
-    get("/profile/keys").should route_to('profiles/keys#index')
+    expect(get("/profile/keys")).to route_to('profiles/keys#index')
   end
 
   it "to #create" do
-    post("/profile/keys").should route_to('profiles/keys#create')
+    expect(post("/profile/keys")).to route_to('profiles/keys#create')
   end
 
   it "to #new" do
-    get("/profile/keys/new").should route_to('profiles/keys#new')
+    expect(get("/profile/keys/new")).to route_to('profiles/keys#new')
   end
 
   it "to #edit" do
-    get("/profile/keys/1/edit").should route_to('profiles/keys#edit', id: '1')
+    expect(get("/profile/keys/1/edit")).to route_to('profiles/keys#edit', id: '1')
   end
 
   it "to #show" do
-    get("/profile/keys/1").should route_to('profiles/keys#show', id: '1')
+    expect(get("/profile/keys/1")).to route_to('profiles/keys#show', id: '1')
   end
 
   it "to #update" do
-    put("/profile/keys/1").should route_to('profiles/keys#update', id: '1')
+    expect(put("/profile/keys/1")).to route_to('profiles/keys#update', id: '1')
   end
 
   it "to #destroy" do
-    delete("/profile/keys/1").should route_to('profiles/keys#destroy', id: '1')
+    expect(delete("/profile/keys/1")).to route_to('profiles/keys#destroy', id: '1')
   end
 
   # get all the ssh-keys of a user
   it "to #get_keys" do
-    get("/foo.keys").should route_to('profiles/keys#get_keys', username: 'foo')
+    expect(get("/foo.keys")).to route_to('profiles/keys#get_keys', username: 'foo')
   end
 end
 
@@ -188,22 +188,22 @@ end
 #          DELETE /keys/:id(.:format)      keys#destroy
 describe Profiles::EmailsController, "routing" do
   it "to #index" do
-    get("/profile/emails").should route_to('profiles/emails#index')
+    expect(get("/profile/emails")).to route_to('profiles/emails#index')
   end
 
   it "to #create" do
-    post("/profile/emails").should route_to('profiles/emails#create')
+    expect(post("/profile/emails")).to route_to('profiles/emails#create')
   end
 
   it "to #destroy" do
-    delete("/profile/emails/1").should route_to('profiles/emails#destroy', id: '1')
+    expect(delete("/profile/emails/1")).to route_to('profiles/emails#destroy', id: '1')
   end
 end
 
 # profile_avatar DELETE /profile/avatar(.:format) profiles/avatars#destroy
 describe Profiles::AvatarsController, "routing" do
   it "to #destroy" do
-    delete("/profile/avatar").should route_to('profiles/avatars#destroy')
+    expect(delete("/profile/avatar")).to route_to('profiles/avatars#destroy')
   end
 end
 
@@ -213,16 +213,16 @@ end
 #                     root        /                                   dashboard#show
 describe DashboardController, "routing" do
   it "to #index" do
-    get("/dashboard").should route_to('dashboard#show')
-    get("/").should route_to('dashboard#show')
+    expect(get("/dashboard")).to route_to('dashboard#show')
+    expect(get("/")).to route_to('dashboard#show')
   end
 
   it "to #issues" do
-    get("/dashboard/issues").should route_to('dashboard#issues')
+    expect(get("/dashboard/issues")).to route_to('dashboard#issues')
   end
 
   it "to #merge_requests" do
-    get("/dashboard/merge_requests").should route_to('dashboard#merge_requests')
+    expect(get("/dashboard/merge_requests")).to route_to('dashboard#merge_requests')
   end
 end
 
@@ -241,11 +241,11 @@ end
 
 describe "Groups", "routing" do
   it "to #show" do
-    get("/groups/1").should route_to('groups#show', id: '1')
+    expect(get("/groups/1")).to route_to('groups#show', id: '1')
   end
 
   it "also display group#show on the short path" do
-    get('/1').should route_to('namespaces#show', id: '1')
+    expect(get('/1')).to route_to('namespaces#show', id: '1')
   end
 end
 

--- a/spec/services/event_create_service_spec.rb
+++ b/spec/services/event_create_service_spec.rb
@@ -7,7 +7,7 @@ describe EventCreateService do
     describe :open_issue do
       let(:issue) { create(:issue) }
 
-      it { service.open_issue(issue, issue.author).should be_true }
+      it { expect(service.open_issue(issue, issue.author)).to be_true }
 
       it "should create new event" do
         expect { service.open_issue(issue, issue.author) }.to change { Event.count }
@@ -17,7 +17,7 @@ describe EventCreateService do
     describe :close_issue do
       let(:issue) { create(:issue) }
 
-      it { service.close_issue(issue, issue.author).should be_true }
+      it { expect(service.close_issue(issue, issue.author)).to be_true }
 
       it "should create new event" do
         expect { service.close_issue(issue, issue.author) }.to change { Event.count }
@@ -27,7 +27,7 @@ describe EventCreateService do
     describe :reopen_issue do
       let(:issue) { create(:issue) }
 
-      it { service.reopen_issue(issue, issue.author).should be_true }
+      it { expect(service.reopen_issue(issue, issue.author)).to be_true }
 
       it "should create new event" do
         expect { service.reopen_issue(issue, issue.author) }.to change { Event.count }
@@ -39,7 +39,7 @@ describe EventCreateService do
     describe :open_mr do
       let(:merge_request) { create(:merge_request) }
 
-      it { service.open_mr(merge_request, merge_request.author).should be_true }
+      it { expect(service.open_mr(merge_request, merge_request.author)).to be_true }
 
       it "should create new event" do
         expect { service.open_mr(merge_request, merge_request.author) }.to change { Event.count }
@@ -49,7 +49,7 @@ describe EventCreateService do
     describe :close_mr do
       let(:merge_request) { create(:merge_request) }
 
-      it { service.close_mr(merge_request, merge_request.author).should be_true }
+      it { expect(service.close_mr(merge_request, merge_request.author)).to be_true }
 
       it "should create new event" do
         expect { service.close_mr(merge_request, merge_request.author) }.to change { Event.count }
@@ -59,7 +59,7 @@ describe EventCreateService do
     describe :merge_mr do
       let(:merge_request) { create(:merge_request) }
 
-      it { service.merge_mr(merge_request, merge_request.author).should be_true }
+      it { expect(service.merge_mr(merge_request, merge_request.author)).to be_true }
 
       it "should create new event" do
         expect { service.merge_mr(merge_request, merge_request.author) }.to change { Event.count }
@@ -69,7 +69,7 @@ describe EventCreateService do
     describe :reopen_mr do
       let(:merge_request) { create(:merge_request) }
 
-      it { service.reopen_mr(merge_request, merge_request.author).should be_true }
+      it { expect(service.reopen_mr(merge_request, merge_request.author)).to be_true }
 
       it "should create new event" do
         expect { service.reopen_mr(merge_request, merge_request.author) }.to change { Event.count }
@@ -83,7 +83,7 @@ describe EventCreateService do
     describe :open_milestone do
       let(:milestone) { create(:milestone) }
 
-      it { service.open_milestone(milestone, user).should be_true }
+      it { expect(service.open_milestone(milestone, user)).to be_true }
 
       it "should create new event" do
         expect { service.open_milestone(milestone, user) }.to change { Event.count }
@@ -93,7 +93,7 @@ describe EventCreateService do
     describe :close_mr do
       let(:milestone) { create(:milestone) }
 
-      it { service.close_milestone(milestone, user).should be_true }
+      it { expect(service.close_milestone(milestone, user)).to be_true }
 
       it "should create new event" do
         expect { service.close_milestone(milestone, user) }.to change { Event.count }

--- a/spec/services/fork_service_spec.rb
+++ b/spec/services/fork_service_spec.rb
@@ -15,8 +15,8 @@ describe Projects::ForkService do
       it "successfully creates project in the user namespace" do
         @to_project = fork_project(@from_project, @to_user)
 
-        @to_project.owner.should == @to_user
-        @to_project.namespace.should == @to_user.namespace
+        expect(@to_project.owner).to eq(@to_user)
+        expect(@to_project.namespace).to eq(@to_user.namespace)
       end
     end
 
@@ -26,8 +26,8 @@ describe Projects::ForkService do
         # make the mock gitlab-shell fail
         @to_project = fork_project(@from_project, @to_user, false)
 
-        @to_project.errors.should_not be_empty
-        @to_project.errors[:base].should include("Fork transaction failed.")
+        expect(@to_project.errors).not_to be_empty
+        expect(@to_project.errors[:base]).to include("Fork transaction failed.")
       end
 
     end
@@ -38,9 +38,9 @@ describe Projects::ForkService do
         @existing_project = create(:project, creator_id: @to_user.id, name: @from_project.name, namespace: @to_namespace)
         @to_project = fork_project(@from_project, @to_user)
 
-        @existing_project.persisted?.should be_true
-        @to_project.errors[:base].should include("Invalid fork destination")
-        @to_project.errors[:base].should_not include("Fork transaction failed.")
+        expect(@existing_project.persisted?).to be_true
+        expect(@to_project.errors[:base]).to include("Invalid fork destination")
+        expect(@to_project.errors[:base]).not_to include("Fork transaction failed.")
       end
 
     end

--- a/spec/services/git_tag_push_service_spec.rb
+++ b/spec/services/git_tag_push_service_spec.rb
@@ -39,7 +39,7 @@ describe GitTagPushService do
   describe "Web Hooks" do
     context "execute web hooks" do
       it "when pushing tags" do
-        project.should_receive(:execute_hooks)
+        expect(project).to receive(:execute_hooks)
         service.execute(project, user, 'oldrev', 'newrev', 'refs/tags/v1.0.0')
       end
     end

--- a/spec/services/issues/bulk_update_context_spec.rb
+++ b/spec/services/issues/bulk_update_context_spec.rb
@@ -30,11 +30,11 @@ describe Issues::BulkUpdateService do
 
     it {
       result = Issues::BulkUpdateService.new(@project, @user, @params).execute
-      result[:success].should be_true
-      result[:count].should == @issues.count
+      expect(result[:success]).to be_true
+      expect(result[:count]).to eq(@issues.count)
 
-      @project.issues.opened.should be_empty
-      @project.issues.closed.should_not be_empty
+      expect(@project.issues.opened).to be_empty
+      expect(@project.issues.closed).not_to be_empty
     }
 
   end
@@ -55,11 +55,11 @@ describe Issues::BulkUpdateService do
 
     it {
       result = Issues::BulkUpdateService.new(@project, @user, @params).execute
-      result[:success].should be_true
-      result[:count].should == @issues.count
+      expect(result[:success]).to be_true
+      expect(result[:count]).to eq(@issues.count)
 
-      @project.issues.closed.should be_empty
-      @project.issues.opened.should_not be_empty
+      expect(@project.issues.closed).to be_empty
+      expect(@project.issues.opened).not_to be_empty
     }
 
   end
@@ -78,10 +78,10 @@ describe Issues::BulkUpdateService do
 
     it {
       result = Issues::BulkUpdateService.new(@project, @user, @params).execute
-      result[:success].should be_true
-      result[:count].should == 1
+      expect(result[:success]).to be_true
+      expect(result[:count]).to eq(1)
 
-      @project.issues.first.assignee.should == @new_assignee
+      expect(@project.issues.first.assignee).to eq(@new_assignee)
     }
 
   end
@@ -100,10 +100,10 @@ describe Issues::BulkUpdateService do
 
     it {
       result = Issues::BulkUpdateService.new(@project, @user, @params).execute
-      result[:success].should be_true
-      result[:count].should == 1
+      expect(result[:success]).to be_true
+      expect(result[:count]).to eq(1)
 
-      @project.issues.first.milestone.should == @milestone
+      expect(@project.issues.first.milestone).to eq(@milestone)
     }
   end
 

--- a/spec/services/issues/close_service_spec.rb
+++ b/spec/services/issues/close_service_spec.rb
@@ -17,18 +17,18 @@ describe Issues::CloseService do
         @issue = Issues::CloseService.new(project, user, {}).execute(issue)
       end
 
-      it { @issue.should be_valid }
-      it { @issue.should be_closed }
+      it { expect(@issue).to be_valid }
+      it { expect(@issue).to be_closed }
 
       it 'should send email to user2 about assign of new issue' do
         email = ActionMailer::Base.deliveries.last
-        email.to.first.should == user2.email
-        email.subject.should include(issue.title)
+        expect(email.to.first).to eq(user2.email)
+        expect(email.subject).to include(issue.title)
       end
 
       it 'should create system note about issue reassign' do
         note = @issue.notes.last
-        note.note.should include "Status changed to closed"
+        expect(note.note).to include "Status changed to closed"
       end
     end
   end

--- a/spec/services/issues/create_service_spec.rb
+++ b/spec/services/issues/create_service_spec.rb
@@ -16,8 +16,8 @@ describe Issues::CreateService do
         @issue = Issues::CreateService.new(project, user, opts).execute
       end
 
-      it { @issue.should be_valid }
-      it { @issue.title.should == 'Awesome issue' }
+      it { expect(@issue).to be_valid }
+      it { expect(@issue.title).to eq('Awesome issue') }
     end
   end
 end

--- a/spec/services/issues/update_service_spec.rb
+++ b/spec/services/issues/update_service_spec.rb
@@ -24,20 +24,20 @@ describe Issues::UpdateService do
         @issue = Issues::UpdateService.new(project, user, opts).execute(issue)
       end
 
-      it { @issue.should be_valid }
-      it { @issue.title.should == 'New title' }
-      it { @issue.assignee.should == user2 }
-      it { @issue.should be_closed }
+      it { expect(@issue).to be_valid }
+      it { expect(@issue.title).to eq('New title') }
+      it { expect(@issue.assignee).to eq(user2) }
+      it { expect(@issue).to be_closed }
 
       it 'should send email to user2 about assign of new issue' do
         email = ActionMailer::Base.deliveries.last
-        email.to.first.should == user2.email
-        email.subject.should include(issue.title)
+        expect(email.to.first).to eq(user2.email)
+        expect(email.subject).to include(issue.title)
       end
 
       it 'should create system note about issue reassign' do
         note = @issue.notes.last
-        note.note.should include "Reassigned to \@#{user2.username}"
+        expect(note.note).to include "Reassigned to \@#{user2.username}"
       end
     end
   end

--- a/spec/services/merge_requests/close_service_spec.rb
+++ b/spec/services/merge_requests/close_service_spec.rb
@@ -17,18 +17,18 @@ describe MergeRequests::CloseService do
         @merge_request = MergeRequests::CloseService.new(project, user, {}).execute(merge_request)
       end
 
-      it { @merge_request.should be_valid }
-      it { @merge_request.should be_closed }
+      it { expect(@merge_request).to be_valid }
+      it { expect(@merge_request).to be_closed }
 
       it 'should send email to user2 about assign of new merge_request' do
         email = ActionMailer::Base.deliveries.last
-        email.to.first.should == user2.email
-        email.subject.should include(merge_request.title)
+        expect(email.to.first).to eq(user2.email)
+        expect(email.subject).to include(merge_request.title)
       end
 
       it 'should create system note about merge_request reassign' do
         note = @merge_request.notes.last
-        note.note.should include "Status changed to closed"
+        expect(note.note).to include "Status changed to closed"
       end
     end
   end

--- a/spec/services/merge_requests/create_service_spec.rb
+++ b/spec/services/merge_requests/create_service_spec.rb
@@ -18,8 +18,8 @@ describe MergeRequests::CreateService do
         @merge_request = MergeRequests::CreateService.new(project, user, opts).execute
       end
 
-      it { @merge_request.should be_valid }
-      it { @merge_request.title.should == 'Awesome merge_request' }
+      it { expect(@merge_request).to be_valid }
+      it { expect(@merge_request.title).to eq('Awesome merge_request') }
     end
   end
 end

--- a/spec/services/merge_requests/update_service_spec.rb
+++ b/spec/services/merge_requests/update_service_spec.rb
@@ -24,20 +24,20 @@ describe MergeRequests::UpdateService do
         @merge_request = MergeRequests::UpdateService.new(project, user, opts).execute(merge_request)
       end
 
-      it { @merge_request.should be_valid }
-      it { @merge_request.title.should == 'New title' }
-      it { @merge_request.assignee.should == user2 }
-      it { @merge_request.should be_closed }
+      it { expect(@merge_request).to be_valid }
+      it { expect(@merge_request.title).to eq('New title') }
+      it { expect(@merge_request.assignee).to eq(user2) }
+      it { expect(@merge_request).to be_closed }
 
       it 'should send email to user2 about assign of new merge_request' do
         email = ActionMailer::Base.deliveries.last
-        email.to.first.should == user2.email
-        email.subject.should include(merge_request.title)
+        expect(email.to.first).to eq(user2.email)
+        expect(email.subject).to include(merge_request.title)
       end
 
       it 'should create system note about merge_request reassign' do
         note = @merge_request.notes.last
-        note.note.should include "Reassigned to \@#{user2.username}"
+        expect(note.note).to include "Reassigned to \@#{user2.username}"
       end
     end
   end

--- a/spec/services/notes/create_service_spec.rb
+++ b/spec/services/notes/create_service_spec.rb
@@ -19,8 +19,8 @@ describe Notes::CreateService do
         @note = Notes::CreateService.new(project, user, opts).execute
       end
 
-      it { @note.should be_valid }
-      it { @note.note.should == 'Awesome comment' }
+      it { expect(@note).to be_valid }
+      it { expect(@note.note).to eq('Awesome comment') }
     end
   end
 end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -7,10 +7,10 @@ describe NotificationService do
     describe :new_key do
       let!(:key) { create(:personal_key) }
 
-      it { notification.new_key(key).should be_true }
+      it { expect(notification.new_key(key)).to be_true }
 
       it 'should sent email to key owner' do
-        Notify.should_receive(:new_ssh_key_email).with(key.id)
+        expect(Notify).to receive(:new_ssh_key_email).with(key.id)
         notification.new_key(key)
       end
     end
@@ -20,10 +20,10 @@ describe NotificationService do
     describe :new_email do
       let!(:email) { create(:email) }
 
-      it { notification.new_email(email).should be_true }
+      it { expect(notification.new_email(email)).to be_true }
 
       it 'should send email to email owner' do
-        Notify.should_receive(:new_email_email).with(email.id)
+        expect(Notify).to receive(:new_email_email).with(email.id)
         notification.new_email(email)
       end
     end
@@ -54,7 +54,7 @@ describe NotificationService do
         it 'filters out "mentioned in" notes' do
           mentioned_note = Note.create_cross_reference_note(mentioned_issue, issue, issue.author, issue.project)
 
-          Notify.should_not_receive(:note_issue_email)
+          expect(Notify).not_to receive(:note_issue_email)
           notification.new_note(mentioned_note)
         end
       end
@@ -87,11 +87,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:note_issue_email).with(user_id, note.id)
+        expect(Notify).to receive(:note_issue_email).with(user_id, note.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:note_issue_email).with(user_id, note.id)
+        expect(Notify).not_to receive(:note_issue_email).with(user_id, note.id)
       end
     end
 
@@ -124,17 +124,17 @@ describe NotificationService do
         it 'filters out "mentioned in" notes' do
           mentioned_note = Note.create_cross_reference_note(mentioned_issue, issue, issue.author, issue.project)
 
-          Notify.should_not_receive(:note_issue_email)
+          expect(Notify).not_to receive(:note_issue_email)
           notification.new_note(mentioned_note)
         end
       end
 
       def should_email(user_id)
-        Notify.should_receive(:note_issue_email).with(user_id, note.id)
+        expect(Notify).to receive(:note_issue_email).with(user_id, note.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:note_issue_email).with(user_id, note.id)
+        expect(Notify).not_to receive(:note_issue_email).with(user_id, note.id)
       end
     end
 
@@ -169,11 +169,11 @@ describe NotificationService do
         end
 
         def should_email(user_id, n)
-          Notify.should_receive(:note_commit_email).with(user_id, n.id)
+          expect(Notify).to receive(:note_commit_email).with(user_id, n.id)
         end
 
         def should_not_email(user_id, n)
-          Notify.should_not_receive(:note_commit_email).with(user_id, n.id)
+          expect(Notify).not_to receive(:note_commit_email).with(user_id, n.id)
         end
       end
     end
@@ -196,11 +196,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:new_issue_email).with(user_id, issue.id)
+        expect(Notify).to receive(:new_issue_email).with(user_id, issue.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:new_issue_email).with(user_id, issue.id)
+        expect(Notify).not_to receive(:new_issue_email).with(user_id, issue.id)
       end
     end
 
@@ -215,11 +215,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:reassigned_issue_email).with(user_id, issue.id, issue.assignee_id, @u_disabled.id)
+        expect(Notify).to receive(:reassigned_issue_email).with(user_id, issue.id, issue.assignee_id, @u_disabled.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:reassigned_issue_email).with(user_id, issue.id, issue.assignee_id, @u_disabled.id)
+        expect(Notify).not_to receive(:reassigned_issue_email).with(user_id, issue.id, issue.assignee_id, @u_disabled.id)
       end
     end
 
@@ -235,11 +235,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:closed_issue_email).with(user_id, issue.id, @u_disabled.id)
+        expect(Notify).to receive(:closed_issue_email).with(user_id, issue.id, @u_disabled.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:closed_issue_email).with(user_id, issue.id, @u_disabled.id)
+        expect(Notify).not_to receive(:closed_issue_email).with(user_id, issue.id, @u_disabled.id)
       end
     end
   end
@@ -261,11 +261,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:new_merge_request_email).with(user_id, merge_request.id)
+        expect(Notify).to receive(:new_merge_request_email).with(user_id, merge_request.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:new_merge_request_email).with(user_id, merge_request.id)
+        expect(Notify).not_to receive(:new_merge_request_email).with(user_id, merge_request.id)
       end
     end
 
@@ -279,11 +279,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:reassigned_merge_request_email).with(user_id, merge_request.id, merge_request.assignee_id, merge_request.author_id)
+        expect(Notify).to receive(:reassigned_merge_request_email).with(user_id, merge_request.id, merge_request.assignee_id, merge_request.author_id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:reassigned_merge_request_email).with(user_id, merge_request.id, merge_request.assignee_id, merge_request.author_id)
+        expect(Notify).not_to receive(:reassigned_merge_request_email).with(user_id, merge_request.id, merge_request.assignee_id, merge_request.author_id)
       end
     end
 
@@ -297,11 +297,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:closed_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
+        expect(Notify).to receive(:closed_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:closed_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
+        expect(Notify).not_to receive(:closed_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
     end
 
@@ -315,11 +315,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
+        expect(Notify).to receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
+        expect(Notify).not_to receive(:merged_merge_request_email).with(user_id, merge_request.id, @u_disabled.id)
       end
     end
   end
@@ -340,11 +340,11 @@ describe NotificationService do
       end
 
       def should_email(user_id)
-        Notify.should_receive(:project_was_moved_email).with(project.id, user_id)
+        expect(Notify).to receive(:project_was_moved_email).with(project.id, user_id)
       end
 
       def should_not_email(user_id)
-        Notify.should_not_receive(:project_was_moved_email).with(project.id, user_id)
+        expect(Notify).not_to receive(:project_was_moved_email).with(project.id, user_id)
       end
     end
   end

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -16,9 +16,9 @@ describe Projects::CreateService do
         @project = create_project(@user, @opts)
       end
 
-      it { @project.should be_valid }
-      it { @project.owner.should == @user }
-      it { @project.namespace.should == @user.namespace }
+      it { expect(@project).to be_valid }
+      it { expect(@project.owner).to eq(@user) }
+      it { expect(@project.namespace).to eq(@user.namespace) }
     end
 
     context 'group namespace' do
@@ -30,9 +30,9 @@ describe Projects::CreateService do
         @project = create_project(@user, @opts)
       end
 
-      it { @project.should be_valid }
-      it { @project.owner.should == @group }
-      it { @project.namespace.should == @group }
+      it { expect(@project).to be_valid }
+      it { expect(@project.owner).to eq(@group) }
+      it { expect(@project.namespace).to eq(@group) }
     end
 
     context 'wiki_enabled creates repository directory' do
@@ -42,7 +42,7 @@ describe Projects::CreateService do
           @path = ProjectWiki.new(@project, @user).send(:path_to_repo)
         end
 
-        it { File.exists?(@path).should be_true }
+        it { expect(File.exists?(@path)).to be_true }
       end
 
       context 'wiki_enabled false does not create wiki repository directory' do
@@ -52,60 +52,60 @@ describe Projects::CreateService do
           @path = ProjectWiki.new(@project, @user).send(:path_to_repo)
         end
 
-        it { File.exists?(@path).should be_false }
+        it { expect(File.exists?(@path)).to be_false }
       end
     end
 
     context 'respect configured visibility setting' do
       before(:each) do
         @settings = double("settings")
-        @settings.stub(:issues) { true }
-        @settings.stub(:merge_requests) { true }
-        @settings.stub(:wiki) { true }
-        @settings.stub(:snippets) { true }
+        allow(@settings).to receive(:issues) { true }
+        allow(@settings).to receive(:merge_requests) { true }
+        allow(@settings).to receive(:wiki) { true }
+        allow(@settings).to receive(:snippets) { true }
         Gitlab.config.gitlab.stub(restricted_visibility_levels: [])
-        Gitlab.config.gitlab.stub(:default_projects_features).and_return(@settings)
+        allow(Gitlab.config.gitlab).to receive(:default_projects_features).and_return(@settings)
       end
 
       context 'should be public when setting is public' do
         before do
-          @settings.stub(:visibility_level) { Gitlab::VisibilityLevel::PUBLIC }
+          allow(@settings).to receive(:visibility_level) { Gitlab::VisibilityLevel::PUBLIC }
           @project = create_project(@user, @opts)
         end
 
-        it { @project.public?.should be_true }
+        it { expect(@project.public?).to be_true }
       end
 
       context 'should be private when setting is private' do
         before do
-          @settings.stub(:visibility_level) { Gitlab::VisibilityLevel::PRIVATE }
+          allow(@settings).to receive(:visibility_level) { Gitlab::VisibilityLevel::PRIVATE }
           @project = create_project(@user, @opts)
         end
 
-        it { @project.private?.should be_true }
+        it { expect(@project.private?).to be_true }
       end
 
       context 'should be internal when setting is internal' do
         before do
-          @settings.stub(:visibility_level) { Gitlab::VisibilityLevel::INTERNAL }
+          allow(@settings).to receive(:visibility_level) { Gitlab::VisibilityLevel::INTERNAL }
           @project = create_project(@user, @opts)
         end
 
-        it { @project.internal?.should be_true }
+        it { expect(@project.internal?).to be_true }
       end
     end
 
     context 'respect configured visibility restrictions setting' do
       before(:each) do
         @settings = double("settings")
-        @settings.stub(:issues) { true }
-        @settings.stub(:merge_requests) { true }
-        @settings.stub(:wiki) { true }
-        @settings.stub(:snippets) { true }
-        @settings.stub(:visibility_level) { Gitlab::VisibilityLevel::PRIVATE }
+        allow(@settings).to receive(:issues) { true }
+        allow(@settings).to receive(:merge_requests) { true }
+        allow(@settings).to receive(:wiki) { true }
+        allow(@settings).to receive(:snippets) { true }
+        allow(@settings).to receive(:visibility_level) { Gitlab::VisibilityLevel::PRIVATE }
         @restrictions = [ Gitlab::VisibilityLevel::PUBLIC ]
         Gitlab.config.gitlab.stub(restricted_visibility_levels: @restrictions)
-        Gitlab.config.gitlab.stub(:default_projects_features).and_return(@settings)
+        allow(Gitlab.config.gitlab).to receive(:default_projects_features).and_return(@settings)
       end
 
       context 'should be private when option is public' do
@@ -114,7 +114,7 @@ describe Projects::CreateService do
           @project = create_project(@user, @opts)
         end
 
-        it { @project.private?.should be_true }
+        it { expect(@project.private?).to be_true }
       end
 
       context 'should be public when option is public for admin' do
@@ -123,7 +123,7 @@ describe Projects::CreateService do
           @project = create_project(@admin, @opts)
         end
 
-        it { @project.public?.should be_true }
+        it { expect(@project.public?).to be_true }
       end
 
       context 'should be private when option is private' do
@@ -132,7 +132,7 @@ describe Projects::CreateService do
           @project = create_project(@user, @opts)
         end
 
-        it { @project.private?.should be_true }
+        it { expect(@project.private?).to be_true }
       end
 
       context 'should be internal when option is internal' do
@@ -141,7 +141,7 @@ describe Projects::CreateService do
           @project = create_project(@user, @opts)
         end
 
-        it { @project.internal?.should be_true }
+        it { expect(@project.internal?).to be_true }
       end
     end
   end

--- a/spec/services/projects/transfer_service_spec.rb
+++ b/spec/services/projects/transfer_service_spec.rb
@@ -14,8 +14,8 @@ describe Projects::TransferService do
       @result = @service.execute
     end
 
-    it { @result.should be_true }
-    it { project.namespace.should == group }
+    it { expect(@result).to be_true }
+    it { expect(project.namespace).to eq(group) }
   end
 
   context 'namespace -> no namespace' do
@@ -26,8 +26,8 @@ describe Projects::TransferService do
       @result = @service.execute
     end
 
-    it { @result.should be_false }
-    it { project.namespace.should == user.namespace }
+    it { expect(@result).to be_false }
+    it { expect(project.namespace).to eq(user.namespace) }
   end
 
   context 'namespace -> not allowed namespace' do
@@ -37,7 +37,7 @@ describe Projects::TransferService do
       @result = @service.execute
     end
 
-    it { @result.should be_false }
-    it { project.namespace.should == user.namespace }
+    it { expect(@result).to be_false }
+    it { expect(project.namespace).to eq(user.namespace) }
   end
 end

--- a/spec/services/projects/update_service_spec.rb
+++ b/spec/services/projects/update_service_spec.rb
@@ -17,8 +17,8 @@ describe Projects::UpdateService do
         update_project(@project, @user, @opts)
       end
 
-      it { @created_private.should be_true }
-      it { @project.private?.should be_true }
+      it { expect(@created_private).to be_true }
+      it { expect(@project.private?).to be_true }
     end
 
     context 'should be internal when updated to internal' do
@@ -29,8 +29,8 @@ describe Projects::UpdateService do
         update_project(@project, @user, @opts)
       end
 
-      it { @created_private.should be_true }
-      it { @project.internal?.should be_true }
+      it { expect(@created_private).to be_true }
+      it { expect(@project.internal?).to be_true }
     end
 
     context 'should be public when updated to public' do
@@ -41,14 +41,14 @@ describe Projects::UpdateService do
         update_project(@project, @user, @opts)
       end
 
-      it { @created_private.should be_true }
-      it { @project.public?.should be_true }
+      it { expect(@created_private).to be_true }
+      it { expect(@project.public?).to be_true }
     end
 
     context 'respect configured visibility restrictions setting' do
       before(:each) do
         @restrictions = double("restrictions")
-        @restrictions.stub(:restricted_visibility_levels) { [ Gitlab::VisibilityLevel::PUBLIC ] }
+        allow(@restrictions).to receive(:restricted_visibility_levels) { [ Gitlab::VisibilityLevel::PUBLIC ] }
         Settings.stub_chain(:gitlab).and_return(@restrictions)
       end
 
@@ -60,8 +60,8 @@ describe Projects::UpdateService do
           update_project(@project, @user, @opts)
         end
 
-        it { @created_private.should be_true }
-        it { @project.private?.should be_true }
+        it { expect(@created_private).to be_true }
+        it { expect(@project.private?).to be_true }
       end
 
       context 'should be internal when updated to internal' do
@@ -72,8 +72,8 @@ describe Projects::UpdateService do
           update_project(@project, @user, @opts)
         end
 
-        it { @created_private.should be_true }
-        it { @project.internal?.should be_true }
+        it { expect(@created_private).to be_true }
+        it { expect(@project.internal?).to be_true }
       end
 
       context 'should be private when updated to public' do
@@ -84,8 +84,8 @@ describe Projects::UpdateService do
           update_project(@project, @user, @opts)
         end
 
-        it { @created_private.should be_true }
-        it { @project.private?.should be_true }
+        it { expect(@created_private).to be_true }
+        it { expect(@project.private?).to be_true }
       end
 
       context 'should be public when updated to public by admin' do
@@ -96,8 +96,8 @@ describe Projects::UpdateService do
           update_project(@project, @admin, @opts)
         end
 
-        it { @created_private.should be_true }
-        it { @project.public?.should be_true }
+        it { expect(@created_private).to be_true }
+        it { expect(@project.public?).to be_true }
       end
     end
   end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -19,7 +19,7 @@ describe 'Search::GlobalService' do
       it 'should return public projects only' do
         context = Search::GlobalService.new(nil, search: "searchable")
         results = context.execute
-        results[:projects].should match_array [public_project]
+        expect(results[:projects]).to match_array [public_project]
       end
     end
 
@@ -27,19 +27,19 @@ describe 'Search::GlobalService' do
       it 'should return public, internal and private projects' do
         context = Search::GlobalService.new(user, search: "searchable")
         results = context.execute
-        results[:projects].should match_array [public_project, found_project, internal_project]
+        expect(results[:projects]).to match_array [public_project, found_project, internal_project]
       end
 
       it 'should return only public & internal projects' do
         context = Search::GlobalService.new(internal_user, search: "searchable")
         results = context.execute
-        results[:projects].should match_array [internal_project, public_project]
+        expect(results[:projects]).to match_array [internal_project, public_project]
       end
 
       it 'namespace name should be searchable' do
         context = Search::GlobalService.new(user, search: found_project.namespace.path)
         results = context.execute
-        results[:projects].should match_array [found_project]
+        expect(results[:projects]).to match_array [found_project]
       end
     end
   end

--- a/spec/services/system_hooks_service_spec.rb
+++ b/spec/services/system_hooks_service_spec.rb
@@ -6,21 +6,21 @@ describe SystemHooksService do
   let (:users_project) { create :users_project }
 
   context 'event data' do
-    it { event_data(user, :create).should include(:event_name, :name, :created_at, :email, :user_id) }
-    it { event_data(user, :destroy).should include(:event_name, :name, :created_at, :email, :user_id) }
-    it { event_data(project, :create).should include(:event_name, :name, :created_at, :path, :project_id, :owner_name, :owner_email, :project_visibility) }
-    it { event_data(project, :destroy).should include(:event_name, :name, :created_at, :path, :project_id, :owner_name, :owner_email, :project_visibility) }
-    it { event_data(users_project, :create).should include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
-    it { event_data(users_project, :destroy).should include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
+    it { expect(event_data(user, :create)).to include(:event_name, :name, :created_at, :email, :user_id) }
+    it { expect(event_data(user, :destroy)).to include(:event_name, :name, :created_at, :email, :user_id) }
+    it { expect(event_data(project, :create)).to include(:event_name, :name, :created_at, :path, :project_id, :owner_name, :owner_email, :project_visibility) }
+    it { expect(event_data(project, :destroy)).to include(:event_name, :name, :created_at, :path, :project_id, :owner_name, :owner_email, :project_visibility) }
+    it { expect(event_data(users_project, :create)).to include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
+    it { expect(event_data(users_project, :destroy)).to include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
   end
 
   context 'event names' do
-    it { event_name(user, :create).should eq "user_create" }
-    it { event_name(user, :destroy).should eq "user_destroy" }
-    it { event_name(project, :create).should eq "project_create" }
-    it { event_name(project, :destroy).should eq "project_destroy" }
-    it { event_name(users_project, :create).should eq "user_add_to_team" }
-    it { event_name(users_project, :destroy).should eq "user_remove_from_team" }
+    it { expect(event_name(user, :create)).to eq "user_create" }
+    it { expect(event_name(user, :destroy)).to eq "user_destroy" }
+    it { expect(event_name(project, :create)).to eq "project_create" }
+    it { expect(event_name(project, :destroy)).to eq "project_destroy" }
+    it { expect(event_name(users_project, :create)).to eq "user_add_to_team" }
+    it { expect(event_name(users_project, :destroy)).to eq "user_remove_from_team" }
   end
 
   def event_data(*args)

--- a/spec/services/test_hook_service_spec.rb
+++ b/spec/services/test_hook_service_spec.rb
@@ -8,7 +8,7 @@ describe TestHookService do
   describe :execute do
     it "should execute successfully" do
       stub_request(:post, hook.url).to_return(status: 200)
-      TestHookService.new.execute(hook, user).should be_true
+      expect(TestHookService.new.execute(hook, user)).to be_true
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,4 +48,8 @@ RSpec.configure do |config|
   config.before(:each) do
     TestEnv.setup_stubs
   end
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 end

--- a/spec/support/mentionable_shared_examples.rb
+++ b/spec/support/mentionable_shared_examples.rb
@@ -42,22 +42,22 @@ shared_examples 'a mentionable' do
   common_mentionable_setup
 
   it 'generates a descriptive back-reference' do
-    subject.gfm_reference.should == backref_text
+    expect(subject.gfm_reference).to eq(backref_text)
   end
 
   it "extracts references from its reference property" do
     # De-duplicate and omit itself
     refs = subject.references(mproject)
 
-    refs.should have(3).items
-    refs.should include(mentioned_issue)
-    refs.should include(mentioned_mr)
-    refs.should include(mentioned_commit)
+    expect(refs.size).to eq(3)
+    expect(refs).to include(mentioned_issue)
+    expect(refs).to include(mentioned_mr)
+    expect(refs).to include(mentioned_commit)
   end
 
   it 'creates cross-reference notes' do
     [mentioned_issue, mentioned_mr, mentioned_commit].each do |referenced|
-      Note.should_receive(:create_cross_reference_note).with(referenced, subject.local_reference, mauthor, mproject)
+      expect(Note).to receive(:create_cross_reference_note).with(referenced, subject.local_reference, mauthor, mproject)
     end
 
     subject.create_cross_references!(mproject, mauthor)
@@ -66,8 +66,8 @@ shared_examples 'a mentionable' do
   it 'detects existing cross-references' do
     Note.create_cross_reference_note(mentioned_issue, subject.local_reference, mauthor, mproject)
 
-    subject.has_mentioned?(mentioned_issue).should be_true
-    subject.has_mentioned?(mentioned_mr).should be_false
+    expect(subject.has_mentioned?(mentioned_issue)).to be_true
+    expect(subject.has_mentioned?(mentioned_mr)).to be_false
   end
 end
 
@@ -81,11 +81,11 @@ shared_examples 'an editable mentionable' do
       "but now it mentions ##{other_issue.iid}, too."
 
     [mentioned_issue, mentioned_commit].each do |oldref|
-      Note.should_not_receive(:create_cross_reference_note).with(oldref, subject.local_reference,
+      expect(Note).not_to receive(:create_cross_reference_note).with(oldref, subject.local_reference,
         mauthor, mproject)
     end
 
-    Note.should_receive(:create_cross_reference_note).with(other_issue, subject.local_reference, mauthor, mproject)
+    expect(Note).to receive(:create_cross_reference_note).with(other_issue, subject.local_reference, mauthor, mproject)
 
     subject.save
     set_mentionable_text.call(new_text)

--- a/spec/support/test_env.rb
+++ b/spec/support/test_env.rb
@@ -30,13 +30,13 @@ module TestEnv
   end
 
   def enable_mailer
-    NotificationService.any_instance.unstub(:mailer)
+    allow_any_instance_of(NotificationService).to receive(:mailer).and_call_original
   end
 
   def setup_stubs()
     # Use tmp dir for FS manipulations
     repos_path = testing_path()
-    ProjectWiki.any_instance.stub(:init_repo) do |path|
+    allow_any_instance_of(ProjectWiki).to receive(:init_repo) do |path|
       create_temp_repo(File.join(repos_path, "#{path}.git"))
     end
 

--- a/spec/tasks/gitlab/backup_rake_spec.rb
+++ b/spec/tasks/gitlab/backup_rake_spec.rb
@@ -13,7 +13,7 @@ describe 'gitlab:app namespace rake task' do
   describe 'backup_restore' do
     before do
       # avoid writing task output to spec progress
-      $stdout.stub :write
+      allow($stdout).to receive :write
     end
 
     let :run_rake_task do
@@ -24,7 +24,7 @@ describe 'gitlab:app namespace rake task' do
     context 'gitlab version' do
       before do
         Dir.stub glob: []
-        Dir.stub :chdir
+        allow(Dir).to receive :chdir
         File.stub exists?: true
         Kernel.stub system: true
         FileUtils.stub cp_r: true
@@ -41,9 +41,9 @@ describe 'gitlab:app namespace rake task' do
 
       it 'should invoke restoration on mach' do
         YAML.stub load_file: {gitlab_version: gitlab_version}
-        Rake::Task["gitlab:backup:db:restore"].should_receive :invoke
-        Rake::Task["gitlab:backup:repo:restore"].should_receive :invoke
-        Rake::Task["gitlab:shell:setup"].should_receive :invoke
+        expect(Rake::Task["gitlab:backup:db:restore"]).to receive :invoke
+        expect(Rake::Task["gitlab:backup:repo:restore"]).to receive :invoke
+        expect(Rake::Task["gitlab:shell:setup"]).to receive :invoke
         expect { run_rake_task }.to_not raise_error
       end
     end

--- a/spec/workers/post_receive_spec.rb
+++ b/spec/workers/post_receive_spec.rb
@@ -4,7 +4,7 @@ describe PostReceive do
 
   context "as a resque worker" do
     it "reponds to #perform" do
-      PostReceive.new.should respond_to(:perform)
+      expect(PostReceive.new).to respond_to(:perform)
     end
   end
 
@@ -14,23 +14,23 @@ describe PostReceive do
     let(:key_id) { key.shell_id }
 
     it "fetches the correct project" do
-      Project.should_receive(:find_with_namespace).with(project.path_with_namespace).and_return(project)
+      expect(Project).to receive(:find_with_namespace).with(project.path_with_namespace).and_return(project)
       PostReceive.new.perform(pwd(project), 'sha-old', 'sha-new', 'refs/heads/master', key_id)
     end
 
     it "does not run if the author is not in the project" do
-      Key.stub(:find_by).with(hash_including(id: anything())) { nil }
+      allow(Key).to receive(:find_by).with(hash_including(id: anything())) { nil }
 
-      project.should_not_receive(:execute_hooks)
+      expect(project).not_to receive(:execute_hooks)
 
-      PostReceive.new.perform(pwd(project), 'sha-old', 'sha-new', 'refs/heads/master', key_id).should be_false
+      expect(PostReceive.new.perform(pwd(project), 'sha-old', 'sha-new', 'refs/heads/master', key_id)).to be_false
     end
 
     it "asks the project to trigger all hooks" do
       Project.stub(find_with_namespace: project)
-      project.should_receive(:execute_hooks)
-      project.should_receive(:execute_services)
-      project.should_receive(:update_merge_requests)
+      expect(project).to receive(:execute_hooks)
+      expect(project).to receive(:execute_services)
+      expect(project).to receive(:update_merge_requests)
 
       PostReceive.new.perform(pwd(project), 'sha-old', 'sha-new', 'refs/heads/master', key_id)
     end


### PR DESCRIPTION
With a release of RSpec 3 it makes sense to switch to the new `expect` syntax.

http://betterspecs.org/#expect
