### PR TITLE
API: Fix labels return code

### DIFF
--- a/doc/api/labels.md
+++ b/doc/api/labels.md
@@ -45,7 +45,7 @@ Parameters:
 
 It returns 200 and the newly created label, if the operation succeeds.
 If the label already exists, 409 and an error message is returned.
-If label parameters are invalid, 405 and an explaining error message is returned.
+If label parameters are invalid, 400 and an explaining error message is returned.
 
 ## Delete a label
 
@@ -58,8 +58,8 @@ DELETE /projects/:id/labels
 - `id` (required) - The ID of a project
 - `name` (required) - The name of the label to be deleted
 
-It returns 200 if the label successfully was deleted, 404 for wrong parameters
-and 400 if the label does not exist.
+It returns 200 if the label successfully was deleted, 400 for wrong parameters
+and 404 if the label does not exist.
 In case of an error, additionally an error message is returned.
 
 ## Edit an existing label
@@ -79,7 +79,6 @@ Parameters:
 - `color` (optional) -  New color of the label given in 6-digit hex notation with leading '#' sign (e.g. #FFAABB)
 
 On success, this method returns 200 with the updated label.
-If required parameters are missing, 400 is returned.
+If required parameters are missing or parameters are invalid, 400 is returned.
 If the label to be updated is missing, 404 is returned.
-If parameters are invalid, 405 is returned. In case of an error,
-additionally an error message is returned.
+In case of an error, additionally an error message is returned.

--- a/lib/api/labels.rb
+++ b/lib/api/labels.rb
@@ -38,7 +38,7 @@ module API
         if label.valid?
           present label, with: Entities::Label
         else
-          render_api_error!(label.errors.full_messages.join(', '), 405)
+          render_api_error!(label.errors.full_messages.join(', '), 400)
         end
       end
 
@@ -92,7 +92,7 @@ module API
         if label.update(attrs)
           present label, with: Entities::Label
         else
-          render_api_error!(label.errors.full_messages.join(', '), 405)
+          render_api_error!(label.errors.full_messages.join(', '), 400)
         end
       end
     end

--- a/spec/requests/api/labels_spec.rb
+++ b/spec/requests/api/labels_spec.rb
@@ -42,19 +42,19 @@ describe API::API, api: true  do
       response.status.should == 400
     end
 
-    it 'should return 405 for invalid color' do
+    it 'should return 400 for invalid color' do
       post api("/projects/#{project.id}/labels", user),
            name: 'Foo',
            color: '#FFAA'
-      response.status.should == 405
+      response.status.should == 400
       json_response['message'].should == 'Color is invalid'
     end
 
-    it 'should return 405 for invalid name' do
+    it 'should return 400 for invalid name' do
       post api("/projects/#{project.id}/labels", user),
            name: '?',
            color: '#FFAABB'
-      response.status.should == 405
+      response.status.should == 400
       json_response['message'].should == 'Title is invalid'
     end
 
@@ -131,20 +131,20 @@ describe API::API, api: true  do
       response.status.should == 400
     end
 
-    it 'should return 405 for invalid name' do
+    it 'should return 400 for invalid name' do
       put api("/projects/#{project.id}/labels", user),
           name: 'label1',
           new_name: '?',
           color: '#FFFFFF'
-      response.status.should == 405
+      response.status.should == 400
       json_response['message'].should == 'Title is invalid'
     end
 
-    it 'should return 405 for invalid name' do
+    it 'should return 400 for invalid name' do
       put api("/projects/#{project.id}/labels", user),
           name: 'label1',
           color: '#FF'
-      response.status.should == 405
+      response.status.should == 400
       json_response['message'].should == 'Color is invalid'
     end
   end


### PR DESCRIPTION
##### What does this MR do?

This PR fixes the return codes of labels API in case of errors. It's better to return 400 for invalid parameters than 409. Thanks @jubianchi
