### PR TITLE
Show build status badge in public project list

### DIFF
--- a/app/views/public/projects/index.html.haml
+++ b/app/views/public/projects/index.html.haml
@@ -54,6 +54,9 @@
 
         .repo-info
           - unless project.empty_repo?
+            - if project.gitlab_ci?
+              = link_to project.gitlab_ci_service.builds_path do
+                = image_tag project.gitlab_ci_service.status_img_path, alt: "build status"
             = link_to pluralize(project.repository.round_commit_count, 'commit'), project_commits_path(project, project.default_branch)
             &middot;
             = link_to pluralize(project.repository.branch_names.count, 'branch'), project_branches_path(project)


### PR DESCRIPTION
We use GitLab for a while now and often discover that the list of projects is a bit overwhelming for a lot of our developers. They might not know if it's safe to use that particular package or not.

Clicking through every project isn't sufficient for us, so a possibility to see the build status right from the list would be a nice improvement.

Cheers and keep up the good work!
