### PR TITLE
Clarify squash comes after review.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ For examples of feedback on merge requests please look at already [closed merge 
 1. Contains functionality we think other users will benefit from too
 1. Doesn't add configuration options since they complicate future changes
 1. Initially contains a single commit (please use `git rebase -i` to squash commits)
-1. Changes after submitting the merge request should be in separate commits (no squashing)
+1. Changes after submitting the merge request should be in separate commits (no squashing). You will be asked to squash when the review is over, before merging.
 1. It conforms to the following style guides
 
 ## Style guides


### PR DESCRIPTION
So people don't focus on writing good commit messages for a bunch of unrelated fixes.
