### PR TITLE
Generate a deterministic development seed merge conflict from gitlabhq/testme.

### DIFF
--- a/db/fixtures/development/10_merge_requests.rb
+++ b/db/fixtures/development/10_merge_requests.rb
@@ -1,23 +1,31 @@
+def create_merge_request(project, source_branch, target_branch, options = {})
+  params = {
+    source_branch: source_branch,
+    target_branch: target_branch,
+    title: options[:title] || Faker::Lorem.sentence(6),
+    description: options[:description] || Faker::Lorem.sentences(3).join(' '),
+    milestone: project.milestones.sample,
+    assignee: project.team.users.sample
+  }
+  MergeRequests::CreateService.new(
+    project, project.team.users.sample, params).execute
+  print '.'
+end
+
 Gitlab::Seeder.quiet do
   Project.all.reject(&:empty_repo?).each do |project|
     branches = project.repository.branch_names
-
     branches.each do |branch_name|
       break if branches.size < 2
       source_branch = branches.pop
       target_branch = branches.pop
-
-      params = {
-        source_branch: source_branch,
-        target_branch: target_branch,
-        title: Faker::Lorem.sentence(6),
-        description: Faker::Lorem.sentences(3).join(" "),
-        milestone: project.milestones.sample,
-        assignee: project.team.users.sample
-      }
-
-      MergeRequests::CreateService.new(project, project.team.users.sample, params).execute
-      print '.'
+      create_merge_request(project, source_branch, target_branch)
     end
   end
+
+  # Predictable merge conflicts.
+  project = Project.find_with_namespace('gitlabhq/testme')
+  create_merge_request(project, 'conflict2', 'conflict1',
+                       title: 'Conflict',
+                       description: 'Contains merge conflicts.')
 end


### PR DESCRIPTION
It is currently very hard to test merge request conflict status interactively as they are all generated randomly.

This generates one predictable merge request conflict. For it to work, the following two branches have to be **added, not merged** to gitlabhq/testme: https://github.com/gitlabhq/testme/pull/4 https://github.com/gitlabhq/testme/pull/5

I have tested it with my fork and it worked fine: https://github.com/cirosantilli/testme/tree/conflict1

This is a preparation for: http://feedback.gitlab.com/forums/176466-general/suggestions/5590496-resolve-any-merge-request-conflict-from-the-web-in

BTW: more deterministic dev seed at: https://github.com/gitlabhq/gitlabhq/pull/7211
