### PR TITLE
Add command to remove GitLab user

### DIFF
--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -162,3 +162,7 @@ sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
 ```
 
 **P.S. If everything works as expected you can remove gitlab user from system**
+
+```bash
+sudo userdel -r gitlab
+```


### PR DESCRIPTION
Adds the command to remove the GitLab user in the 4.2 to 5.0 upgrade guide.
