### PR TITLE
A Developer cannot manage milestones

### DIFF
--- a/doc/permissions/permissions.md
+++ b/doc/permissions/permissions.md
@@ -16,7 +16,6 @@ If a user is a GitLab administrator they receive all permissions.
 | Pull project code                     |         | ✓          | ✓           | ✓        | ✓      |
 | Download project                      |         | ✓          | ✓           | ✓        | ✓      |
 | Create code snippets                  |         | ✓          | ✓           | ✓        | ✓      |
-| Create new milestones                 |         |            | ✓           | ✓        | ✓      |
 | Create new merge request              |         |            | ✓           | ✓        | ✓      |
 | Create new branches                   |         |            | ✓           | ✓        | ✓      |
 | Push to non-protected branches        |         |            | ✓           | ✓        | ✓      |
@@ -24,6 +23,7 @@ If a user is a GitLab administrator they receive all permissions.
 | Add tags                              |         |            | ✓           | ✓        | ✓      |
 | Write a wiki                          |         |            | ✓           | ✓        | ✓      |
 | Manage issue tracker                  |         |            | ✓           | ✓        | ✓      |
+| Create new milestones                 |         |            |             | ✓        | ✓      |
 | Add new team members                  |         |            |             | ✓        | ✓      |
 | Push to protected branches            |         |            |             | ✓        | ✓      |
 | Enable/Disable branch protection      |         |            |             | ✓        | ✓      |


### PR DESCRIPTION
**What does this MR do?**
Developers dont have the permissions to manage milestones, the docs said they did. After this MR the docs reflects the correct permission model again.

**Related MR's/issues**
https://github.com/gitlabhq/gitlabhq/pull/7167
