### PR TITLE
Fix 500 while renaming repo, fixes #7400

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,6 +37,7 @@ class ProjectsController < ApplicationController
         format.html { redirect_to edit_project_path(@project), notice: 'Project was successfully updated.' }
         format.js
       else
+        flash[:alert] = 'Error while updating project.'
         format.html { render "edit", layout: "project_settings" }
         format.js
       end

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -12,11 +12,16 @@ module Projects
         project.change_head(new_branch)
       end
 
-      if project.update_attributes(params.except(:default_branch))
-        if project.previous_changes.include?('path')
-          project.rename_repo
-        end
+      new_path = params[:path]
+      status = true
+
+      if new_path && new_path != project.path
+        status = project.rename_repo(new_path)
       end
+
+      project.update_attributes(params.except(:default_branch))
+      status
+    rescue RuntimeError
     end
   end
 end


### PR DESCRIPTION
#### What does this MR do?

This PR fixes a regression when renaming a repo. Instead of relying to the dirty state, it get's the new path from update service. I
#### Why was this MR needed?

When renaming a repo, a 500 error is raised.

This PR fixes regression #7400

/cc @randx @dosire
