### PR TITLE
Users with group permission users should also create groups via API, fixes #6417

### DIFF
--- a/doc/api/groups.md
+++ b/doc/api/groups.md
@@ -33,7 +33,7 @@ Parameters:
 
 ## New group
 
-Creates a new project group. Available only for admin.
+Creates a new project group. Available only for users who can create groups.
 
 ```
 POST /groups

--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -33,7 +33,7 @@ module API
         present @groups, with: Entities::Group
       end
 
-      # Create group. Available only for admin
+      # Create group. Available only for users who can create groups.
       #
       # Parameters:
       #   name (required) - The name of the group
@@ -41,7 +41,7 @@ module API
       # Example Request:
       #   POST /groups
       post do
-        authenticated_as_admin!
+        authorize! :create_group, current_user
         required_attributes! [:name, :path]
 
         attrs = attributes_for_keys [:name, :path]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,7 @@ FactoryGirl.define do
     password_confirmation { password }
     confirmed_at { Time.now }
     confirmation_token { nil }
+    can_create_group true
 
     trait :admin do
       admin true

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe API::API, api: true  do
   include ApiHelpers
 
-  let(:user1) { create(:user) }
+  let(:user1) { create(:user, can_create_group: false) }
   let(:user2) { create(:user) }
+  let(:user3) { create(:user) }
   let(:admin) { create(:admin) }
   let!(:group1) { create(:group) }
   let!(:group2) { create(:group) }
@@ -76,31 +77,31 @@ describe API::API, api: true  do
   end
 
   describe "POST /groups" do
-    context "when authenticated as user" do
+    context 'when authenticated as user without group permissions' do
       it "should not create group" do
         post api("/groups", user1), attributes_for(:group)
         response.status.should == 403
       end
     end
 
-    context "when authenticated as admin" do
+    context 'when authenticated as user with group permissions' do
       it "should create group" do
-        post api("/groups", admin), attributes_for(:group)
+        post api('/groups', user3), attributes_for(:group)
         response.status.should == 201
       end
 
       it "should not create group, duplicate" do
-        post api("/groups", admin), {name: "Duplicate Test", path: group2.path}
+        post api('/groups', user3), name: 'Duplicate Test', path: group2.path
         response.status.should == 404
       end
 
       it "should return 400 bad request error if name not given" do
-        post api("/groups", admin), {path: group2.path}
+        post api('/groups', user3), path: group2.path
         response.status.should == 400
       end
 
       it "should return 400 bad request error if path not given" do
-        post api("/groups", admin), { name: 'test' }
+        post api('/groups', user3), name: 'test'
         response.status.should == 400
       end
     end
@@ -114,8 +115,8 @@ describe API::API, api: true  do
       end
 
       it "should not remove a group if not an owner" do
-        user3 = create(:user)
-        group1.add_user(user3, Gitlab::Access::MASTER)
+        user4 = create(:user)
+        group1.add_user(user4, Gitlab::Access::MASTER)
         delete api("/groups/#{group1.id}", user3)
         response.status.should == 403
       end


### PR DESCRIPTION
##### What does this MR do?

This PR determines ability to create a group, based on the `can_create_group` property of an user. This allows non-admins which are allowed to create groups, to also create them via API.
##### Why was this MR needed?

Currently only admins were allowed to do that.
##### What are the relevant issue numbers / Feature requests?

Fixes #6417
