### PR TITLE
[DOC] Mention the @all GFM reference in documentation

### DIFF
--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -163,13 +163,14 @@ Consult the [Emoji Cheat Sheet](http://www.emoji-cheat-sheet.com/) for a list of
 
 GFM recognized special references.
 
-You can easily reference e.g. a team member, an issue, or a commit within a project.
+You can easily reference e.g. an issue, a commit, a team member or even the whole team within a project.
 
 GFM will turn that reference into a link so you can navigate between them easily.
 
 GFM will recognize the following:
 
 - @foo : for team members
+- @all : for the whole team
 - #123 : for issues
 - !123 : for merge requests
 - $123 : for snippets


### PR DESCRIPTION
#### What does this MR do?

This PR adds documentation of the @all reference available since GitLab 7.1

/cc @jvanbaarsen 
