### PR TITLE
Fixes wrong avatar url when relative_url_root is used

### DIFF
--- a/app/assets/javascripts/branch-graph.js.coffee
+++ b/app/assets/javascripts/branch-graph.js.coffee
@@ -201,7 +201,7 @@ class BranchGraph
       stroke: @colors[commit.space]
       "stroke-width": 2
     )
-    r.image(gon.relative_url_root + commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
+    r.image(commit.author.icon, avatar_box_x, avatar_box_y, 20, 20)
     r.text(@offsetX + @unitSpace * @mspace + 35, y, commit.message.split("\n")[0]).attr(
       "text-anchor": "start"
       font: "14px Monaco, monospace"
@@ -274,7 +274,7 @@ class BranchGraph
 Raphael::commitTooltip = (x, y, commit) ->
   boxWidth = 300
   boxHeight = 200
-  icon = @image(gon.relative_url_root + commit.author.icon, x, y, 20, 20)
+  icon = @image(commit.author.icon, x, y, 20, 20)
   nameText = @text(x + 25, y + 10, commit.author.name)
   idText = @text(x, y + 35, commit.id)
   messageText = @text(x, y + 50, commit.message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,7 +489,7 @@ class User < ActiveRecord::Base
 
   def avatar_url(size = nil)
     if avatar.present?
-      URI::join(Gitlab.config.gitlab.url, avatar.url).to_s
+      avatar.url
     else
       GravatarService.new.execute(email, size)
     end


### PR DESCRIPTION
I'm having problems with master/7.0.0 with custom avatars (avatars that are uploaded by the user). The url used for the image is missing the part from relative_url_rool config setting. This litte patch fixes this.
- Introduced with commit ae564c97d48bf728745c57720734cb40378fd90f
