### PR TITLE
Enable CentOS packaging.

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -17,3 +17,10 @@ targets:
       - libicu52
       - libpcre3
       - git
+  centos-6:
+    build_dependencies:
+      - libicu-devel
+    dependencies:
+      - libicu
+      - pcre
+      - git


### PR DESCRIPTION
Add the required build and runtime dependencies for automatically generating RPMs using Packager.
https://packager.io/gh/pkgr/gitlabhq/install?bid=18#centos6

Instructions will follow in gitlab-recipes.
