### PR TITLE
Revert "Fix for failing specs"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -199,7 +199,7 @@ group :development, :test do
   # gem 'rails-dev-tweaks'
   gem 'spinach-rails'
   gem "rspec-rails"
-  gem "capybara", '~> 2.2.1'
+  gem "capybara"
   gem "pry"
   gem "awesome_print"
   gem "database_cleaner"
@@ -222,7 +222,7 @@ group :development, :test do
   gem 'rb-inotify', require: linux_only('rb-inotify')
 
   # PhantomJS driver for Capybara
-  gem 'poltergeist', '~> 1.5.1'
+  gem 'poltergeist', '~> 1.4.1'
 
   gem 'jasmine', '2.0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     celluloid (0.15.2)
       timers (~> 1.1.0)
     charlock_holmes (0.6.9.4)
-    cliver (0.3.2)
+    cliver (0.2.2)
     code_analyzer (0.4.3)
       sexp_processor
     coderay (1.1.0)
@@ -283,9 +283,9 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.0)
-    minitest (5.3.4)
-    multi_json (1.10.1)
+    mini_portile (0.5.3)
+    minitest (4.7.5)
+    multi_json (1.10.0)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     mysql2 (0.3.16)
@@ -293,8 +293,8 @@ GEM
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.8.0)
-    nokogiri (1.6.2.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     nprogress-rails (0.1.2.3)
     oauth (0.4.7)
     oauth2 (0.8.1)
@@ -326,9 +326,9 @@ GEM
     orm_adapter (0.5.0)
     pg (0.15.1)
     phantomjs (1.9.2.0)
-    poltergeist (1.5.1)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
+    poltergeist (1.4.1)
+      capybara (~> 2.1.0)
+      cliver (~> 0.2.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     polyglot (0.3.4)
@@ -562,7 +562,7 @@ GEM
     webmock (1.16.0)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    websocket-driver (0.3.3)
+    websocket-driver (0.3.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -578,7 +578,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass (~> 3.0)
-  capybara (~> 2.2.1)
+  capybara
   carrierwave
   coffee-rails
   colored
@@ -635,7 +635,7 @@ DEPENDENCIES
   omniauth-twitter
   org-ruby
   pg
-  poltergeist (~> 1.5.1)
+  poltergeist (~> 1.4.1)
   protected_attributes
   pry
   quiet_assets (~> 1.0.1)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -28,7 +28,7 @@ WebMock.allow_net_connect!
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 90)
+    Capybara::Poltergeist::Driver.new(app, :js_errors => false, :timeout => 60)
 end
 Spinach.hooks.on_tag("javascript") do
   ::Capybara.current_driver = ::Capybara.javascript_driver

--- a/spec/support/db_cleaner.rb
+++ b/spec/support/db_cleaner.rb
@@ -1,21 +1,22 @@
+require 'database_cleaner'
+
 RSpec.configure do |config|
-  config.around(:each) do
-    DatabaseCleaner.clean_with(:truncation)
+  config.before do
+    if example.metadata[:js]
+      DatabaseCleaner.strategy = :truncation
+      Capybara::Selenium::Driver::DEFAULT_OPTIONS[:resynchronize] = true
+    else
+      DatabaseCleaner.strategy = :transaction
+    end
+
+    unless example.metadata[:no_db]
+      DatabaseCleaner.start
+    end
   end
 
-  config.around(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.around(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
+  config.after do
+    unless example.metadata[:no_db]
+      DatabaseCleaner.clean
+    end
   end
 end


### PR DESCRIPTION
@randx please revert this as quick as possible, it looks like the fix i created in this PR is causing rspec to skip tests. I'm currently working on a new fix for the specs, but this one is causing more issues apparently. 

This reverts commit 2314438925af827b694fbaaf59c31c49dd2c0c31.

Conflicts:
    Gemfile.lock
