### PR TITLE
fix undefined method `shift' error on migration

### DIFF
--- a/db/migrate/20140416074002_add_index_on_iid.rb
+++ b/db/migrate/20140416074002_add_index_on_iid.rb
@@ -19,7 +19,7 @@ class RemoveDuplicateIid
       iid = duplicate.iid
       items = klass.of_projects(project_id).where(iid: iid)
 
-      if items.size > 1
+      if items.is_a? Array && items.size > 1
         puts "Remove #{klass.name} duplicates for iid: #{iid} and project_id: #{project_id}"
         items.shift
         items.each do |item|

--- a/db/migrate/20140416074002_add_index_on_iid.rb
+++ b/db/migrate/20140416074002_add_index_on_iid.rb
@@ -17,9 +17,9 @@ class RemoveDuplicateIid
     duplicates.each do |duplicate|
       project_id = duplicate.send(project_field)
       iid = duplicate.iid
-      items = klass.of_projects(project_id).where(iid: iid)
+      items = klass.of_projects(project_id).where(iid: iid).to_a
 
-      if items.is_a? Array && items.size > 1
+      if items.size > 1
         puts "Remove #{klass.name} duplicates for iid: #{iid} and project_id: #{project_id}"
         items.shift
         items.each do |item|


### PR DESCRIPTION
Fixes an error I was having during the 6.0 -> 7.1 migration on a long running GitLab instance:

```
undefined method `shift' for #<Issue::ActiveRecord_Relation:0x007f29837d1050>
```

I got the solution from https://gitlab.com/gitlab-org/gitlab-ce/issues/380.

I'm unsure how I can check to make sure this is completely correct and that the migration went as expected however I am reloading my 6.0 install to make sure the data between the 6.0 and 7.1 install appears correct.

Looks like this should be ported back to each of the following so that users don't have errors during the upgrade to 7.1:

v7.1.1 v7.1.0 v7.0.0 v6.9.2 v6.9.1 v6.9.0

Fixes https://github.com/gitlabhq/gitlabhq/issues/7869.
