### PR TITLE
Improve git timeout logging

### DIFF
--- a/lib/gitlab/satellite/action.rb
+++ b/lib/gitlab/satellite/action.rb
@@ -48,7 +48,11 @@ module Gitlab
       end
 
       def handle_exception(exception)
-        Gitlab::GitLogger.error(exception.message)
+        if exception.instance_of?(Grit::Git::GitTimeout)
+          Gitlab::GitLogger.error(exception.message + " " + exception.command + " " + exception.bytes_read)
+        else
+          Gitlab::GitLogger.error(exception.message)
+        end
         false
       end
     end

--- a/lib/gitlab/satellite/action.rb
+++ b/lib/gitlab/satellite/action.rb
@@ -49,7 +49,10 @@ module Gitlab
 
       def handle_exception(exception)
         if exception.instance_of?(Grit::Git::GitTimeout)
-          Gitlab::GitLogger.error(exception.message + " " + exception.command + " " + exception.bytes_read)
+          detailed_message = exception.message
+          detailed_message << ' ' << exception.command
+          detailed_message << ' ' << exception.bytes_read
+          Gitlab::GitLogger.error(detailed_message)
         else
           Gitlab::GitLogger.error(exception.message)
         end


### PR DESCRIPTION
When timeout occurs in Grit, by default `GitTimeout` exception doesn't contains information about command and bytes_read property.
