### PR TITLE
add git config --global core.autocrlf check

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -318,7 +318,8 @@ namespace :gitlab do
 
       options = {
         "user.name"  => "GitLab",
-        "user.email" => Gitlab.config.gitlab.email_from
+        "user.email" => Gitlab.config.gitlab.email_from,
+        "core.autocrlf" => "input"
       }
       correct_options = options.map do |name, value|
         run(%W(git config --global --get #{name})).try(:squish) == value
@@ -330,7 +331,8 @@ namespace :gitlab do
         puts "no".red
         try_fixing_it(
           sudo_gitlab("git config --global user.name  \"#{options["user.name"]}\""),
-          sudo_gitlab("git config --global user.email \"#{options["user.email"]}\"")
+          sudo_gitlab("git config --global user.email \"#{options["user.email"]}\""),
+          sudo_gitlab("git config --global core.autocrlf \"#{options["core.autocrlf"]}\"")
         )
         for_more_information(
           see_installation_guide_section "GitLab"


### PR DESCRIPTION
`core.autocrlf` was added to install guide in https://github.com/gitlabhq/gitlabhq/commit/2d681c0d1ed14bf23c041aa04fa3e77caceda9a1 but not added to check script.
