### PR TITLE
bundle omniauth-shibboleth gem for shibboleth authenticaiton

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "devise", '3.2.4'
 gem "devise-async", '0.9.0'
 gem 'omniauth', "~> 1.1.3"
 gem 'omniauth-google-oauth2'
+gem 'omniauth-shibboleth'
 gem 'omniauth-twitter'
 gem 'omniauth-github'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,8 @@ GEM
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
+    omniauth-shibboleth (1.1.1)
+      omniauth (>= 1.0.0)
     omniauth-twitter (1.0.1)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
@@ -641,6 +643,7 @@ DEPENDENCIES
   omniauth (~> 1.1.3)
   omniauth-github
   omniauth-google-oauth2
+  omniauth-shibboleth
   omniauth-twitter
   org-ruby (= 0.9.1)
   pg


### PR DESCRIPTION
Adding gem omniauth-shibboleth will enable option to configure shibboleth authentication in Gitlab. 
It also works with omnibus-gitlab and can be enabled and configured using /etc/gitlab/gitlab.rb.
