### PR TITLE
[WIP] Blob edit commit and continue editing button.

### DIFF
--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -44,11 +44,16 @@ class Projects::EditTreeController < Projects::BaseTreeController
 
   def after_edit_path
     @after_edit_path ||=
-      if from_merge_request
-        diffs_project_merge_request_path(from_merge_request.target_project, from_merge_request) +
-          "#file-path-#{hexdigest(@path)}"
+      if params[:continue_editing] == '1'
+        project_edit_tree_path(@project, @id)
       else
-        project_blob_path(@project, @id)
+        if from_merge_request
+          diffs_project_merge_request_path(
+            from_merge_request.target_project, from_merge_request) +
+            "#file-path-#{hexdigest(@path)}"
+        else
+          project_blob_path(@project, @id)
+        end
       end
   end
 

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -32,8 +32,12 @@
       = hidden_field_tag 'last_commit', @last_commit
       = hidden_field_tag 'content', '', id: "file-content"
       = hidden_field_tag 'from_merge_request_id', params[:from_merge_request_id]
+      = hidden_field_tag 'continue_editing', '0'
       .commit-button-annotation
         = button_tag "Commit changes", class: 'btn commit-btn js-commit-button btn-primary'
+        = button_tag "and continue editing",
+            class: 'btn commit-btn js-commit-button btn-primary',
+            data: {'continue-editing' => '1'}, style: 'margin-left: 5px;'
         .message
           to branch
           %strong= @ref
@@ -52,6 +56,9 @@
 
   $(".js-commit-button").click(function(){
     $("#file-content").val(editor.getValue());
+    if ($(this).data('continue-editing')) {
+      $('#continue_editing').val('1');
+    }
     $(".file-editor form").submit();
   });
 


### PR DESCRIPTION
Fix http://feedback.gitlab.com/forums/176466-general/suggestions/6171315-add-button-on-blob-edit-page-to-save-continue-ed, analogous to AMR http://feedback.gitlab.com/forums/176466-general/suggestions/5900530-add-button-on-wiki-edit-pages-to-save-continue-e but for blobs instead of wiki.

![screenshot from 2014-08-13 13 31 23 continue editing button](https://cloud.githubusercontent.com/assets/1429315/3904774/cae7b610-22dd-11e4-8d58-4bf0e0877437.png)

Will add tests if concept is OK.
