### PR TITLE
Changed explore area to match more to the style and user-experience of GitLab

### DIFF
--- a/app/views/layouts/explore.html.haml
+++ b/app/views/layouts/explore.html.haml
@@ -8,23 +8,14 @@
       = render "layouts/head_panel", title: page_title
     - else
       = render "layouts/public_head_panel", title: page_title
-    .container.navless-container
+    %nav.main-nav.navbar-collapse.collapse
+      .container= render 'layouts/nav/explore'
+
+    .container
       .content
-        .explore-title
-          %h3
-            Explore GitLab
-          %p.lead
-            Discover projects and groups. Share your projects with others
-
-
-        %ul.nav.nav-tabs
-          = nav_link(path: 'projects#trending') do
-            = link_to 'Trending Projects', explore_root_path
-          = nav_link(path: 'projects#starred') do
-            = link_to 'Most Starred Projects', starred_explore_projects_path
-          = nav_link(path: 'projects#index') do
-            = link_to 'All Projects', explore_projects_path
-          = nav_link(controller: :groups) do
-            = link_to 'All Groups', explore_groups_path
-
+        %h3.page-title
+          Explore GitLab
+        %p.light
+          Discover projects and groups. Share your projects with others.
+        %hr
         = yield

--- a/app/views/layouts/nav/_explore.html.haml
+++ b/app/views/layouts/nav/_explore.html.haml
@@ -1,0 +1,9 @@
+%ul
+  = nav_link(path: 'projects#trending') do
+    = link_to 'Trending Projects', explore_root_path
+  = nav_link(path: 'projects#starred') do
+    = link_to 'Most Starred Projects', starred_explore_projects_path
+  = nav_link(path: 'projects#index') do
+    = link_to 'All Projects', explore_projects_path
+  = nav_link(controller: :groups) do
+    = link_to 'All Groups', explore_groups_path


### PR DESCRIPTION
Hey,

first of all. We like the new explore area very much and it enhances the user experience for our colleagues a lot.

But after the switch to 7.2. many of our co-workers came to me and said, that it's not fitting really to the overall style of GitLab. The user got accustomed to a navigation below the head panel and to a more defensive and streamlined style.

**So what does this MR do**
This MR changes the navigation from the tab system to the normal sub-navigation system.
Additionally the big prominent text to explain what this area is for changed to a bit more defensive header title.
Therefore, the style is more aligned to the overall style and flow of the tool.

**New look**
![explore_area_revised](https://cloud.githubusercontent.com/assets/6304496/4089572/714bc298-2f6e-11e4-89e3-0b5effa53eb1.jpg)

**Old look**
![explore_area_old](https://cloud.githubusercontent.com/assets/6304496/4089583/c559524c-2f6e-11e4-8a91-1e283209d2a6.jpg)
