### PR TITLE
Refine Spec Project#last_activity_date

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -115,7 +115,9 @@ describe Project do
     describe 'last_activity_date' do
       it 'returns the creation date of the project\'s last event if present' do
         last_activity_event = create(:event, project: project)
-        project.last_activity_at.to_i.should == last_event.created_at.to_i
+        # Give it 1 second tolerance so that this test passes on slow systems
+        # like Travis CI.
+        (project.last_activity_date - last_event.created_at).to_i.abs.should < 2
       end
 
       it 'returns the project\'s last update date if it has no events' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -117,7 +117,8 @@ describe Project do
         last_activity_event = create(:event, project: project)
         # Give it 1 second tolerance so that this test passes on slow systems
         # like Travis CI.
-        (project.last_activity_date - last_event.created_at).to_i.abs.should < 2
+        date_difference = (project.last_activity_date - last_event.created_at).to_i.abs
+        expect(date_difference).to be_within(2)
       end
 
       it 'returns the project\'s last update date if it has no events' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -117,8 +117,8 @@ describe Project do
         last_activity_event = create(:event, project: project)
         # Give it 1 second tolerance so that this test passes on slow systems
         # like Travis CI.
-        date_difference = (project.last_activity_date - last_event.created_at).to_i.abs
-        expect(date_difference).to be_within(2)
+        diff = (project.last_activity_date - last_event.created_at).to_i.abs
+        expect(diff).to be_within(2)
       end
 
       it 'returns the project\'s last update date if it has no events' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -118,7 +118,7 @@ describe Project do
         # Give it 1 second tolerance so that this test passes on slow systems
         # like Travis CI.
         diff = (project.last_activity_date - last_event.created_at).to_i.abs
-        expect(diff).to be_within(2)
+        expect(diff).to be_between(0, 2)
       end
 
       it 'returns the project\'s last update date if it has no events' do


### PR DESCRIPTION
### What does this MR do?

It fixes two issues with the spec for `Project#last_activity_date`:
- make timing requirement less stringent so that it doesn't fail on slow systems like Travis CI
- fix logical error, replace `project.last_activity_at` with `project.last_activity_date` since this is what's being tested in this spec.

For more details please see #7223
### Why was this MR needed?

Because Travis CI builds fail unnecessarily and the test has a logical error that renders the test useless.
### What are the relevant issue numbers / Feature requests?

Fixes #7223

/cc @jvanbaarsen
