### PR TITLE
follow curl redirects

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -69,7 +69,7 @@ Is the system packaged Git too old? Remove it and compile from source.
 
     # Download and compile from source
     cd /tmp
-    curl --progress https://www.kernel.org/pub/software/scm/git/git-2.0.0.tar.gz | tar xz
+    curl -L --progress https://www.kernel.org/pub/software/scm/git/git-2.0.0.tar.gz | tar xz
     cd git-2.0.0/
     make prefix=/usr/local all
 
@@ -95,7 +95,7 @@ Remove the old Ruby 1.8 if present
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+    curl -L --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
     cd ruby-2.1.2
     ./configure --disable-install-rdoc
     make

--- a/doc/update/4.0-to-4.1.md
+++ b/doc/update/4.0-to-4.1.md
@@ -36,7 +36,7 @@ sudo -u gitlab -H bundle exec rake db:migrate RAILS_ENV=production
 sudo mv /etc/init.d/gitlab /etc/init.d/gitlab.old
 
 # get new one using sidekiq
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/4-1-stable/init.d/gitlab
+sudo curl -L --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/4-1-stable/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 
 ```

--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -115,7 +115,7 @@ sudo chmod -R u+rwX  /home/git/gitlab/tmp/pids
 ```bash
 # init.d
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-0-stable/init.d/gitlab
+sudo curl -L --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-0-stable/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 
 # unicorn

--- a/doc/update/5.0-to-5.1.md
+++ b/doc/update/5.0-to-5.1.md
@@ -52,7 +52,7 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 ```bash
 # init.d
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-1-stable/init.d/gitlab
+sudo curl -L --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlab-recipes/5-1-stable/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 

--- a/doc/update/5.2-to-5.3.md
+++ b/doc/update/5.2-to-5.3.md
@@ -50,7 +50,7 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5-3-stable/lib/support/init.d/gitlab
+sudo curl -L --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5-3-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 

--- a/doc/update/5.3-to-5.4.md
+++ b/doc/update/5.3-to-5.4.md
@@ -54,7 +54,7 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 
 ```bash
 sudo rm /etc/init.d/gitlab
-sudo curl --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5-4-stable/lib/support/init.d/gitlab
+sudo curl -L --output /etc/init.d/gitlab https://raw.github.com/gitlabhq/gitlabhq/5-4-stable/lib/support/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -32,7 +32,7 @@ Download and compile Ruby:
 
 ```bash
 mkdir /tmp/ruby && cd /tmp/ruby
-curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+curl -L --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
 cd ruby-2.1.2
 ./configure --disable-install-rdoc
 make

--- a/doc/update/7.0-to-7.1.md
+++ b/doc/update/7.0-to-7.1.md
@@ -32,7 +32,7 @@ Download and compile Ruby:
 
 ```bash
 mkdir /tmp/ruby && cd /tmp/ruby
-curl --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
+curl -L --progress ftp://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz | tar xz
 cd ruby-2.1.2
 ./configure --disable-install-rdoc
 make


### PR DESCRIPTION
Update `curl` commands to follow redirects (see http://curl.haxx.se/docs/manpage.html#-L). Current `curl` commands will return unexpected results if the requested content has been moved and is returning information about where it has been moved to. Including the `-L` option tells `curl` to follow the redirect so the file can be
correctly acquired. For example:

https://raw.github.com/gitlabhq/gitlab-recipes/4-1-stable/init.d/gitlab

Now redirects to:

https://raw.githubusercontent.com/gitlabhq/gitlab-recipes/4-1-stable/init.d/gitlab
