### PR TITLE
Fixed external links to non-JIRA issue trackers

### DIFF
--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -181,7 +181,8 @@ module Gitlab
     end
 
     def reference_issue(identifier, project = @project)
-      if project.used_default_issues_tracker? || !external_issues_tracker_enabled?
+      if project.used_default_issues_tracker? ||
+        (external_issues_tracker_enabled? && project.issues_tracker != "jira")
         if project.issue_exists? identifier
           url = url_for_issue(identifier, project)
           title = title_for_issue(identifier)
@@ -192,7 +193,7 @@ module Gitlab
 
           link_to("##{identifier}", url, options)
         end
-      elsif project.issues_tracker == 'jira'
+      elsif project.issues_tracker == "jira"
         reference_jira_issue(identifier, project)
       end
     end


### PR DESCRIPTION
External issue links (like #123) to Redmine stopped working, this fixes what seems to be the cause.

Originally the check was `if project.used_default_issues_tracker? || !external_issues_tracker_enabled?` which was necessary because jira is external, and we need special handling for jira. However, this broke linking for other issue trackers like redmine.

This PR modifies the conditional slightly to still allow external trackers that are not jira to link
