### PR TITLE
[UI] Increase diff byte highlight contrast.

### DIFF
--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -40,12 +40,12 @@
     font-size: 12px;
     .old {
       span.idiff {
-        background-color: #FAA;
+        background-color: #F99;
       }
     }
     .new {
       span.idiff {
-        background-color: #AFA;
+        background-color: #8F8;
       }
     }
 


### PR DESCRIPTION
Currently I have to concentrate too much to find the byte highlight in a line, specially the additions. This would make it easier to spot.

Before:

![screenshot from 2014-07-21 12 26 13 gitlab diff highlight before](https://cloud.githubusercontent.com/assets/1429315/3642424/a83e945e-10c1-11e4-95f9-17d935e09eb9.png)

After:

![screenshot from 2014-07-21 12 26 37 gitlab diff highlight after](https://cloud.githubusercontent.com/assets/1429315/3642428/ad2a8d24-10c1-11e4-80dd-e6d596a4f28a.png)

Would be even more important if we decide to do: http://feedback.gitlab.com/forums/176466-general/suggestions/6191324-highlight-bytes-words-in-diffs-on-adjacent-multi
