### PR TITLE
rtrim() input before checking if note form is empty

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -58,10 +58,10 @@ window.disableButtonIfEmptyField = (field_selector, button_selector) ->
   field = $(field_selector)
   closest_submit = field.closest("form").find(button_selector)
 
-  closest_submit.disable() if field.val() is ""
+  closest_submit.disable() if field.val().replace(/\s+$/, "") is ""
 
   field.on "input", ->
-    if $(@).val() is ""
+    if $(@).val().replace(/\s+$/, "") is ""
       closest_submit.disable()
     else
       closest_submit.enable()


### PR DESCRIPTION
##### What does this MR do?

This PR prevents the `Add Comment` button to get activated when only entering whitespace. This is done be doing an `rtrim` before checking if the input is empty.
##### Why was this MR needed?

Currently when entering a comment with only whitespace, the `Add comment` button gets activated.

@jvanbaarsen Can you take a look? :innocent:
