### PR TITLE
Group master can manage group members

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v 7.2.0
+  - Group masters can manage group members
   - Explore page
   - Add project stars (Ciro Santilli)
   - Log Sidekiq arguments

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -74,6 +74,16 @@ class GroupsController < ApplicationController
 
     @members = @members.order('group_access DESC').page(params[:page]).per(50)
     @users_group = UsersGroup.new
+
+    if current_user.nil?
+      return
+    end
+
+    current_users_group = group.users_groups.where(user_id: current_user.id).first
+    @current_users_group_roles = {}
+    unless current_users_group.nil?
+      @current_users_group_roles = current_users_group.access_roles
+    end
   end
 
   def edit

--- a/app/controllers/projects/team_members_controller.rb
+++ b/app/controllers/projects/team_members_controller.rb
@@ -7,6 +7,7 @@ class Projects::TeamMembersController < Projects::ApplicationController
   def index
     @group = @project.group
     @users_projects = @project.users_projects.order('project_access DESC')
+    @current_users_group_roles = UsersGroup.group_access_roles
   end
 
   def new

--- a/app/controllers/users_groups_controller.rb
+++ b/app/controllers/users_groups_controller.rb
@@ -7,14 +7,23 @@ class UsersGroupsController < ApplicationController
   layout 'group'
 
   def create
-    @group.add_users(params[:user_ids].split(','), params[:group_access])
+    @current_users_group_roles = UsersGroup.where(user: current_user, group: group).first.access_roles
 
-    redirect_to members_group_path(@group), notice: 'Users were successfully added.'
+    if @current_users_group_roles.has_value?(params[:group_access].to_i)
+      @group.add_users(params[:user_ids].split(','), params[:group_access])
+      redirect_to members_group_path(@group), notice: 'Users were successfully added.'
+    else
+      redirect_to members_group_path(@group)
+    end
   end
 
   def update
+    @current_users_group_roles = UsersGroup.where(user: current_user, group: group).first.access_roles
     @member = @group.users_groups.find(params[:id])
-    @member.update_attributes(member_params)
+
+    if @current_users_group_roles.has_value?(params[:users_group]["group_access"].to_i)
+      @member.update_attributes(member_params)
+    end
   end
 
   def destroy

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -194,6 +194,7 @@ class Ability
       # Only group masters and group owners can create new projects in group
       if group.has_master?(user) || group.has_owner?(user) || user.admin?
         rules += [
+          :manage_group,
           :create_projects,
         ]
       end

--- a/app/models/users_group.rb
+++ b/app/models/users_group.rb
@@ -45,6 +45,10 @@ class UsersGroup < ActiveRecord::Base
     group_access
   end
 
+  def access_roles
+    Gitlab::Access.options_with_owner.select { |k, v| v <= group_access }
+  end
+
   def notify_create
     notification_service.new_group_member(self)
   end

--- a/app/views/groups/_new_group_member.html.haml
+++ b/app/views/groups/_new_group_member.html.haml
@@ -5,7 +5,7 @@
 
   .form-group
     = f.label :group_access, "Group Access", class: 'control-label'
-    .col-sm-10= select_tag :group_access, options_for_select(UsersGroup.group_access_roles, @users_group.group_access), class: "project-access-select select2"
+    .col-sm-10= select_tag :group_access, options_for_select(@current_users_group_roles, @users_group.group_access), class: "project-access-select select2"
 
   .form-actions
     = f.submit 'Add users into group', class: "btn btn-create"

--- a/app/views/users_groups/_users_group.html.haml
+++ b/app/views/users_groups/_users_group.html.haml
@@ -27,5 +27,5 @@
     .edit-member.hide.js-toggle-content
       = form_for [@group, member], remote: true do |f|
         .alert.prepend-top-20
-          = f.select :group_access, options_for_select(UsersGroup.group_access_roles, member.group_access)
+          = f.select :group_access, options_for_select(@current_users_group_roles, member.group_access)
           = f.submit 'Save', class: 'btn btn-save btn-small'

