### PR TITLE
change X-Frame-Options to SAMEORIGIN for nginx SSL config

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -81,7 +81,7 @@ server {
   ssl_prefer_server_ciphers   on;
 
   add_header Strict-Transport-Security max-age=63072000;
-  add_header X-Frame-Options DENY;
+  add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
 
   ## Individual nginx logs for this GitLab vhost


### PR DESCRIPTION
The current setting in the SSL nginx config does not allow sidekiq to load on background jobs tab, this should fix that and still be secure since it is `SAMEORIGIN`.
