### PR TITLE
Attachment URL with non-/ relative root

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -27,7 +27,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def url
-    Gitlab.config.gitlab.relative_url_root + '' + super unless super.nil?
+    Gitlab.config.gitlab.relative_url_root + super unless super.nil?
   end
 
   def file_storage?

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -26,6 +26,10 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     Gitlab.config.gitlab.relative_url_root + "/files/#{model.class.to_s.underscore}/#{model.id}/#{file.filename}"
   end
 
+  def url
+    Gitlab.config.gitlab.relative_url_root + '' + super unless super.nil?
+  end
+
   def file_storage?
     self.class.storage == CarrierWave::Storage::File
   end


### PR DESCRIPTION
The attachment URL was not working with relative_url_root not equal to '/'. I suggest this fix.
