### PR TITLE
Add system hook for ssh key changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 7.3.0
   - Deprecate LDAP account takeover based on partial LDAP email / GitLab username match
   - Keyboard shortcuts for productivity (Robert Schilling)
   - API: filter issues by state (Julien Bianchi)
+  - Add system hook for ssh key changes
 
 v 7.2.0
   - Explore page

--- a/app/services/system_hooks_service.rb
+++ b/app/services/system_hooks_service.rb
@@ -22,6 +22,16 @@ class SystemHooksService
     }
 
     case model
+    when Key
+      data.merge!(
+        key: model.key,
+        id: model.id
+      )
+      if model.user
+        data.merge!(
+          username: model.user.username
+        )
+      end
     when Project
       owner = model.owner
 

--- a/doc/system_hooks/system_hooks.md
+++ b/doc/system_hooks/system_hooks.md
@@ -1,6 +1,6 @@
 # System hooks
 
-Your GitLab instance can perform HTTP POST requests on the following events: `create_project`, `delete_project`, `create_user`, `delete_user` and `change_team_member`.
+Your GitLab instance can perform HTTP POST requests on the following events: `project_create`, `project_destroy`, `user_add_to_team`, `user_remove_from_team`, `user_create`, `user_destroy`, `key_create` and `key_destroy`.
 
 System hooks can be used, e.g. for logging or changing information in a LDAP server.
 
@@ -91,5 +91,29 @@ System hooks can be used, e.g. for logging or changing information in a LDAP ser
    "event_name": "user_destroy",
          "name": "John Smith",
       "user_id": 41
+}
+```
+
+**Key added**
+
+```json
+{
+    "event_name": "key_create",
+    "created_at": "2014-08-18 18:45:16 UTC",
+      "username": "root",
+           "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC58FwqHUbebw2SdT7SP4FxZ0w+lAO/erhy2ylhlcW/tZ3GY3mBu9VeeiSGoGz8hCx80Zrz+aQv28xfFfKlC8XQFpCWwsnWnQqO2Lv9bS8V1fIHgMxOHIt5Vs+9CAWGCCvUOAurjsUDoE2ALIXLDMKnJxcxD13XjWdK54j6ZXDB4syLF0C2PnAQSVY9X7MfCYwtuFmhQhKaBussAXpaVMRHltie3UYSBUUuZaB3J4cg/7TxlmxcNd+ppPRIpSZAB0NI6aOnqoBCpimscO/VpQRJMVLr3XiSYeT6HBiDXWHnIVPfQc03OGcaFqOit6p8lYKMaP/iUQLm+pgpZqrXZ9vB john@localhost",
+           "id": 4
+}
+```
+
+**Key removed**
+
+```json
+{
+    "event_name": "key_destroy",
+    "created_at": "2014-08-18 18:45:16 UTC",
+      "username": "root",
+           "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC58FwqHUbebw2SdT7SP4FxZ0w+lAO/erhy2ylhlcW/tZ3GY3mBu9VeeiSGoGz8hCx80Zrz+aQv28xfFfKlC8XQFpCWwsnWnQqO2Lv9bS8V1fIHgMxOHIt5Vs+9CAWGCCvUOAurjsUDoE2ALIXLDMKnJxcxD13XjWdK54j6ZXDB4syLF0C2PnAQSVY9X7MfCYwtuFmhQhKaBussAXpaVMRHltie3UYSBUUuZaB3J4cg/7TxlmxcNd+ppPRIpSZAB0NI6aOnqoBCpimscO/VpQRJMVLr3XiSYeT6HBiDXWHnIVPfQc03OGcaFqOit6p8lYKMaP/iUQLm+pgpZqrXZ9vB john@localhost",
+            "id": 4
 }
 ```

--- a/spec/services/system_hooks_service_spec.rb
+++ b/spec/services/system_hooks_service_spec.rb
@@ -4,6 +4,7 @@ describe SystemHooksService do
   let (:user)          { create :user }
   let (:project)       { create :project }
   let (:users_project) { create :users_project }
+  let (:key)           { create(:key, user: user) }
 
   context 'event data' do
     it { event_data(user, :create).should include(:event_name, :name, :created_at, :email, :user_id) }
@@ -12,6 +13,8 @@ describe SystemHooksService do
     it { event_data(project, :destroy).should include(:event_name, :name, :created_at, :path, :project_id, :owner_name, :owner_email, :project_visibility) }
     it { event_data(users_project, :create).should include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
     it { event_data(users_project, :destroy).should include(:event_name, :created_at, :project_name, :project_path, :project_id, :user_name, :user_email, :project_access, :project_visibility) }
+    it { event_data(key, :create).should include(:username, :key, :id) }
+    it { event_data(key, :destroy).should include(:username, :key, :id) }
   end
 
   context 'event names' do
@@ -21,6 +24,8 @@ describe SystemHooksService do
     it { event_name(project, :destroy).should eq "project_destroy" }
     it { event_name(users_project, :create).should eq "user_add_to_team" }
     it { event_name(users_project, :destroy).should eq "user_remove_from_team" }
+    it { event_name(key, :create).should eq 'key_create' }
+    it { event_name(key, :destroy).should eq 'key_destroy' }
   end
 
   def event_data(*args)


### PR DESCRIPTION
Enabling SSH Key create/delete notification in system hooks makes it possible to automatically push ssh keys to other systems so gitlab can be more tightly integrated with a development environment.

Code is self-explaining. It adds after_create and after_destroy hooks to the Key model and adds logic to process a Key update in the build_event_data method of the system hook service.
