### PR TITLE
fixes gitlab.com issue #506 - Asignee for Issuables not checked

### DIFF
--- a/app/models/concerns/issuable.rb
+++ b/app/models/concerns/issuable.rb
@@ -18,6 +18,7 @@ module Issuable
 
     validates :author, presence: true
     validates :title, presence: true, length: { within: 0..255 }
+    validate :can_be_assigned?, if: 'assignee'
 
     scope :authored, ->(user) { where(author_id: user) }
     scope :assigned_to, ->(u) { where(assignee_id: u.id)}

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -49,6 +49,14 @@ class Issue < ActiveRecord::Base
     state :closed
   end
 
+  # Assignee check overwrite
+
+  def can_be_assigned?
+    unless project.team_members.include? assignee
+      errors.add(:assignee, 'cannot assign an user without permission')
+    end
+  end
+
   # Mentionable overrides.
 
   def gfm_reference

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -144,6 +144,14 @@ class MergeRequest < ActiveRecord::Base
     end
   end
 
+  # Assignee check overwrite
+
+  def can_be_assigned?
+    unless target_project.team_members.include? assignee
+      errors.add(:assignee, 'cannot assign an user without permission')
+    end
+  end
+
   def update_merge_request_diff
     if source_branch_changed? || target_branch_changed?
       reload_code

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -31,27 +31,59 @@ describe Issue do
     it { should include_module(Issuable) }
   end
 
-  subject { create(:issue) }
+  describe 'assignment' do
+    subject { create(:issue) }
 
-  describe '#is_being_reassigned?' do
-    it 'returns true if the issue assignee has changed' do
-      subject.assignee = create(:user)
-      subject.is_being_reassigned?.should be_true
+    context 'without an assignee' do
+      it 'can be created' do
+        subject.assignee = nil
+        expect(subject.valid?).to be_true
+      end
     end
-    it 'returns false if the issue assignee has not changed' do
-      subject.is_being_reassigned?.should be_false
+
+    context 'with an assignee without permissions on the project' do
+      it 'cannot assign the issue' do
+        subject.project = create(:project)
+        subject.assignee = create(:user)
+        expect(subject.valid?).to be_false
+      end
     end
-  end
 
-  describe '#is_being_reassigned?' do
-    it 'returns issues assigned to user' do
-      user = create :user
+    context 'with an assignee with permissions on the project' do
+      let(:user) { create(:user) }
+      let(:project) do
+        p = create(:project)
+        p.team.add_user(user, Gitlab::Access::DEVELOPER)
+        p
+      end
+      let(:issue) { create(:issue, project: project) }
 
-      2.times do
-        issue = create :issue, assignee: user
+      it 'can assign the issue' do
+        issue.assignee = user
+        expect(issue.valid?).to be_true
       end
 
-      Issue.open_for(user).count.should eq 2
+      describe '#is_being_reassigned?' do
+        it 'returns true if the issue assignee has changed' do
+          issue.assignee = user
+          expect(issue.is_being_reassigned?).to be_true
+        end
+        it 'returns false if the issue assignee has not changed' do
+          expect(issue.is_being_reassigned?).to be_false
+        end
+      end
+
+      describe '#is_being_reassigned?' do
+        it 'returns issues assigned to user' do
+
+          2.times do
+            issue = create :issue, project: project, assignee: user
+          end
+
+          expect(Issue.open_for(user).count).to eq 2
+        end
+      end
+
     end
   end
 

--- a/spec/models/merge_request_spec.rb
+++ b/spec/models/merge_request_spec.rb
@@ -57,13 +57,33 @@ describe MergeRequest do
 
   subject { create(:merge_request) }
 
-  describe '#is_being_reassigned?' do
-    it 'returns true if the merge_request assignee has changed' do
-      subject.assignee = create(:user)
-      subject.is_being_reassigned?.should be_true
+  describe 'assignment' do
+
+    context 'without an assignee' do
+      it 'can be created' do
+        subject.assignee = nil
+        expect(subject.valid?).to be_true
+      end
     end
-    it 'returns false if the merge request assignee has not changed' do
-      subject.is_being_reassigned?.should be_false
+
+    context 'with an assignee without permissions on the target_project' do
+      it 'cannot assign the issue' do
+        subject.target_project = create(:project)
+        subject.assignee = create(:user)
+        expect(subject.valid?).to be_false
+      end
+    end
+
+    context 'with an assignee with permissions on the target_project' do
+      describe '#is_being_reassigned?' do
+        it 'returns true if the merge_request assignee has changed' do
+          subject.assignee = create(:user)
+          expect(subject.is_being_reassigned?).to be_true
+        end
+        it 'returns false if the merge request assignee has not changed' do
+          expect(subject.is_being_reassigned?).to be_false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
As seen in https://gitlab.com/gitlab-org/gitlab-ce/issues/506, the assignee of an Issue and/or MergeRequest wasn't checked for permission on the project.

This PR comes with enhanced specs in both `Issue` and `Mergerequest`. These
two models are the only users of `Issuable` as far as I see. The
validation method needs to be overwritten in both of them as the
iactual implementation of permissions is unknown in the Issuable Concern
module.
