### PR TITLE
Allow editing of notes via the api

### DIFF
--- a/doc/api/notes.md
+++ b/doc/api/notes.md
@@ -80,6 +80,23 @@ Parameters:
 + `body` (required) - The content of a note
 
 
+### Edit existing issue note
+
+Updates the body of an existing note for a specific project issue.  The user editing
+the note must be the same as the one who created it.
+
+```
+POST /projects/:id/issues/:issue_id/notes/:note_id
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
++ `issue_id` (required) - The ID of a project issue
++ `note_id` (required) - The ID of an issue note
++ `body` (required) - The new content for the note
+
+
 ## Snippets
 
 ### List all snippet notes
@@ -144,6 +161,23 @@ Parameters:
 + `body` (required) - The content of a note
 
 
+### Edit existing snippet note
+
+Updates the body of an existing note for a specific project snippet.  The user editing
+the note must be the same as the one who created it.
+
+```
+POST /projects/:id/snippets/:snippet_id/notes/:note_id
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
++ `snippet_id` (required) - The ID of a project snippet
++ `note_id` (required) - The ID of an snippet note
++ `body` (required) - The new content for the note
+
+
 ## Merge Requests
 
 ### List all merge request notes
@@ -204,4 +238,21 @@ Parameters:
 + `id` (required) - The ID of a project
 + `merge_request_id` (required) - The ID of a merge request
 + `body` (required) - The content of a note
+
+
+### Edit existing merge request note
+
+Updates the body of an existing note for a given merge request.  The user editing
+the note must be the same as the one who created it.
+
+```
+POST /projects/:id/merge_requests/:merge_request_id/notes/:note_id
+```
+
+Parameters:
+
++ `id` (required) - The ID of a project
++ `merge request_id` (required) - The ID of a merge request
++ `note_id` (required) - The ID of an merge request note
++ `body` (required) - The new content for the note
 

--- a/lib/api/notes.rb
+++ b/lib/api/notes.rb
@@ -64,6 +64,33 @@ module API
             not_found!
           end
         end
+
+        # Edit a +noteable+ note
+        #
+        # Parameters:
+        #   id (required) - The ID of a project
+        #   noteable_id (required) - The ID of an issue or snippet
+        #   note_id (required) - The ID of a note
+        #   body (required) - The content of a note
+        # Example Request:
+        #   POST /projects/:id/issues/:noteable_id/notes/:note_id
+        #   POST /projects/:id/snippets/:noteable_id/notes/:note_id
+        post ":id/#{noteables_str}/:#{noteable_id_str}/notes/:note_id" do
+          required_attributes! [:body]
+
+          @noteable = user_project.send(:"#{noteables_str}").find(params[:"#{noteable_id_str}"])
+          @note = @noteable.notes.find(params[:note_id])
+
+          if @note.author != current_user
+            forbidden!
+          elsif @note.project != user_project
+            not_found!
+          elsif @note.update_attributes(note: params[:body])
+            present @note, with: Entities::Note
+          else
+            not_found!
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Adds the ability to edit notes using a POST to the existing GET endpoint for fetching an individual note.  The user editing the note must be the same one who created it.

Tested using curl:
curl -H "PRIVATE-TOKEN: <token>" -H "Content-Type: application/json" https://gitlab/api/v3/projects/51/merge_requests/11/notes/38 -d '{"body": ":thumbsup:"}'
