### PR TITLE
Update bulk_add_permission.rake

### DIFF
--- a/lib/tasks/gitlab/bulk_add_permission.rake
+++ b/lib/tasks/gitlab/bulk_add_permission.rake
@@ -44,5 +44,15 @@ namespace :gitlab do
         group.add_users(Array.wrap(user.id), UsersGroup::DEVELOPER)
       end
     end
+    
+    desc "GITLAB | Add a specific user to all groups (as a guest) without clobbering higher privileges."
+    task :user_to_groups_as_guest, [:email] => :environment  do |t, args|
+      user = User.find_by_email args.email
+      groups = Group.all
+      puts "Importing #{user.email} users into #{groups.size} groups"
+      groups.each do |group|
+        group.add_users(Array.wrap(user.id), UsersGroup::GUEST) unless group.users_groups.find_by(user_id: user.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
We had a need for certain users to have read-only access to all groups. This is how we accomplished it.
