### PR TITLE
change git to git bin path

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -322,7 +322,7 @@ namespace :gitlab do
         "core.autocrlf" => "input"
       }
       correct_options = options.map do |name, value|
-        run(%W(git config --global --get #{name})).try(:squish) == value
+        run(%W(#{Gitlab.config.git.bin_path} config --global --get #{name})).try(:squish) == value
       end
 
       if correct_options.all?
@@ -330,9 +330,9 @@ namespace :gitlab do
       else
         puts "no".red
         try_fixing_it(
-          sudo_gitlab("git config --global user.name  \"#{options["user.name"]}\""),
-          sudo_gitlab("git config --global user.email \"#{options["user.email"]}\""),
-          sudo_gitlab("git config --global core.autocrlf \"#{options["core.autocrlf"]}\"")
+          sudo_gitlab("\"#{Gitlab.config.git.bin_path}\" config --global user.name  \"#{options["user.name"]}\""),
+          sudo_gitlab("\"#{Gitlab.config.git.bin_path}\" config --global user.email \"#{options["user.email"]}\""),
+          sudo_gitlab("\"#{Gitlab.config.git.bin_path}\" config --global core.autocrlf \"#{options["core.autocrlf"]}\"")
         )
         for_more_information(
           see_installation_guide_section "GitLab"


### PR DESCRIPTION
Changes references to git in the check script to the git bin path so as to match how other parts of GitLab reference the git binary.

Changes untested, please test before merge.
