### PR TITLE
Ensure that uid in OAuth is a string

### DIFF
--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -61,7 +61,9 @@ module Gitlab
         end
 
         def uid
-          auth.info.uid || auth.uid
+          uid = auth.info.uid || auth.uid
+          uid = uid.to_s unless uid.nil?
+          uid
         end
 
         def email


### PR DESCRIPTION
In our company we use Redmine as OAuth provider (with https://github.com/suer/redmine_oauth_provider and https://github.com/suer/omniauth-redmine on GitLab side). In this case `uid` returned from Redmine is its database ID as integer. This leads to:

```
PG::Error: ERROR:  operator does not exist: character varying = integer
LINE 1: ..."."provider" = 'redmine' AND "users"."extern_uid" = 422  ORD...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT  "users".* FROM "users"  WHERE "users"."provider" = 'redmine' AND "users"."extern_uid" = 422  ORDER BY "users"."id" DESC LIMIT 1
Completed 500 Internal Server Error in 27ms

ActiveRecord::StatementInvalid (PG::Error: ERROR:  operator does not exist: character varying = integer
LINE 1: ..."."provider" = 'redmine' AND "users"."extern_uid" = 422  ORD...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT  "users".* FROM "users"  WHERE "users"."provider" = 'redmine' AND "users"."extern_uid" = 422  ORDER BY "users"."id" DESC LIMIT 1):
  lib/gitlab/oauth/user.rb:56:in `find_by_uid_and_provider'
  lib/gitlab/oauth/user.rb:14:in `find'
  app/controllers/omniauth_callbacks_controller.rb:36:in `handle_omniauth'
  app/controllers/omniauth_callbacks_controller.rb:4:in `block (2 levels) in <class:OmniauthCallbacksController>'
  app/controllers/application_controller.rb:59:in `set_current_user_for_thread'
```

Casting `uid` to string fixes this issue.
