### PR TITLE
upgrade ruby and gitlab shell config during 6.0->7.1 & 6.0->7.2 upgrades

### DIFF
--- a/doc/update/6.0-to-7.1.md
+++ b/doc/update/6.0-to-7.1.md
@@ -22,7 +22,39 @@ sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 
     sudo service gitlab stop
 
-## 2. Get latest code
+## 2. Update Ruby
+
+If you are still using Ruby 1.9.3 or below, you will need to update Ruby.
+You can check which version you are running with `ruby -v`.
+
+If you are you running Ruby 2.0.x, you do not need to upgrade ruby, but can consider doing so for performance reasons.
+
+If you are running Ruby 2.1.1 consider upgrading to 2.1.2, because of the high memory usage of Ruby 2.1.1.
+
+Install, update dependencies:
+
+```bash
+sudo apt-get install build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl
+```
+
+Download and compile Ruby:
+
+```bash
+mkdir /tmp/ruby && cd /tmp/ruby
+curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+cd ruby-2.1.2
+./configure --disable-install-rdoc
+make
+sudo make install
+```
+
+Install Bundler:
+
+```bash
+sudo gem install bundler --no-ri --no-rdoc
+```
+
+## 3. Get latest code
 
 ```bash
 cd /home/git/gitlab
@@ -44,14 +76,14 @@ sudo -u git -H git checkout 7-1-stable-ee
 ```
 
 
-## 3. Install additional packages
+## 4. Install additional packages
 
 ```bash
 # Add support for lograte for better log file handling
 sudo apt-get install logrotate
 ```
 
-## 4. Update gitlab-shell
+## 5. Update gitlab-shell
 
 ```bash
 cd /home/git/gitlab-shell
@@ -59,7 +91,7 @@ sudo -u git -H git fetch
 sudo -u git -H git checkout v1.9.6 # Addresses multiple critical security vulnerabilities
 ```
 
-## 5. Install libs, migrations, etc.
+## 6. Install libs, migrations, etc.
 
 ```bash
 cd /home/git/gitlab
@@ -84,7 +116,7 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
 ```
 
-## 6. Update config files
+## 7. Update config files
 
 TIP: to see what changed in gitlab.yml.example in this release use next command: 
 
@@ -94,6 +126,7 @@ git diff 6-0-stable:config/gitlab.yml.example 7-1-stable:config/gitlab.yml.examp
 
 * Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-1-stable/config/gitlab.yml.example but with your settings.
 * Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-1-stable/config/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab-shell/config.yml` the same as https://gitlab.com/gitlab-org/gitlab-shell/blob/v1.9.6/config.yml.example but with your settings.
 * Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-1-stable/lib/support/nginx/gitlab but with your settings.
 * Copy rack attack middleware config
 
@@ -107,18 +140,18 @@ sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers
 sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 ```
 
-## 7. Update Init script
+## 8. Update Init script
 
 ```bash
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 ```
 
-## 8. Start application
+## 9. Start application
 
     sudo service gitlab start
     sudo service nginx restart
 
-## 9. Check application status
+## 10. Check application status
 
 Check if GitLab and its environment are configured correctly:
 

--- a/doc/update/6.0-to-7.2.md
+++ b/doc/update/6.0-to-7.2.md
@@ -20,7 +20,39 @@ sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 
     sudo service gitlab stop
 
-## 2. Get latest code
+## 2. Update Ruby
+
+If you are still using Ruby 1.9.3 or below, you will need to update Ruby.
+You can check which version you are running with `ruby -v`.
+
+If you are you running Ruby 2.0.x, you do not need to upgrade ruby, but can consider doing so for performance reasons.
+
+If you are running Ruby 2.1.1 consider upgrading to 2.1.2, because of the high memory usage of Ruby 2.1.1.
+
+Install, update dependencies:
+
+```bash
+sudo apt-get install build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl
+```
+
+Download and compile Ruby:
+
+```bash
+mkdir /tmp/ruby && cd /tmp/ruby
+curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+cd ruby-2.1.2
+./configure --disable-install-rdoc
+make
+sudo make install
+```
+
+Install Bundler:
+
+```bash
+sudo gem install bundler --no-ri --no-rdoc
+```
+
+## 3. Get latest code
 
 ```bash
 cd /home/git/gitlab
@@ -42,14 +74,14 @@ sudo -u git -H git checkout 7-2-stable-ee
 ```
 
 
-## 3. Install additional packages
+## 4. Install additional packages
 
 ```bash
 # Add support for lograte for better log file handling
 sudo apt-get install logrotate
 ```
 
-## 4. Update gitlab-shell
+## 5. Update gitlab-shell
 
 ```bash
 cd /home/git/gitlab-shell
@@ -57,7 +89,7 @@ sudo -u git -H git fetch
 sudo -u git -H git checkout v1.9.7
 ```
 
-## 5. Install libs, migrations, etc.
+## 6. Install libs, migrations, etc.
 
 ```bash
 cd /home/git/gitlab
@@ -82,7 +114,7 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
 ```
 
-## 6. Update config files
+## 7. Update config files
 
 TIP: to see what changed in gitlab.yml.example in this release use next command:
 
@@ -92,6 +124,7 @@ git diff 6-0-stable:config/gitlab.yml.example 7-2-stable:config/gitlab.yml.examp
 
 * Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-2-stable/config/gitlab.yml.example but with your settings.
 * Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-2-stable/config/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab-shell/config.yml` the same as https://gitlab.com/gitlab-org/gitlab-shell/blob/v1.9.7/config.yml.example but with your settings.
 * Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-2-stable/lib/support/nginx/gitlab but with your settings.
 * Copy rack attack middleware config
 
@@ -105,18 +138,18 @@ sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers
 sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 ```
 
-## 7. Update Init script
+## 8. Update Init script
 
 ```bash
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 ```
 
-## 8. Start application
+## 9. Start application
 
     sudo service gitlab start
     sudo service nginx restart
 
-## 9. Check application status
+## 10. Check application status
 
 Check if GitLab and its environment are configured correctly:
 
@@ -129,7 +162,7 @@ To make sure you didn't miss anything run a more thorough check with:
 
 If all items are green, then congratulations upgrade complete!
 
-## 10. Update OmniAuth configuration
+## 11. Update OmniAuth configuration
 
 When using Google omniauth login, changes of the Google account required.
 Ensure that `Contacts API` and the `Google+ API` are enabled in the [Google Developers Console](https://console.developers.google.com/).


### PR DESCRIPTION
Ruby needs to be 2.0+ for GitLab 7.0+.
