### PR TITLE
Removed some constant allready defined warnings

### DIFF
--- a/lib/gitlab/theme.rb
+++ b/lib/gitlab/theme.rb
@@ -1,10 +1,10 @@
 module Gitlab
   class Theme
-    BASIC  = 1
-    MARS   = 2
-    MODERN = 3
-    GRAY   = 4
-    COLOR  = 5
+    BASIC  = 1 unless const_defined?(:BASIC)
+    MARS   = 2 unless const_defined?(:MARS)
+    MODERN = 3 unless const_defined?(:MODERN)
+    GRAY   = 4 unless const_defined?(:GRAY)
+    COLOR  = 5 unless const_defined?(:COLOR)
 
     def self.css_class_by_id(id)
       themes = {

--- a/lib/gitlab/visibility_level.rb
+++ b/lib/gitlab/visibility_level.rb
@@ -5,9 +5,9 @@
 #
 module Gitlab
   module VisibilityLevel
-    PRIVATE  = 0
-    INTERNAL = 10
-    PUBLIC   = 20
+    PRIVATE  = 0 unless const_defined?(:PRIVATE)
+    INTERNAL = 10 unless const_defined?(:INTERNAL)
+    PUBLIC   = 20 unless const_defined?(:PUBLIC)
 
     class << self
       def values
@@ -21,7 +21,7 @@ module Gitlab
           'Public'   => PUBLIC
         }
       end
-      
+
       def allowed_for?(user, level)
         user.is_admin? || !Gitlab.config.gitlab.restricted_visibility_levels.include?(level)
       end


### PR DESCRIPTION
**What does this MR do?**
It makes sure that warnings of already defined constants are not shown anymore

**Why is this MR needed?**
Its a little annoying that you see constant warnings every time you run a command

The warnings it removes:

```
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:3: warning: already initialized constant Gitlab::Theme::BASIC
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:3: warning: previous definition of BASIC was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:4: warning: already initialized constant Gitlab::Theme::MARS
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:4: warning: previous definition of MARS was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:5: warning: already initialized constant Gitlab::Theme::MODERN
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:5: warning: previous definition of MODERN was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:6: warning: already initialized constant Gitlab::Theme::GRAY
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:6: warning: previous definition of GRAY was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:7: warning: already initialized constant Gitlab::Theme::COLOR
/Users/jeroen/Development/gitlabhq/lib/gitlab/theme.rb:7: warning: previous definition of COLOR was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:8: warning: already initialized constant Gitlab::VisibilityLevel::PRIVATE
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:8: warning: previous definition of PRIVATE was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:9: warning: already initialized constant Gitlab::VisibilityLevel::INTERNAL
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:9: warning: previous definition of INTERNAL was here
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:10: warning: already initialized constant Gitlab::VisibilityLevel::PUBLIC
/Users/jeroen/Development/gitlabhq/lib/gitlab/visibility_level.rb:10: warning: previous definition of PUBLIC was here

```
