### PR TITLE
Self signed SSL cert not supported until 5.1

### DIFF
--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -7,6 +7,7 @@ GitLab 5.0 is affected by critical security vulnerability CVE-2013-4490.
 ## Important changes
 
 - We don't use `gitlab` user any more. Everything will be moved to `git` user
+- Self signed SSL certificates are not supported until GitLab 5.1
 - **requires ruby1.9.3**
 
 ## 0. Stop gitlab


### PR DESCRIPTION
Adds a note to the 4.2 to 5.0 upgrade guide about how self signed SSL certificates are not supported until GitLab 5.1 (actually gitlab-shell 1.2). Self signed certs worked in 4.2 but not 5.0 so this minor note will be helpful for those working to upgrade to newer versions.
