### PR TITLE
set the collation to utf8_general_ci

### DIFF
--- a/config/database.yml.mysql
+++ b/config/database.yml.mysql
@@ -4,6 +4,7 @@
 production:
   adapter: mysql2
   encoding: utf8
+  collation: utf8_general_ci
   reconnect: false
   database: gitlabhq_production
   pool: 10
@@ -18,6 +19,7 @@ production:
 development:
   adapter: mysql2
   encoding: utf8
+  collation: utf8_general_ci
   reconnect: false
   database: gitlabhq_development
   pool: 5
@@ -31,6 +33,7 @@ development:
 test: &test
   adapter: mysql2
   encoding: utf8
+  collation: utf8_general_ci
   reconnect: false
   database: gitlabhq_test
   pool: 5


### PR DESCRIPTION
I get problems with strange characters in merge requests unless the collation is set to utf8_general_ci
