### PR TITLE
fix double check for all issues

### DIFF
--- a/app/assets/javascripts/issues.js.coffee
+++ b/app/assets/javascripts/issues.js.coffee
@@ -38,7 +38,7 @@
 
   initChecks: ->
     $(".check_all_issues").click ->
-      $(".selected_issue").attr "checked", @checked
+      $(".selected_issue").prop("checked", @checked)
       Issues.checkChanged()
 
     $(".selected_issue").bind "change", Issues.checkChanged


### PR DESCRIPTION
![bug mp4](https://cloud.githubusercontent.com/assets/1488195/3262132/d3067464-f261-11e3-8103-57803ef661bc.gif)

From jquery documentation http://api.jquery.com/prop/

_The attribute actually corresponds to the defaultChecked property and should be used only to set the initial value of the checkbox. The checked attribute value does not change with the state of the checkbox, while the checked property does._
