### PR TITLE
Adding snippet search capability

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,6 +9,8 @@ class SearchController < ApplicationController
       return access_denied! unless can?(current_user, :download_code, @project)
 
       @search_results = Search::ProjectService.new(@project, current_user, params).execute
+    elsif params[:snippets].present?
+      @search_results = Search::SnippetService.new(current_user, params).execute
     else
       @search_results = Search::GlobalService.new(current_user, params).execute
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,9 @@ module ApplicationHelper
   end
 
   def search_placeholder
-    if @project && @project.persisted?
+    if @snippet || @snippets || (params && params[:snippets])
+      "Search snippets"
+    elsif @project && @project.persisted?
       "Search in this project"
     elsif @group && @group.persisted?
       "Search in this group"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,7 +177,7 @@ module ApplicationHelper
 
   def search_placeholder
     if @snippet || @snippets || (params && params[:snippets])
-      "Search snippets"
+      'Search snippets'
     elsif @project && @project.persisted?
       "Search in this project"
     elsif @group && @group.persisted?

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -67,11 +67,11 @@ class Snippet < ActiveRecord::Base
   end
 
   class << self
-    def search (query)
+    def search(query)
       where('(title LIKE :query OR file_name LIKE :query)', query: "%#{query}%")
     end 
 
-    def search_code (query)
+    def search_code(query)
       where('(content LIKE :query)', query: "%#{query}%")
     end 
 

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -67,17 +67,16 @@ class Snippet < ActiveRecord::Base
   end
 
   class << self
-    def search query
-      where("(title LIKE :query OR file_name LIKE :query)", query: "%#{query}%")
+    def search (query)
+      where('(title LIKE :query OR file_name LIKE :query)', query: "%#{query}%")
     end 
 
-    def search_code query
-      where("(content LIKE :query)", query: "%#{query}%")
+    def search_code (query)
+      where('(content LIKE :query)', query: "%#{query}%")
     end 
 
     def accessible_to(user)
-      where("private = ? OR author_id = ?", false, user)
+      where('private = ? OR author_id = ?', false, user)
     end
   end
-
 end

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -65,4 +65,19 @@ class Snippet < ActiveRecord::Base
   def expired?
     expires_at && expires_at < Time.current
   end
+
+  class << self
+    def search query
+      where("(title LIKE :query OR file_name LIKE :query)", query: "%#{query}%")
+    end 
+
+    def search_code query
+      where("(content LIKE :query)", query: "%#{query}%")
+    end 
+
+    def accessible_to(user)
+      where("private = ? OR author_id = ?", false, user)
+    end
+  end
+
 end

--- a/app/services/search/snippet_service.rb
+++ b/app/services/search/snippet_service.rb
@@ -1,0 +1,84 @@
+module Search
+  class SnippetService
+    require 'set'
+
+    attr_accessor :current_user, :params
+
+    def initialize(user, params)
+      @current_user, @params = user, params.dup
+    end
+
+    def execute
+      query = params[:search]
+      query = Shellwords.shellescape(query) if query.present?
+      return result unless query.present?
+      snippets = Snippet.accessible_to(current_user)
+
+      page_size = 20
+      result_limit = 500
+      if params[:search_code]
+        surrounding_lines = 3
+        matching_snippets = snippets.search_code(query)
+        matching_snippets = matching_snippets.order('updated_at DESC').limit(result_limit).to_a
+        matching_snippets.each_with_index { |blob, blob_index|
+          used_lines = SortedSet.new
+          lined_content = blob.content.split("\n")
+          lined_content.each_with_index { |line, line_number|
+            if line.include?(query)
+              for i in 0..surrounding_lines
+                used_lines << line_number - i unless line_number - i < 0
+                used_lines << line_number + i unless line_number + i >= lined_content.size
+              end
+            end
+          }
+
+          snippet_chunk = []
+          snippet_chunks = []
+          snippet_start_line = 0
+          last_line = -1
+          used_lines.each { |line_number|
+            if last_line < 0
+              snippet_start_line = line_number
+              snippet_chunk << lined_content[line_number]
+            elsif last_line == line_number - 1
+              snippet_chunk << lined_content[line_number]
+            else
+              snippet_chunks << {
+                :data => snippet_chunk.join("\n"),
+                :start_line => snippet_start_line + 1
+              }
+              snippet_chunk = [lined_content[line_number]]
+              snippet_start_line = line_number
+            end
+            last_line = line_number
+          }
+          snippet_chunks << {
+            :data => snippet_chunk.join("\n"),
+            :start_line => snippet_start_line + 1
+          }
+          matching_snippets[blob_index] = {
+            :snippet_object => blob,
+            :snippet_chunks => snippet_chunks
+          }
+        }
+
+        paginated_matching_snippets = Kaminari.paginate_array(matching_snippets).page(params[:page]).per(page_size)
+        result[:snippets] = paginated_matching_snippets
+        result[:total_results] = paginated_matching_snippets.total_count
+      else
+        snippets_array = snippets.search(query).order('updated_at DESC').to_a
+        result[:snippets] = Kaminari.paginate_array(snippets_array).page(params[:page]).per(page_size)
+        result[:total_results] = snippets_array.size
+      end
+
+      result
+    end
+
+    def result
+      @result ||= {
+        snippets: [],
+        total_results: 0
+      }
+    end
+  end
+end

