### PR TITLE
Renamed Graphs to Stats

### DIFF
--- a/app/views/layouts/nav/_project.html.haml
+++ b/app/views/layouts/nav/_project.html.haml
@@ -17,7 +17,7 @@
 
   - if project_nav_tab? :graphs
     = nav_link(controller: %w(graphs)) do
-      = link_to "Graphs", project_graph_path(@project, @ref || @repository.root_ref)
+      = link_to "Stats", project_graph_path(@project, @ref || @repository.root_ref)
 
   - if project_nav_tab? :issues
     = nav_link(controller: %w(issues milestones labels)) do


### PR DESCRIPTION
**What does this MR do?**
It renames the menu item Graphs to Status, I hope this prevents some unclearness about what Network and Graphs means. Since I almost always click on Graphs when I want to see the Network Graphs.

**Relevant issues**
It was suggested by @zyphrax in https://github.com/gitlabhq/gitlabhq/issues/7505
