### PR TITLE
Add Hipchat services API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ v 7.4.0
   - New milestone and label links on issue edit form
   - Improved repository graphs
   - Improve event note display in dashboard and project activity views (Vinnie Okada)
+  - API: Add support for Hipchat (Kevin Houdebert)
 
 v 7.3.2
   - Fix creating new file via web editor

--- a/doc/api/services.md
+++ b/doc/api/services.md
@@ -1,0 +1,46 @@
+# Services
+
+## GitLab CI
+
+### Edit GitLab CI service
+
+Set GitLab CI service for a project.
+
+```
+PUT /projects/:id/services/gitlab-ci
+```
+
+Parameters:
+
+- `token` (required) - CI project token
+- `project_url` (required) - CI project url
+
+### Delete GitLab CI service
+
+Delete GitLab CI service settings for a project.
+
+```
+DELETE /projects/:id/services/gitlab-ci
+```
+
+## Hipchat
+
+### Edit Hipchat service
+
+Set Hipchat service for project.
+
+```
+PUT /projects/:id/services/hipchat
+```
+Parameters:
+
+- `token` (required) - Hipchat token
+- `room` (required) - Hipchat room name
+
+### Delete Hipchat service
+
+Delete Hipchat service for a project.
+
+```
+DELETE /projects/:id/services/hipchat
+```

--- a/lib/api/services.rb
+++ b/lib/api/services.rb
@@ -28,7 +28,7 @@ module API
       # Delete GitLab CI service settings
       #
       # Example Request:
-      #   DELETE /projects/:id/keys/:id
+      #   DELETE /projects/:id/services/gitlab-ci
       delete ":id/services/gitlab-ci" do
         if user_project.gitlab_ci_service
           user_project.gitlab_ci_service.update_attributes(
@@ -38,7 +38,41 @@ module API
           )
         end
       end
+
+      # Set Hipchat service for project
+      #
+      # Parameters:
+      #   token (required) - Hipchat token
+      #   room (required) - Hipchat room name
+      #
+      # Example Request:
+      #   PUT /projects/:id/services/hipchat
+      put ':id/services/hipchat' do
+        required_attributes! [:token, :room]
+        attrs = attributes_for_keys [:token, :room]
+        user_project.build_missing_services
+
+        if user_project.hipchat_service.update_attributes(
+            attrs.merge(active: true))
+          true
+        else
+          not_found!
+        end
+      end
+
+      # Delete Hipchat service settings
+      #
+      # Example Request:
+      #   DELETE /projects/:id/services/hipchat
+      delete ':id/services/hipchat' do
+        if user_project.hipchat_service
+          user_project.hipchat_service.update_attributes(
+            active: false,
+            token: nil,
+            room: nil
+          )
+        end
+      end
     end
   end
 end
-

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -27,4 +27,30 @@ describe API::API, api: true  do
       project.gitlab_ci_service.should be_nil
     end
   end
+
+  describe 'PUT /projects/:id/services/hipchat' do
+    it 'should update hipchat settings' do
+      put api("/projects/#{project.id}/services/hipchat", user),
+          token: 'secret-token', room: 'test'
+
+      response.status.should == 200
+      project.hipchat_service.should_not be_nil
+    end
+
+    it 'should return if required fields missing' do
+      put api("/projects/#{project.id}/services/gitlab-ci", user),
+          token: 'secret-token', active: true
+
+      response.status.should == 400
+    end
+  end
+
+  describe 'DELETE /projects/:id/services/hipchat' do
+    it 'should delete hipchat settings' do
+      delete api("/projects/#{project.id}/services/hipchat", user)
+
+      response.status.should == 200
+      project.hipchat_service.should be_nil
+    end
+  end
 end


### PR DESCRIPTION
There was no way to add a Hipchat services through the API.

This commit add two API route:
`PUT /projects/:id/services/hipchat (:token, :room)`
`DELETE /projects/:id/services/hipchat`

To add or remove a hipchat service for a project.
