### PR TITLE
Delete mailer queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec unicorn_rails -p ${PORT:="3000"} -E ${RAILS_ENV:="development"} -c ${UNICORN_CONFIG:="config/unicorn.rb"}
-worker: bundle exec sidekiq -q post_receive,mailer,system_hook,project_web_hook,common,default,gitlab_shell
+worker: bundle exec sidekiq -q post_receive,system_hook,project_web_hook,common,default,gitlab_shell

--- a/bin/background_jobs
+++ b/bin/background_jobs
@@ -37,7 +37,7 @@ function start_no_deamonize
 
 function start_sidekiq
 {
-  bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
+  bundle exec sidekiq -q post_receive -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
 }
 
 function load_ok


### PR DESCRIPTION
because we never use sidekiq_mailer gem. The sidekiq queue to send mails names 'default',not 'mailer' .

2014-07-03T10:26:06Z 11190 TID-1wru8c Sidekiq::Extensions::DelayedMailer JID-635dd95ab68f2c6695da15b7 INFO: start
2014-07-03T10:26:06Z 11190 TID-1wru8c Sidekiq::Extensions::DelayedMailer JID-635dd95ab68f2c6695da15b7 INFO: fail: 0.265 sec
2014-07-03T10:26:06Z 11190 TID-1wru8c WARN: {"retry"=>true, "queue"=>"default", "class"=>"Sidekiq::Extensions::DelayedMailer", "args"=>["---\n- !ruby/class 'Notify'\n- :project_was_moved_email\n- - 1299\n  - 4\n"], "jid"=>"635dd95ab68f2c6695da15b7", "enqueued_at"=>1404381797.3215425, "error_message"=>"Connection reset by peer", "error_class"=>"Errno::ECONNRESET", "failed_at"=>"2014-07-03T10:03:20Z", "retry_count"=>6, "retried_at"=>2014-07-03 10:26:06 UTC}
