### PR TITLE
No code blocks in update links

### DIFF
--- a/doc/update/5.1-to-5.2.md
+++ b/doc/update/5.1-to-5.2.md
@@ -60,7 +60,7 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 ```bash
 cd /home/git/gitlab
 sudo rm /etc/init.d/gitlab
-sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab 
+sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 sudo chmod +x /etc/init.d/gitlab
 ```
 
@@ -93,7 +93,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.0 to 5.1`](5.0-to-5.1.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.0 to 5.1](5.0-to-5.1.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup
 

--- a/doc/update/5.1-to-5.4.md
+++ b/doc/update/5.1-to-5.4.md
@@ -89,7 +89,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.2 to 5.3`](5.2-to-5.3.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.2 to 5.3](5.2-to-5.3.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/5.1-to-6.0.md
+++ b/doc/update/5.1-to-6.0.md
@@ -139,7 +139,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.0 to 5.1`](5.0-to-5.1.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.0 to 5.1](5.0-to-5.1.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/5.2-to-5.3.md
+++ b/doc/update/5.2-to-5.3.md
@@ -75,7 +75,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.1 to 5.2`](5.1-to-5.2.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.1 to 5.2](5.1-to-5.2.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/5.3-to-5.4.md
+++ b/doc/update/5.3-to-5.4.md
@@ -79,7 +79,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.2 to 5.3`](5.2-to-5.3.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.2 to 5.3](5.2-to-5.3.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/6.0-to-6.1.md
+++ b/doc/update/6.0-to-6.1.md
@@ -98,7 +98,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.4 to 6.0`](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.4 to 6.0](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/6.0-to-7.1.md
+++ b/doc/update/6.0-to-7.1.md
@@ -86,7 +86,7 @@ sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
 
 ## 6. Update config files
 
-TIP: to see what changed in gitlab.yml.example in this release use next command: 
+TIP: to see what changed in gitlab.yml.example in this release use next command:
 
 ```
 git diff 6-0-stable:config/gitlab.yml.example 7-1-stable:config/gitlab.yml.example
@@ -135,7 +135,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.4 to 6.0`](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.4 to 6.0](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 
@@ -146,4 +146,4 @@ sudo -u git -H bundle exec rake gitlab:backup:restore RAILS_ENV=production
 
 ## Login issues after upgrade?
 
-If running in HTTPS mode, be sure to read [Can't Verify CSRF token authenticity](https://github.com/gitlabhq/gitlab-public-wiki/wiki/Trouble-Shooting-Guide#cant-verify-csrf-token-authenticitycant-get-past-login-pageredirected-to-login-page) 
+If running in HTTPS mode, be sure to read [Can't Verify CSRF token authenticity](https://github.com/gitlabhq/gitlab-public-wiki/wiki/Trouble-Shooting-Guide#cant-verify-csrf-token-authenticitycant-get-past-login-pageredirected-to-login-page)

--- a/doc/update/6.0-to-7.2.md
+++ b/doc/update/6.0-to-7.2.md
@@ -84,7 +84,7 @@ sudo chmod u+rwx,g+rx,o-rwx /home/git/gitlab-satellites
 
 ## 6. Update config files
 
-TIP: to see what changed in gitlab.yml.example in this release use next command: 
+TIP: to see what changed in gitlab.yml.example in this release use next command:
 
 ```
 git diff 6-0-stable:config/gitlab.yml.example 7-2-stable:config/gitlab.yml.example
@@ -133,7 +133,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 5.4 to 6.0`](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 5.4 to 6.0](5.4-to-6.0.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 
@@ -144,4 +144,4 @@ sudo -u git -H bundle exec rake gitlab:backup:restore RAILS_ENV=production
 
 ## Login issues after upgrade?
 
-If running in HTTPS mode, be sure to read [Can't Verify CSRF token authenticity](https://github.com/gitlabhq/gitlab-public-wiki/wiki/Trouble-Shooting-Guide#cant-verify-csrf-token-authenticitycant-get-past-login-pageredirected-to-login-page) 
+If running in HTTPS mode, be sure to read [Can't Verify CSRF token authenticity](https://github.com/gitlabhq/gitlab-public-wiki/wiki/Trouble-Shooting-Guide#cant-verify-csrf-token-authenticitycant-get-past-login-pageredirected-to-login-page)

--- a/doc/update/6.1-to-6.2.md
+++ b/doc/update/6.1-to-6.2.md
@@ -59,7 +59,7 @@ sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
 
 ## 6. Update config files
 
-TIP: to see what changed in `gitlab.yml.example` in this release use next command: 
+TIP: to see what changed in `gitlab.yml.example` in this release use next command:
 
 ```
 git diff 6-1-stable:config/gitlab.yml.example 6-2-stable:config/gitlab.yml.example
@@ -112,7 +112,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.0 to 6.1`](6.0-to-6.1.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.0 to 6.1](6.0-to-6.1.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/6.2-to-6.3.md
+++ b/doc/update/6.2-to-6.3.md
@@ -98,7 +98,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.1 to 6.2`](6.1-to-6.2.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.1 to 6.2](6.1-to-6.2.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/6.3-to-6.4.md
+++ b/doc/update/6.3-to-6.4.md
@@ -79,7 +79,7 @@ If all items are green, then congratulations upgrade complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.2 to 6.3`](6.2-to-6.3.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.2 to 6.3](6.2-to-6.3.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup:
 

--- a/doc/update/6.4-to-6.5.md
+++ b/doc/update/6.4-to-6.5.md
@@ -83,7 +83,7 @@ If all items are green, then congratulations upgrade is complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.3 to 6.4`](6.3-to-6.4.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.3 to 6.4](6.3-to-6.4.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup
 

--- a/doc/update/6.5-to-6.6.md
+++ b/doc/update/6.5-to-6.6.md
@@ -83,7 +83,7 @@ If all items are green, then congratulations upgrade is complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.4 to 6.5`](6.4-to-6.5.md), except for the database migration 
+Follow the [upgrade guide from 6.4 to 6.5](6.4-to-6.5.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:

--- a/doc/update/6.6-to-6.7.md
+++ b/doc/update/6.6-to-6.7.md
@@ -93,7 +93,7 @@ If all items are green, then congratulations upgrade is complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.5 to 6.6`](6.5-to-6.6.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.5 to 6.6](6.5-to-6.6.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup
 

--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -111,7 +111,7 @@ If all items are green, then congratulations upgrade is complete!
 
 ### 1. Revert the code to the previous version
 
-Follow the [`upgrade guide from 6.6 to 6.7`](6.6-to-6.7.md), except for the database migration (the backup is already migrated to the previous version).
+Follow the [upgrade guide from 6.6 to 6.7](6.6-to-6.7.md), except for the database migration (the backup is already migrated to the previous version).
 
 ### 2. Restore from the backup
 

--- a/doc/update/6.8-to-6.9.md
+++ b/doc/update/6.8-to-6.9.md
@@ -90,7 +90,7 @@ If all items are green, then congratulations upgrade is complete!
 ## Things went south? Revert to previous version (6.8)
 
 ### 1. Revert the code to the previous version
-Follow the [`upgrade guide from 6.7 to 6.8`](6.7-to-6.8.md), except for the database migration
+Follow the [upgrade guide from 6.7 to 6.8](6.7-to-6.8.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -126,7 +126,7 @@ If all items are green, then congratulations upgrade is complete!
 ## Things went south? Revert to previous version (6.9)
 
 ### 1. Revert the code to the previous version
-Follow the [`upgrade guide from 6.8 to 6.9`](6.8-to-6.9.md), except for the database migration
+Follow the [upgrade guide from 6.8 to 6.9](6.8-to-6.9.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:

--- a/doc/update/7.0-to-7.1.md
+++ b/doc/update/7.0-to-7.1.md
@@ -126,7 +126,7 @@ If all items are green, then congratulations upgrade is complete!
 ## Things went south? Revert to previous version (7.0)
 
 ### 1. Revert the code to the previous version
-Follow the [`upgrade guide from 6.9 to 7.0`](6.9-to-7.0.md), except for the database migration
+Follow the [upgrade guide from 6.9 to 7.0](6.9-to-7.0.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:

--- a/doc/update/7.1-to-7.2.md
+++ b/doc/update/7.1-to-7.2.md
@@ -94,7 +94,7 @@ If all items are green, then congratulations upgrade is complete!
 ## Things went south? Revert to previous version (7.1)
 
 ### 1. Revert the code to the previous version
-Follow the [`upgrade guide from 7.0 to 7.1`](7.0-to-7.1.md), except for the database migration
+Follow the [upgrade guide from 7.0 to 7.1](7.0-to-7.1.md), except for the database migration
 (The backup is already migrated to the previous version)
 
 ### 2. Restore from the backup:


### PR DESCRIPTION
#### What does it to?

Currently links in update guides have active codeblocks. This renders very ugly on gitlab: 

![screenshot 2014-08-19 15 33 34](https://cloud.githubusercontent.com/assets/278301/3966640/74e7f58c-27a5-11e4-90c3-84fa7c9ccd4f.png)

This PR removes the codeblocks.
