### PR TITLE
fix file cut down for side-by-side diff

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -122,9 +122,11 @@ module CommitsHelper
     old_lines = []
     new_lines = []
 
-    max_length.times do |line_index|
-      line_index1 = line_index - offset1
-      line_index2 = line_index - offset2
+    line_index1 = 0
+    line_index2 = 0
+    line_index = 0
+
+    while line_index1 < max_length && line_index2 < max_length
       deleted_line = deleted_lines[line_index1 + 1]
       added_line = added_lines[line_index2 + 1]
       old_line = old_file.lines[line_index1] if old_file
@@ -175,6 +177,10 @@ module CommitsHelper
       else
         new_lines[line_index].type = :deleted
       end
+
+      line_index += 1
+      line_index1 = line_index - offset1
+      line_index2 = line_index - offset2
     end
 
     return old_lines, new_lines


### PR DESCRIPTION
For ex:
https://gitlab.com/gitlab-org/gitlab-ce/commit/664112b47eb40386f8fa982a748e279a1a5039e2?view=parallel#diff-3
app/mailers/notify.rb - 126 real lines
![before1](https://cloud.githubusercontent.com/assets/1488195/3522071/c0e4144e-0747-11e4-9ca3-e771515144eb.png)
https://gitlab.com/gitlab-org/gitlab-ce/commit/6947d3c0baba7fd68e8373892c6fdad73e0c0457?view=parallel#diff-0
header.scss - 272 real lines
https://gitlab.com/gitlab-org/gitlab-ce/commit/00455a478b1b8e0dbc927729cdd60accac635a95?view=parallel#diff-0
milestones_controller.rb - 57 real lines
