### PR TITLE
Prevent 500 if hook url is down when testing a hook, fixes #7376

### DIFF
--- a/app/controllers/projects/hooks_controller.rb
+++ b/app/controllers/projects/hooks_controller.rb
@@ -25,8 +25,13 @@ class Projects::HooksController < Projects::ApplicationController
 
   def test
     if !@project.empty_repo?
-      TestHookService.new.execute(hook, current_user)
-      flash[:notice] = 'Hook successfully executed.'
+      status = TestHookService.new.execute(hook, current_user)
+      if status
+        flash[:notice] = 'Hook successfully executed.'
+      else
+        flash[:alert] = 'Hook execution failed. '\
+                        'Ensure hook URL is correct and service is up.'
+      end
     else
       flash[:alert] = 'Hook execution failed. Ensure the project has commits.'
     end

--- a/app/services/test_hook_service.rb
+++ b/app/services/test_hook_service.rb
@@ -2,5 +2,8 @@ class TestHookService
   def execute(hook, current_user)
     data = GitPushService.new.sample_data(hook.project, current_user)
     hook.execute(data)
+    true
+  rescue SocketError
+    false
   end
 end

--- a/features/project/hooks.feature
+++ b/features/project/hooks.feature
@@ -24,3 +24,9 @@ Feature: Project Hooks
     And I visit project hooks page
     When I click test hook button
     Then I should see hook error message
+
+  Scenario: I test a hook on down URL
+    Given project has hook
+    And I visit project hooks page
+    When I click test hook button with invalid URL
+    Then I should see hook service down error message

--- a/features/steps/project/hooks.rb
+++ b/features/steps/project/hooks.rb
@@ -38,6 +38,11 @@ class ProjectHooks < Spinach::FeatureSteps
     click_link 'Test Hook'
   end
 
+  step 'I click test hook button with invalid URL' do
+    stub_request(:post, @hook.url).to_raise(SocketError)
+    click_link 'Test Hook'
+  end
+
   step 'hook should be triggered' do
     page.current_path.should == project_hooks_path(current_project)
     page.should have_selector '.flash-notice',
@@ -48,5 +53,12 @@ class ProjectHooks < Spinach::FeatureSteps
     page.should have_selector '.flash-alert',
                               text: 'Hook execution failed. '\
                               'Ensure the project has commits.'
+  end
+
+  step 'I should see hook service down error message' do
+    page.should have_selector '.flash-alert',
+                              text: 'Hook execution failed. '\
+                                    'Ensure hook URL is correct and '\
+                                    'service is up.'
   end
 end


### PR DESCRIPTION
##### What does this MR do?

This PR catches errors if the target webhook url is not down. If so, an error message is displayed at the bottom of the page.
##### Why was this MR needed?

Currently, if the user adds a webhook URL which is down, a 500 error is raised when pressing the `Test Hook` button.
##### What are the relevant issue numbers / Feature requests?

This PR fixes #7376
