### PR TITLE
Add Asana service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ v 7.4.0
   - API: filter project issues by milestone (Julien Bianchi)
   - Fail harder in the backup script
   - Zen mode for wiki and milestones (Robert Schilling)
+  - Added Asana service integration (Jeremy Benoist)
 
 v 7.3.2
   - Fix creating new file via web editor

--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,9 @@ gem "gemnasium-gitlab-service", "~> 0.2"
 # Slack integration
 gem "slack-notifier", "~> 0.3.2"
 
+# Asana integration
+gem 'asana', '~> 0.0.6'
+
 # d3
 gem "d3_rails", "~> 3.1.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,10 @@ GEM
       activemodel (= 4.1.1)
       activesupport (= 4.1.1)
       arel (~> 5.0.0)
+    activeresource (4.0.0)
+      activemodel (~> 4.0)
+      activesupport (~> 4.0)
+      rails-observers (~> 0.1.1)
     activesupport (4.1.1)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
@@ -36,6 +40,8 @@ GEM
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
     arel (5.0.1.20140414130214)
+    asana (0.0.6)
+      activeresource (>= 3.2.3)
     asciidoctor (0.1.4)
     awesome_print (1.2.0)
     axiom-types (0.0.5)
@@ -376,6 +382,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.1)
       sprockets-rails (~> 2.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     rails_autolink (1.1.6)
       rails (> 3.1)
     rails_best_practices (1.14.4)
@@ -591,6 +599,7 @@ DEPENDENCIES
   ace-rails-ap
   acts-as-taggable-on
   annotate (~> 2.6.0.beta2)
+  asana (~> 0.0.6)
   asciidoctor (= 0.1.4)
   awesome_print
   better_errors

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,6 +62,7 @@ class Project < ActiveRecord::Base
   has_one :hipchat_service, dependent: :destroy
   has_one :flowdock_service, dependent: :destroy
   has_one :assembla_service, dependent: :destroy
+  has_one :asana_service, dependent: :destroy
   has_one :gemnasium_service, dependent: :destroy
   has_one :slack_service, dependent: :destroy
   has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
@@ -311,7 +312,7 @@ class Project < ActiveRecord::Base
   end
 
   def available_services_names
-    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla emails_on_push gemnasium slack)
+    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla asana emails_on_push gemnasium slack)
   end
 
   def gitlab_ci?

--- a/app/models/project_services/asana_service.rb
+++ b/app/models/project_services/asana_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'asana'
 
 class AsanaService < Service
+  prop_accessor :api_key
   validates :api_key, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/asana_service.rb
+++ b/app/models/project_services/asana_service.rb
@@ -15,7 +15,7 @@
 require 'asana'
 
 class AsanaService < Service
-  prop_accessor :api_key
+  prop_accessor :api_key, :restrict_to_branch
   validates :api_key, presence: true, if: :activated?
 
   def title
@@ -42,7 +42,8 @@ You can find your Api Keys here: http://developer.asana.com/documentation/#api_k
 
   def fields
     [
-      { type: 'text', name: 'api_key', placeholder: 'User API token. User must have access to task, all comments will be attributed to this user.' }
+      { type: 'text', name: 'api_key', placeholder: 'User API token. User must have access to task, all comments will be attributed to this user.' },
+      { type: 'text', name: 'restrict_to_branch', placeholder: 'Comma-separated list of branches which will be automatically inspected. Leave blank to include all branches.' }
     ]
   end
 
@@ -53,6 +54,14 @@ You can find your Api Keys here: http://developer.asana.com/documentation/#api_k
 
     user = push[:user_name]
     branch = push[:ref].gsub('refs/heads/', '')
+
+    branch_restriction = restrict_to_branch.to_s
+
+    # check the branch restriction is poplulated and branch is not included
+    if branch_restriction.length > 0 && branch_restriction.index(branch) == nil
+      return
+    end
+
     project_name = project.name_with_namespace
     push_msg = user + ' pushed to branch ' + branch + ' of ' + project_name
 

