### PR TITLE
Removed redundant spans

### DIFF
--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -2,10 +2,9 @@
   .panel-heading.clearfix
     = search_field_tag :filter_group, nil, placeholder: 'Filter by name', class: 'dash-filter form-control'
     - if current_user.can_create_group?
-      %span.pull-right
-        = link_to new_group_path, class: "btn btn-new" do
-          %i.icon-plus
-          New group
+      = link_to new_group_path, class: "btn btn-new pull-right" do
+        %i.icon-plus
+        New group
   %ul.well-list.dash-list
     - groups.each do |group|
       %li.group-row

--- a/app/views/dashboard/_projects.html.haml
+++ b/app/views/dashboard/_projects.html.haml
@@ -2,10 +2,9 @@
   .panel-heading.clearfix
     = search_field_tag :filter_projects, nil, placeholder: 'Filter by name', class: 'dash-filter form-control'
     - if current_user.can_create_project?
-      %span.pull-right
-        = link_to new_project_path, class: "btn btn-new" do
-          %i.icon-plus
-          New project
+      = link_to new_project_path, class: "btn btn-new pull-right" do
+        %i.icon-plus
+        New project
 
   %ul.well-list.dash-list
     - projects.each do |project|


### PR DESCRIPTION
This removes two span elements which surrounded the 'new project' and 'new group' links in the dashboard. As far as I can tell these elements didn't serve any purpose other than having the 'pull-right' class applied to them. However, the layout is the same when this class is added to the links so these spans can be removed to simplify the HTML.
