### PR TITLE
Moved padding from li to a in dashboard groups / projects listing

### DIFF
--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -60,12 +60,13 @@
 }
 
 .project-row, .group-row {
-  padding: 8px 15px !important;
+  padding: 0 !important;
   font-size: 14px;
   line-height: 24px;
 
   a {
     display: block;
+    padding: 8px 15px;
   }
 
   .project-name, .group-name {


### PR DESCRIPTION
When the padding around items in the group / project list in the dashboard was applied to the li the link hit area didn't cover the whole list item.

This change applies the padding to the anchor tag so that the hit area covers the whole space of the items in the projects & groups lists which is slightly more user friendly. It also removes the slightly odd situation where if you hovered over the top or bottom of an item you got the change in background colour but there was no link to click on.
