### PR TITLE
Fix commit msg

### DIFF
--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -55,4 +55,4 @@
     = gfm escape_once(@commit.title)
   - if @commit.description.present?
     %pre.commit-description
-      = gfm escape_once(@commit.description)
+      = preserve(gfm(escape_once(@commit.description)))

--- a/app/views/projects/commits/_commit.html.haml
+++ b/app/views/projects/commits/_commit.html.haml
@@ -23,7 +23,7 @@
   - if commit.description?
     .commit-row-description.js-toggle-content
       %pre
-        = commit.description
+        = preserve(gfm(escape_once(commit.description)))
 
   .commit-row-info
     = commit_author_link(commit, avatar: true, size: 16)


### PR DESCRIPTION
![screenshot at 14 15-39-02](https://cloud.githubusercontent.com/assets/1488195/3919397/fa3e0b9c-23a7-11e4-9adf-10033add2101.png)

fixes bugs: 
1) `#1` is not  link
2) message begin with whitespace which is missing here
