### PR TITLE
change bash to sh

### DIFF
--- a/bin/background_jobs
+++ b/bin/background_jobs
@@ -43,7 +43,7 @@ start_sidekiq()
 load_ok()
 {
   sidekiq_pid=$(cat $sidekiq_pidfile)
-  if [[ -z $sidekiq_pid ]] ; then
+  if [ -z $sidekiq_pid ] ; then
     warn "Could not find a PID in $sidekiq_pidfile"
     exit 0
   fi

--- a/bin/background_jobs
+++ b/bin/background_jobs
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 cd $(dirname $0)/..
 app_root=$(pwd)
@@ -6,22 +6,22 @@ sidekiq_pidfile="$app_root/tmp/pids/sidekiq.pid"
 sidekiq_logfile="$app_root/log/sidekiq.log"
 gitlab_user=$(ls -l config.ru | awk '{print $3}')
 
-function warn
+warn()
 {
   echo "$@" 1>&2
 }
 
-function stop
+stop()
 {
   bundle exec sidekiqctl stop $sidekiq_pidfile >> $sidekiq_logfile 2>&1
 }
 
-function killall
+killall()
 {
   pkill -u $gitlab_user -f 'sidekiq [0-9]'
 }
 
-function restart
+restart()
 {
   if [ -f $sidekiq_pidfile ]; then
     stop
@@ -30,17 +30,17 @@ function restart
   start_sidekiq -d -L $sidekiq_logfile
 }
 
-function start_no_deamonize
+start_no_deamonize()
 {
   start_sidekiq
 }
 
-function start_sidekiq
+start_sidekiq()
 {
   bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile $@ >> $sidekiq_logfile 2>&1
 }
 
-function load_ok
+load_ok()
 {
   sidekiq_pid=$(cat $sidekiq_pidfile)
   if [[ -z $sidekiq_pid ]] ; then

--- a/bin/web
+++ b/bin/web
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 cd $(dirname $0)/..
 app_root=$(pwd)
@@ -6,7 +6,7 @@ app_root=$(pwd)
 unicorn_pidfile="$app_root/tmp/pids/unicorn.pid"
 unicorn_config="$app_root/config/unicorn.rb"
 
-function get_unicorn_pid
+get_unicorn_pid()
 {
   local pid=$(cat $unicorn_pidfile)
   if [ -z $pid ] ; then
@@ -16,18 +16,18 @@ function get_unicorn_pid
   unicorn_pid=$pid
 }
 
-function start
+start()
 {
   bundle exec unicorn_rails -D -c $unicorn_config -E $RAILS_ENV
 }
 
-function stop
+stop()
 {
   get_unicorn_pid
   kill -QUIT $unicorn_pid
 }
 
-function reload
+reload()
 {
   get_unicorn_pid
   kill -USR2 $unicorn_pid


### PR DESCRIPTION
Not all modern UNIX system have bash by default (FreeBSD as example).
This change achieve same run method on various systems without need to change scripts after install or update.
I think there is no need to use bash to do this simple job.
