### PR TITLE
Add 7.1.1 patch release changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,11 @@ v 7.2.0
   - Test gitlab-shell integration
   - Repository import timeout increased from 2 to 4 minutes allowing larger repos to be imported
 
+v 7.1.1
+  - Fix cpu usage issue in Firefox
+  - Fix redirect loop when changing password by new user
+  - Fix 500 error on new merge request page
+
 v 7.1.0
   - Remove observers
   - Improve MR discussions


### PR DESCRIPTION
Changelog entries for 7.1.1 are missing for master. 

@jvanbaarsen Can you merge?
