### PR TITLE
Fixed issue with nginx config

### DIFF
--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -20,7 +20,7 @@ upstream gitlab {
 }
 
 server {
-  listen *:80 default_server;         # e.g., listen 192.168.1.1:80; In most cases *:80 is a good idea
+  listen *:80;                      # e.g., listen 192.168.1.1:80; In most cases *:80 is a good idea
   server_name YOUR_SERVER_FQDN;     # e.g., server_name source.example.com;
   server_tokens off;     # don't show the version number, a security best practice
   root /home/git/gitlab/public;


### PR DESCRIPTION
With default_server set in the config file, nginx fails to start because it already has a default server. The suggested fix found somewhere is to delete the other default config (sites-enabled/default), but this makes any subdomain (instead of just git.example.com) point to GitLab. This fixes the issue. Note that if GitLab is the only server config setup that it should have default_server set.
