### PR TITLE
Add missing elements to webhook doc

### DIFF
--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -76,7 +76,9 @@ Triggered when a new issue is created or an existing issue was updated/closed/re
     "description": "Create new API for manipulations with repository",
     "milestone_id": null,
     "state": "opened",
-    "iid": 23
+    "iid": 23,
+    "url": "http://example.com/diaspora/issues/23",
+    "action": "open"
   }
 }
 ```


### PR DESCRIPTION
#7013 added  elements (`url` and `action`) to issue webhook response.

But webhook document was not updated.
