### PR TITLE
add command to start rails console

### DIFF
--- a/doc/update/5.1-to-6.0.md
+++ b/doc/update/5.1-to-6.0.md
@@ -149,6 +149,12 @@ sudo -u git -H bundle exec rake gitlab:backup:restore RAILS_ENV=production
 
 The migrations in this update are very sensitive to incomplete or inconsistent data. If you have a long-running GitLab installation and some of the previous upgrades did not work out 100% correct this may bite you now. The following commands can be run in the rails console to look for 'bad' data.
 
+Start rails console:
+
+```
+sudo -u git -H rails console production
+```
+
 All project owners should have an owner:
 
 ```


### PR DESCRIPTION
For troubleshooting upgrade errors you need to know how to start the rails console.
