### PR TITLE
Replace HTML5 obsolete center element with CSS.

### DIFF
--- a/app/assets/stylesheets/generic/common.scss
+++ b/app/assets/stylesheets/generic/common.scss
@@ -16,6 +16,7 @@
 .append-bottom-15 { margin-bottom:15px }
 .append-bottom-20 { margin-bottom:20px }
 .inline { display: inline-block }
+.center { text-align: center }
 
 .underlined-link { text-decoration: underline; }
 .hint { font-style: italic; color: #999; }

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -5,7 +5,7 @@
     = render "layouts/flash"
     .container
       .content
-        %center
+        .center
           %h1 GitLab
           %p.light
             GitLab is open source software to collaborate on code.

--- a/app/views/layouts/errors.html.haml
+++ b/app/views/layouts/errors.html.haml
@@ -6,5 +6,5 @@
     = render "layouts/flash"
     .container
       .content
-        %center.padded.prepend-top-20
+        .center.padded.prepend-top-20
           = yield

--- a/app/views/projects/blob/_download.html.haml
+++ b/app/views/projects/blob/_download.html.haml
@@ -1,5 +1,5 @@
 .file-content.blob_file.blob-no-preview
-  %center
+  .center
     = link_to project_raw_path(@project, @id) do
       %h1.light
         %i.icon-download-alt

--- a/app/views/projects/compare/show.html.haml
+++ b/app/views/projects/compare/show.html.haml
@@ -33,7 +33,7 @@
 
 - else
   .light-well
-    %center
+    .center
       %h4
         There isn't anything to compare.
       %p.slead

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -183,7 +183,7 @@
           .nothing-here-block Only project owner can remove a project
 
 .save-project-loader.hide
-  %center
+  .center
     %h2
       %i.icon-spinner.icon-spin
       Saving project.

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -18,7 +18,7 @@
       .file-content.code
         %pre.js-edit-mode-pane#editor= @blob.data
         .js-edit-mode-pane#preview.hide
-          %center
+          .center
             %h2
               %i.icon-spinner.icon-spin
 

--- a/app/views/projects/graphs/show.html.haml
+++ b/app/views/projects/graphs/show.html.haml
@@ -1,5 +1,5 @@
 .loading-graph
-  %center
+  .center
     %h3.page-title
       %i.icon-spinner.icon-spin
       Building repository graph.

--- a/app/views/projects/import.html.haml
+++ b/app/views/projects/import.html.haml
@@ -1,6 +1,6 @@
 - if @project.import_in_progress?
   .save-project-loader
-    %center
+    .center
       %h2
         %i.icon-spinner.icon-spin
         Import in progress.
@@ -11,7 +11,7 @@
 
 - elsif @project.import_failed?
   .save-project-loader
-    %center
+    .center
       %h2
         Import failed. Retry?
   %hr

--- a/app/views/projects/merge_requests/_new_compare.html.haml
+++ b/app/views/projects/merge_requests/_new_compare.html.haml
@@ -39,7 +39,7 @@
         %p We can't compare selected branches. It may be because of huge diff or satellite timeout. Please try again or select different branches.
     - else
       .light-well
-        %center
+        .center
           %h4
             There isn't anything to merge.
           %p.slead

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -72,7 +72,7 @@
                 Create a group
 
 .save-project-loader.hide
-  %center
+  .center
     %h2
       %i.icon-spinner.icon-spin
       Creating project &amp; repository.


### PR DESCRIPTION
Fix #6901. Would generate invalid HTML5.

   git ls-files | xargs perl -pi -e 's/%center/.center/'
