### PR TITLE
Clarify that bbastov is the style of Hound CI 2.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,13 @@ For examples of feedback on merge requests please look at already [closed merge 
 
 ## Style guides
 
-1. [Ruby](https://github.com/bbatsov/ruby-style-guide)
-1. [Rails](https://github.com/bbatsov/rails-style-guide)
-1. [Formatting](https://github.com/thoughtbot/guides/tree/master/style#formatting)
-1. [Naming](https://github.com/thoughtbot/guides/tree/master/style#naming) 
-1. [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
-1. [CoffeeScript](https://github.com/thoughtbot/guides/tree/master/style#coffeescript)
-1. [Shell commands](doc/development/shell_commands.md)
-1. [Markdown](http://www.cirosantilli.com/markdown-styleguide)
+1.  [Ruby](https://github.com/bbatsov/ruby-style-guide). Important sections include [Source Code Layout](https://github.com/bbatsov/ruby-style-guide#source-code-layout) and [Naming](https://github.com/bbatsov/ruby-style-guide#naming). Use:
+    - multi-line method chaining style **Option A**: leading `.`
+    - string literal quoting style **Option A**: single quoted by default
+1.  [Rails](https://github.com/bbatsov/rails-style-guide)
+1.  [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
+1.  [CoffeeScript](https://github.com/thoughtbot/guides/tree/master/style#coffeescript)
+1.  [Shell commands](doc/development/shell_commands.md)
+1.  [Markdown](http://www.cirosantilli.com/markdown-styleguide)
+
+The above styles are used by Hound CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,10 @@ For examples of feedback on merge requests please look at already [closed merge 
 
 ## Style guides
 
-1.  [Ruby](https://github.com/bbatsov/ruby-style-guide). Important sections include [Source Code Layout](https://github.com/bbatsov/ruby-style-guide#source-code-layout) and [Naming](https://github.com/bbatsov/ruby-style-guide#naming). Use:
-    - multi-line method chaining style **Option A**: leading `.`
+1.  [Ruby](https://github.com/bbatsov/ruby-style-guide).
+    Important sections include [Source Code Layout](https://github.com/bbatsov/ruby-style-guide#source-code-layout)
+    and [Naming](https://github.com/bbatsov/ruby-style-guide#naming). Use:
+    - multi-line method chaining style **Option B**: dot `.` on previous line
     - string literal quoting style **Option A**: single quoted by default
 1.  [Rails](https://github.com/bbatsov/rails-style-guide)
 1.  [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
@@ -111,4 +113,5 @@ For examples of feedback on merge requests please look at already [closed merge 
 1.  [Shell commands](doc/development/shell_commands.md)
 1.  [Markdown](http://www.cirosantilli.com/markdown-styleguide)
 
-The above styles are used by Hound CI.
+This is also the style used by linting tools such as [Rubocop](https://github.com/bbatsov/rubocop)
+and [Hound CI](https://houndci.com).


### PR DESCRIPTION
Continued from https://github.com/gitlabhq/gitlabhq/pull/6786

Added Rubocop link.

Set option B, previous line.

---

Since I wrote this, Hound docs improved. [They say their default is](https://github.com/thoughtbot/guides/tree/master/style#formatting):

> If you break up a chain of method invocations, keep each method invocation on its own line. Place the . at the end of each line, except the last.

I don't think bbastov specifies one method per line, so in theory Hound should check more like "Option B + one method per line."

In practice however hound [does not seem to enforce one method by line by default](https://github.com/cirosantilli/test/pull/9#discussion-diff-13595616R36), so it ends up being the same as bbastov because of that bug.

For now we can leave Option B.

For the future I propose we use one single tool and the style that comes with it to reduce the probability of conflicts between the styles, so either:
- Hound + [hound style](https://github.com/thoughtbot/guides/tree/master/style#ruby)
- Rubocop + [bbastov style](https://github.com/bbatsov/ruby-style-guide)
