### PR TITLE
Add RedCloth to fix problem with textile files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem "seed-fu"
 gem "redcarpet",     "~> 2.2.2"
 gem "github-markup"
 gem "org-ruby" # For rendering .org files
+gem "RedCloth"
 
 # Diffs
 gem 'diffy', '~> 3.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    RedCloth (4.2.9)
     ace-rails-ap (2.0.1)
     actionmailer (4.1.1)
       actionpack (= 4.1.1)
@@ -570,6 +571,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  RedCloth
   ace-rails-ap
   acts-as-taggable-on
   annotate (~> 2.6.0.beta2)


### PR DESCRIPTION
Missing RedCloth gem in Gemfile prevent textile files to be read when using github markup gem which is provoking 500 error on Gitlab.
Fix consist only on adding the gem to the Gemfile.
