### PR TITLE
Use a ? after the $request_uri to perform a valid Redirect while cloning...

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -54,7 +54,7 @@ server {
   server_name YOUR_SERVER_FQDN; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
   root /nowhere; ## root doesn't have to be a valid path since we are redirecting
-  rewrite ^ https://$server_name$request_uri permanent;
+  rewrite ^ https://$server_name$request_uri? permanent;
 }
 
 server {


### PR DESCRIPTION
see https://github.com/gitlabhq/gitlabhq/issues/6203#issuecomment-50244473

before:

❯ curl -I http://gitlab/namespace/repo.git/info/refs?service=git-upload-pack
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Sat, 26 Jul 2014 18:20:27 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://gitlab/namespace/repo.git/info/refs?**service=git-upload-pack?service=git-upload-pack**

after:

❯ curl -I
http://gitlab/namespace/repo.git/info/refs\?service=git-upload-pack
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Sat, 26 Jul 2014 18:23:54 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://gitlab/namespace/repo.git/info/refs?service=git-upload-pack
