### PR TITLE
Use xmlschema date format (ISO 8601) on system hooks timestamp

### DIFF
--- a/app/services/system_hooks_service.rb
+++ b/app/services/system_hooks_service.rb
@@ -18,7 +18,7 @@ class SystemHooksService
   def build_event_data(model, event)
     data = {
       event_name: build_event_name(model, event),
-      created_at: model.created_at
+      created_at: model.created_at.xmlschema
     }
 
     case model


### PR DESCRIPTION
Official document (http://doc.gitlab.com/ce/api/system_hooks.html) says `created_on` date in system hook json should follow ISO 8601, but it doesn't.

This PR fixes that.
