### PR TITLE
Splitted the Spinach tests to prevent time-outs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ env:
   global:
     - TRAVIS=true
   matrix:
-    - TASK=spinach DB=mysql
+    - TASK=spinach_project DB=mysql
+    - TASK=spinach_other DB=mysql
     - TASK=spec:api DB=mysql
     - TASK=spec:feature DB=mysql
     - TASK=spec:other DB=mysql
     - TASK=jasmine:ci DB=mysql
-    - TASK=spinach DB=postgresql
+    - TASK=spinach_project DB=postgresql
+    - TASK=spinach_other DB=postgresql
     - TASK=spec:api DB=postgresql
     - TASK=spec:feature DB=postgresql
     - TASK=spec:other DB=postgresql

--- a/features/admin/active_tab.feature
+++ b/features/admin/active_tab.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin active tab
   Background:
     Given I sign in as an admin

--- a/features/admin/broadcast_messages.feature
+++ b/features/admin/broadcast_messages.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin Broadcast Messages
   Background:
     Given I sign in as an admin

--- a/features/admin/groups.feature
+++ b/features/admin/groups.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin Groups
   Background:
     Given I sign in as an admin

--- a/features/admin/logs.feature
+++ b/features/admin/logs.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin Logs
   Background:
     Given I sign in as an admin

--- a/features/admin/projects.feature
+++ b/features/admin/projects.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin Projects
   Background:
     Given I sign in as an admin

--- a/features/admin/users.feature
+++ b/features/admin/users.feature
@@ -1,3 +1,4 @@
+@admin
 Feature: Admin Users
   Background:
     Given I sign in as an admin

--- a/features/dashboard/active_tab.feature
+++ b/features/dashboard/active_tab.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard active tab
   Background:
     Given I sign in as a user

--- a/features/dashboard/archived_projects.feature
+++ b/features/dashboard/archived_projects.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard with archived projects
   Background:
     Given I sign in as a user

--- a/features/dashboard/dashboard.feature
+++ b/features/dashboard/dashboard.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard
   Background:
     Given I sign in as a user

--- a/features/dashboard/event_filters.feature
+++ b/features/dashboard/event_filters.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Event filters
   Background:
     Given I sign in as a user

--- a/features/dashboard/help.feature
+++ b/features/dashboard/help.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Help
   Background:
     Given I sign in as a user

--- a/features/dashboard/issues.feature
+++ b/features/dashboard/issues.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard Issues
   Background:
     Given I sign in as a user

--- a/features/dashboard/merge_requests.feature
+++ b/features/dashboard/merge_requests.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard Merge Requests
   Background:
     Given I sign in as a user

--- a/features/dashboard/projects.feature
+++ b/features/dashboard/projects.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard projects
   Background:
     Given I sign in as a user

--- a/features/dashboard/search.feature
+++ b/features/dashboard/search.feature
@@ -1,3 +1,4 @@
+@dashboard
 Feature: Dashboard Search
   Background:
     Given I sign in as a user

--- a/features/profile/active_tab.feature
+++ b/features/profile/active_tab.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile active tab
   Background:
     Given I sign in as a user

--- a/features/profile/emails.feature
+++ b/features/profile/emails.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile Emails
   Background:
     Given I sign in as a user

--- a/features/profile/group.feature
+++ b/features/profile/group.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile Group
   Background:
     Given I sign in as "John Doe"

--- a/features/profile/notifications.feature
+++ b/features/profile/notifications.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile Notifications
   Background:
     Given I sign in as a user

--- a/features/profile/profile.feature
+++ b/features/profile/profile.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile
   Background:
     Given I sign in as a user

--- a/features/profile/ssh_keys.feature
+++ b/features/profile/ssh_keys.feature
@@ -1,3 +1,4 @@
+@profile
 Feature: Profile SSH Keys
   Background:
     Given I sign in as a user

--- a/features/public/projects.feature
+++ b/features/public/projects.feature
@@ -1,3 +1,4 @@
+@public
 Feature: Public Projects Feature
   Background:
     Given public project "Community"

--- a/features/public/public_groups.feature
+++ b/features/public/public_groups.feature
@@ -1,3 +1,4 @@
+@public
 Feature: Public Projects Feature
   Background:
     Given group "TestGroup" has private project "Enterprise"

--- a/features/snippets/discover.feature
+++ b/features/snippets/discover.feature
@@ -1,3 +1,4 @@
+@snippets
 Feature: Discover Snippets
   Background:
     Given I sign in as a user

--- a/features/snippets/snippets.feature
+++ b/features/snippets/snippets.feature
@@ -1,3 +1,4 @@
+@snippets
 Feature: Snippets Feature
   Background:
     Given I sign in as a user

--- a/features/snippets/user.feature
+++ b/features/snippets/user.feature
@@ -1,3 +1,4 @@
+@snippets
 Feature: User Snippets
   Background:
     Given I sign in as a user

--- a/lib/tasks/spinach.rake
+++ b/lib/tasks/spinach.rake
@@ -6,7 +6,28 @@ task :spinach do
     %W(rake gitlab:setup),
     %W(spinach),
   ]
+  run_commands(cmds)
+end
 
+desc "GITLAB | Run project spinach features"
+task :spinach_project do
+  cmds = [
+    %W(rake gitlab:setup),
+    %W(spinach --tags ~@admin,~@dashboard,~@profile,~@public,~@snippets),
+  ]
+  run_commands(cmds)
+end
+
+desc "GITLAB | Run other spinach features"
+task :spinach_other do
+  cmds = [
+    %W(rake gitlab:setup),
+    %W(spinach --tags @admin,@dashboard,@profile,@public,@snippets),
+  ]
+  run_commands(cmds)
+end
+
+def run_commands(cmds)
   cmds.each do |cmd|
     system({'RAILS_ENV' => 'test', 'force' => 'yes'}, *cmd) or raise("#{cmd} failed!")
   end


### PR DESCRIPTION
**What does this MR do?**
It splits the Spinach test suite in Project and Non project spinach tests

**Why is this MR needed?**
Spinach seems to time-out more and more on Travis, i hope this split will prevent the suit to hit the 50 minutes mark.

**Extra note**
I've only tagged the non-project spinach features, since that where the fewest. If this MR is accepted i'll tag the project folder as well. 