--- a/doc/permissions/permissions.md
+++ b/doc/permissions/permissions.md
@@ -40,9 +40,9 @@ If a user is a GitLab administrator they receive all permissions.
 | Action                  | Guest | Reporter | Developer | Master | Owner |
 |-------------------------|-------|----------|-----------|--------|-------|
 | Browse group            | ✓     | ✓        | ✓         | ✓      | ✓     |
-| Edit group              |       |          |           |        | ✓     |
 | Create project in group |       |          |           | ✓      | ✓     |
-| Manage group members    |       |          |           |        | ✓     |
+| Manage group members    |       |          |           | ✓      | ✓     |
+| Edit group              |       |          |           |        | ✓     |
 | Remove group            |       |          |           |        | ✓     |
 
 Any user can remove himself from a group, unless he is the last Owner of the group.

--- a/spec/features/security/group/group_access_spec.rb
+++ b/spec/features/security/group/group_access_spec.rb
@@ -75,7 +75,7 @@ describe "Group access", feature: true  do
       subject { edit_group_path(group) }
 
       it { should be_allowed_for owner }
-      it { should be_denied_for master }
+      it { should be_allowed_for master }
       it { should be_denied_for reporter }
       it { should be_allowed_for :admin }
       it { should be_denied_for guest }
@@ -87,7 +87,7 @@ describe "Group access", feature: true  do
       subject { projects_group_path(group) }
 
       it { should be_allowed_for owner }
-      it { should be_denied_for master }
+      it { should be_allowed_for master }
       it { should be_denied_for reporter }
       it { should be_allowed_for :admin }
       it { should be_denied_for guest }

--- a/spec/features/security/group/internal_group_access_spec.rb
+++ b/spec/features/security/group/internal_group_access_spec.rb
@@ -71,7 +71,7 @@ describe "Group with internal project access", feature: true  do
       subject { edit_group_path(group) }
 
       it { should be_allowed_for owner }
-      it { should be_denied_for master }
+      it { should be_allowed_for master }
       it { should be_denied_for reporter }
       it { should be_allowed_for :admin }
       it { should be_denied_for guest }

--- a/spec/features/security/group/mixed_group_access_spec.rb
+++ b/spec/features/security/group/mixed_group_access_spec.rb
@@ -72,7 +72,7 @@ describe "Group access", feature: true  do
       subject { edit_group_path(group) }
 
       it { should be_allowed_for owner }
-      it { should be_denied_for master }
+      it { should be_allowed_for master }
       it { should be_denied_for reporter }
       it { should be_allowed_for :admin }
       it { should be_denied_for guest }

--- a/spec/features/security/group/public_group_access_spec.rb
+++ b/spec/features/security/group/public_group_access_spec.rb
@@ -71,7 +71,7 @@ describe "Group with public project access", feature: true  do
       subject { edit_group_path(group) }
 
       it { should be_allowed_for owner }
-      it { should be_denied_for master }
+      it { should be_allowed_for master }
       it { should be_denied_for reporter }
       it { should be_allowed_for :admin }
       it { should be_denied_for guest }

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -113,9 +113,9 @@ describe API::API, api: true  do
         response.status.should == 200
       end
 
-      it "should not remove a group if not an owner" do
+      it "should not remove a group if a developer" do
         user3 = create(:user)
-        group1.add_user(user3, Gitlab::Access::MASTER)
+        group1.add_user(user3, Gitlab::Access::DEVELOPER)
         delete api("/groups/#{group1.id}", user3)
         response.status.should == 403
       end


### PR DESCRIPTION
In the current implementation only **Group Owner** can manage users within a group.

This change will grand **Group Master** to manage users within a group. It will also prevent a master to add a user with a higher access role then it's own (**Master** cannot create **Owner**, only **Owner** can create **Owner**).

Use case for this change is a distributed teams where you have localized managers who are responsible for group setup but should not be able to do operations like deletion of repositories.
