### PR TITLE
Update gems with errors, to prevent 500 errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem "github-markup"
 gem 'redcarpet', '~> 2.2.2'
 gem 'RedCloth'
 gem 'rdoc', '~>3.6'
-gem 'org-ruby', '= 0.9.1'
+gem 'org-ruby'
 gem 'creole', '~>0.3.6'
 gem 'wikicloth', '=0.8.1'
 gem 'asciidoctor', '= 0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.4)
-    gemnasium-gitlab-service (0.2.1)
+    gemnasium-gitlab-service (0.2.2)
       rugged (~> 0.19)
     gherkin-ruby (0.3.1)
       racc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,8 +323,8 @@ GEM
     omniauth-twitter (1.0.1)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
-    org-ruby (0.9.1)
-      rubypants (>= 0.2.0)
+    org-ruby (0.9.8)
+      rubypants (~> 0.2)
     orm_adapter (0.5.0)
     pg (0.15.1)
     phantomjs (1.9.2.0)
@@ -642,7 +642,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   omniauth-twitter
-  org-ruby (= 0.9.1)
+  org-ruby
   pg
   poltergeist (~> 1.5.1)
   pry


### PR DESCRIPTION
##### What does this PR do?

This PR updates the following gems
- gemnasium-gitlab-service
- org-ruby
##### Why is this PR needed?

Updating these gems fixes a 500 error related to gemnasium integration, and a previous 500 error when parsing an org file. Thank you @wallyqs for updating the `org-ruby` gem.

@randx All tests pass locally
