### PR TITLE
check if gitlab.yml contains newest added setting

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -105,7 +105,7 @@ namespace :gitlab do
       end
 
       # omniauth or ldap could have been deleted from the file
-      unless Gitlab.config['git_host']
+      if Settings.satellites['timeout']
         puts "no".green
       else
         puts "yes".red


### PR DESCRIPTION
Updates check.rake to check for newest setting added in 7.2.

Allows us to more accurately return config file status using:

`sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production`
