### PR TITLE
Add "Without sign-in last 30 days" and "Without sign-in" filters

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,6 +178,9 @@ class User < ActiveRecord::Base
   scope :not_in_team, ->(team){ where('users.id NOT IN (:ids)', ids: team.member_ids) }
   scope :not_in_project, ->(project) { project.users.present? ? where("id not in (:ids)", ids: project.users.map(&:id) ) : all }
   scope :without_projects, -> { where('id NOT IN (SELECT DISTINCT(user_id) FROM members)') }
+  scope :without_sign_in_30_days, -> {
+         where(current_sign_in_at: [nil, Date.new(2000)..30.days.ago]) }
+  scope :without_sign_in, -> { where(current_sign_in_at: nil) }
   scope :ldap, -> { where('provider LIKE ?', 'ldap%') }
   scope :potential_team_members, ->(team) { team.members.any? ? active.not_in_team(team) : active  }
 
@@ -217,6 +220,8 @@ class User < ActiveRecord::Base
       when "admins"; self.admins
       when "blocked"; self.blocked
       when "wop"; self.without_projects
+      when 'wosi30'; without_sign_in_30_days
+      when 'wosi'; without_sign_in
       else
         self.active
       end

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -18,6 +18,14 @@
           = link_to admin_users_path(filter: "wop") do
             Without projects
             %small.pull-right= User.without_projects.count
+        %li{class: "#{'active' if params[:filter] == "wosi30"}"}
+          = link_to admin_users_path(filter: "wosi30") do
+            Without sign-in last 30 days
+            %small.pull-right= User.without_sign_in_30_days.count
+        %li{class: "#{'active' if params[:filter] == "wosi"}"}
+          = link_to admin_users_path(filter: "wosi") do
+            Without sign-in
+            %small.pull-right= User.without_sign_in.count
       %hr
       = form_tag admin_users_path, method: :get, class: 'form-inline' do
         .form-group


### PR DESCRIPTION
Adds two new filters for the `admin/users` page:
- Without sign-in last 30 days
- Without sign-in

![image](https://cloud.githubusercontent.com/assets/1192780/4034670/a7736f0e-2c87-11e4-8391-cba14b8291ef.png)

Ideally I'd like to have some advanced filters and sort options like the `admin/projects` page but this is an improvement. It'd be great if we tracked when each user last committed (e.g. `last_commited_at`) or completed an activity (e.g. `last_activity_at`) such as commenting on an issue so we could gauge how active users are.

I'll squash commits and add a meaningful commit message later.
