### PR TITLE
Fix branch remove for branches containing a '/'

### DIFF
--- a/app/views/projects/branches/destroy.js.haml
+++ b/app/views/projects/branches/destroy.js.haml
@@ -1,3 +1,1 @@
-:plain
-  $(".js-branch-#{@branch_name}").remove();
-  $('.js-totalbranch-count').html("#{@repository.branches.size}")
+$('.js-totalbranch-count').html("#{@repository.branches.size}")

--- a/features/project/commits/branches.feature
+++ b/features/project/commits/branches.feature
@@ -17,3 +17,9 @@ Feature: Project Browse branches
     And I click new branch link
     When I submit new branch form
     Then I should see new branch created
+
+  @javascript
+  Scenario: I delete a branch
+    Given I visit project branches page
+    And I click branch 'improve/awesome' delete link
+    Then I should not see branch 'improve/awesome'

--- a/features/steps/project/browse_branches.rb
+++ b/features/steps/project/browse_branches.rb
@@ -43,4 +43,15 @@ class ProjectBrowseBranches < Spinach::FeatureSteps
       page.should have_content 'deploy_keys'
     end
   end
+
+  step "I click branch 'improve/awesome' delete link" do
+    within '.js-branch-improve\/awesome' do
+      find('.btn-remove').click
+      sleep 0.05
+    end
+  end
+
+  step "I should not see branch 'improve/awesome'" do
+    page.all(visible: true).should_not have_content 'improve/awesome'
+  end
 end


### PR DESCRIPTION
##### What does this MR do?

This PR removed the DOM lookup for the branch name. This is not necessary, because the element already gets a `hidden` style applied.
##### Are there points in the code the reviewer needs to double check?

This adds a testcase, but this will fail currently. It depends on having the branch `improve/awesome` on the sample repository. See https://github.com/gitlabhq/testme/issues/6
##### Why was this MR needed?

If the branch name contains an invalid jQuery character like `/` the lookup for this element fails. As a result the element not gets removed from the DOM --> stale UX

/cc @jvanbaarsen
