### PR TITLE
Fixes #7148, Add 'create milestone permission' to docs

### DIFF
--- a/doc/permissions/permissions.md
+++ b/doc/permissions/permissions.md
@@ -16,6 +16,7 @@ If a user is a GitLab administrator they receive all permissions.
 | Pull project code                     |         | ✓          | ✓           | ✓        | ✓      |
 | Download project                      |         | ✓          | ✓           | ✓        | ✓      |
 | Create code snippets                  |         | ✓          | ✓           | ✓        | ✓      |
+| Create new milestones                 |         |            | ✓           | ✓        | ✓      |
 | Create new merge request              |         |            | ✓           | ✓        | ✓      |
 | Create new branches                   |         |            | ✓           | ✓        | ✓      |
 | Push to non-protected branches        |         |            | ✓           | ✓        | ✓      |


### PR DESCRIPTION
The permission page does not show up the level for creating a milestone.
This PR adds this to documentation.