--- a/app/services/search/snippet_service.rb
+++ b/app/services/search/snippet_service.rb
@@ -1,6 +1,5 @@
 module Search
   class SnippetService
-
     attr_accessor :current_user, :params
 
     def initialize(user, params)

--- a/app/services/search/snippet_service.rb
+++ b/app/services/search/snippet_service.rb
@@ -1,6 +1,5 @@
 module Search
   class SnippetService
-    require 'set'
 
     attr_accessor :current_user, :params
 
@@ -17,61 +16,32 @@ module Search
       page_size = 20
       result_limit = 500
       if params[:search_code]
-        surrounding_lines = 3
         matching_snippets = snippets.search_code(query)
-        matching_snippets = matching_snippets.order('updated_at DESC').limit(result_limit).to_a
-        matching_snippets.each_with_index { |blob, blob_index|
-          used_lines = SortedSet.new
-          lined_content = blob.content.split("\n")
-          lined_content.each_with_index { |line, line_number|
-            if line.include?(query)
-              for i in 0..surrounding_lines
-                used_lines << line_number - i unless line_number - i < 0
-                used_lines << line_number + i unless line_number + i >= lined_content.size
-              end
-            end
-          }
+        matching_snippets = matching_snippets.order('updated_at DESC')
+        matching_snippets = matching_snippets.limit(result_limit).to_a
+        snippets = []
+        matching_snippets.each { |e| snippets << chunk_snippet(e, query) }
 
-          snippet_chunk = []
-          snippet_chunks = []
-          snippet_start_line = 0
-          last_line = -1
-          used_lines.each { |line_number|
-            if last_line < 0
-              snippet_start_line = line_number
-              snippet_chunk << lined_content[line_number]
-            elsif last_line == line_number - 1
-              snippet_chunk << lined_content[line_number]
-            else
-              snippet_chunks << {
-                :data => snippet_chunk.join("\n"),
-                :start_line => snippet_start_line + 1
-              }
-              snippet_chunk = [lined_content[line_number]]
-              snippet_start_line = line_number
-            end
-            last_line = line_number
-          }
-          snippet_chunks << {
-            :data => snippet_chunk.join("\n"),
-            :start_line => snippet_start_line + 1
-          }
-          matching_snippets[blob_index] = {
-            :snippet_object => blob,
-            :snippet_chunks => snippet_chunks
-          }
-        }
-
-        paginated_matching_snippets = Kaminari.paginate_array(matching_snippets).page(params[:page]).per(page_size)
-        result[:snippets] = paginated_matching_snippets
-        result[:total_results] = paginated_matching_snippets.total_count
+        paginated_chunked_snippets = Kaminari.
+          paginate_array(snippets).page(params[:page]).per(page_size)
+        result[:snippets] = paginated_chunked_snippets
+        result[:total_results] = paginated_chunked_snippets.total_count
       else
         snippets_array = snippets.search(query).order('updated_at DESC').to_a
-        result[:snippets] = Kaminari.paginate_array(snippets_array).page(params[:page]).per(page_size)
+        result[:snippets] = Kaminari.paginate_array(snippets_array).
+          page(params[:page]).per(page_size)
         result[:total_results] = snippets_array.size
       end
 
       result
