### PR TITLE
Fix overflow in 'my projects' list

### DIFF
--- a/app/assets/stylesheets/sections/projects.scss
+++ b/app/assets/stylesheets/sections/projects.scss
@@ -159,6 +159,7 @@ ul.nav.nav-projects-tabs {
   li {
     .project-info {
       margin-bottom: 10px;
+      overflow: hidden;
     }
 
     .access-icon {


### PR DESCRIPTION
**What does this MR do?**
This MR fixes a small overflow problem in the "My projects" list.

![my_projects_list](https://cloud.githubusercontent.com/assets/6304496/4073187/7c52a4be-2e91-11e4-97cf-a18afd30a595.jpg)
