### PR TITLE
commit_description helper method

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -232,4 +232,9 @@ module CommitsHelper
   def diff_file_mode_changed?(diff)
     diff.a_mode && diff.b_mode && diff.a_mode != diff.b_mode
   end
+
+  def commit_description(commit)
+    description = preserve(gfm(escape_once(commit.description)))
+    content_tag(:pre, description, class: 'commit-description')
+  end
 end

--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -54,5 +54,4 @@
   %h3.commit-title
     = gfm escape_once(@commit.title)
   - if @commit.description.present?
-    %pre.commit-description
-      = gfm escape_once(@commit.description)
+    = commit_description(@commit)

--- a/app/views/projects/commits/_commit.html.haml
+++ b/app/views/projects/commits/_commit.html.haml
@@ -23,7 +23,7 @@
   - if commit.description?
     .commit-row-description.js-toggle-content
       %pre
-        = commit.description
+        = commit_description(commit)
 
   .commit-row-info
     = commit_author_link(commit, avatar: true, size: 16)


### PR DESCRIPTION
same commit description in commit#index as in commit#show

I have white space at description beginning but this isn't
![screenshot at 13 13-19-20](https://cloud.githubusercontent.com/assets/1488195/3905225/d6486d04-22e4-11e4-9356-5017ef3f151b.png)
so fix that
![screenshot at 13 13-18-41](https://cloud.githubusercontent.com/assets/1488195/3905235/ed431270-22e4-11e4-9f22-0698f9f05d6d.png)

at commits#show commit description looks another rather than commit#show . Look at html tags and refs.
![screenshot at 13 15-47-51](https://cloud.githubusercontent.com/assets/1488195/3905264/4fa0621a-22e5-11e4-869e-002802a03bc5.png)
also fix that
![Uploading Screenshot at авг. 13 15-49-02.png . . .]()
