### PR TITLE
Do not execute hooks on empty projects, fixes #6108

### DIFF
--- a/app/controllers/projects/hooks_controller.rb
+++ b/app/controllers/projects/hooks_controller.rb
@@ -24,7 +24,12 @@ class Projects::HooksController < Projects::ApplicationController
   end
 
   def test
-    TestHookService.new.execute(hook, current_user)
+    if !@project.empty_repo?
+      TestHookService.new.execute(hook, current_user)
+      flash[:notice] = 'Hook successfully executed.'
+    else
+      flash[:alert] = 'Hook execution failed. Ensure the project has commits.'
+    end
 
     redirect_to :back
   end

--- a/features/project/hooks.feature
+++ b/features/project/hooks.feature
@@ -19,3 +19,8 @@ Feature: Project Hooks
     When I click test hook button
     Then hook should be triggered
 
+  Scenario: I test a hook on empty project
+    Given I own empty project with hook
+    And I visit project hooks page
+    When I click test hook button
+    Then I should see hook error message

--- a/features/steps/project/hooks.rb
+++ b/features/steps/project/hooks.rb
@@ -8,31 +8,45 @@ class ProjectHooks < Spinach::FeatureSteps
   include RSpec::Mocks::ExampleMethods
   include WebMock::API
 
-  Given 'project has hook' do
+  step 'project has hook' do
     @hook = create(:project_hook, project: current_project)
   end
 
-  Then 'I should see project hook' do
+  step 'I own empty project with hook' do
+    @project = create(:empty_project,
+                      name: 'Empty Project', namespace: @user.namespace)
+    @hook = create(:project_hook, project: current_project)
+  end
+
+  step 'I should see project hook' do
     page.should have_content @hook.url
   end
 
-  When 'I submit new hook' do
+  step 'I submit new hook' do
     @url = Faker::Internet.uri("http")
     fill_in "hook_url", with: @url
     expect { click_button "Add Web Hook" }.to change(ProjectHook, :count).by(1)
   end
 
-  Then 'I should see newly created hook' do
+  step 'I should see newly created hook' do
     page.current_path.should == project_hooks_path(current_project)
     page.should have_content(@url)
   end
 
-  When 'I click test hook button' do
+  step 'I click test hook button' do
     stub_request(:post, @hook.url).to_return(status: 200)
     click_link 'Test Hook'
   end
 
-  Then 'hook should be triggered' do
+  step 'hook should be triggered' do
     page.current_path.should == project_hooks_path(current_project)
+    page.should have_selector '.flash-notice',
+                              text: 'Hook successfully executed.'
+  end
+
+  step 'I should see hook error message' do
+    page.should have_selector '.flash-alert',
+                              text: 'Hook execution failed. '\
+                              'Ensure the project has commits.'
   end
 end


### PR DESCRIPTION
#### What does this MR do?

This PR fixes the problem executing a webhook on a empty project. If there are no commits yet on the repository, a flash message indicating the is shown. Fur successful executed hooks also a flash message is shown.
#### Why was this MR needed?

Currently, executing the _Test Hook_ command on an empty project raises a 500 error. This PR fixes this.
#### What are the relevant issue numbers / Feature requests?

This PR fixes #6108
