### PR TITLE
make bullet punctuation on protected branches page consistent

### DIFF
--- a/app/views/projects/protected_branches/index.html.haml
+++ b/app/views/projects/protected_branches/index.html.haml
@@ -5,7 +5,7 @@
 .bs-callout.bs-callout-info
   %p Protected branches designed to
   %ul
-    %li prevent push for all except #{link_to "masters", help_page_path("permissions", "permissions"), class: "vlink"}.
+    %li prevent push for all except #{link_to "masters", help_page_path("permissions", "permissions"), class: "vlink"}
     %li prevent branch from force push
     %li prevent branch from removal
   %p Read more about project permissions #{link_to "here", help_page_path("permissions", "permissions"), class: "underlined-link"}


### PR DESCRIPTION
Currently the following appears:
- prevent push for all except masters.
- prevent branch from force push
- prevent branch from removal

Changes to:
- prevent push for all except masters
- prevent branch from force push
- prevent branch from removal
