### PR TITLE
Added public groups area to enhance searching and exploring of projects

### DIFF
--- a/app/controllers/public/groups_controller.rb
+++ b/app/controllers/public/groups_controller.rb
@@ -1,0 +1,14 @@
+class Public::GroupsController < ApplicationController
+  skip_before_filter :authenticate_user!,
+                     :reject_blocked, :set_current_user_for_observers,
+                     :add_abilities
+
+  layout "public_groups"
+
+  def index
+    @groups = GroupsFinder.new.execute(current_user)
+    @groups = @groups.search(params[:search]) if params[:search].present?
+    @groups = @groups.sort(@sort = params[:sort])
+    @groups = @groups.page(params[:page]).per(20)
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -73,4 +73,20 @@ class Group < Namespace
   def public_profile?
     projects.public_only.any?
   end
+
+  class << self
+    def search(query)
+      where("LOWER(namespaces.name) LIKE :query", query: "%#{query.downcase}%")
+    end
+
+    def sort(method)
+      case method.to_s
+      when "newest" then reorder("namespaces.created_at DESC")
+      when "oldest" then reorder("namespaces.created_at ASC")
+      when "recently_updated" then reorder("namespaces.updated_at DESC")
+      when "last_updated" then reorder("namespaces.updated_at ASC")
+      else reorder("namespaces.path, namespaces.name ASC")
+      end
+    end
+  end
 end

--- a/app/views/layouts/public_groups.html.haml
+++ b/app/views/layouts/public_groups.html.haml
@@ -1,0 +1,11 @@
+!!! 5
+%html{ lang: "en"}
+  = render "layouts/head", title: "Public Groups"
+  %body{class: "#{app_theme} application", :'data-page' => body_data_page}
+    = render "layouts/broadcast"
+    - if current_user
+      = render "layouts/head_panel", title: "Public Groups"
+    - else
+      = render "layouts/public_head_panel", title: "Public Groups"
+    .container.navless-container
+      .content= yield

--- a/app/views/public/groups/index.html.haml
+++ b/app/views/public/groups/index.html.haml
@@ -1,0 +1,59 @@
+%h3.page-title
+  Groups (#{@groups.total_count})
+
+%p.light
+  Group allows you to keep projects organized.
+  Use groups for uniting related projects.
+
+%hr
+.clearfix
+  .pull-left
+    = form_tag public_groups_path, method: :get, class: 'form-inline form-tiny' do |f|
+      .form-group
+        = search_field_tag :search, params[:search], placeholder: "Filter by name", class: "form-control search-text-input input-mn-300", id: "groups_search"
+      .form-group
+        = submit_tag 'Search', class: "btn btn-primary wide"
+
+  .pull-right
+    .dropdown.inline
+      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+        %span.light sort:
+        - if @sort.present?
+          = @sort.humanize
+        - else
+          Name
+        %b.caret
+      %ul.dropdown-menu
+        %li
+          = link_to public_groups_path(sort: nil) do
+            Name
+          = link_to public_groups_path(sort: 'newest') do
+            Newest
+          = link_to public_groups_path(sort: 'oldest') do
+            Oldest
+          = link_to public_groups_path(sort: 'recently_updated') do
+            Recently updated
+          = link_to public_groups_path(sort: 'last_updated') do
+            Last updated
+
+%hr
+
+%ul.bordered-list
+  - @groups.each do |group|
+    %li
+      .clearfix
+        %h4
+          = link_to group_path(id: group.path) do
+            %i.icon-group
+            = group.name
+      .clearfix
+        %p
+          = truncate group.description, length: 150
+      .clearfix
+        %p.light
+          #{pluralize(group.members.size, 'member')}, #{pluralize(group.projects.count, 'project')}
+  - unless @groups.present?
+    .nothing-here-block No public groups
+
+
+= paginate @groups, theme: "gitlab"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Gitlab::Application.routes.draw do
   #
   namespace :public do
     resources :projects, only: [:index]
+    resources :groups, only: [:index]
     root to: "projects#index"
   end
 

--- a/features/public/public_groups.feature
+++ b/features/public/public_groups.feature
@@ -117,3 +117,35 @@ Feature: Public Projects Feature
     And I visit group "TestGroup" members page
     Then I should see group member "John Doe"
     And I should not see member roles
+
+  Scenario: I should see group with public project in public groups area
+    Given group "TestGroup" has public project "Community"
+    When I visit the public groups area
+    Then I should see group "TestGroup"
+
+  Scenario: I should not see group with internal project in public groups area
+    Given group "TestGroup" has internal project "Internal"
+    When I visit the public groups area
+    Then I should not see group "TestGroup"
+
+  Scenario: I should not see group with private project in public groups area
+    When I visit the public groups area
+    Then I should not see group "TestGroup"
+
+  Scenario: I should see group with public project in public groups area as user
+    Given group "TestGroup" has public project "Community"
+    When I sign in as a user
+    And I visit the public groups area
+    Then I should see group "TestGroup"
+
+  Scenario: I should see group with internal project in public groups area as user
+    Given group "TestGroup" has internal project "Internal"
+    When I sign in as a user
+    And I visit the public groups area
+    Then I should see group "TestGroup"
+
+  Scenario: I should not see group with private project in public groups area as user
+    When I sign in as a user
+    And I visit the public groups area
+    Then I should not see group "TestGroup"
+

--- a/features/steps/shared/group.rb
+++ b/features/steps/shared/group.rb
@@ -21,6 +21,14 @@ module SharedGroup
     is_member_of("Mary Jane", "Guest", Gitlab::Access::GUEST)
   end
 
+  step 'I should see group "TestGroup"' do
+    page.should have_content "TestGroup"
+  end
+
+  step 'I should not see group "TestGroup"' do
+    page.should_not have_content "TestGroup"
+  end
+
   protected
 
   def is_member_of(username, groupname, role)

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -332,6 +332,14 @@ module SharedPaths
   end
 
   # ----------------------------------------
+  # Public Groups
+  # ----------------------------------------
+
+  step 'I visit the public groups area' do
+    visit public_groups_path
+  end
+
+  # ----------------------------------------
   # Snippets
   # ----------------------------------------
 


### PR DESCRIPTION
**What does this MR do?**
This MR adds an area, where the user can see the public groups. If he's not logged in, he will see all groups that have public only projects available. If he's logged in, he will see all groups that provide public and/or internal projects.

**Why was this MR needed?**
We're often missing the possibility to have a list of groups (e.g. Backend, Tools, Payment etc..) instead of searching for possible groups in a rather large project list.

This MR therefore enhances the search behaviour for the user.

**Screenshots (If appropiate)**
![gitlab-groups-list-feature-signed-off](https://cloud.githubusercontent.com/assets/6304496/3555692/4d47d99c-091a-11e4-8d63-2209db5f9f4c.jpg)
![gitlab-groups-list-feature-signed-in](https://cloud.githubusercontent.com/assets/6304496/3555734/cd9a0be2-091a-11e4-935e-b54a23d237da.jpg)
