### PR TITLE
API: Labels validation in issues API

### DIFF
--- a/app/models/concerns/issuable.rb
+++ b/app/models/concerns/issuable.rb
@@ -138,6 +138,10 @@ module Issuable
     labels.order('title ASC').pluck(:title)
   end
 
+  def remove_labels
+    labels.delete_all
+  end
+
   def add_labels_by_names(label_names)
     label_names.each do |label_name|
       label = project.labels.create_with(

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -6,14 +6,14 @@ class Label < ActiveRecord::Base
   has_many :issues, through: :label_links, source: :target, source_type: 'Issue'
 
   validates :color,
-            format: { with: /\A\#[0-9A-Fa-f]{6}+\Z/ },
+            format: { with: /\A#[0-9A-Fa-f]{6}\Z/ },
             allow_blank: false
   validates :project, presence: true
 
   # Don't allow '?', '&', and ',' for label titles
   validates :title,
             presence: true,
-            format: { with: /\A[^&\?,&]*\z/ },
+            format: { with: /\A[^&\?,&]+\z/ },
             uniqueness: { scope: :project_id }
 
   scope :order_by_name, -> { reorder("labels.title ASC") }

--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -114,17 +114,21 @@ module API
 
     # Helper method for validating all labels against its names
     def validate_label_params(params)
+      errors = {}
+
       if params[:labels].present?
         params[:labels].split(',').each do |label_name|
           label = user_project.labels.create_with(
             color: Label::DEFAULT_COLOR).find_or_initialize_by(
               title: label_name.strip)
+
           if label.invalid?
-            return true
+            errors[label.title] = label.errors
           end
         end
       end
-      false
+
+      errors
     end
 
     # error helpers

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -5,4 +5,27 @@ describe Label do
   it { label.should be_valid }
 
   it { should belong_to(:project) }
+
+  describe 'Validation' do
+    it 'should validate color code' do
+      build(:label, color: 'G-ITLAB').should_not be_valid
+      build(:label, color: 'AABBCC').should_not be_valid
+      build(:label, color: '#AABBCCEE').should_not be_valid
+      build(:label, color: '#GGHHII').should_not be_valid
+      build(:label, color: '#').should_not be_valid
+      build(:label, color: '').should_not be_valid
+
+      build(:label, color: '#AABBCC').should be_valid
+    end
+
+    it 'should validate title' do
+      build(:label, title: 'G,ITLAB').should_not be_valid
+      build(:label, title: 'G?ITLAB').should_not be_valid
+      build(:label, title: 'G&ITLAB').should_not be_valid
+      build(:label, title: '').should_not be_valid
+
+      build(:label, title: 'GITLAB').should be_valid
+      build(:label, title: 'gitlab').should be_valid
+    end
+  end
 end

--- a/spec/requests/api/labels_spec.rb
+++ b/spec/requests/api/labels_spec.rb
@@ -50,6 +50,14 @@ describe API::API, api: true  do
       json_response['message'].should == 'Color is invalid'
     end
 
+    it 'should return 400 for too long color code' do
+      post api("/projects/#{project.id}/labels", user),
+           name: 'Foo',
+           color: '#FFAAFFFF'
+      response.status.should == 400
+      json_response['message'].should == 'Color is invalid'
+    end
+
     it 'should return 400 for invalid name' do
       post api("/projects/#{project.id}/labels", user),
            name: '?',
@@ -144,6 +152,14 @@ describe API::API, api: true  do
       put api("/projects/#{project.id}/labels", user),
           name: 'label1',
           color: '#FF'
+      response.status.should == 400
+      json_response['message'].should == 'Color is invalid'
+    end
+
+    it 'should return 400 for too long color code' do
+      post api("/projects/#{project.id}/labels", user),
+           name: 'Foo',
+           color: '#FFAAFFFF'
       response.status.should == 400
       json_response['message'].should == 'Color is invalid'
     end


### PR DESCRIPTION
I ran into some issues while trying [laboard]() on Gitlab 7.2.0.pre.

On Gitlab 7.1, I was able to:
- Create label with titles like `foo:bar`
- Add and **remove** labels from an issue

On Gitlab 7.2, I am not able to do any of those:
- Creating labels like `foo:bar` returns `405` errors
- Removing label does not work anymore

In this PR, I changed some things to get those features back:
- I changed `405` error to `400` when labels do not validate:

> 405 Method Not Allowed
> A request was made of a resource using a request method not supported by that resource; for example, using GET on a form which requires data to be presented via POST, or using PUT on a read-only resource.

We are not dealing with HTTP methods here but with data validation.
- I changed labels validation to get better results and expose error messages in responses
- When editing an issue from the API, if `labels` is provided, we start by removing all issue's labels and then add them back, according to what is in the `labels` attributes of the JSON
