### PR TITLE
Invalidate username starting with ?. Fix #7205.

### DIFF
--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -3,11 +3,13 @@ module Gitlab
     extend self
 
     def username_regex
-      default_regex
+      /\A[.]?[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*(?<!\.git)\z/
     end
 
     def username_regex_message
-      default_regex_message
+      "can contain only letters, digits, '_', '-' and '.'. " \
+      "It must start with letter, digit or '_', optionally preceeded by '.'. " \
+      "It must not end in '.git'."
     end
 
     def project_name_regex
@@ -28,11 +30,14 @@ module Gitlab
     end
 
     def path_regex
-      default_regex
+      /\A[.?]?[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*(?<!\.git)\z/
     end
 
     def path_regex_message
-      default_regex_message
+      "can contain only letters, digits, '_', '-' and '.'. " \
+      "It must start with letter, digit or '_', " \
+      "optionally preceeded by '.' or '?'. " \
+      "It must not end in '.git'."
     end
 
     def archive_formats_regex
@@ -61,18 +66,6 @@ module Gitlab
         (?<!\.lock)               (?# rule #1)
         (?<![\/.])                (?# rule #6-7)
       }x
-    end
-
-    protected
-
-    def default_regex_message
-      "can contain only letters, digits, '_', '-' and '.'. " \
-      "It must start with letter, digit or '_', optionally preceeded by '.'. " \
-      "It must not end in '.git'."
-    end
-
-    def default_regex
-      /\A[.?]?[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*(?<!\.git)\z/
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,6 +107,13 @@ describe User do
         expect(user).to be_invalid
       end
     end
+
+    describe "username" do
+      it "cannot start with ?" do
+        user = build(:user, username: "?a")
+        expect(user).to be_invalid
+      end
+    end
   end
 
   describe "Respond to" do


### PR DESCRIPTION
Fix #7205

This fixes the issue minimally, but what I would really like to do is:

```
/\A(?!(\.git|\.|\.\.)\z)[.]?[a-zA-Z0-9_][a-zA-Z0-9_.-]*\z/
```

Which would also allow:
- usernames that end in `.git`, except `.git` exactly. Denying extension feels like an unnecessary restriction.
- `.`, `-` and `_` to be used anywhere, execpt for `.` and `..` exactly. The validation would be simpler for humans to understand, and ugly usernames are already possible like `._` so it does not matter much.

I wish we had used:

```
/\A[a-zA-Z][a-zA-Z0-9-]*\z/
```

from day one like GitHub, but now would be data destructive =(
