### PR TITLE
Call every service, even if one fails

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -391,7 +391,11 @@ class Project < ActiveRecord::Base
     services.each do |service|
 
       # Call service hook only if it is active
-      service.execute(data) if service.active
+      begin
+        service.execute(data) if service.active
+      rescue => e
+        logger.error(e)
+      end
     end
   end
 


### PR DESCRIPTION
**What does this MR do?**
It makes sure that all the service hooks will be called, even if one fails

**Why is this MR needed?**
At this point, if one services fails, we want the others to still run, by catching the error we make sure the worker process is not killed.

**Related issues/MR's**
Fixes: #5803
