### PR TITLE
Making the API return the correct status code when a group already exists

### DIFF
--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -44,6 +44,13 @@ module API
         authenticated_as_admin!
         required_attributes! [:name, :path]
 
+        if Group.find_by name: params[:name]
+          render_api_error!("Group name already exists", 409)
+        end
+        if Group.find_by path: params[:path]
+          render_api_error!("Group path already exists", 409)
+        end
+
         attrs = attributes_for_keys [:name, :path]
         @group = Group.new(attrs)
         @group.owner = current_user

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -82,6 +82,11 @@ module API
       #   POST /projects
       post do
         required_attributes! [:name]
+
+        if Project.find_by name: params[:name]
+          error!("Project name already exists", 409)
+        end
+
         attrs = attributes_for_keys [:name,
                                      :path,
                                      :description,

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -84,7 +84,7 @@ module API
         required_attributes! [:name]
 
         if Project.find_by name: params[:name]
-          error!("Project name already exists", 409)
+          render_api_error!("Project name already exists", 409)
         end
 
         attrs = attributes_for_keys [:name,


### PR DESCRIPTION
I was working with the API and noticed that I received a "not found" error when a group already existed. I made this change to make it return the correct status code for when a group name or a group path already exists.
