### PR TITLE
Fixed the avatar problem when gitlab is deployed at the relative url.

### DIFF
--- a/app/assets/javascripts/branch-graph.js.coffee
+++ b/app/assets/javascripts/branch-graph.js.coffee
@@ -201,7 +201,7 @@ class BranchGraph
       stroke: @colors[commit.space]
       "stroke-width": 2
     )
-    r.image(gon.relative_url_root + commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
+    r.image(commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
     r.text(@offsetX + @unitSpace * @mspace + 35, y, commit.message.split("\n")[0]).attr(
       "text-anchor": "start"
       font: "14px Monaco, monospace"
@@ -274,7 +274,7 @@ class BranchGraph
 Raphael::commitTooltip = (x, y, commit) ->
   boxWidth = 300
   boxHeight = 200
-  icon = @image(gon.relative_url_root + commit.author.icon, x, y, 20, 20)
+  icon = @image(commit.author.icon, x, y, 20, 20)
   nameText = @text(x + 25, y + 10, commit.author.name)
   idText = @text(x, y + 35, commit.id)
   messageText = @text(x, y + 50, commit.message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,7 +482,7 @@ class User < ActiveRecord::Base
 
   def avatar_url(size = nil)
     if avatar.present?
-      [gitlab_config.url, avatar.url].join("/")
+      [Gitlab.config.gitlab.url, avatar.url].join().to_s
     else
       GravatarService.new.execute(email, size)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,7 +482,7 @@ class User < ActiveRecord::Base
 
   def avatar_url(size = nil)
     if avatar.present?
-      [Gitlab.config.gitlab.url, avatar.url].join().to_s
+      [Gitlab.config.gitlab.url, avatar.url].join.to_s
     else
       GravatarService.new.execute(email, size)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,7 +482,7 @@ class User < ActiveRecord::Base
 
   def avatar_url(size = nil)
     if avatar.present?
-      [Gitlab.config.gitlab.url, avatar.url].join.to_s
+      [Gitlab.config.gitlab.url, avatar.url].join
     else
       GravatarService.new.execute(email, size)
     end


### PR DESCRIPTION
The commit fixes the following problems:
The avatar is broken when the gitlab is deployed at the relative url.
(Gitlab-7.0-stable)
The avatars in the network diagrams are displayed incorrectly. (Before
Gitlab-7.0-stable)
