### PR TITLE
Restrict commit area resize to vertical.

### DIFF
--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -244,6 +244,7 @@ li.commit {
     font-family: inherit;
     padding-left: $left;
     position: relative;
+    resize: vertical;
     z-index: 2;
   }
 }


### PR DESCRIPTION
Otherwise, it is possible to make things unaligned, and worse: make the 70 char mark pop out of the textarea as in the screenshot:

![screenshot from 2014-08-12 20 40 18 commit new file resize vertical break](https://cloud.githubusercontent.com/assets/1429315/3895873/e1276d76-2251-11e4-92f8-5c66a36e4011.png)
