### PR TITLE
Fixes #7163, copy init script while upgrading (stable branch)

### DIFF
--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -58,6 +58,10 @@ sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
 
 # Clean up assets and cache
 sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS_ENV=production
+
+# Update init.d script
+sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+sudo chmod +x /etc/init.d/gitlab
 ```
 
 ### 5. Update config files


### PR DESCRIPTION
Init script needs to be updated while upgrading to GitLab 7.0.

Ping @jacobvosmaer
