### PR TITLE
Fixed typo in upgrade docs that might confuse some users

### DIFF
--- a/doc/update/5.1-to-5.2.md
+++ b/doc/update/5.1-to-5.2.md
@@ -39,10 +39,10 @@ sudo -u git -H git checkout v1.4.0
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/5.1-to-5.4.md
+++ b/doc/update/5.1-to-5.4.md
@@ -36,10 +36,10 @@ sudo -u git -H git checkout v1.7.9 # Addresses multiple critical security vulner
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/5.1-to-6.0.md
+++ b/doc/update/5.1-to-6.0.md
@@ -70,10 +70,10 @@ sudo apt-get install python-docutils
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/5.2-to-5.3.md
+++ b/doc/update/5.2-to-5.3.md
@@ -30,10 +30,10 @@ sudo -u git -H git checkout 5-3-stable
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/5.3-to-5.4.md
+++ b/doc/update/5.3-to-5.4.md
@@ -34,10 +34,10 @@ sudo -u git -H git checkout v1.7.9 # Addresses multiple critical security vulner
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -69,10 +69,10 @@ sudo apt-get install python-docutils
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production

--- a/doc/update/6.0-to-6.1.md
+++ b/doc/update/6.0-to-6.1.md
@@ -49,10 +49,10 @@ sudo -u git -H git checkout v1.7.9
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.0-to-7.1.md
+++ b/doc/update/6.0-to-7.1.md
@@ -64,10 +64,10 @@ sudo -u git -H git checkout v1.9.6 # Addresses multiple critical security vulner
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.1-to-6.2.md
+++ b/doc/update/6.1-to-6.2.md
@@ -44,10 +44,10 @@ sudo apt-get install logrotate
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-#PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.2-to-6.3.md
+++ b/doc/update/6.2-to-6.3.md
@@ -39,10 +39,10 @@ The Gitlab-shell config changed recently, so check for config file changes and m
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.3-to-6.4.md
+++ b/doc/update/6.3-to-6.4.md
@@ -35,10 +35,10 @@ sudo -u git -H git checkout v1.8.0
 ```bash
 cd /home/git/gitlab
 
-# MySQL
+# PostgreSQL
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL
+# MySQL
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.4-to-6.5.md
+++ b/doc/update/6.4-to-6.5.md
@@ -45,10 +45,10 @@ sudo -u git -H git checkout v1.8.0
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.5-to-6.6.md
+++ b/doc/update/6.5-to-6.6.md
@@ -45,10 +45,10 @@ sudo -u git -H git checkout v1.8.0
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.6-to-6.7.md
+++ b/doc/update/6.6-to-6.7.md
@@ -45,10 +45,10 @@ sudo -u git -H git checkout v1.9.1
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -47,10 +47,10 @@ sudo -u git -H git checkout v1.9.3
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 

--- a/doc/update/6.8-to-6.9.md
+++ b/doc/update/6.8-to-6.9.md
@@ -47,10 +47,10 @@ sudo -u git -H git checkout v1.9.4
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 # Run database migrations

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -79,10 +79,10 @@ sudo -u git -H git checkout v1.9.6
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 # Run database migrations

--- a/doc/update/7.0-to-7.1.md
+++ b/doc/update/7.0-to-7.1.md
@@ -79,10 +79,10 @@ sudo -u git -H git checkout v1.9.6
 ```bash
 cd /home/git/gitlab
 
-# MySQL installations (note: the line below states '--without ... postgres')
+# PostgreSQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 
-# PostgreSQL installations (note: the line below states '--without ... mysql')
+# MySQL installations (note: the line below states '--without ... mysql')
 sudo -u git -H bundle install --without development test mysql --deployment
 
 # Run database migrations


### PR DESCRIPTION
Typo in upgrade docs since 5.1-to-5.2.md where comment indicating database type was wrong, which might confuse some users.
