### PR TITLE
Fixed parralel diff button on 'merge_requests/new' page

### DIFF
--- a/app/views/projects/commits/_diffs.html.haml
+++ b/app/views/projects/commits/_diffs.html.haml
@@ -4,9 +4,12 @@
   .col-md-4
     %ul.nav.nav-tabs
       %li.pull-right{class: params[:view] == 'parallel' ? 'active' : ''}
-        = link_to "Side-by-side Diff", url_for(view: 'parallel'), {id: "commit-diff-viewtype"}
+        - params_copy = params.dup
+        - params_copy[:view] = 'parallel'
+        = link_to "Side-by-side Diff", url_for(params_copy), {id: "commit-diff-viewtype"}
       %li.pull-right{class: params[:view] != 'parallel' ? 'active' : ''}
-        = link_to "Inline Diff", url_for(view: 'inline'), {id: "commit-diff-viewtype"}
+        - params_copy[:view] = 'inline'
+        = link_to "Inline Diff", url_for(params_copy), {id: "commit-diff-viewtype"}
 
 - if show_diff_size_warninig?(diffs)
   = render 'projects/commits/diff_warning', diffs: diffs


### PR DESCRIPTION
Pressing "Side-by-side Diff" leads to initial merge request branch selection page, instead of showing the parallel diff. The problem seems to be caused by url_for not preserving current get parameters.
