### PR TITLE
Fix timeout error when preparing git graph.

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -134,7 +134,7 @@ class Repository
 
   def graph_log
     Rails.cache.fetch(cache_key(:graph_log)) do
-      stats = Gitlab::Git::GitStats.new(raw, root_ref)
+      stats = Gitlab::Git::GitStats.new(raw, root_ref, Gitlab.config.git.timeout)
       stats.parsed_log
     end
   end


### PR DESCRIPTION
**gitlab_git** use 30s as the default timeout limit. But, if **Gitlab** is running on a slow machine, 30s is still not long enough to load and display large project's graph. (My machine takes 70s to do this)

Changing timeout setting in `gitlab.yml` doesn't help anying, it's weird. It should change that timeout setting in graph too.

I found that there is already an interface in `gitlab_git` to change timeout setting, then I use it, then my problem resolved. Why **Gitlab** did not do this before?

I hope this PR can be merged, this can really help many people.
