### PR TITLE
Fix username validation message to match regexp.

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -25,12 +25,12 @@ class Namespace < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true,
             length: { within: 0..255 },
             format: { with: Gitlab::Regex.name_regex,
-                      message: "only letters, digits, spaces & '_' '-' '.' allowed." }
+                      message: Gitlab::Regex.name_regex_message }
   validates :description, length: { within: 0..255 }
   validates :path, uniqueness: { case_sensitive: false }, presence: true, length: { within: 1..255 },
             exclusion: { in: Gitlab::Blacklist.path },
             format: { with: Gitlab::Regex.path_regex,
-                      message: "only letters, digits & '_' '-' '.' allowed. Letter should be first" }
+                      message: Gitlab::Regex.path_regex_message }
 
   delegate :name, to: :owner, allow_nil: true, prefix: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -93,11 +93,11 @@ class Project < ActiveRecord::Base
   validates :description, length: { maximum: 2000 }, allow_blank: true
   validates :name, presence: true, length: { within: 0..255 },
             format: { with: Gitlab::Regex.project_name_regex,
-                      message: "only letters, digits, spaces & '_' '-' '.' allowed. Letter or digit should be first" }
+                      message: Gitlab::Regex.project_regex_message }
   validates :path, presence: true, length: { within: 0..255 },
             exclusion: { in: Gitlab::Blacklist.path },
             format: { with: Gitlab::Regex.path_regex,
-                      message: "only letters, digits & '_' '-' '.' allowed. Letter or digit should be first" }
+                      message: Gitlab::Regex.path_regex_message }
   validates :issues_enabled, :merge_requests_enabled,
             :wiki_enabled, inclusion: { in: [true, false] }
   validates :issues_tracker_id, length: { maximum: 255 }, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,7 @@ class User < ActiveRecord::Base
   validates :username, presence: true, uniqueness: { case_sensitive: false },
             exclusion: { in: Gitlab::Blacklist.path },
             format: { with: Gitlab::Regex.username_regex,
-                      message: "only letters, digits & '_' '-' '.' allowed. Letter should be first" }
+                      message: Gitlab::Regex.username_regex_message }
 
   validates :notification_level, inclusion: { in: Notification.notification_levels }, presence: true
   validate :namespace_uniq, if: ->(user) { user.username_changed? }

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -21,7 +21,10 @@ module Files
       file_path = path
 
       unless file_name =~ Gitlab::Regex.path_regex
-        return error("Your changes could not be committed, because file name contains not allowed characters")
+        return error(
+          'Your changes could not be committed, because the file name ' +
+          Gitlab::Regex.path_regex_message
+        )
       end
 
       blob = repository.blob_at_branch(ref, file_path)

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -6,16 +6,33 @@ module Gitlab
       default_regex
     end
 
+    def username_regex_message
+      default_regex_message
+    end
+
     def project_name_regex
       /\A[a-zA-Z0-9_][a-zA-Z0-9_\-\. ]*\z/
+    end
+
+    def project_regex_message
+      "can contain only letters, digits, '_', '-' and '.' and space. " \
+      "It must start with letter, digit or '_'."
     end
 
     def name_regex
       /\A[a-zA-Z0-9_\-\. ]*\z/
     end
 
+    def name_regex_message
+      "can contain only letters, digits, '_', '-' and '.' and space."
+    end
+
     def path_regex
       default_regex
+    end
+
+    def path_regex_message
+      default_regex_message
     end
 
     def archive_formats_regex
@@ -47,6 +64,12 @@ module Gitlab
     end
 
     protected
+
+    def default_regex_message
+      "can contain only letters, digits, '_', '-' and '.'. " \
+      "It must start with letter, digit or '_', optionally preceeded by '.'. " \
+      "It must not end in '.git'."
+    end
 
     def default_regex
       /\A[.?]?[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*(?<!\.git)\z/


### PR DESCRIPTION
Fix https://github.com/gitlabhq/gitlabhq/issues/7199

Also correct the analogous problem for project, group names and web UI file creation.

Touches only user interface error message: behavior is unchanged.