--- a/app/models/project_services/asana_service.rb
+++ b/app/models/project_services/asana_service.rb
@@ -1,0 +1,98 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id          :integer          not null, primary key
+#  type        :string(255)
+#  title       :string(255)
+#  token       :string(255)
+#  project_id  :integer          not null
+#  created_at  :datetime
+#  updated_at  :datetime
+#  active      :boolean          default(FALSE), not null
+#  project_url :string(255)
+#  subdomain   :string(255)
+#  room        :string(255)
+#  recipients  :text
+#  api_key     :string(255)
+#
+
+require 'asana'
+
+class AsanaService < Service
+  validates :api_key, presence: true, if: :activated?
+
+  def title
+    'Asana'
+  end
+
+  def description
+    'Asana - Teamwork without email'
+  end
+
+  def help
+    'This service adds commit messages as comments to Asana tasks. Once enabled, commit messages
+are checked for Asana task URLs (for example, `https://app.asana.com/0/123456/987654`) or task IDs
+starting with # (for example, `#987654`). Every task ID found will get the commit comment added to it.
+
+You can also close a task with a message containing: `fix #123456`.
+
+You can find your Api Keys here: http://developer.asana.com/documentation/#api_keys'
+  end
+
+  def to_param
+    'asana'
+  end
+
+  def fields
+    [
+      { type: 'text', name: 'api_key', placeholder: 'User API token. User must have access to task, all comments will be attributed to this user.' }
+    ]
+  end
+
+  def execute(push)
+    Asana.configure do |client|
+      client.api_key = api_key
+    end
+
+    user = push[:user_name]
+    branch = push[:ref].gsub('refs/heads/', '')
+    project_name = project.name_with_namespace
+    push_msg = user + ' pushed to branch ' + branch + ' of ' + project_name
+
+    push[:commits].each do |commit|
+      check_commit(' ( ' + commit[:url] + ' ): ' + commit[:message], push_msg)
+    end
+  end
+
+  def check_commit(message, push_msg)
+    task_list = []
+    close_list = []
+
+    message.split("\n").each do |line|
+      # look for a task ID or a full Asana url
+      task_list.concat(line.scan(/#(\d+)/))
+      task_list.concat(line.scan(/https:\/\/app\.asana\.com\/\d+\/\d+\/(\d+)/))
+      # look for a word starting with 'fix' followed by a task ID
+      close_list.concat(line.scan(/(fix\w*)\W*#(\d+)/i))
+    end
+
+    # post commit to every taskid found
+    task_list.each do |taskid|
+      task = Asana::Task.find(taskid[0])
+
+      if task
+        task.create_story(text: push_msg + ' ' + message)
+      end
+    end
+
+    # close all tasks that had 'fix(ed/es/ing) #:id' in them
+    close_list.each do |taskid|
+      task = Asana::Task.find(taskid.last)
+
+      if task
+        task.modify(completed: true)
+      end
+    end
+  end
+end

--- a/app/views/projects/services/_form.html.haml
+++ b/app/views/projects/services/_form.html.haml
@@ -19,7 +19,8 @@
 
   - if @service.help.present?
     .bs-callout
-      = @service.help
+      = preserve do
+        = markdown @service.help
 
   .form-group
     = f.label :active, "Active", class: "control-label"

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -48,3 +48,9 @@ Feature: Project Services
     And I click email on push service link
     And I fill email on push settings
     Then I should see email on push service settings saved
+
+  Scenario: Activate Asana service
+    When I visit project "Shop" services page
+    And I click Asana service link
+    And I fill Asana settings
+    Then I should see Asana service settings saved

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -13,6 +13,7 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
     page.should have_content 'Hipchat'
     page.should have_content 'GitLab CI'
     page.should have_content 'Assembla'
+    page.should have_content 'Asana'
   end
 
   step 'I click gitlab-ci service link' do
@@ -86,6 +87,20 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
 
   step 'I should see Assembla service settings saved' do
     find_field('Token').value.should == 'verySecret'
+  end
+
+  step 'I click Asana service link' do
+    click_link 'Asana'
+  end
+
+  step 'I fill Asana settings' do
+    check 'Active'
+    fill_in 'Api key', with: 'verySecret'
+    click_button 'Save'
+  end
+
+  step 'I should see Asana service settings saved' do
+    find_field('Api key').value.should == 'verySecret'
   end
 
   step 'I click email on push service link' do

--- a/spec/models/asana_service_spec.rb
+++ b/spec/models/asana_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/asana_service_spec.rb
+++ b/spec/models/asana_service_spec.rb
@@ -1,0 +1,67 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id          :integer          not null, primary key
+#  type        :string(255)
+#  title       :string(255)
+#  token       :string(255)
+#  project_id  :integer          not null
+#  created_at  :datetime
+#  updated_at  :datetime
+#  active      :boolean          default(FALSE), not null
+#  project_url :string(255)
+#  subdomain   :string(255)
+#  room        :string(255)
+#  recipients  :text
+#  api_key     :string(255)
+#
+
+require 'spec_helper'
+
+describe AsanaService, models: true do
+  describe 'Associations' do
+    it { should belong_to :project }
+    it { should have_one :service_hook }
+  end
+
+  describe 'Validations' do
+    context 'active' do
+      before do
+        subject.active = true
+      end
+
+      it { should validate_presence_of :api_key }
+    end
+  end
+
+  describe 'Execute' do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+
+    before do
+      @asana = AsanaService.new
+      @asana.stub(
+        project: project,
+        project_id: project.id,
+        service_hook: true,
+        api_key: 'verySecret'
+      )
+    end
+
+    it 'should call Asana service to created a story' do
+      Asana::Task.should_receive(:find).with('123456').once
+      # Asana::Task.should_receive(:create_story).with('pushed related to #123456').once
+
+      @asana.check_commit('related to #123456', 'pushed')
+    end
+
+    it 'should call Asana service to created a story and close a task' do
+      Asana::Task.should_receive(:find).with('456789').twice
+      # Asana::Task.should_receive(:create_story).with('pushed related to #456789').once
+      # Asana::Task.should_receive(:modify).with(completed: true).once
+
+      @asana.check_commit('fix #456789', 'pushed')
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,6 +47,7 @@ describe Project do
     it { should have_many(:protected_branches).dependent(:destroy) }
     it { should have_one(:forked_project_link).dependent(:destroy) }
     it { should have_one(:slack_service).dependent(:destroy) }
+    it { should have_one(:asana_service).dependent(:destroy) }
   end
 
   describe "Mass assignment" do


### PR DESCRIPTION
Current state: WIP - Do not merge
- [x] working asana communication
- [x] ability to restrict to Branch (like the `master`)
#### What does this MR do?

When someone commit with a message including
- "blabla #123456", it will attach a new message to the task 123456 in Asana.
- "fix #456789", it will attach a new message and close (mark as done) the task 456789 in Asana

Also, I've added ability to render `service.help` as markdown. It's more easy to write the help message then.
#### Are there points in the code the reviewer needs to double check?
- `app/models/project_services/asana_service.rb`
- `app/views/projects/services/_form.html.haml`
#### Why was this MR needed?

We use Asana as our Issue tracking system. It will ease the relation between Asana and Gitlab by linking Asana tickets to git commit.
#### What are the relevant issue numbers / Feature requests?

Nope.
#### Screenshots (If appropiate)

From the Gitlab service page:
![](http://i.imgur.com/3oZ9ct4.png)

In Asana:
![](http://i.imgur.com/sjcCbN6.png)
