### PR TITLE
cmake is required during the installation of the rugged gem

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -49,7 +49,7 @@ up-to-date and install it.
 
 Install the required packages (needed to compile Ruby and native extensions to Ruby gems):
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils
+    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils cmake
 
 Make sure you have the right version of Git installed
 


### PR DESCRIPTION
The following error is encountered during the installation of the rugged gem:

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

```
/usr/bin/ruby2.1 extconf.rb
checking for cmake... no
ERROR: CMake is required to build Rugged.
*** extconf.rb failed ***
```
