### PR TITLE
Handle undefined text area values

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -54,7 +54,7 @@ window.extractLast = (term) ->
   return split( term ).pop()
 
 window.rstrip = (val) ->
-  return val.replace(/\s+$/, '')
+  return if val then val.replace(/\s+$/, '') else val
 
 # Disable button if text field is empty
 window.disableButtonIfEmptyField = (field_selector, button_selector) ->


### PR DESCRIPTION
Check to see if a text area's `val` is defined before trying to call
`replace()` on it.

This was causing failures in RSpec tests; here's a snippet of output from `bundle exec rspec spec/features/notes_on_merge_requests_spec.rb`:

```
Failures:

  1) Comments On a merge request the note form should be valid
     Failure/Error: visit project_merge_request_path(project, merge_request)
     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).

       TypeError: 'undefined' is not an object (evaluating 'val.replace')
       TypeError: 'undefined' is not an object (evaluating 'val.replace')
           at http://127.0.0.1:58906/assets/application.js:76468
           at http://127.0.0.1:58906/assets/application.js:76475
           at http://127.0.0.1:58906/assets/application.js:74482 in MergeRequest
           at http://127.0.0.1:58906/namespace1/gitlabhq/merge_requests/1:553
     # ./spec/features/notes_on_merge_requests_spec.rb:13:in `block (3 levels) in <top (required)>'
```
