### PR TITLE
Consistency: Capitalize hex values of sugested colors

### DIFF
--- a/app/helpers/labels_helper.rb
+++ b/app/helpers/labels_helper.rb
@@ -14,13 +14,13 @@ module LabelsHelper
 
   def suggested_colors
     [
-      '#d9534f',
-      '#f0ad4e',
-      '#428bca',
-      '#5cb85c',
-      '#34495e',
-      '#7f8c8d',
-      '#8e44ad',
+      '#D9534F',
+      '#F0AD4E',
+      '#428BCA',
+      '#5CB85C',
+      '#34495E',
+      '#7F8C8D',
+      '#8E44AD',
       '#FFECDB'
     ]
   end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,5 +1,5 @@
 class Label < ActiveRecord::Base
-  DEFAULT_COLOR = '#428bca'
+  DEFAULT_COLOR = '#428BCA'
 
   belongs_to :project
   has_many :label_links, dependent: :destroy


### PR DESCRIPTION
Just a minor UI improvement. Preview colors should all be capitalised sine placeholder also uses this format.