+    end
+
+    protected
+
+    def bounded_line_numbers(line, min, max, surrounding_lines)
+      lower = line - surrounding_lines > min ? line - surrounding_lines : min
+      upper = line + surrounding_lines < max ? line + surrounding_lines : max
+      (lower..upper).to_a
     end
 
     def result
@@ -79,6 +49,49 @@ module Search
         snippets: [],
         total_results: 0
       }
+    end
+
+    def chunk_snippet(snippet, query)
+      surrounding_lines = 3
+      used_lines = []
+      lined_content = snippet.content.split("\n")
+      lined_content.each_with_index { |line, line_number|
+        used_lines.concat bounded_line_numbers(
+          line_number,
+          0,
+          lined_content.size,
+          surrounding_lines
+        ) if line.include?(query)
+      }
+
+      used_lines = used_lines.uniq.sort
+
+      snippet_chunk = []
+      snippet_chunks = []
+      snippet_start_line = 0
+      last_line = -1
+      used_lines.each { |line_number|
+        if last_line < 0
+          snippet_start_line = line_number
+          snippet_chunk << lined_content[line_number]
+        elsif last_line == line_number - 1
+          snippet_chunk << lined_content[line_number]
+        else
+          snippet_chunks << {
+            data: snippet_chunk.join("\n"),
+            start_line: snippet_start_line + 1
+          }
+          snippet_chunk = [lined_content[line_number]]
+          snippet_start_line = line_number
+        end
+        last_line = line_number
+      }
+      snippet_chunks << {
+        data: snippet_chunk.join("\n"),
+        start_line: snippet_start_line + 1
+      }
+
+      { snippet_object: snippet, snippet_chunks: snippet_chunks }
     end
   end
 end

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -2,6 +2,8 @@
   = form_tag search_path, method: :get, class: 'navbar-form pull-left' do |f|
     = search_field_tag "search", nil, placeholder: search_placeholder, class: "search-input"
     = hidden_field_tag :group_id, @group.try(:id)
+    - if @snippet || @snippets
+      = hidden_field_tag :snippets, true
     - if @project && @project.persisted?
       = hidden_field_tag :project_id, @project.id
       = hidden_field_tag :search_code, true

--- a/app/views/search/_filter.html.haml
+++ b/app/views/search/_filter.html.haml
@@ -1,35 +1,36 @@
-.dropdown.inline
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-    %i.icon-tags
-    %span.light Group:
-    - if @group.present?
-      %strong= @group.name
-    - else
-      Any
-    %b.caret
-  %ul.dropdown-menu
-    %li
-      = link_to search_path(group_id: nil, search: params[:search]) do
+- unless params[:snippets]
+  .dropdown.inline
+    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+      %i.icon-tags
+      %span.light Group:
+      - if @group.present?
+        %strong= @group.name
+      - else
         Any
-    - current_user.authorized_groups.sort_by(&:name).each do |group|
+      %b.caret
+    %ul.dropdown-menu
       %li
-        = link_to search_path(group_id: group.id, search: params[:search]) do
-          = group.name
+        = link_to search_path(group_id: nil, search: params[:search]) do
+          Any
+      - current_user.authorized_groups.sort_by(&:name).each do |group|
+        %li
+          = link_to search_path(group_id: group.id, search: params[:search]) do
+            = group.name
 
-.dropdown.inline.prepend-left-10
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-    %i.icon-tags
-    %span.light Project:
-    - if @project.present?
-      %strong= @project.name_with_namespace
-    - else
-      Any
-    %b.caret
-  %ul.dropdown-menu
-    %li
-      = link_to search_path(project_id: nil, search: params[:search]) do
+  .dropdown.inline.prepend-left-10
+    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+      %i.icon-tags
+      %span.light Project:
+      - if @project.present?
+        %strong= @project.name_with_namespace
+      - else
         Any
-    - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
+      %b.caret
+    %ul.dropdown-menu
       %li
-        = link_to search_path(project_id: project.id, search: params[:search]) do
-          = project.name_with_namespace
+        = link_to search_path(project_id: nil, search: params[:search]) do
+          Any
+      - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
+        %li
+          = link_to search_path(project_id: project.id, search: params[:search]) do
+            = project.name_with_namespace

