### PR TITLE
Add dependency info for mysql-postgresql converter

### DIFF
--- a/doc/update/mysql_to_postgresql.md
+++ b/doc/update/mysql_to_postgresql.md
@@ -68,6 +68,7 @@ test -e /opt/gitlab/embedded/service/gitlab-rails/db/schema.rb.bundled || sudo /
 ```
 
 ## Converting a GitLab backup file from MySQL to Postgres
+**Note:** Please make sure to have Python 2.7.x (or higher) installed.
 
 GitLab backup files (<timestamp>_gitlab_backup.tar) contain a SQL dump. Using the lanyrd database converter we can replace a MySQL database dump inside the tar file with a Postgres database dump. This can be useful if you are moving to another server.
 


### PR DESCRIPTION
Running converter with Python 2.6.x installed gives the following error:
AttributeError: 'module' object has no attribute 'check_output'

After installing Python 2.7.x everything works fine.
