### PR TITLE
[minor-refactor] Remove unused title parameter on merge request creation helper.

### DIFF
--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -19,8 +19,7 @@ module MergeRequestsHelper
       source_project_id: event.project.id,
       target_project_id: target_project.id,
       source_branch: event.branch_name,
-      target_branch: target_project.repository.root_ref,
-      title: event.branch_name.titleize.humanize
+      target_branch: target_project.repository.root_ref
     }
   end
 


### PR DESCRIPTION
Every new merge request path will pass through the `new` action: https://github.com/gitlabhq/gitlabhq/blob/cb0d63b9e3fa464ae8c0cd9cf7bdb8d080a7e02f/app/controllers/projects/merge_requests_controller.rb#L60, which in turn uses `MergeRequests::BuildService`, which fixes the title to a humanized branch name no matter what `:title` parameter you pass: https://github.com/gitlabhq/gitlabhq/blob/cb0d63b9e3fa464ae8c0cd9cf7bdb8d080a7e02f/app/services/merge_requests/build_service.rb#L20
