### PR TITLE
[DOC] Replace invalid emojis

### DIFF
--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -139,25 +139,25 @@ But let's throw in a <b>tag</b>.
 
 ## Emoji
 
-	Sometimes you want to be :cool: and add some :sparkles: to your :speech_balloon:. Well we have a :gift: for you:
+	Sometimes you want to be a :ninja: and add some :glowing_star: to your :speech_balloon:. Well we have a gift for you:
 
-	:exclamation: You can use emoji anywhere GFM is supported. :sunglasses:
+	:high_voltage_sign: You can use emoji anywhere GFM is supported. :victory_hand:
 
-	You can use it to point out a :bug: or warn about :monkey:patches. And if someone improves your really :snail: code, send them a :bouquet: or some :candy:. People will :heart: you for that.
+	You can use it to point out a :bug: or warn about :speak_no_evil_monkey: patches. And if someone improves your really :snail: code, send them some :cake:. People will :heart: you for that.
 
-	If you are :new: to this, don't be :fearful:. You can easily join the emoji :circus_tent:. All you need to do is to :book: up on the supported codes.
+	If you are new to this, don't be :fearful_face:. You can easily join the emoji :family:. All you need to do is to look up on the supported codes.
 
-	Consult the [Emoji Cheat Sheet](http://www.emoji-cheat-sheet.com/) for a list of all supported emoji codes. :thumbsup:
+	Consult the [Emoji Cheat Sheet](https://www.dropbox.com/s/b9xaqb977s6d8w1/cheat_sheet.pdf) for a list of all supported emoji codes. :thumbsup:
 
-Sometimes you want to be :cool: and add some :sparkles: to your :speech_balloon:. Well we have a :gift: for you:
+Sometimes you want to be a :ninja: and add some :glowing_star: to your :speech_balloon:. Well we have a gift for you:
 
-:exclamation: You can use emoji anywhere GFM is supported. :sunglasses:
+:high_voltage_sign: You can use emoji anywhere GFM is supported. :victory_hand:
 
-You can use it to point out a :bug: or warn about :monkey:patches. And if someone improves your really :snail: code, send them a :bouquet: or some :candy:. People will :heart: you for that.
+You can use it to point out a :bug: or warn about :speak_no_evil_monkey: patches. And if someone improves your really :snail: code, send them some :cake:. People will :heart: you for that.
 
-If you are :new: to this, don't be :fearful:. You can easily join the emoji :circus_tent:. All you need to do is to :book: up on the supported codes.
+If you are new to this, don't be :fearful_face:. You can easily join the emoji :family:. All you need to do is to look up on the supported codes.
 
-Consult the [Emoji Cheat Sheet](http://www.emoji-cheat-sheet.com/) for a list of all supported emoji codes. :thumbsup:
+Consult the [Emoji Cheat Sheet](https://www.dropbox.com/s/b9xaqb977s6d8w1/cheat_sheet.pdf) for a list of all supported emoji codes. :thumbsup:
 
 ## Special GitLab References
 


### PR DESCRIPTION
#### What does this MR do?

This PR replaces invalid emojis. Additionally it links to the emoji cheatsheet on [dropbox](https://www.dropbox.com/s/b9xaqb977s6d8w1/cheat_sheet.pdf) @dosire Is that ok? Point to the original cheatsheet doesn't make sense, because the symbols are quite different.
#### Why was this MR needed?

With the switch to the Phantom Open emoji library, not all emojis are valid anymore and aren't shown properly anymore.
#### Screenshots
##### Before

![screenshot 2014-08-03 11 50 37](https://cloud.githubusercontent.com/assets/278301/3790248/ab774332-1af3-11e4-9782-8cd9bc051160.png)
##### After

![screenshot 2014-08-03 11 51 35](https://cloud.githubusercontent.com/assets/278301/3790252/c8d18bfe-1af3-11e4-85ff-1a9487bb838c.png)
