### PR TITLE
add current sign-in date

### DIFF
--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -71,6 +71,14 @@
                   No
 
             %li
+              %span.light Current sign-in at:
+              %strong
+                - if @user.current_sign_in_at
+                  = @user.current_sign_in_at.stamp("Nov 12, 2031")
+                - else
+                  never
+
+            %li
               %span.light Last sign-in at:
               %strong
                 - if @user.last_sign_in_at


### PR DESCRIPTION
Add current sign-in date to admin section profile view.

![image](https://cloud.githubusercontent.com/assets/1192780/4026899/75867f76-2c24-11e4-9b34-ffc60b50ce47.png)

I'm a bit confused why both `current_sign_in_at` and `last_sign_in_at` exist but regardless they do not match and as such I believe both should be shown.
