### PR TITLE
[WIP] Allow users to request access to projects.

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -64,6 +64,10 @@
             %span.count
               = @repository.blob_by_oid(version.id).data
 
+        -# TODO use correct link.
+        = link_to project_compare_index_path(@project, from: @repository.root_ref, to: @ref || @repository.root_ref), class: 'btn btn-block' do
+          Request access
+
     .prepend-top-10
       %p
         %span.light Created on

--- a/app/views/projects/team_members/_team_request.html.haml
+++ b/app/views/projects/team_members/_team_request.html.haml
@@ -1,0 +1,34 @@
+-# TODO implement. Mock only.
+.team-table
+  - can_admin_project = (can? current_user, :admin_project, @project)
+  .panel.panel-default
+    .panel-heading
+      %strong #{@project.name}
+      pending access requests (#{members.count})
+    %ul.well-list
+      - members.each do |team_member|
+        -#= render 'team_request', member: team_member, current_user_can_admin_project: can_admin_project
+        - member = team_member
+        - current_user_can_admin_project = can_admin_project
+        - user = member.user
+        %li{id: dom_id(user), class: "team_member_row access-#{member.human_access.downcase}"}
+          .pull-right
+            - if current_user_can_admin_project
+              - unless @project.personal? && user == current_user
+                .pull-left
+                  = form_for(member, as: :team_member, url: project_team_member_path(@project, member.user)) do |f|
+                    = f.select :project_access, options_for_select(UsersProject.access_roles, member.project_access), {}, class: "medium project-access-select span2 trigger-submit"
+                  &nbsp;
+                = link_to project_team_member_path(@project, user), data: { confirm: remove_from_project_team_message(@project, user)}, method: :delete, class: "btn-tiny btn btn-new", title: 'Remove user from team' do
+                  %i.icon-plus.icon-white
+                = link_to project_team_member_path(@project, user), data: { confirm: remove_from_project_team_message(@project, user)}, method: :delete, class: "btn-tiny btn btn-remove", title: 'Remove user from team' do
+                  %i.icon-minus.icon-white
+          = image_tag avatar_icon(user.email, 32), class: "avatar s32"
+          %p
+            %strong= user.name
+          %span.cgray= user.username
+    -# TODO find best way to add form to a panel at bottom (e.g. footer or some type of separator).
+    .panel-footer{style: 'text-align:right;'}
+      = button_to 'TODO', class: 'btn btn-new', title: 'Accept all requests' do
+        %i.icon-plus.icon-white
+        Accept all requests

--- a/app/views/projects/team_members/index.html.haml
+++ b/app/views/projects/team_members/index.html.haml
@@ -14,3 +14,4 @@
 = render "team", members: @users_projects
 - if @group
   = render "group_members"
+= render "team_request", members: @users_projects


### PR DESCRIPTION
Fix http://feedback.gitlab.com/forums/176466-general/suggestions/6201690-request-access-procedure

User requests access from the project's main page:

![screenshot from 2014-08-11 21 28 44 gitlab request access home](https://cloud.githubusercontent.com/assets/1429315/3881585/159608e2-218f-11e4-8960-bd357ea1c1df.png)

Project admins get an email linking to the moderation page, where it is possible to either accept or decline them one by one, or accept all at once:

![screenshot from 2014-08-11 21 33 41 gitlab request access members](https://cloud.githubusercontent.com/assets/1429315/3881597/2d027236-218f-11e4-9ec6-9ab90742fd82.png)

All access requests are initially set to the same access level: I propose Developper as it is a common use case. Guest would be too little since you need it or equivalent (e.g. public project) to see the project and make the request in the first place. In another PR we could also allow the requester to determine the level he wishes to request if people feel the need.
