### PR TITLE
Fix ruby quoting style to match used by hound.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ For examples of feedback on merge requests please look at already [closed merge 
     Important sections include [Source Code Layout](https://github.com/bbatsov/ruby-style-guide#source-code-layout)
     and [Naming](https://github.com/bbatsov/ruby-style-guide#naming). Use:
     - multi-line method chaining style **Option B**: dot `.` on previous line
-    - string literal quoting style **Option A**: single quoted by default
+    - string literal quoting style **Option B**: double quoted by default
 1.  [Rails](https://github.com/bbatsov/rails-style-guide)
 1.  [Testing](https://github.com/thoughtbot/guides/tree/master/style#testing)
 1.  [CoffeeScript](https://github.com/thoughtbot/guides/tree/master/style#coffeescript)


### PR DESCRIPTION
Fix it to the current enforced style as seen at: https://github.com/gitlabhq/gitlabhq/pull/7233#discussion_r14397848

Did Hound change the default quoting style or did this project change some configuration? It was enforcing single quotes only 5 days ago: https://github.com/gitlabhq/gitlabhq/pull/7211/files#diff-fd1bf4337c05855a90dd234bf800e9e6R25

Hound docs are horrible, can't find a link to their Ruby style or their config options...
