### PR TITLE
use default white-space for sidebar buttons, fixes #7549

### DIFF
--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -192,6 +192,7 @@ ul.nav.nav-projects-tabs {
     background-image: none;
 
     .btn, &.btn {
+      white-space: normal;
       text-align: left;
       padding: 10px 15px;
       background-color: #F1f1f1;


### PR DESCRIPTION
#### What does this PR do?

Fixes wrapping of star/fork count for firefox. Related to a 5 year old firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=488725
