### PR TITLE
Set charset encoding to UTF-8 for snippets

### DIFF
--- a/app/controllers/projects/snippets_controller.rb
+++ b/app/controllers/projects/snippets_controller.rb
@@ -63,7 +63,7 @@ class Projects::SnippetsController < Projects::ApplicationController
   def raw
     send_data(
       @snippet.content,
-      type: "text/plain",
+      type: 'text/plain; charset=utf-8',
       disposition: 'inline',
       filename: @snippet.file_name
     )

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -86,7 +86,7 @@ class SnippetsController < ApplicationController
   def raw
     send_data(
       @snippet.content,
-      type: "text/plain",
+      type: 'text/plain; charset=utf-8',
       disposition: 'inline',
       filename: @snippet.file_name
     )


### PR DESCRIPTION
**What does this MR do?**
It makes sure that a raw snippet gets the HTTP headers charset=utf-8. That way snippets with weird characters gets rendered properly

**What issues does this fix?**
Fixes #2678
