### PR TITLE
Add tag push events to the API

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -421,7 +421,7 @@ Parameters:
   "push_events": "true",
   "issues_events": "true",
   "merge_requests_events": "true",
-  'tag_push_events': "true",
+  "tag_push_events": "true",
   "created_at": "2012-10-12T17:04:47Z"
 }
 ```

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -421,6 +421,7 @@ Parameters:
   "push_events": "true",
   "issues_events": "true",
   "merge_requests_events": "true",
+  'tag_s': "true",
   "created_at": "2012-10-12T17:04:47Z"
 }
 ```
@@ -441,6 +442,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
++ `tag_s` - Trigger hook on tag push events
 
 
 ### Edit project hook
@@ -459,6 +461,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
++ `tag_s` - Trigger hook on tag push events
 
 
 ### Delete project hook

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -421,7 +421,7 @@ Parameters:
   "push_events": "true",
   "issues_events": "true",
   "merge_requests_events": "true",
-  'tag_s': "true",
+  'tag_push_events': "true",
   "created_at": "2012-10-12T17:04:47Z"
 }
 ```
@@ -442,7 +442,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
-+ `tag_s` - Trigger hook on tag push events
++ `tag_push_events` - Trigger hook on tag push events
 
 
 ### Edit project hook
@@ -461,7 +461,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
-+ `tag_s` - Trigger hook on tag push events
++ `tag_push_events` - Trigger hook on tag push events
 
 
 ### Delete project hook

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -421,6 +421,7 @@ Parameters:
   "push_events": "true",
   "issues_events": "true",
   "merge_requests_events": "true",
+  "tag_push_events": "true",
   "created_at": "2012-10-12T17:04:47Z"
 }
 ```
@@ -441,6 +442,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
++ `tag_push_events` - Trigger hook on tag push events
 
 
 ### Edit project hook
@@ -459,6 +461,7 @@ Parameters:
 + `push_events` - Trigger hook on push events
 + `issues_events` - Trigger hook on issues events
 + `merge_requests_events` - Trigger hook on merge_requests events
++ `tag_push_events` - Trigger hook on tag push events
 
 
 ### Delete project hook

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -30,7 +30,7 @@ module API
     end
 
     class ProjectHook < Hook
-      expose :project_id, :push_events, :issues_events, :merge_requests_events
+      expose :project_id, :push_events, :issues_events, :merge_requests_events, :tag_push_events
     end
 
     class ForkedFromProject < Grape::Entity

--- a/lib/api/project_hooks.rb
+++ b/lib/api/project_hooks.rb
@@ -38,7 +38,14 @@ module API
       #   POST /projects/:id/hooks
       post ":id/hooks" do
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
+
         @hook = user_project.hooks.new(attrs)
 
         if @hook.save
@@ -62,7 +69,13 @@ module API
       put ":id/hooks/:hook_id" do
         @hook = user_project.hooks.find(params[:hook_id])
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
 
         if @hook.update_attributes attrs
           present @hook, with: Entities::ProjectHook

--- a/lib/api/project_hooks.rb
+++ b/lib/api/project_hooks.rb
@@ -38,7 +38,14 @@ module API
       #   POST /projects/:id/hooks
       post ":id/hooks" do
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events, :tag_push_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
+
         @hook = user_project.hooks.new(attrs)
 
         if @hook.save
@@ -62,7 +69,13 @@ module API
       put ":id/hooks/:hook_id" do
         @hook = user_project.hooks.find(params[:hook_id])
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events, :tag_push_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
 
         if @hook.update_attributes attrs
           present @hook, with: Entities::ProjectHook

--- a/lib/api/project_hooks.rb
+++ b/lib/api/project_hooks.rb
@@ -38,7 +38,7 @@ module API
       #   POST /projects/:id/hooks
       post ":id/hooks" do
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events, :tag_push_events]
         @hook = user_project.hooks.new(attrs)
 
         if @hook.save
@@ -62,7 +62,7 @@ module API
       put ":id/hooks/:hook_id" do
         @hook = user_project.hooks.find(params[:hook_id])
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events, :tag_push_events]
 
         if @hook.update_attributes attrs
           present @hook, with: Entities::ProjectHook


### PR DESCRIPTION
A few months back you added push events on tags. However, you cannot set the tag URL via the API.

This adds the tag events as a valid API parameter and updates the documentation accordingly.

Without this patch, if you try to add the "tag_push_events" hook, it falls into the system hooks and essentially does nothing.

From what I can tell in the code, this might just be an oversight from when the tag events were added in the first place since it took very little to enable this functionality.
