### PR TITLE
prevent events duplication loading

### DIFF
--- a/app/assets/javascripts/pager.js.coffee
+++ b/app/assets/javascripts/pager.js.coffee
@@ -1,24 +1,21 @@
 @Pager =
-  limit: 0
-  offset: 0
-  disable: false
-  init: (limit, preload) ->
-    @limit = limit
+  init: (@limit = 0, preload, @disable = false) ->
+    @loading = $(".loading")
     if preload
       @offset = 0
       @getOld()
     else
-      @offset = limit
+      @offset = @limit
     @initLoadMore()
 
   getOld: ->
-    $(".loading").show()
+    @loading.show()
     $.ajax
       type: "GET"
       url: location.href
       data: "limit=" + @limit + "&offset=" + @offset
-      complete: ->
-        $(".loading").hide()
+      complete: =>
+        @loading.hide()
       success: (data) ->
         Pager.append(data.count, data.html)
       dataType: "json"
@@ -39,6 +36,7 @@
       ceaseFire: ->
         Pager.disable
 
-      callback: (i) ->
-        $(".loading").show()
-        Pager.getOld()
+      callback: (i) =>
+        unless @loading.is(':visible')
+          @loading.show()
+          Pager.getOld()


### PR DESCRIPTION
It can be reproduced by scroll down events fast. When events loading it is possible to trigger scrollend with same params.
![bug3](https://cloud.githubusercontent.com/assets/1488195/3372242/005124dc-fba9-11e3-931c-7e5f0b4b1dde.png)
