### PR TITLE
Fix git satellite timeout

### DIFF
--- a/lib/gitlab/satellite/action.rb
+++ b/lib/gitlab/satellite/action.rb
@@ -1,7 +1,7 @@
 module Gitlab
   module Satellite
     class Action
-      DEFAULT_OPTIONS = { git_timeout: 30.seconds }
+      DEFAULT_OPTIONS = { git_timeout: Gitlab.config.git.timeout }
 
       attr_accessor :options, :project, :user
 


### PR DESCRIPTION
When working with satellites, default timeout is hardcoded to 30 seconds.
But for larger repositories bigger timeout is required.
Raising timeout value in config does nothing without this fix
