### PR TITLE
Improve login screen when only OmniAuth providers are enabled

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,6 +1,18 @@
 %div
-  = render 'devise/shared/signin_box'
+  - if signin_enabled? || ldap_enabled?
+    = render 'devise/shared/signin_box'
 
-  - if signup_enabled?
+  -# Omniauth fits between signin/ldap signin and signup and does not have a surrounding box
+  - if Gitlab.config.omniauth.enabled && devise_mapping.omniauthable?
+    .clearfix.prepend-top-20
+      = render 'devise/shared/omniauth_box'
+
+  -# Signup only makes sense if you can also sign-in
+  - if signin_enabled? && signup_enabled?
     .prepend-top-20
       = render 'devise/shared/signup_box'
+
+  -# Show a message if none of the mechanisms above are enabled
+  - if !signin_enabled? && !ldap_enabled? && !(Gitlab.config.omniauth.enabled && devise_mapping.omniauthable?)
+    %div
+      No authentication methods configured.

--- a/app/views/devise/shared/_omniauth_box.html.haml
+++ b/app/views/devise/shared/_omniauth_box.html.haml
@@ -1,0 +1,10 @@
+%p
+  %span.light
+    Sign in with &nbsp;
+  - providers = additional_providers
+  - providers.each do |provider|
+    %span.light
+      - if default_providers.include?(provider)
+        = link_to authbutton(provider, 32), omniauth_authorize_path(resource_name, provider)
+      - else
+        = link_to provider.to_s.titleize, omniauth_authorize_path(resource_name, provider), class: "btn"

--- a/app/views/devise/shared/_signin_box.html.haml
+++ b/app/views/devise/shared/_signin_box.html.haml
@@ -24,19 +24,3 @@
 
     - elsif signin_enabled?
       = render 'devise/sessions/new_base'
-    - else
-      %div
-        No authentication methods configured.
-
-- if Gitlab.config.omniauth.enabled && devise_mapping.omniauthable?
-  .clearfix.prepend-top-20
-    %p
-      %span.light
-        Sign in with &nbsp;
-      - providers = additional_providers
-      - providers.each do |provider|
-        %span.light
-          - if default_providers.include?(provider)
-            = link_to authbutton(provider, 32), omniauth_authorize_path(resource_name, provider)
-          - else
-            = link_to provider.to_s.titleize, omniauth_authorize_path(resource_name, provider), class: "btn"


### PR DESCRIPTION
Hide the text "No authentication methods configured." when Signin and LDAP are disabled but OmniAuth is enabled.
Hide the link to "Did not receive confirmation email?" when Signup is disabled.
