### PR TITLE
Fix project description on explore page, fixes #7458

### DIFF
--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -89,6 +89,10 @@
   }
 }
 
+.project-description {
+  overflow: hidden;
+}
+
 .project-access-icon {
   margin-left: 10px;
   float: left;

--- a/app/views/explore/projects/_project.html.haml
+++ b/app/views/explore/projects/_project.html.haml
@@ -1,25 +1,26 @@
 %li
-  %h4.project-title
-    .project-access-icon
-      = visibility_level_icon(project.visibility_level)
-    = link_to project.name_with_namespace, project
+  .project-access-icon
+    = visibility_level_icon(project.visibility_level)
 
-    - if current_page?(starred_explore_projects_path)
-      %strong.pull-right
-        = pluralize project.star_count, 'star'
+  .project-description
+    %h4.project-title
+      = link_to project.name_with_namespace, project
 
-  - if project.description.present?
-    %p.project-description.str-truncated
-      = project.description
+      - if current_page?(starred_explore_projects_path)
+        %strong.pull-right
+          = pluralize project.star_count, 'star'
 
-  .repo-info
-    - unless project.empty_repo?
-      = link_to pluralize(project.repository.round_commit_count, 'commit'), project_commits_path(project, project.default_branch)
-      &middot;
-      = link_to pluralize(project.repository.branch_names.count, 'branch'), project_branches_path(project)
-      &middot;
-      = link_to pluralize(project.repository.tag_names.count, 'tag'), project_tags_path(project)
-    - else
-      %i.icon-warning-sign
-      Empty repository
+    - if project.description.present?
+      %p.project-description.str-truncated
+        = project.description
 
+    .repo-info
+      - unless project.empty_repo?
+        = link_to pluralize(project.repository.round_commit_count, 'commit'), project_commits_path(project, project.default_branch)
+        &middot;
+        = link_to pluralize(project.repository.branch_names.count, 'branch'), project_branches_path(project)
+        &middot;
+        = link_to pluralize(project.repository.tag_names.count, 'tag'), project_tags_path(project)
+      - else
+        %i.icon-warning-sign
+        Empty repository


### PR DESCRIPTION
##### What does this PR do?

This PR adds the `overflow: hidden` to the content next to the image, to avoid wrapping around the visibility image.

@cirosantilli  @dreis2211  @arif-ali Could someone of you verify this PR fixes the problem?
