### PR TITLE
Added a checkbox to toggle line wrapping in diff.

### DIFF
--- a/app/assets/javascripts/behaviors/toggle_diff_line_wrap_behavior.coffee
+++ b/app/assets/javascripts/behaviors/toggle_diff_line_wrap_behavior.coffee
@@ -1,0 +1,14 @@
+$ ->
+  # Toggle line wrapping in diff.
+  #
+  # %div.diff-file
+  #   %input.js-toggle-diff-line-wrap
+  #   %td.line_content
+  #
+  $("body").on "click", ".js-toggle-diff-line-wrap", (e) ->
+    diffFile = $(@).closest(".diff-file")
+    if $(@).is(":checked")
+      diffFile.addClass("diff-wrap-lines")
+    else
+      diffFile.removeClass("diff-wrap-lines")
+

--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -125,8 +125,6 @@
     }
     .line_content {
       display: block;
-      white-space: pre;
-      height: 18px;
       margin: 0px;
       padding: 0px 0.5em;
       border: none;
@@ -341,3 +339,12 @@
   margin: 0;
   border: none;
 }
+
+.diff-file .line_content {
+  white-space: pre;
+}
+
+.diff-wrap-lines .line_content {
+  white-space: pre-wrap;
+}
+

--- a/app/views/projects/commits/_diff_file.html.haml
+++ b/app/views/projects/commits/_diff_file.html.haml
@@ -16,6 +16,10 @@
         %span.file-mode= "#{diff.a_mode} → #{diff.b_mode}"
 
       .diff-btn-group
+        %label
+          = check_box_tag nil, 1, false, class: "js-toggle-diff-line-wrap"
+          Wrap text
+        &nbsp;
         = link_to "#", class: "js-toggle-diff-comments btn btn-small" do
           %i.icon-chevron-down
           Diff comments


### PR DESCRIPTION
This is a better solution for [7488](https://github.com/gitlabhq/gitlabhq/pull/7488).

Before:
![before](https://cloud.githubusercontent.com/assets/6962409/4056773/577b8930-2dbf-11e4-8cd3-0a7aafbed72a.png)

After:
![after](https://cloud.githubusercontent.com/assets/6962409/4056775/6259df96-2dbf-11e4-914f-32a8ebc92eb4.png)

By default, the text is not wrapped, as it was previously. The result of wrapping is the same as in [7488](https://github.com/gitlabhq/gitlabhq/pull/7488).

Should taste better with [7611](https://github.com/gitlabhq/gitlabhq/pull/7611) =)
