### PR TITLE
[refactor] Remove HAML eval for const strings.

### DIFF
--- a/app/views/notify/project_was_moved_email.html.haml
+++ b/app/views/notify/project_was_moved_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  = "Project was moved to another location"
+  Project was moved to another location
 %p
   The project is now located under
   = link_to project_url(@project) do

--- a/app/views/projects/commits/_diff_stats.html.haml
+++ b/app/views/projects/commits/_diff_stats.html.haml
@@ -26,7 +26,7 @@
               %a{href: "#diff-#{i}"}
                 %i.icon-minus
                 = diff.old_path
-                = "->"
+                \->
                 = diff.new_path
           - elsif diff.new_file
             %span.new-file

--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -9,7 +9,7 @@
       = link_to_gfm issue.title, project_issue_path(issue.project, issue), class: "row_title"
     - if issue.closed?
       %small.pull-right
-        = "CLOSED"
+        CLOSED
 
   .issue-info
     - if issue.assignee

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -5,7 +5,7 @@
     - if merge_request.merged?
       %small.pull-right
         %i.icon-ok
-        = "MERGED"
+        MERGED
     - else
       %span.pull-right
         - if merge_request.for_fork?

--- a/app/views/projects/merge_requests/_new_submit.html.haml
+++ b/app/views/projects/merge_requests/_new_submit.html.haml
@@ -16,7 +16,7 @@
       .form-group
         .light
           = f.label :title do
-            = "Title *"
+            Title *
         = f.text_field :title, class: "form-control input-lg js-gfm-input", maxlength: 255, rows: 5, required: true
       .form-group
         .light

--- a/app/views/projects/team_members/_form.html.haml
+++ b/app/views/projects/team_members/_form.html.haml
@@ -1,5 +1,5 @@
 %h3.page-title
-  = "New project member(s)"
+  New project member(s)
 
 = form_for @user_project_relation, as: :team_member, url: project_team_members_path(@project), html: { class: "form-horizontal users-project-form" } do |f|
   -if @user_project_relation.errors.any?

--- a/app/views/projects/team_members/import.html.haml
+++ b/app/views/projects/team_members/import.html.haml
@@ -1,5 +1,5 @@
 %h3.page-title
-  = "Import members from another project"
+  Import members from another project
 %p.light
   Only project members will be imported. Group members will be skipped.
 %hr


### PR DESCRIPTION
- faster
- equally readable

Found with: `git grep '^\s*\= "' | grep -v '#{'`
