### PR TITLE
Added AsciiDoc support for the Project Wikis

### DIFF
--- a/app/models/project_wiki.rb
+++ b/app/models/project_wiki.rb
@@ -3,7 +3,8 @@ class ProjectWiki
 
   MARKUPS = {
     "Markdown" => :markdown,
-    "RDoc"     => :rdoc
+    "RDoc"     => :rdoc,
+    "AsciiDoc" => :asciidoc
   }
 
   class CouldNotCreateWikiError < StandardError; end


### PR DESCRIPTION
the gem asciidoctor is already instaled inside gitlab, so you can use asciidoc support inside the project wikis.
