### PR TITLE
Fix 500 on searching on empty project, restyle search page

### DIFF
--- a/app/assets/stylesheets/generic/common.scss
+++ b/app/assets/stylesheets/generic/common.scss
@@ -341,3 +341,18 @@ table {
 .footer-links a {
   margin-right: 15px;
 }
+
+.search_box {
+  position: relative;
+  padding: 30px;
+  text-align: center;
+  background-color: #F9F9F9;
+  border: 1px solid #DDDDDD;
+  border-radius: 0px;
+}
+
+.search_glyph {
+  color: #555;
+  font-size: 42px;
+}
+

--- a/app/services/search/project_service.rb
+++ b/app/services/search/project_service.rb
@@ -12,7 +12,13 @@ module Search
       return result unless query.present?
 
       if params[:search_code].present?
-        blobs = project.repository.search_files(query, params[:repository_ref]) unless project.empty_repo?
+        if !@project.empty_repo?
+          blobs = project.repository.search_files(query,
+                                                  params[:repository_ref])
+        else
+          blobs = Array.new
+        end
+
         blobs = Kaminari.paginate_array(blobs).page(params[:page]).per(20)
         result[:blobs] = blobs
         result[:total_results] = blobs.total_count

--- a/app/views/search/_project_results.html.haml
+++ b/app/views/search/_project_results.html.haml
@@ -9,8 +9,11 @@
 .search_results
   - if params[:search_code].present?
     .blob-results
-      = render partial: "search/results/blob", collection: @search_results[:blobs]
-      = paginate @search_results[:blobs], theme: 'gitlab'
+      - if !@search_results[:blobs].empty?
+        = render partial: "search/results/blob", collection: @search_results[:blobs]
+        = paginate @search_results[:blobs], theme: 'gitlab'
+      - else
+        %span We couldn't find any matching code
   - else
     %ul.bordered-list
       = render partial: "search/results/merge_request", collection: @search_results[:merge_requests]

--- a/app/views/search/_project_results.html.haml
+++ b/app/views/search/_project_results.html.haml
@@ -13,9 +13,12 @@
         = render partial: "search/results/blob", collection: @search_results[:blobs]
         = paginate @search_results[:blobs], theme: 'gitlab'
       - else
-        %span We couldn't find any matching code
+        = render partial: "search/results/empty", :locals => { message: "We couldn't find any matching code" }
   - else
-    %ul.bordered-list
-      = render partial: "search/results/merge_request", collection: @search_results[:merge_requests]
-      = render partial: "search/results/issue", collection: @search_results[:issues]
-      = render partial: "search/results/note", collection: @search_results[:notes]
+    - if (@search_results[:merge_requests] || @search_results[:issues] || @search_results[:notes]).length > 0
+      %ul.bordered-list
+        = render partial: "search/results/merge_request", collection: @search_results[:merge_requests]
+        = render partial: "search/results/issue", collection: @search_results[:issues]
+        = render partial: "search/results/note", collection: @search_results[:notes]
+    - else
+      = render partial: "search/results/empty", :locals => { message: "We couldn't find any issues, merge requests or notes" }

--- a/app/views/search/results/_empty.html.haml
+++ b/app/views/search/results/_empty.html.haml
@@ -1,0 +1,4 @@
+.search_box
+  .search_glyph
+    %span.icon-search
+  %h4 #{message}

--- a/features/project/source/search_code.feature
+++ b/features/project/source/search_code.feature
@@ -1,9 +1,15 @@
 Feature: Project Search code
   Background:
     Given I sign in as a user
-    And I own project "Shop"
-    Given I visit project source page
 
   Scenario: Search for term "coffee"
+    Given I own project "Shop"
+    And I visit project source page
     When I search for term "coffee"
     Then I should see files from repository containing "coffee"
+
+  Scenario: Search on empty project
+    Given I own an empty project
+    And I visit my project's home page
+    When I search for term "coffee"
+    Then I should see empty result

--- a/features/steps/project/search_code.rb
+++ b/features/steps/project/search_code.rb
@@ -3,14 +3,18 @@ class ProjectSearchCode < Spinach::FeatureSteps
   include SharedProject
   include SharedPaths
 
-  When 'I search for term "coffee"' do
+  step 'I search for term "coffee"' do
     fill_in "search", with: "coffee"
     click_button "Go"
     click_link 'Repository Code'
   end
 
-  Then 'I should see files from repository containing "coffee"' do
-    page.should have_content "coffee"
-    page.should have_content " CONTRIBUTING.md"
+  step 'I should see files from repository containing "coffee"' do
+    page.should have_content 'coffee'
+    page.should have_content 'CONTRIBUTING.md'
+  end
+
+  step 'I should see empty result' do
+    page.should have_content "We couldn't find any matching code"
   end
 end

--- a/features/steps/shared/project.rb
+++ b/features/steps/shared/project.rb
@@ -21,6 +21,13 @@ module SharedProject
     @project.team << [@user, :master]
   end
 
+  # Create an empty project without caring about the name
+  And 'I own an empty project' do
+    @project = create(:empty_project,
+                      name: 'Empty Project', namespace: @user.namespace)
+    @project.team << [@user, :master]
+  end
+
   And 'project "Shop" has push event' do
     @project = Project.find_by(name: "Shop")
 


### PR DESCRIPTION
#### What does this MR do?

This PR fixes searching on empty projects and adds a testcase therefore. For this reason, an empty search result displays a notification message as shown below. Since this is needed for the testcase, I also do restyling of the page here.
#### Why was this MR needed?

Currently searching on an empty project raises a 500 error. 
#### What are the relevant issue numbers / Feature requests?

This PR fixes
- #7217
- #6776
- https://gitlab.com/gitlab-org/gitlab-ce/issues/119
#### TODO
- [x] Better styling if there is no search result
- [x] Extend notice message if there is no search result to issues
#### Screenshots
##### Before

![screenshot 2014-07-31 00 09 46](https://cloud.githubusercontent.com/assets/278301/3757334/ad6fa008-1837-11e4-9eae-cd1237524a79.png)
##### After

![screenshot 2014-07-31 00 05 56](https://cloud.githubusercontent.com/assets/278301/3757337/b56df48a-1837-11e4-9020-629007806e9f.png)
![screenshot 2014-07-31 00 06 44](https://cloud.githubusercontent.com/assets/278301/3757340/bd6f1844-1837-11e4-9053-bc85bb23802e.png)
