### PR TITLE
Issue-280 Send notifications when a note is added to a commit and author...

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -251,8 +251,8 @@ class Note < ActiveRecord::Base
 
   def commit_author
     @commit_author ||=
-      project.users.find_by(email: noteable.author_email) ||
-      project.users.find_by(name: noteable.author_name)
+      project.team.users.find_by(email: noteable.author_email) ||
+      project.team.users.find_by(name: noteable.author_name)
   rescue
     nil
   end


### PR DESCRIPTION
... is a group member

This fixes a bug where commit authors weren't receiving email notifications for notes
added to their commits and their membership was in the group but not the project.
The fix is to look up membership from the group in addition to the lookup that was being performed
for the project.

I do plan on writing rspec tests for this but I wanted to get this MR submitted without the test so that it receives visibility since I've been sitting on this fix for a while. I'd like for this to make it into 7.3.

This is a fix for Issue-280 and the duplicate Issue-530.
https://gitlab.com/gitlab-org/gitlab-ce/issues/280
https://gitlab.com/gitlab-org/gitlab-ce/issues/530
