### PR TITLE
Change git protocol to https protocol in Gemfile for GitLab 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'settingslogic'
 # github-linquist needs pygments 0.4.2 but Gollum 2.4.11
 # requires pygments 0.3.2. The latest master Gollum has been updated
 # to use pygments 0.4.2. Change this after next Gollum release.
-gem "gollum", "~> 2.4.0", git: "git://github.com/gollum/gollum.git", ref: "5dcd3c8c8f"
+gem "gollum", "~> 2.4.0", git: "https://github.com/gollum/gollum.git", ref: "5dcd3c8c8f"
 
 # Misc
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/gollum/gollum.git
+  remote: https://github.com/gollum/gollum.git
   revision: 5dcd3c8c8f68158e43ff79861279088ee56d0ebe
   ref: 5dcd3c8c8f
   specs:


### PR DESCRIPTION
Changes gems to use https protocol rather than the git protocol for GitLab 5.0 release. Git protocol does not work behind some firewalls and/or proxies. This change helps users upgrading from 4.2 to 7.1 have a smoother upgrade process. Fixes https://github.com/gitlabhq/gitlabhq/issues/3416 & https://github.com/gitlabhq/gitlabhq/issues/3478.
