### PR TITLE
Don't remove trailing newline when editing a file in web UI editor

### DIFF
--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -28,8 +28,6 @@ class Projects::EditTreeController < Projects::BaseTreeController
 
   def preview
     @content = params[:content]
-    #FIXME workaround https://github.com/gitlabhq/gitlabhq/issues/5936
-    @content += "\n" if @blob.data.end_with?("\n")
 
     diffy = Diffy::Diff.new(@blob.data, @content, diff: '-U 3',
                             include_diff_info: true)

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -16,7 +16,7 @@
           .btn-group.tree-btn-group
             = link_to "Cancel", @after_edit_path, class: "btn btn-tiny btn-cancel", data: { confirm: leave_edit_message }
       .file-content.code
-        %pre.js-edit-mode-pane#editor= @blob.data
+        %pre.js-edit-mode-pane#editor
         .js-edit-mode-pane#preview.hide
           .center
             %h2
@@ -43,6 +43,7 @@
   ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")
   var ace_mode = "#{@blob.language.try(:ace_mode)}";
   var editor = ace.edit("editor");
+  editor.setValue("#{escape_javascript(@blob.data)}");
   if (ace_mode) {
     editor.getSession().setMode('ace/mode/' + ace_mode);
   }


### PR DESCRIPTION
### What does this MR do?

It addresses an issue where editing a file through the web UI (ACE editor) removes trailing newlines from the edited file.

The current implementation populates the ACE editor’s contents via the inner text of the `pre#editor` html tag. Since whitespace is not significant in HTML, any trailing newlines are lost when the ACE editor loads its contents from the HTML element. When the user saves the edits, the new file doesn’t have a trailing newline any more.

This commit changes how the editor’s content is populated to use the editor’s `editor.setValue();` Javascript API method. Using the API preserves trailing newlines.
### Why was this MR needed?

Because editing content via gitlab’s web UI should not strip the edited file’s trailing newlines.
### What are the relevant issue numbers / Feature requests?
- #5936
- This fix makes the workaround in [`gitlabhq/app/controllers/projects/edit_tree_controller.rb#preview`](https://github.com/gitlabhq/gitlabhq/blob/master/app/controllers/projects/edit_tree_controller.rb#L31) obsolete.
