### PR TITLE
Disable 'Save changes' button if input is empty, fixes #6351

### DIFF
--- a/app/assets/javascripts/notes.js.coffee
+++ b/app/assets/javascripts/notes.js.coffee
@@ -321,7 +321,9 @@ class Notes
     GitLab.GfmAutoComplete.setup()
     form = note.find(".note-edit-form")
     form.show()
-    form.find("textarea").focus()
+    textarea = form.find("textarea")
+    textarea.focus()
+    disableButtonIfEmptyField textarea, form.find(".js-comment-button")
 
   ###
   Called in response to clicking the edit note link

--- a/app/views/projects/notes/_note.html.haml
+++ b/app/views/projects/notes/_note.html.haml
@@ -38,10 +38,10 @@
         = f.text_area :note, class: 'note_text js-note-text js-gfm-input turn-on'
 
         .form-actions.clearfix
-          = f.submit 'Save changes', class: "btn btn-primary btn-save"
+          = f.submit 'Save changes', class: "btn btn-primary btn-save js-comment-button"
 
           .note-form-option
-            %a.choose-btn.btn.btn-small.js-choose-note-attachment-button
+            %a.choose-btn.btn.js-choose-note-attachment-button
               %i.icon-paper-clip
               %span Choose File ...
             &nbsp;


### PR DESCRIPTION
##### What does this MR do?

This PR deactivates the save button of a note, if the input is empty (similar as creating a note). Additionally, it changes the class of the `Choose File` button to be the size as when creating a note
##### Why was this MR needed?

Currently it's possible to edit a comment to be empty.
##### What are the relevant issue numbers / Feature requests?

This PR fixes #6351
#### Screenshots
##### Before

![screenshot 2014-08-11 09 54 57](https://cloud.githubusercontent.com/assets/278301/3873233/e61d1c52-212c-11e4-92e8-ed6dae7c89ab.png)
##### After

![screenshot 2014-08-11 09 58 03](https://cloud.githubusercontent.com/assets/278301/3873261/3e6c1138-212d-11e4-935c-4ac95f7022e2.png)

@jvanbaarsen Can you take a look?
