### PR TITLE
Turn if/else branch for valid compare error message

### DIFF
--- a/app/views/projects/compare/show.html.haml
+++ b/app/views/projects/compare/show.html.haml
@@ -27,9 +27,9 @@
         There isn't anything to compare.
       %p.slead
         - if params[:to] == params[:from]
-          You'll need to use different branch names to get a valid comparison.
-        - else
           %span.label-branch #{params[:from]}
           and
           %span.label-branch #{params[:to]}
           are the same.
+        - else
+          You'll need to use different branch names to get a valid comparison.


### PR DESCRIPTION
##### What does this MR do?

This PR switches the error messages, if compare logic can't provide a comparison result.
##### Why was this MR needed?

If we're comparing the same revision, UI says `You'll need to use different branch names to get a valid comparison.`. If it can't compare for some reason (e.g. branch doesn't exist), it says `branch1 and master are the same`.
##### What are the relevant issue numbers?

This is related to #7446
