### PR TITLE
[WIP] Resolve MR conflicts from web interface.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,9 @@ gem 'omniauth-github'
 
 # Extracting information from a git repository
 # Provide access to Gitlab::Git library
-gem "gitlab_git", '~> 6.0'
+# TODO bump version
+#gem "gitlab_git", '~> 6.0'
+gem "gitlab_git", path: 'vendor/bundle/gitlab_git'
 
 # Ruby/Rack Git Smart-HTTP Server Handler
 gem 'gitlab-grack', '~> 2.0.0.pre', require: 'grack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+PATH
+  remote: vendor/bundle/gitlab_git
+  specs:
+    gitlab_git (6.2.1)
+      activesupport (~> 4.0)
+      charlock_holmes (~> 0.6)
+      gitlab-grit (~> 2.6)
+      gitlab-linguist (~> 3.0)
+      rugged (~> 0.21.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -179,12 +189,6 @@ GEM
       mime-types (~> 1.19)
     gitlab_emoji (0.0.1.1)
       emoji (~> 1.0.1)
-    gitlab_git (6.2.1)
-      activesupport (~> 4.0)
-      charlock_holmes (~> 0.6)
-      gitlab-grit (~> 2.6)
-      gitlab-linguist (~> 3.0)
-      rugged (~> 0.21.0)
     gitlab_meta (7.0)
     gitlab_omniauth-ldap (1.1.0)
       net-ldap (~> 0.7.0)
@@ -614,7 +618,7 @@ DEPENDENCIES
   gitlab-grack (~> 2.0.0.pre)
   gitlab-linguist (~> 3.0.0)
   gitlab_emoji (~> 0.0.1.1)
-  gitlab_git (~> 6.0)
+  gitlab_git!
   gitlab_meta (= 7.0)
   gitlab_omniauth-ldap (= 1.1.0)
   gollum-lib (~> 3.0.0)

--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -73,13 +73,22 @@ class MergeRequest
       this.$('.remove_source_branch_in_progress').hide()
       this.$('.remove_source_branch_widget.failed').show()
 
+  bindTabEvents: (action) ->
+    tab = this.tabFromAction(action)
+    switch action
+      when "conflicts"
+        tab.find(".actions .button-holder").on "click", ->
+          textarea = $(this).closest('tbody').find('textarea')
+          textarea.val(textarea.val() + '\n' + $(this).next().text())
+
   activateTab: (action) ->
     this.$('.merge-request-tabs li').removeClass 'active'
     this.$('.tab-content').hide()
     if action == 'diffs' or action == 'conflicts'
       this.$(".merge-request-tabs .#{action}-tab").addClass 'active'
       this.loadTab(action) unless @tabs_loaded[action]
-      this.$(".#{action}").show()
+      this.bindTabEvents(action)
+      this.tabFromAction(action).show()
     else
       this.$('.merge-request-tabs .notes-tab').addClass 'active'
       this.$('.notes').show()
@@ -114,7 +123,9 @@ class MergeRequest
         @tabs_loaded[action] = true
         this.$(".mr-loading-status .loading").hide()
       success: (data) =>
-        this.$(".#{action}").html(data.html)
+        tab_content = this.tabFromAction(action)
+        tab_content.html(data.html)
+        this.bindTabEvents(action)
       dataType: "json"
 
   showAllCommits: ->
@@ -125,5 +136,8 @@ class MergeRequest
     this.$('.automerge_widget').hide()
     this.$('.merge-in-progress').hide()
     this.$('.automerge_widget.already_cannot_be_merged').show()
+
+  tabFromAction: (action) ->
+    this.$(".#{action}")
 
 this.MergeRequest = MergeRequest

--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -2,7 +2,10 @@ class MergeRequest
   constructor: (@opts) ->
     @initContextWidget()
     this.$el = $('.merge-request')
-    @diffs_loaded = if @opts.action == 'diffs' then true else false
+    @tabs_loaded =
+      diffs: false
+      conflicts: false
+    @tabs_loaded[@opts.action] = true
     @commits_loaded = false
 
     this.activateTab(@opts.action)
@@ -73,14 +76,13 @@ class MergeRequest
   activateTab: (action) ->
     this.$('.merge-request-tabs li').removeClass 'active'
     this.$('.tab-content').hide()
-    switch action
-      when 'diffs'
-        this.$('.merge-request-tabs .diffs-tab').addClass 'active'
-        this.loadDiff() unless @diffs_loaded
-        this.$('.diffs').show()
-      else
-        this.$('.merge-request-tabs .notes-tab').addClass 'active'
-        this.$('.notes').show()
+    if action == 'diffs' or action == 'conflicts'
+      this.$(".merge-request-tabs .#{action}-tab").addClass 'active'
+      this.loadTab(action) unless @tabs_loaded[action]
+      this.$(".#{action}").show()
+    else
+      this.$('.merge-request-tabs .notes-tab').addClass 'active'
+      this.$('.notes').show()
 
   showState: (state) ->
     $('.automerge_widget').hide()
@@ -102,20 +104,18 @@ class MergeRequest
       when "running", "pending"
         $('.mr-state-widget').addClass("panel-warning")
 
-
-
-  loadDiff: (event) ->
+  loadTab: (action) ->
     $.ajax
       type: 'GET'
-      url: this.$('.merge-request-tabs .diffs-tab a').attr('href')
+      url: this.$(".merge-request-tabs .#{action}-tab a").attr("href")
       beforeSend: =>
-        this.$('.mr-loading-status .loading').show()
+        this.$(".mr-loading-status .loading").show()
       complete: =>
-        @diffs_loaded = true
-        this.$('.mr-loading-status .loading').hide()
+        @tabs_loaded[action] = true
+        this.$(".mr-loading-status .loading").hide()
       success: (data) =>
-        this.$(".diffs").html(data.html)
-      dataType: 'json'
+        this.$(".#{action}").html(data.html)
+      dataType: "json"
 
   showAllCommits: ->
     this.$('.first-commits').remove()

--- a/app/assets/stylesheets/generic/common.scss
+++ b/app/assets/stylesheets/generic/common.scss
@@ -355,6 +355,3 @@ table {
   color: #555;
   font-size: 42px;
 }
-
-$diff_old_line: #FCC;
-$diff_new_line: #CFC;

--- a/app/assets/stylesheets/generic/common.scss
+++ b/app/assets/stylesheets/generic/common.scss
@@ -356,3 +356,5 @@ table {
   font-size: 42px;
 }
 
+$diff_old_line: #FCC;
+$diff_new_line: #CFC;

--- a/app/assets/stylesheets/generic/diff.scss
+++ b/app/assets/stylesheets/generic/diff.scss
@@ -1,0 +1,5 @@
+/* Shared between diffs and conflicts.*/
+$diff_file_border: #CCC;
+$diff_new_line: #CFC;
+$diff_old_line: #FCC;
+$line_content_padding_left: 0.5em;

--- a/app/assets/stylesheets/sections/conflict.scss
+++ b/app/assets/stylesheets/sections/conflict.scss
@@ -1,5 +1,5 @@
 .diff-file {
-  tbody.radio_holder {
+  tbody.actions {
     border: 2px solid #666;
     tr.line_holder {
       &.theirs {
@@ -37,10 +37,13 @@
       td.old_line {
         padding: 0px;
         text-align: center;
+        &.button-holder {
+          cursor:pointer;
+        }
       }
       td.line_content {
-        /* TODO same padding as context to align things */
         height: initial;
+        /* TODO DRY this out with same padding as context to align things. */
         padding-left: 0.5em;
         pre {
           background: transparent;

--- a/app/assets/stylesheets/sections/conflict.scss
+++ b/app/assets/stylesheets/sections/conflict.scss
@@ -36,17 +36,7 @@
       }
       td.old_line {
         padding: 0px;
-        label {
-          display: block;
-          /* TODO make this work with parent of unknown height */
-          height: 100%;
-          margin: 0px;
-          text-align: center;
-          width: 100%;
-          input {
-            margin: 0;
-          }
-        }
+        text-align: center;
       }
       td.line_content {
         /* TODO same padding as context to align things */

--- a/app/assets/stylesheets/sections/conflict.scss
+++ b/app/assets/stylesheets/sections/conflict.scss
@@ -1,0 +1,65 @@
+.diff-file {
+  tbody.radio_holder {
+    border: 2px solid #666;
+    tr.line_holder {
+      &.theirs {
+        td.old_line {
+          background: #CCF;
+        }
+        td.line_content {
+          background: #DDF;
+          span.idiff {
+            background: #AAF;
+          }
+        }
+      }
+      &.custom {
+        td.old_line {
+          background: #FFA;
+        }
+        td.line_content {
+          background: #FFA;
+          padding: 1px;
+          textarea {
+            font: inherit;
+            /* TODO determine exact of lines to show */
+            height: 4em;
+            /* TODO DRY 4px to match context lines (6px = 1 td padding + 1 border + 4 textarea padding) */
+            padding: 1px 4px;
+            resize: vertical;
+          }
+        }
+      }
+      &:not(:last-child) {
+        /* TODO factor out with other colors */
+        border-bottom: 1px solid #666;
+      }
+      td.old_line {
+        padding: 0px;
+        label {
+          display: block;
+          /* TODO make this work with parent of unknown height */
+          height: 100%;
+          margin: 0px;
+          text-align: center;
+          width: 100%;
+          input {
+            margin: 0;
+          }
+        }
+      }
+      td.line_content {
+        /* TODO same padding as context to align things */
+        height: initial;
+        padding-left: 0.5em;
+        pre {
+          background: transparent;
+          border-style: none;
+          margin: 0;
+          padding: 0;
+        }
+        white-space: initial;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/sections/conflict.scss
+++ b/app/assets/stylesheets/sections/conflict.scss
@@ -1,14 +1,12 @@
 .conflicts {
   $resolution_bg_color: #FFA;
   $theirs_bg_color: #CCF;
-  $line_content_diff: (17/16);
   .legend-item {
     &:not(:last-child) {
       margin-right: 1.5em;
     }
     span.color {
-      // TODO harmonize and DRY out with other borders.
-      border: 1px solid black;
+      border: 1px solid $diff_file_border;
       display: inline-block;
       height: 1em;
       width: 1em;
@@ -29,8 +27,11 @@
   }
   .diff-file {
     tbody.actions {
-      border: 2px solid #666;
+      border-color: $diff_file_border;
+      border-style: solid none;
+      border-width: 1px;
       tr.line_holder {
+        $line_content_diff: (17/16);
         td.old_line {
           padding: 0px;
           text-align: center;
@@ -40,8 +41,7 @@
         }
         td.line_content {
           height: initial;
-          /* TODO DRY this out with same padding as context to align things. */
-          padding-left: 0.5em;
+          padding-left: $line_content_padding_left;
           pre {
             background: transparent;
             border-style: none;
@@ -51,8 +51,7 @@
           white-space: initial;
         }
         &:not(:last-child) {
-          /* TODO factor out with other colors */
-          border-bottom: 1px solid #666;
+          border-bottom: 1px solid $diff_file_border;
         }
         &.theirs {
           td.old_line {
@@ -70,14 +69,14 @@
             background: $resolution_bg_color;
           }
           td.line_content {
+            $textarea_inner_padding_left: 0.25em;
             background: $resolution_bg_color * $line_content_diff;
-            padding: 1px;
+            padding: $line_content_padding_left - $textarea_inner_padding_left;
             textarea {
               font: inherit;
-              /* TODO determine exact of lines to show */
+              /* TODO Make this automatically grow as necessary with Javascript + resizable on bottom border (not just corner). */
               height: 4em;
-              /* TODO DRY 4px to match context lines (6px = 1 td padding + 1 border + 4 textarea padding) */
-              padding: 1px 4px;
+              padding: 1px $textarea_inner_padding_left;
               resize: vertical;
             }
           }

--- a/app/assets/stylesheets/sections/conflict.scss
+++ b/app/assets/stylesheets/sections/conflict.scss
@@ -1,57 +1,87 @@
-.diff-file {
-  tbody.actions {
-    border: 2px solid #666;
-    tr.line_holder {
+.conflicts {
+  $resolution_bg_color: #FFA;
+  $theirs_bg_color: #CCF;
+  $line_content_diff: (17/16);
+  .legend-item {
+    &:not(:last-child) {
+      margin-right: 1.5em;
+    }
+    span.color {
+      // TODO harmonize and DRY out with other borders.
+      border: 1px solid black;
+      display: inline-block;
+      height: 1em;
+      width: 1em;
+      vertical-align: middle;
+      &.ours {
+        background: $diff_new_line;
+      }
+      &.base {
+        background: $diff_old_line;
+      }
       &.theirs {
+        background: $theirs_bg_color;
+      }
+      &.resolution {
+        background: $resolution_bg_color;
+      }
+    }
+  }
+  .diff-file {
+    tbody.actions {
+      border: 2px solid #666;
+      tr.line_holder {
         td.old_line {
-          background: #CCF;
-        }
-        td.line_content {
-          background: #DDF;
-          span.idiff {
-            background: #AAF;
+          padding: 0px;
+          text-align: center;
+          &.button-holder {
+            cursor:pointer;
           }
         }
-      }
-      &.custom {
-        td.old_line {
-          background: #FFA;
-        }
         td.line_content {
-          background: #FFA;
-          padding: 1px;
-          textarea {
-            font: inherit;
-            /* TODO determine exact of lines to show */
-            height: 4em;
-            /* TODO DRY 4px to match context lines (6px = 1 td padding + 1 border + 4 textarea padding) */
-            padding: 1px 4px;
-            resize: vertical;
+          height: initial;
+          /* TODO DRY this out with same padding as context to align things. */
+          padding-left: 0.5em;
+          pre {
+            background: transparent;
+            border-style: none;
+            margin: 0;
+            padding: 0;
+          }
+          white-space: initial;
+        }
+        &:not(:last-child) {
+          /* TODO factor out with other colors */
+          border-bottom: 1px solid #666;
+        }
+        &.theirs {
+          td.old_line {
+            background: $theirs_bg_color;
+          }
+          td.line_content {
+            background: $theirs_bg_color * $line_content_diff;
+            span.idiff {
+              background: #AAF;
+            }
           }
         }
-      }
-      &:not(:last-child) {
-        /* TODO factor out with other colors */
-        border-bottom: 1px solid #666;
-      }
-      td.old_line {
-        padding: 0px;
-        text-align: center;
-        &.button-holder {
-          cursor:pointer;
+        &.resolution {
+          td.old_line {
+            background: $resolution_bg_color;
+          }
+          td.line_content {
+            background: $resolution_bg_color * $line_content_diff;
+            padding: 1px;
+            textarea {
+              font: inherit;
+              /* TODO determine exact of lines to show */
+              height: 4em;
+              /* TODO DRY 4px to match context lines (6px = 1 td padding + 1 border + 4 textarea padding) */
+              padding: 1px 4px;
+              resize: vertical;
+            }
+          }
         }
-      }
-      td.line_content {
-        height: initial;
-        /* TODO DRY this out with same padding as context to align things. */
-        padding-left: 0.5em;
-        pre {
-          background: transparent;
-          border-style: none;
-          margin: 0;
-          padding: 0;
-        }
-        white-space: initial;
       }
     }
   }

--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -1,11 +1,11 @@
 .diff-file {
-  border: 1px solid #CCC;
+  border: 1px solid $diff_file_border;
   margin-bottom: 1em;
 
   .diff-header {
     @extend .clearfix;
     background: #EEE;
-    border-bottom: 1px solid #CCC;
+    border-bottom: 1px solid $diff_file_border;
     padding: 5px 5px 5px 10px;
     color: #555;
 
@@ -126,7 +126,7 @@
     .line_content {
       display: block;
       margin: 0px;
-      padding: 0px 0.5em;
+      padding: 0px $line_content_padding_left;
       border: none;
       &.new {
         background: #CFD;

--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -114,12 +114,12 @@
     .line_holder {
       &.old .old_line,
       &.old .new_line {
-        background: #FCC;
+        background: $diff_old_line;
         border-color: #E7BABA;
       }
       &.new .old_line,
       &.new .new_line {
-        background: #CFC;
+        background: $diff_new_line;
         border-color: #B9ECB9;
       }
     }

--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -2,10 +2,10 @@ require 'gitlab/satellite/satellite'
 
 class Projects::MergeRequestsController < Projects::ApplicationController
   before_filter :module_enabled
-  before_filter :merge_request, only: [:edit, :update, :show, :diffs, :automerge, :automerge_check, :ci_status]
-  before_filter :closes_issues, only: [:edit, :update, :show, :diffs]
-  before_filter :validates_merge_request, only: [:show, :diffs]
-  before_filter :define_show_vars, only: [:show, :diffs]
+  before_filter :merge_request, only: [:edit, :update, :show, :diffs, :conflicts, :automerge, :automerge_check, :ci_status]
+  before_filter :closes_issues, only: [:edit, :update, :show, :diffs, :conflicts]
+  before_filter :validates_merge_request, only: [:show, :diffs, :conflicts]
+  before_filter :define_show_vars, only: [:show, :diffs, :conflicts]
 
   # Allow read any merge_request
   before_filter :authorize_read_merge_request!
@@ -54,6 +54,16 @@ class Projects::MergeRequestsController < Projects::ApplicationController
     respond_to do |format|
       format.html
       format.json { render json: { html: view_to_html_string("projects/merge_requests/show/_diffs") } }
+    end
+  end
+
+  def conflicts
+    @conflicts = @merge_request.conflicts
+    @commit = @merge_request.last_commit
+
+    respond_to do |format|
+      format.html
+      format.json { render json: { html: view_to_html_string("projects/merge_requests/show/_conflicts") } }
     end
   end
 
@@ -127,6 +137,11 @@ class Projects::MergeRequestsController < Projects::ApplicationController
     else
       @status = false
     end
+  end
+
+  def resolve_conflict_merge
+    return access_denied! unless allowed_to_merge?
+    # TODO stub
   end
 
   def branch_from

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -267,4 +267,8 @@ module ProjectsHelper
     result.password = '*****' if result.password.present?
     result
   end
+
+  def hidden_lines_placeholder
+    '...'
+  end
 end

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -18,6 +18,7 @@
 #  iid               :integer
 #  description       :text
 #  position          :integer          default(0)
+#  conflicts         :text
 #
 
 require Rails.root.join("app/models/commit")
@@ -93,6 +94,8 @@ class MergeRequest < ActiveRecord::Base
     state :can_be_merged
     state :cannot_be_merged
   end
+
+  serialize :conflicts
 
   validates :source_project, presence: true, unless: :allow_broken
   validates :source_branch, presence: true

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -318,4 +318,73 @@ class MergeRequest < ActiveRecord::Base
       source_project.repository.branch_names
     end
   end
+
+  def conflicts
+    # TODO stub
+    [
+      # Context don't touch each other nor file borders.
+      OpenStruct.new(
+        path: 'conflict/conflict1.md',
+        lines: [
+          OpenStruct.new(type: :context,  content: 'a', number: 1),
+          OpenStruct.new(type: :context,  content: 'b', number: 2),
+          OpenStruct.new(type: :context,  content: 'c', number: 3),
+          OpenStruct.new(type: :conflict, id: 1,
+            ours:   %{d d <span class="idiff">2</span>\nd <span class="idiff">2</span> d\n},
+            base:   %{d <span class="idiff">d</span> <span class="idiff">d</span>\nd <span class="idiff">d</span> <span class="idiff">d</span>\n},
+            theirs: %{d <span class="idiff">1</span> d\nd d <span class="idiff">1</span>\n},
+            custom: %{d d 2\nd 2 d\n},
+          ),
+          OpenStruct.new(type: :context,  content: 'e', number: 5),
+          OpenStruct.new(type: :context,  content: 'f', number: 6),
+          OpenStruct.new(type: :context,  content: 'g', number: 7),
+          OpenStruct.new(type: :match),
+          OpenStruct.new(type: :context,  content: 'i', number: 9),
+          OpenStruct.new(type: :context,  content: 'j', number: 10),
+          OpenStruct.new(type: :context,  content: 'k', number: 11),
+          OpenStruct.new(type: :conflict, id: 2,
+            ours:   %{l l <span class="idiff">2</span>\nl <span class="idiff">2</span> l\n},
+            base:   %{l <span class="idiff">l</span> <span class="idiff">l</span>\nl <span class="idiff">l</span> <span class="idiff">l</span>\n},
+            theirs: %{l <span class="idiff">1</span> l\nl l <span class="idiff">1</span>\n},
+            custom: %{l l 2\nl 2 l\n},
+          ),
+          OpenStruct.new(type: :context,  content: 'm', number: 13),
+          OpenStruct.new(type: :context,  content: 'n', number: 14),
+          OpenStruct.new(type: :context,  content: 'o', number: 15),
+        ]
+      ),
+
+      # Context don't touch each other nor file borders.
+      OpenStruct.new(
+        path: 'conflict/conflict2.md',
+        lines: [
+          OpenStruct.new(type: :context,  content: 'a', number: 1),
+          OpenStruct.new(type: :context,  content: 'b', number: 2),
+          OpenStruct.new(type: :context,  content: 'c', number: 3),
+          OpenStruct.new(type: :conflict, id: 1,
+            ours:   %{d d <span class="idiff">2</span>\nd <span class="idiff">2</span> d\n},
+            base:   %{d <span class="idiff">d</span> <span class="idiff">d</span>\nd <span class="idiff">d</span> <span class="idiff">d</span>\n},
+            theirs: %{d <span class="idiff">1</span> d\nd d <span class="idiff">1</span>\n},
+            custom: %{d d 2\nd 2 d\n},
+          ),
+          OpenStruct.new(type: :context,  content: 'e', number: 5),
+          OpenStruct.new(type: :context,  content: 'f', number: 6),
+          OpenStruct.new(type: :context,  content: 'g', number: 7),
+          OpenStruct.new(type: :match),
+          OpenStruct.new(type: :context,  content: 'i', number: 9),
+          OpenStruct.new(type: :context,  content: 'j', number: 10),
+          OpenStruct.new(type: :context,  content: 'k', number: 11),
+          OpenStruct.new(type: :conflict, id: 2,
+            ours:   %{l l <span class="idiff">2</span>\nl <span class="idiff">2</span> l\n},
+            base:   %{l <span class="idiff">l</span> <span class="idiff">l</span>\nl <span class="idiff">l</span> <span class="idiff">l</span>\n},
+            theirs: %{l <span class="idiff">1</span> l\nl l <span class="idiff">1</span>\n},
+            custom: %{l l 2\nl 2 l\n},
+          ),
+          OpenStruct.new(type: :context,  content: 'm', number: 13),
+          OpenStruct.new(type: :context,  content: 'n', number: 14),
+          OpenStruct.new(type: :context,  content: 'o', number: 15),
+        ]
+      ),
+    ]
+  end
 end

--- a/app/views/projects/diffs/_match_line.html.haml
+++ b/app/views/projects/diffs/_match_line.html.haml
@@ -1,7 +1,7 @@
 %td.old_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_old},
  class: unfold_bottom_class(bottom)}
-  \...
+  = hidden_lines_placeholder
 %td.new_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_new},
  class: unfold_bottom_class(bottom)}
-  \...
+  = hidden_lines_placeholder
 %td.line_content.matched= line

--- a/app/views/projects/edit_tree/preview.html.haml
+++ b/app/views/projects/edit_tree/preview.html.haml
@@ -14,8 +14,8 @@
             - @diff_lines.each do |line|
               %tr.line_holder{ class: "#{line.type}" }
                 - if line.type == "match"
-                  %td.old_line= "..."
-                  %td.new_line= "..."
+                  %td.old_line= hidden_lines_placeholder
+                  %td.new_line= hidden_lines_placeholder
                   %td.line_content.matched= line.text
                 - else
                   %td.old_line

--- a/app/views/projects/merge_requests/_show.html.haml
+++ b/app/views/projects/merge_requests/_show.html.haml
@@ -18,6 +18,11 @@
           %i.icon-list-alt
           Changes
           %span.badge= @merge_request.diffs.size
+      %li.conflicts-tab{data: {action: "conflicts"}}
+        = link_to conflicts_project_merge_request_path(@project, @merge_request) do
+          %i.icon-resize-small
+          Conflicts
+          %span.badge= @merge_request.conflicts.size
 
   - content_for :note_actions do
     - if can?(current_user, :modify_merge_request, @merge_request)
@@ -29,6 +34,9 @@
   .diffs.tab-content
     - if current_page?(action: 'diffs')
       = render "projects/merge_requests/show/diffs"
+  .conflicts.tab-content
+    - if current_page?(action: 'conflicts')
+      = render "projects/merge_requests/show/conflicts"
   .notes.tab-content.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
     = render "projects/notes/notes_with_form"
   .mr-loading-status

--- a/app/views/projects/merge_requests/conflicts.html.haml
+++ b/app/views/projects/merge_requests/conflicts.html.haml
@@ -1,0 +1,1 @@
+= render "show"

--- a/app/views/projects/merge_requests/show/_conflicts.html.haml
+++ b/app/views/projects/merge_requests/show/_conflicts.html.haml
@@ -1,4 +1,9 @@
 .files
+  %p.help-block
+    %span
+    %span
+    %span
+    %span
   = form_tag [:resolve_conflict_merge, @project, @merge_request],
       method: :post do |f|
     - @conflicts.each_with_index do |file_conflicts, file_id|
@@ -11,29 +16,27 @@
               - case line.type
               - when :match
                 %tr.line_holder
-                  -# TODO dry this constant with diff view
-                  %td.old_line= '...'
+                  %td.old_line= hidden_lines_placeholder
                   %td.line_content
               - when :context
                 %tr.line_holder
                   %td.old_line= line.number.to_s
                   %td.line_content= line.content
               - else
-                - radio_name = "#{file_id}-#{line.id}"
-                %tbody.radio_holder
+                %tbody.actions
                   %tr.line_holder.new
-                    %td.old_line
+                    %td.old_line.button-holder
                       %i.icon-plus-sign-alt
                     %td.line_content.new
                       -# TODO remove raw, set html_safe elsewhere considering inserted idiff spans.
                       %pre>= raw line.ours
                   %tr.line_holder.old
-                    %td.old_line
+                    %td.old_line.button-holder
                       %i.icon-plus-sign-alt
                     %td.line_content.old
                       %pre>= raw line.base
                   %tr.line_holder.theirs
-                    %td.old_line
+                    %td.old_line.button-holder
                       %i.icon-plus-sign-alt
                     %td.line_content
                       %pre>= raw line.theirs

--- a/app/views/projects/merge_requests/show/_conflicts.html.haml
+++ b/app/views/projects/merge_requests/show/_conflicts.html.haml
@@ -1,0 +1,52 @@
+.files
+  = form_tag [:resolve_conflict_merge, @project, @merge_request],
+      method: :post do |f|
+    - @conflicts.each_with_index do |file_conflicts, file_id|
+      .diff-file
+        .diff-header
+          %span= file_conflicts.path
+        .diff-content
+          %table.text-file
+            - file_conflicts.lines.each do |line|
+              - case line.type
+              - when :match
+                %tr.line_holder
+                  -# TODO dry this constant with diff view
+                  %td.old_line= '...'
+                  %td.line_content
+              - when :context
+                %tr.line_holder
+                  %td.old_line= line.number.to_s
+                  %td.line_content= line.content
+              - else
+                - radio_name = "#{file_id}-#{line.id}"
+                %tbody.radio_holder
+                  %tr.line_holder.new
+                    %td.old_line
+                      %label
+                        = radio_button_tag radio_name, 'ours', true, title: 'ours'
+                    %td.line_content.new
+                      -# TODO remove raw, set html_safe elsewhere considering inserted idiff spans.
+                      %pre>= raw line.ours
+                  %tr.line_holder.old
+                    %td.old_line
+                      %label
+                        = radio_button_tag radio_name, 'base', false, title: 'base'
+                    %td.line_content.old
+                      %pre>= raw line.base
+                  %tr.line_holder.theirs
+                    %td.old_line
+                      %label
+                        = radio_button_tag radio_name, 'theirs', false, title: 'theirs'
+                    %td.line_content
+                      %pre>= raw line.theirs
+                  %tr.line_holder.custom
+                    %td.old_line
+                      %label
+                        = radio_button_tag radio_name, 'custom', false, title: 'custom'
+                    %td.line_content
+                      = text_area_tag 'custom', line.custom[0..-2],
+                          class: 'form-control'
+-if current_user
+  .line_content
+    = button_tag 'Resolve conflicts and merge pull request.', class: 'btn btn-create accept_merge_request'

--- a/app/views/projects/merge_requests/show/_conflicts.html.haml
+++ b/app/views/projects/merge_requests/show/_conflicts.html.haml
@@ -23,29 +23,24 @@
                 %tbody.radio_holder
                   %tr.line_holder.new
                     %td.old_line
-                      %label
-                        = radio_button_tag radio_name, 'ours', true, title: 'ours'
+                      %i.icon-plus-sign-alt
                     %td.line_content.new
                       -# TODO remove raw, set html_safe elsewhere considering inserted idiff spans.
                       %pre>= raw line.ours
                   %tr.line_holder.old
                     %td.old_line
-                      %label
-                        = radio_button_tag radio_name, 'base', false, title: 'base'
+                      %i.icon-plus-sign-alt
                     %td.line_content.old
                       %pre>= raw line.base
                   %tr.line_holder.theirs
                     %td.old_line
-                      %label
-                        = radio_button_tag radio_name, 'theirs', false, title: 'theirs'
+                      %i.icon-plus-sign-alt
                     %td.line_content
                       %pre>= raw line.theirs
                   %tr.line_holder.custom
                     %td.old_line
-                      %label
-                        = radio_button_tag radio_name, 'custom', false, title: 'custom'
                     %td.line_content
-                      = text_area_tag 'custom', line.custom[0..-2],
+                      = text_area_tag "#{file_id}-#{line.id}", line.custom[0..-2],
                           class: 'form-control'
 -if current_user
   .line_content

--- a/app/views/projects/merge_requests/show/_conflicts.html.haml
+++ b/app/views/projects/merge_requests/show/_conflicts.html.haml
@@ -1,9 +1,17 @@
 .files
   %p.help-block
-    %span
-    %span
-    %span
-    %span
+    %span.legend-item
+      %span.color.ours
+      Ours
+    %span.legend-item
+      %span.color.base
+      Base
+    %span.legend-item
+      %span.color.theirs
+      Theirs
+    %span.legend-item
+      %span.color.resolution
+      Resolution
   = form_tag [:resolve_conflict_merge, @project, @merge_request],
       method: :post do |f|
     - @conflicts.each_with_index do |file_conflicts, file_id|
@@ -40,7 +48,7 @@
                       %i.icon-plus-sign-alt
                     %td.line_content
                       %pre>= raw line.theirs
-                  %tr.line_holder.custom
+                  %tr.line_holder.resolution
                     %td.old_line
                     %td.line_content
                       = text_area_tag "#{file_id}-#{line.id}", line.custom[0..-2],

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -53,11 +53,17 @@
 
   .automerge_widget.cannot_be_merged.hide
     %h4
-      This request can't be merged with GitLab.
+      This request can't be merged automatically.
     %p
-      You should do it manually with
+      You can
       %strong
-        = link_to "command line", "#modal_merge_info", class: "how_to_merge_link", title: "How To Merge", "data-toggle" => "modal"
+        = link_to "resolve the conflicts here", conflicts_project_merge_request_path(@project, @merge_request)
+      or do it from the
+      %strong
+        = link_to "command line", "#modal_merge_info",
+            class: "how_to_merge_link",
+            title: "How to merge from the command line",
+            "data-toggle" => "modal"
 
   .automerge_widget.unchecked
     %p

--- a/app/views/projects/notes/discussions/_diff.html.haml
+++ b/app/views/projects/notes/discussions/_diff.html.haml
@@ -15,8 +15,8 @@
           - line_code = generate_line_code(note.file_path, line)
           %tr.line_holder{ id: line_code }
             - if line.type == "match"
-              %td.old_line= "..."
-              %td.new_line= "..."
+              %td.old_line= hidden_lines_placeholder
+              %td.new_line= hidden_lines_placeholder
               %td.line_content.matched= line.text
             - else
               %td.old_line= raw(line.type == "new" ? "&nbsp;" : line.old_pos)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,7 +273,9 @@ Gitlab::Application.routes.draw do
       resources :merge_requests, constraints: {id: /\d+/}, except: [:destroy] do
         member do
           get :diffs
+          get :conflicts
           post :automerge
+          post :resolve_conflict_merge
           get :automerge_check
           get :ci_status
         end

--- a/db/migrate/20140830190554_add_conflict_to_merge_request.rb
+++ b/db/migrate/20140830190554_add_conflict_to_merge_request.rb
@@ -1,0 +1,5 @@
+class AddConflictsToMergeRequest < ActiveRecord::Migration
+  def change
+    add_column :merge_requests, :conflicts, :text
+  end
+end


### PR DESCRIPTION
Fixes AMR http://feedback.gitlab.com/forums/176466-general/suggestions/5590496-resolve-any-merge-request-conflict-from-the-web-in

When there are conflicts it shows:

![screenshot from 2014-07-21 17 02 05 gitlab resolve here](https://cloud.githubusercontent.com/assets/1429315/3645227/583b6906-10e8-11e4-93dc-810a19b9c137.png)

Then under the `conflicts` URL, there is an AJAX tab like "Changes":

![screenshot from 2014-07-21 17 23 40 gitlab resolve conflicts tab](https://cloud.githubusercontent.com/assets/1429315/3645505/14386436-10eb-11e4-98a2-69095b48562f.png)

When done, user clicks on the "Resolve conflicts and merge pull request" button at the bottom to finish.

Detail of one of the conflicts:

![screenshot from 2014-07-21 17 26 13 gitlab resolve detail](https://cloud.githubusercontent.com/assets/1429315/3645535/64850fd4-10eb-11e4-8627-24ba14af6f24.png)

For each conflict, user must select one of 4 radio boxes: `ours`, `base`, `theirs`, or `custom`.

`ours`, `base` and `theirs` will contain fixed values parsed directly from `git checkout --conflict=diff3`. Bytes that changed between `ours` and `base` and `theirs` and `base` are highlighted like in the diffs with `idiff` spans by Diffy. 

`custom` will use the value of the textarea for a custom resolution. Its value defaults to `ours` which is a reasonable starting point for custom edits.

It is currently not possible to modify parts of the text outside of the conflict: one web UI workaround would be to leave them there, choose ours, merge the MR and only then those points by editing.

Tell me if the concept is OK so I can proceed do the backend.
