### PR TITLE
[UX] Update tag count if tag gets deleted via web interface

### DIFF
--- a/app/controllers/projects/tags_controller.rb
+++ b/app/controllers/projects/tags_controller.rb
@@ -34,7 +34,7 @@ class Projects::TagsController < Projects::ApplicationController
 
     respond_to do |format|
       format.html { redirect_to project_tags_path }
-      format.js { render nothing: true }
+      format.js
     end
   end
 end

--- a/app/views/projects/commits/_head.html.haml
+++ b/app/views/projects/commits/_head.html.haml
@@ -12,7 +12,7 @@
   = nav_link(controller: :tags) do
     = link_to project_tags_path(@project) do
       Tags
-      %span.badge= @repository.tags.length
+      %span.badge.js-totaltags-count= @repository.tags.length
 
   = nav_link(controller: :repositories, action: :stats) do
     = link_to stats_project_repository_path(@project) do

--- a/app/views/projects/tags/destroy.js.haml
+++ b/app/views/projects/tags/destroy.js.haml
@@ -1,0 +1,3 @@
+$('.js-totaltags-count').html("#{@repository.tags.size}")
+- if @repository.tags.size == 0
+  $('.tags').load(document.URL + ' .nothing-here-block').hide().fadeIn(1000)

--- a/app/views/projects/tags/index.html.haml
+++ b/app/views/projects/tags/index.html.haml
@@ -12,18 +12,19 @@
   Tags give the ability to mark specific points in history as being important
 %hr
 
-- unless @tags.empty?
-  %ul.bordered-list
-    - @tags.each do |tag|
-      = render 'tag', tag: @repository.find_tag(tag)
+.tags
+  - unless @tags.empty?
+    %ul.bordered-list
+      - @tags.each do |tag|
+        = render 'tag', tag: @repository.find_tag(tag)
 
-  = paginate @tags, theme: 'gitlab'
+    = paginate @tags, theme: 'gitlab'
 
-- else
-  .nothing-here-block
-    Repository has no tags yet.
-    %br
-    %small
-      Use git tag command to add a new one:
+  - else
+    .nothing-here-block
+      Repository has no tags yet.
       %br
-      %span.monospace git tag -a v1.4 -m 'version 1.4'
+      %small
+        Use git tag command to add a new one:
+        %br
+        %span.monospace git tag -a v1.4 -m 'version 1.4'

--- a/features/project/commits/tags.feature
+++ b/features/project/commits/tags.feature
@@ -27,5 +27,15 @@ Feature: Project Browse tags
     And I submit new tag form with tag that already exists
     Then I should see new an error that tag already exists
 
+  @javascript
+  Scenario: I delete a tag
+    Given I delete tag 'v1.1.0'
+    Then I should not see tag 'v1.1.0'
+
+  @javascript
+  Scenario: I delete all tags and see info message
+    Given I delete all tags
+    Then I should see tags info message
+
   # @wip
   # Scenario: I can download project by tag

--- a/features/steps/project/browse_tags.rb
+++ b/features/steps/project/browse_tags.rb
@@ -51,4 +51,32 @@ class ProjectBrowseTags < Spinach::FeatureSteps
   step 'I should see new an error that tag already exists' do
     page.should have_content 'Tag already exists'
   end
+
+  step "I delete tag 'v1.1.0'" do
+    within '.tags' do
+      first('.btn-remove').click
+      sleep 0.05
+    end
+  end
+
+  step "I should not see tag 'v1.1.0'" do
+    within '.tags' do
+      page.all(visible: true).should_not have_content 'v1.1.0'
+    end
+  end
+
+  step 'I delete all tags' do
+    within '.tags' do
+      all('.btn-remove').each do |remove|
+        remove.click
+        sleep 0.05
+      end
+    end
+  end
+
+  step 'I should see tags info message' do
+    within '.tags' do
+      page.should have_content 'Repository has no tags yet.'
+    end
+  end
 end


### PR DESCRIPTION
##### What does this MR do?
1. Updates tag count in header panel if tag gets deleted
2. Show tags info message, if last tag is deleted
##### Why was this MR needed?

Currently the tags count stays the same if a tag is deleted. If the last tag is deleted, an empty tag list is shown
