### PR TITLE
remove set ssl_url instructions from gitlab-ssl

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -114,7 +114,7 @@ server {
   # ssl_dhparam /etc/ssl/certs/dhparam.pem;
 
   add_header Strict-Transport-Security max-age=63072000;
-  add_header X-Frame-Options DENY;
+  add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
 
   ## Individual nginx logs for this GitLab vhost

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -29,6 +29,8 @@
 ## Edit `gitlab/config/gitlab.yml`:
 ##  1) Define port for http "port: 443"
 ##  2) Enable https "https: true"
+## Check that nginx is setup correctly
+##  1) sudo nginx -t
 ##
 ##################################
 ##        CHUNKED TRANSFER      ##

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -29,7 +29,6 @@
 ## Edit `gitlab/config/gitlab.yml`:
 ##  1) Define port for http "port: 443"
 ##  2) Enable https "https: true"
-##  3) Update ssl for gravatar "ssl_url: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"
 ##
 ##################################
 ##        CHUNKED TRANSFER      ##

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -99,6 +99,7 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
   ssl_trusted_certificate /etc/nginx/ssl/stapling.trusted.crt;
+  ## [Optional] Change to your DNS resolver
   resolver 208.67.222.222 208.67.222.220 valid=300s;
   resolver_timeout 10s;
 

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -105,7 +105,7 @@ server {
   ssl_prefer_server_ciphers   on;
   ## [Optional] Generate a stronger DHE parameter (recommended):
   ##   cd /etc/ssl/certs
-  ##   openssl dhparam -out dhparam.pem 2048
+  ##   sudo openssl dhparam -out dhparam.pem 2048
   ##
   # ssl_dhparam /etc/ssl/certs/dhparam.pem;
 

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -94,16 +94,17 @@ server {
   ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
   ssl_session_cache  builtin:1000  shared:SSL:10m;
 
-  ## Enable OCSP stapling to reduce the overhead and latency of running SSL.
+  ## [Optional] If your certficate has OCSP, enable OCSP stapling to reduce the overhead and latency of running SSL.
   ## Replace with your ssl_trusted_certificate. For more info see:
   ## - https://medium.com/devops-programming/4445f4862461
   ## - https://www.ruby-forum.com/topic/4419319
-  ssl_stapling on;
-  ssl_stapling_verify on;
-  ssl_trusted_certificate /etc/nginx/ssl/stapling.trusted.crt;
+  ## - https://www.digitalocean.com/community/tutorials/how-to-configure-ocsp-stapling-on-apache-and-nginx
+  # ssl_stapling on;
+  # ssl_stapling_verify on;
+  # ssl_trusted_certificate /etc/nginx/ssl/stapling.trusted.crt;
   ## [Optional] Change to your DNS resolver
-  resolver 208.67.222.222 208.67.222.220 valid=300s;
-  resolver_timeout 10s;
+  # resolver 208.67.222.222 208.67.222.220 valid=300s;
+  # resolver_timeout 10s;
 
   ssl_prefer_server_ciphers   on;
   ## [Optional] Generate a stronger DHE parameter (recommended):


### PR DESCRIPTION
gravatar `ssl_url` already defaults to the specified url as seen in https://github.com/gitlabhq/gitlabhq/blob/7-1-stable/config/initializers/1_settings.rb#L108
