### PR TITLE
Add users with deterministic username and password to development seed.

### DIFF
--- a/db/fixtures/development/05_users.rb
+++ b/db/fixtures/development/05_users.rb
@@ -13,4 +13,20 @@ Gitlab::Seeder.quiet do
       print 'F'
     end
   end
+
+  (1..5).each do |i|
+    begin
+      User.seed(:id, [
+        id: i + 10,
+        username: "user#{i}",
+        name: "User #{i}",
+        email: "user#{i}@example.com",
+        confirmed_at: DateTime.now,
+        password: '12345678'
+      ])
+      print '.'
+    rescue ActiveRecord::RecordNotSaved
+      print 'F'
+    end
+  end
 end


### PR DESCRIPTION
While developing, I want to see the system from the point of view of multiple users (often one on each browser). 

Like https://github.com/gitlabhq/gitlabhq/pull/5896, but that was declined because of the option, so no option here. Also this touches only users.

This is worth even without an option.
- we develop much more often than we take screenshots
- given enough faker users, the predictable ones will disappear
