### PR TITLE
Add link to fixed SHA version on blob.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v 7.3.0
   - Support Unix domain sockets for Redis
   - Store session Redis keys in 'session:gitlab:' namespace
   - Deprecate LDAP account takeover based on partial LDAP email / GitLab username match
+  - Add blob permalink link (Ciro Santilli)
 
 v 7.2.0
   - Explore page

--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -13,6 +13,9 @@
     - else
       = link_to "blame", project_blame_path(@project, @id), class: "btn btn-small" unless @blob.empty?
   = link_to "history", project_commits_path(@project, @id), class: "btn btn-small"
+  - if @ref != @commit.sha
+    = link_to 'permalink', project_blob_path(@project,
+        tree_join(@commit.sha, @path)), class: 'btn btn-small'
 
 - if allowed_tree_edit?
   = link_to '#modal-remove-blob', class: "remove-blob btn btn-small btn-remove", "data-toggle" => "modal" do

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -51,3 +51,15 @@ Feature: Project Browse files
   Scenario: I can browse code with Browse Code
     Given I click on history link
     Then I see Browse code link
+
+  # Permalink
+
+  Scenario: I click on the permalink link from a branch ref
+    Given I click on ".gitignore" file in repo
+    And I click on permalink
+    Then I am redirected to the permalink URL
+
+  Scenario: I don't see the permalink link from a SHA ref
+    Given I visit project source page for "6d394385cf567f80a8fd85055db1ab4c5295806f"
+    And I click on ".gitignore" file in repo
+    Then I don't see the permalink link

--- a/features/steps/project/browse_files.rb
+++ b/features/steps/project/browse_files.rb
@@ -90,4 +90,17 @@ class ProjectBrowseFiles < Spinach::FeatureSteps
     page.should_not have_link 'Browse File »'
     page.should_not have_link 'Browse Dir »'
   end
+
+  step 'I click on permalink' do
+    click_link 'permalink'
+  end
+
+  step 'I am redirected to the permalink URL' do
+    expect(current_path).to eq(project_blob_path(
+      @project, @project.repository.commit.sha + '/.gitignore'))
+  end
+
+  step "I don't see the permalink link" do
+    expect(page).not_to have_link('permalink')
+  end
 end

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -269,6 +269,12 @@ module SharedPaths
     visit project_tree_path(@project, "6d39438")
   end
 
+  step 'I visit project source page for' \
+       ' "6d394385cf567f80a8fd85055db1ab4c5295806f"' do
+    visit project_tree_path(@project,
+                            '6d394385cf567f80a8fd85055db1ab4c5295806f')
+  end
+
   step 'I visit project tags page' do
     visit project_tags_path(@project)
   end


### PR DESCRIPTION
Fixes AMR: http://feedback.gitlab.com/forums/176466-general/suggestions/5765123-shortcut-key-to-go-a-static-canonical-version-of-t

Screenshot:

![screenshot from 2014-08-08 16 04 54 fixed sha url blob](https://cloud.githubusercontent.com/assets/1429315/3878393/d90610ea-216e-11e4-960b-7b0c422d3b23.png)

The button will disappear when already on a SHA URL.
