### PR TITLE
Validation of 'Create branch' and 'Create tag' buttons

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -76,24 +76,18 @@ window.disableButtonIfEmptyField = (field_selector, button_selector) ->
 # Disable button if any input field with given selector is empty
 window.disableButtonIfAnyEmptyField = (form, form_selector, button_selector) ->
   closest_submit = form.find(button_selector)
-  empty = false
-  form.find('input').filter(form_selector).each ->
-    empty = true if rstrip($(this).val()) is ""
-
-  if empty
-    closest_submit.disable()
-  else
-    closest_submit.enable()
-
-  form.keyup ->
-    empty = false
+  updateButtons = ->
+    filled = true
     form.find('input').filter(form_selector).each ->
-      empty = true if rstrip($(this).val()) is ""
+      filled = rstrip($(this).val()) != "" || !$(this).attr('required')
 
-    if empty
-      closest_submit.disable()
-    else
+    if filled
       closest_submit.enable()
+    else
+      closest_submit.disable()
+
+  updateButtons()
+  form.keyup(updateButtons)
 
 window.sanitize = (str) ->
   return str.replace(/<(?:.|\n)*?>/gm, '')

--- a/app/views/projects/branches/new.html.haml
+++ b/app/views/projects/branches/new.html.haml
@@ -5,7 +5,7 @@
 %h3.page-title
   %i.fa.fa-code-fork
   New branch
-= form_tag project_branches_path, method: :post, class: "form-horizontal" do
+= form_tag project_branches_path, method: :post, id: "new-branch-form", class: "form-horizontal" do
   .form-group
     = label_tag :branch_name, 'Name for new branch', class: 'control-label'
     .col-sm-10
@@ -19,6 +19,7 @@
     = link_to 'Cancel', project_branches_path(@project), class: 'btn btn-cancel'
 
 :javascript
+  disableButtonIfAnyEmptyField($("#new-branch-form"), ".form-control", ".btn-create");
   var availableTags = #{@project.repository.ref_names.to_json};
 
   $("#ref").autocomplete({

--- a/app/views/projects/tags/new.html.haml
+++ b/app/views/projects/tags/new.html.haml
@@ -5,7 +5,7 @@
 %h3.page-title
   %i.fa.fa-code-fork
   New tag
-= form_tag project_tags_path, method: :post, class: "form-horizontal" do
+= form_tag project_tags_path, method: :post, id: "new-tag-form", class: "form-horizontal" do
   .form-group
     = label_tag :tag_name, 'Name for new tag', class: 'control-label'
     .col-sm-10
@@ -25,6 +25,7 @@
     = link_to 'Cancel', project_tags_path(@project), class: 'btn btn-cancel'
 
 :javascript
+  disableButtonIfAnyEmptyField($("#new-tag-form"), ".form-control", ".btn-create");
   var availableTags = #{@project.repository.ref_names.to_json};
 
   $("#ref").autocomplete({


### PR DESCRIPTION
Fixed validation of "Create branch" button. The issue reproduced on Safari 7.0.6. The button was enabled on the newly loaded page with empty text-fields, and after clicking it it became permanently disabled, so that text-field modification didn't help.

Now it is reflecting current status of the text-fields.