--- a/app/views/search/_global_results.html.haml
+++ b/app/views/search/_global_results.html.haml
@@ -3,3 +3,4 @@
     = render partial: "search/results/project", collection: @search_results[:projects]
     = render partial: "search/results/merge_request", collection: @search_results[:merge_requests]
     = render partial: "search/results/issue", collection: @search_results[:issues]
+    = render partial: "search/results/snippet", collection: @search_results[:snippets]

--- a/app/views/search/_results.html.haml
+++ b/app/views/search/_results.html.haml
@@ -1,14 +1,17 @@
 %h4
   #{@search_results[:total_results]} results found
-  - if @project
-    for #{link_to @project.name_with_namespace, @project}
-  - elsif @group
-    for #{link_to @group.name, @group}
+  - unless params[:snippets]
+    - if @project
+      for #{link_to @project.name_with_namespace, @project}
+    - elsif @group
+      for #{link_to @group.name, @group}
 
 %hr
 
 - if @project
   = render "project_results"
+- elsif params[:snippets]
+  = render "snippet_results"
 - else
   = render "global_results"
 

--- a/app/views/search/_snippet_results.html.haml
+++ b/app/views/search/_snippet_results.html.haml
@@ -1,0 +1,17 @@
+%ul.nav.nav-tabs
+  %li{class: ("active" if params[:search_code].blank?)}
+    = link_to search_path(params.merge(search_code: nil, snippets: true, page: 1)) do
+      Filenames and Titles
+  %li{class: ("active" if params[:search_code].present?)}
+    = link_to search_path(params.merge(search_code: true, snippets: true, page: 1)) do
+      Snippet Code
+     
+.search_results
+  %ul.bordered-list
+  - if params[:search_code].present?
+    .code-results
+      = render partial: "search/results/snippet_code", collection: @search_results[:snippets]
+  - else
+    %ul.bordered-list
+      = render partial: "search/results/snippet", collection: @search_results[:snippets]
+  = paginate @search_results[:snippets], theme: 'gitlab'

--- a/app/views/search/results/_snippet.html.haml
+++ b/app/views/search/results/_snippet.html.haml
@@ -1,0 +1,23 @@
+%li
+  %h4.snippet-title
+    = link_to reliable_snippet_path(snippet) do
+      = truncate(snippet.title, length: 60)
+      - if snippet.private?
+        %span.label.label-gray
+          %i.icon-lock
+          private
+    %span.cgray.monospace.tiny.pull-right
+      = snippet.file_name
+
+  %small.pull-right.cgray
+    - if snippet.project_id?
+      = link_to snippet.project.name_with_namespace, project_path(snippet.project)
+
+  .snippet-info
+    = "##{snippet.id}"
+    %span
+      by
+      = link_to user_snippets_path(snippet.author) do
+        = image_tag avatar_icon(snippet.author_email), class: "avatar avatar-inline s16", alt: ''
+        = snippet.author_name
+      %span.light #{time_ago_with_tooltip(snippet.created_at)}

