### PR TITLE
Expose path argument in commits API endpoint.

### DIFF
--- a/lib/api/commits.rb
+++ b/lib/api/commits.rb
@@ -12,14 +12,18 @@ module API
       # Parameters:
       #   id (required) - The ID of a project
       #   ref_name (optional) - The name of a repository branch or tag, if not given the default branch is used
+      #   path (optional) - The path to a file; if not provided, use commits for all files
+      #   page (optional) - Page to start at; defaults to 0
+      #   per_page (optional) - Number of items to fetch per page; defaults to 20
       # Example Request:
       #   GET /projects/:id/repository/commits
       get ":id/repository/commits" do
         page = (params[:page] || 0).to_i
         per_page = (params[:per_page] || 20).to_i
         ref = params[:ref_name] || user_project.try(:default_branch) || 'master'
+	path = params[:path]
 
-        commits = user_project.repository.commits(ref, nil, per_page, page * per_page)
+        commits = user_project.repository.commits(ref, path, per_page, page * per_page)
         present commits, with: Entities::RepoCommit
       end
 


### PR DESCRIPTION
The `commits` endpoint currently doesn't accept a `path` argument, even though the internal `Repository::commits` method does. Instead, the API endpoint always passes `nil` to `Repository::commits`. This MR exposes the `path` parameter and updates the inline documentation accordingly.
