### PR TITLE
Content-length for Repository Archive

### DIFF
--- a/app/controllers/projects/repositories_controller.rb
+++ b/app/controllers/projects/repositories_controller.rb
@@ -22,6 +22,7 @@ class Projects::RepositoriesController < Projects::ApplicationController
 
     if file_path
       # Send file to user
+      response.headers['Content-Length'] = File.Open(file_path).size.to_s
       send_file file_path
     else
       render_404

--- a/app/controllers/projects/repositories_controller.rb
+++ b/app/controllers/projects/repositories_controller.rb
@@ -22,7 +22,7 @@ class Projects::RepositoriesController < Projects::ApplicationController
 
     if file_path
       # Send file to user
-      response.headers['Content-Length'] = File.Open(file_path).size.to_s
+      response.headers["Content-Length"] = File.Open(file_path).size.to_s
       send_file file_path
     else
       render_404


### PR DESCRIPTION
Enable Content-Length to be defined in header response for repository archive