--- a/app/views/search/results/_snippet_code.html.haml
+++ b/app/views/search/results/_snippet_code.html.haml
@@ -1,0 +1,47 @@
+.li
+  %span
+    = snippet_code[:snippet_object].title
+    by
+    = link_to user_snippets_path(snippet_code[:snippet_object].author) do
+      = image_tag avatar_icon(snippet_code[:snippet_object].author_email), class: "avatar avatar-inline s16", alt: ''
+      = snippet_code[:snippet_object].author_name
+    %span.light #{time_ago_with_tooltip(snippet_code[:snippet_object].created_at)}
+  %h4.snippet-title
+  - snippet_path = reliable_snippet_path(snippet_code[:snippet_object])
+  = link_to snippet_path do
+    .file-holder
+      .file-title
+        %i.icon-file
+        %strong= snippet_code[:snippet_object].file_name
+        %span.options
+          .btn-group.tree-btn-group.pull-right
+            - if snippet_code[:snippet_object].author == current_user
+              = link_to "Edit", edit_snippet_path(snippet_code[:snippet_object]), class: "btn btn-tiny", title: 'Edit Snippet'
+              = link_to "Delete", snippet_path(snippet_code[:snippet_object]), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-tiny", title: 'Delete Snippet'
+            = link_to "Raw", raw_snippet_path(snippet_code[:snippet_object]), class: "btn btn-tiny", target: "_blank"
+      - snippet_code[:snippet_chunks].each do |snippet|
+        - unless snippet[:data].empty?
+          - if gitlab_markdown?(snippet_code[:snippet_object].file_name)
+            .file-content.wiki
+              = preserve do
+                = markdown(snippet[:data])
+          - elsif markup?(snippet_code[:snippet_object].file_name)
+            .file-content.wiki
+              = render_markup(snippet_code[:snippet_object].file_name, snippet[:data])
+          - else
+            .file-content.code
+              %div.highlighted-data{class: user_color_scheme_class}
+                .line-numbers
+                  - snippet[:data].lines.to_a.size.times do |index|
+                    - offset = defined?(snippet[:start_line]) ? snippet[:start_line] : 1
+                    - i = index + offset
+                    = link_to snippet_path+"#L#{i}", id: "L#{i}", rel: "#L#{i}" do
+                      %i.icon-link
+                      = i
+                .highlight
+                  %pre
+                    %code
+                      = snippet[:data]
+        - else
+          .file-content.code
+            .nothing-here-block Empty file

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -13,7 +13,9 @@
         = render 'filter', f: f
       = hidden_field_tag :project_id, params[:project_id]
       = hidden_field_tag :group_id, params[:group_id]
-      = hidden_field_tag :search_code, params[:search_code]
+      = hidden_field_tag :snippets, params[:snippets]
+      - if params[:search_code].present?
+        = hidden_field_tag :search_code, params[:search_code]
 
   .results.prepend-top-10
     - if params[:search].present?


### PR DESCRIPTION
In reference to this merge request:

http://feedback.gitlab.com/forums/176466-general/suggestions/5529795-search-though-snippets
##### What does this MR do?

Adds the capability to search snippets.  This can be accessed  whenever viewing a snippet related page, such as personal snippets, snippet discovery, and search snippets.  There is a tab for searching just filenames and titles, and there is a tab for searching just the code of the snippet.  It searches all public snippets, as well as the private snippets of the user.
##### Are there points in the code the reviewer needs to double check?

The biggest change is the creation of `snippet_service.rb` in `app/services/search/snippet_service.rb`.  One thing I was unsure of was if there is any specific limit on how many snippet results should be returned in total from the query.  I didn't want to leave it unlimited, as a user could search for a single character and potentially slow down the system.  I put the limit at an arbitrary 500, paginating at 20 for the user, but someone may want to make a judgement call.
##### Why was this MR needed?

This is something my users have been asking for, and it should add a great amount of collaborative capability and global discovery to the snippets feature.  In addition, there is a merge request already created with 9 points.
##### What are the relevant issue numbers / Feature requests?

http://feedback.gitlab.com/forums/176466-general/suggestions/5529795-search-though-snippets
##### Screenshots (If appropiate)

Image 1:  Searching title/filename with no results.
![selection_005](https://cloud.githubusercontent.com/assets/236700/4052541/ddd3cdce-2d6c-11e4-8dc0-76502e5c4e85.png)

Image 2: Searching code with results.
![selection_006](https://cloud.githubusercontent.com/assets/236700/4052544/ddd7a912-2d6c-11e4-986a-a05a16f7a971.png)

Image 3: Searching title/filename with paginated results, first page. (the black bar towards the bottom is just ubuntu butting in while i maximize for a screenshot)
![selection_007](https://cloud.githubusercontent.com/assets/236700/4052539/ddd1b908-2d6c-11e4-8d78-490072a106a2.png)
Image 4: Searching title/filename with paginated results, second page.
![selection_008](https://cloud.githubusercontent.com/assets/236700/4052540/ddd35560-2d6c-11e4-9226-694da5dc4c4f.png)
Image 5: "Search Snippets" in search bar available on this page.
![selection_009](https://cloud.githubusercontent.com/assets/236700/4052542/ddd69072-2d6c-11e4-8a72-f8150877f4af.png)
Image 6: Searching in code will display text 3 lines before and 3 lines after any matches.  It will collapse overlapping matches into one block.
![selection_010](https://cloud.githubusercontent.com/assets/236700/4052543/ddd6af62-2d6c-11e4-9b3c-4a3983389c70.png)
