### PR TITLE
Add retry option of travis and bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
     - TASK=jasmine:ci DB=postgresql
 before_install:
   - sudo apt-get install libicu-dev -y
-install: 
-  - "bundle install --deployment --without production"
+install:
+  - "travis_retry bundle install --deployment --without production --retry 5"
 branches:
   only:
     - 'master'


### PR DESCRIPTION
##### What does this MR do?

This PR adds the retry option for bundler and travis. Bundler now tries 3 times to install the bundle. If the command fails Travis tries the command again.
##### Are there points in the code the reviewer needs to double check?

These options are documented [here](http://docs.travis-ci.com/user/build-timeouts/)
##### Why was this MR needed?

Currently often times out when installing gems. This makes Travis pretty useless.
##### What are the relevant issue numbers?

Fixes https://github.com/gitlabhq/gitlabhq/issues/7416
