### PR TITLE
Do not specify postgres-version while installing

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -116,7 +116,7 @@ Create a `git` user for GitLab:
 We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](database_mysql.md). *Note*: because we need to make use of extensions you need at least pgsql 9.1.
 
     # Install the database packages
-    sudo apt-get install -y postgresql-9.1 postgresql-client libpq-dev
+    sudo apt-get install -y postgresql postgresql-client libpq-dev
 
     # Login to PostgreSQL
     sudo -u postgres psql -d template1


### PR DESCRIPTION
Current supported OS will pick the right version (9.1/9.3).

This fixes #7579 

/cc @jacobvosmaer 
