### PR TITLE
Improve markup gems to prevent 500 errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,15 +79,19 @@ gem "six"
 gem "seed-fu"
 
 # Markdown to HTML
-gem "redcarpet",     "~> 2.2.2"
 gem "github-markup"
-gem "org-ruby" # For rendering .org files
+
+# Required markup gems by github-markdown
+gem 'redcarpet', '~> 2.2.2'
+gem 'RedCloth'
+gem 'rdoc', '~>3.6'
+gem 'org-ruby', '= 0.9.1'
+gem 'creole', '~>0.3.6'
+gem 'wikicloth', '=0.8.1'
+gem 'asciidoctor', '= 0.1.4'
 
 # Diffs
 gem 'diffy', '~> 3.0.3'
-
-# Asciidoc to HTML
-gem  "asciidoctor"
 
 # Application server
 group :unicorn do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    RedCloth (4.2.9)
     ace-rails-ap (2.0.1)
     actionmailer (4.1.1)
       actionpack (= 4.1.1)
@@ -86,6 +87,7 @@ GEM
       thor
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
+    creole (0.3.8)
     d3_rails (3.1.10)
       railties (>= 3.1.0)
     daemons (1.1.9)
@@ -121,6 +123,7 @@ GEM
     eventmachine (1.0.3)
     excon (0.32.1)
     execjs (2.0.2)
+    expression_parser (0.9.0)
     factory_girl (4.3.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.3.0)
@@ -320,7 +323,7 @@ GEM
     omniauth-twitter (1.0.1)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
-    org-ruby (0.9.6)
+    org-ruby (0.9.1)
       rubypants (>= 0.2.0)
     orm_adapter (0.5.0)
     pg (0.15.1)
@@ -413,6 +416,7 @@ GEM
     require_all (1.3.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    rinku (1.7.3)
     rouge (1.3.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -563,6 +567,10 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
     websocket-driver (0.3.3)
+    wikicloth (0.8.1)
+      builder
+      expression_parser
+      rinku
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -570,10 +578,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  RedCloth
   ace-rails-ap
   acts-as-taggable-on
   annotate (~> 2.6.0.beta2)
-  asciidoctor
+  asciidoctor (= 0.1.4)
   awesome_print
   better_errors
   binding_of_caller
@@ -583,6 +592,7 @@ DEPENDENCIES
   coffee-rails
   colored
   coveralls
+  creole (~> 0.3.6)
   d3_rails (~> 3.1.4)
   database_cleaner
   default_value_for (~> 3.0.0)
@@ -632,7 +642,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   omniauth-twitter
-  org-ruby
+  org-ruby (= 0.9.1)
   pg
   poltergeist (~> 1.5.1)
   pry
@@ -646,6 +656,7 @@ DEPENDENCIES
   raphael-rails (~> 2.1.2)
   rb-fsevent
   rb-inotify
+  rdoc (~> 3.6)
   redcarpet (~> 2.2.2)
   redis-rails
   request_store
@@ -682,3 +693,4 @@ DEPENDENCIES
   unicorn-worker-killer
   version_sorter
   webmock
+  wikicloth (= 0.8.1)

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -44,8 +44,8 @@ module TreeHelper
   #
   # Returns boolean
   def markup?(filename)
-    filename.downcase.end_with?(*%w(.textile .rdoc .org .creole
-                                    .mediawiki .rst .adoc .asciidoc .pod))
+    filename.downcase.end_with?(*%w(.textile .rdoc .org .creole .wiki .mediawiki
+                                    .rst .adoc .asciidoc .asc))
   end
 
   def gitlab_markdown?(filename)

--- a/spec/helpers/tree_helper_spec.rb
+++ b/spec/helpers/tree_helper_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe TreeHelper do
   describe '#markup?' do
-    %w(textile rdoc org creole mediawiki rst asciidoc pod).each do |type|
+    %w(textile rdoc org creole wiki mediawiki
+       rst adoc asciidoc asc).each do |type|
       it "returns true for #{type} files" do
         markup?("README.#{type}").should be_true
       end


### PR DESCRIPTION
#### What does this MR do?

This PR add support mor missing markup-gems required by `github-markdown`. Gem versions are taken from https://github.com/github/markup/blob/master/Gemfile.

Additional, this PR disables markup for `pod` files, because an external tool is required (`perl`).
#### Why was this MR needed?

Currently, when accessing a `(textile, mediawiki, creole)`-file a 500 error is raised, because of missing gems.
#### What are the relevant issue numbers / Feature requests?

This PR fixes following issues:
- #7143
- #7377
- https://gitlab.com/gitlab-org/gitlab-ce/issues/412
- http://feedback.gitlab.com/forums/176466-general/suggestions/3811439-anyway-to-allow-mediawiki-markup-in-the-wiki-page
