### PR TITLE
Add pkg-config as required dependency for rugged

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -49,7 +49,7 @@ up-to-date and install it.
 
 Install the required packages (needed to compile Ruby and native extensions to Ruby gems):
 
-    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils cmake
+    sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils pkg-config cmake
 
 Make sure you have the right version of Git installed
 

--- a/doc/update/6.0-to-7.2.md
+++ b/doc/update/6.0-to-7.2.md
@@ -85,8 +85,8 @@ sudo -u git -H git checkout 7-2-stable-ee
 # Add support for lograte for better log file handling
 sudo apt-get install logrotate
 
-# Install cmake, which is needed for the latest versions of rugged
-sudo apt-get install cmake
+# Install pkg-config and cmake, which is needed for the latest versions of rugged
+sudo apt-get install pkg-config cmake
 ```
 
 ## 5. Update gitlab-shell

--- a/doc/update/7.1-to-7.2.md
+++ b/doc/update/7.1-to-7.2.md
@@ -51,11 +51,11 @@ sudo -u git -H git checkout v1.9.7
 
 ### 4. Install new system dependencies
 
-The latest version of the 'rugged' gem requires cmake to build its native
-extensions.
+The latest version of the 'rugged' gem requires `pkg-config` and `cmake` to
+build its native extensions.
 
 ```bash
-sudo apt-get install cmake
+sudo apt-get install pkg-config cmake
 ```
 
 ### 5. Install libs, migrations, etc.

--- a/doc/update/upgrader.md
+++ b/doc/update/upgrader.md
@@ -21,7 +21,7 @@ If you have local changes to your GitLab repository the script will stash them a
 
 ## 2. Run GitLab upgrade tool
 
-Note: GitLab 7.2 adds cmake as dependency. Please check the dependencies in the [installation guide.](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/install/installation.md#1-packages-dependencies)
+Note: GitLab 7.2 adds `pkg-config` and `cmake` as dependency. Please check the dependencies in the [installation guide.](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/install/installation.md#1-packages-dependencies)
 
     # Starting with GitLab version 7.0 upgrader script has been moved to bin directory
     cd /home/git/gitlab


### PR DESCRIPTION
This fixes #7588 because rugged officially added `pkg-config` to the docs.

/cc @dosire I backport this also to 7-2 stable branch.
