### PR TITLE
set project id constraint for API

### DIFF
--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -1,3 +1,7 @@
+module API
+  PROJECT_ID_FORMAT = /[a-zA-Z.0-9_\-]+\/[a-zA-Z.0-9_\-]+|\d+/
+end
+
 Dir["#{Rails.root}/lib/api/*.rb"].each {|file| require file}
 
 module API

--- a/lib/api/branches.rb
+++ b/lib/api/branches.rb
@@ -6,7 +6,7 @@ module API
     before { authenticate! }
     before { authorize! :download_code, user_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a project repository branches
       #
       # Parameters:

--- a/lib/api/commits.rb
+++ b/lib/api/commits.rb
@@ -6,7 +6,7 @@ module API
     before { authenticate! }
     before { authorize! :download_code, user_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a project repository commits
       #
       # Parameters:

--- a/lib/api/deploy_keys.rb
+++ b/lib/api/deploy_keys.rb
@@ -4,7 +4,7 @@ module API
     before { authenticate! }
     before { authorize_admin_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a specific project's keys
       #
       # Example Request:

--- a/lib/api/files.rb
+++ b/lib/api/files.rb
@@ -4,7 +4,7 @@ module API
     before { authenticate! }
     before { authorize! :push_code, user_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get file from repository
       # File content is Base64 encoded
       #

--- a/lib/api/issues.rb
+++ b/lib/api/issues.rb
@@ -13,7 +13,7 @@ module API
       end
     end
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a list of project issues
       #
       # Parameters:

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -3,7 +3,7 @@ module API
   class MergeRequests < Grape::API
     before { authenticate! }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       helpers do
         def handle_merge_request_errors!(errors)
           if errors[:project_access].any?

--- a/lib/api/milestones.rb
+++ b/lib/api/milestones.rb
@@ -3,7 +3,7 @@ module API
   class Milestones < Grape::API
     before { authenticate! }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a list of project milestones
       #
       # Parameters:

--- a/lib/api/notes.rb
+++ b/lib/api/notes.rb
@@ -5,7 +5,7 @@ module API
 
     NOTEABLE_TYPES = [Issue, MergeRequest, Snippet]
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get a list of project wall notes
       #
       # Parameters:

--- a/lib/api/project_hooks.rb
+++ b/lib/api/project_hooks.rb
@@ -4,7 +4,7 @@ module API
     before { authenticate! }
     before { authorize_admin_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Get project hooks
       #
       # Parameters:

--- a/lib/api/project_members.rb
+++ b/lib/api/project_members.rb
@@ -3,7 +3,7 @@ module API
   class ProjectMembers < Grape::API
     before { authenticate! }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       helpers do
         def handle_project_member_errors(errors)
           if errors[:project_access].any?

--- a/lib/api/project_snippets.rb
+++ b/lib/api/project_snippets.rb
@@ -3,7 +3,7 @@ module API
   class ProjectSnippets < Grape::API
     before { authenticate! }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       helpers do
         def handle_project_member_errors(errors)
           if errors[:project_access].any?

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -3,7 +3,7 @@ module API
   class Projects < Grape::API
     before { authenticate! }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       helpers do
         def map_public_to_visibility_level(attrs)
           publik = attrs.delete(:public)

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -6,7 +6,7 @@ module API
     before { authenticate! }
     before { authorize! :download_code, user_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       helpers do
         def handle_project_member_errors(errors)
           if errors[:project_access].any?

--- a/lib/api/services.rb
+++ b/lib/api/services.rb
@@ -4,7 +4,7 @@ module API
     before { authenticate! }
     before { authorize_admin_project }
 
-    resource :projects do
+    resource :projects, requirements: { id: PROJECT_ID_FORMAT } do
       # Set GitLab CI service for project
       #
       # Parameters:


### PR DESCRIPTION
- fixes 404 error when using periods in project namespace/path
- makes optional the use of percent encoding for forward slash in project namespace/path

rel #6954
