### PR TITLE
side-by-side diff in full page width

### DIFF
--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -1,6 +1,8 @@
+.files{
+  margin-bottom: 1em;
+}
 .diff-file {
   border: 1px solid #CCC;
-  margin-bottom: 1em;
 
   .diff-header {
     @extend .clearfix;

--- a/app/views/projects/diffs/_diffs.html.haml
+++ b/app/views/projects/diffs/_diffs.html.haml
@@ -25,3 +25,14 @@
       Failed to collect changes
     %p
       Maybe diff is really big and operation failed with timeout. Try to get diff locally
+
+:javascript
+  (function($){
+    var diffParallelView = #{params[:view] == 'parallel'};
+    if(diffParallelView) {
+      var $files = $('.files'),
+        height = $files.outerHeight(true)
+      $files.css('position', 'absolute').css('left', 0)
+      $("<div></div>").height(height).insertAfter($files)
+    }
+  })(jQuery);


### PR DESCRIPTION
Rescue from vertical scroll on side-by-side diff for high-resolution screen
### before

![before](https://cloud.githubusercontent.com/assets/1488195/3520689/ad480e44-0734-11e4-9e6f-39e81bafd332.png)
### after

![after](https://cloud.githubusercontent.com/assets/1488195/3520691/b2d056d2-0734-11e4-958e-31b847504105.png)
