### PR TITLE
Fix ace mode and worker paths. refs #6850

### DIFF
--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -41,6 +41,7 @@
 
 :javascript
   ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")
+  ace.config.set("workerPath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")
   var ace_mode = "#{@blob.language.try(:ace_mode)}";
   var editor = ace.edit("editor");
   editor.setValue("#{escape_javascript(@blob.data)}");

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -43,7 +43,8 @@
       = link_to "Cancel", project_tree_path(@project, @id), class: "btn btn-cancel", data: { confirm: leave_edit_message}
 
 :javascript
-  ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")
+  ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")
+  ace.config.set("workerPath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")
   var editor = ace.edit("editor");
 
   disableButtonIfEmptyField("#commit_message", ".js-commit-button");


### PR DESCRIPTION
Ace editor need both modes and workers to function properly (workers are not that necessary, but without them it works slower)
It's an overkill to add whole ace to javascript manifest, as not all modes are always used, plus workers must be loaded in separate request anyway.

Symlink `public/assets/ace` to `vendor/bundle/ruby/<ruby version>/gems/ace-rails-ap-<gem version>/vendor/assets/javascripts/ace/`, set paths and editor will work.

This PR sets paths, did not yet figured a proper way to make a symlink on assets compilation
