### PR TITLE
Switched position of buttons in profile/groups

### DIFF
--- a/app/views/profiles/groups/index.html.haml
+++ b/app/views/profiles/groups/index.html.haml
@@ -17,15 +17,15 @@
       - group = user_group.group
       %li
         .pull-right
-          - if can?(current_user, :manage_group, group)
-            = link_to edit_group_path(group), class: "btn-small btn btn-grouped" do
-              %i.icon-cogs
-              Settings
-
           - if can?(current_user, :destroy, user_group)
             = link_to leave_profile_group_path(group), data: { confirm: leave_group_message(group.name) }, method: :delete, class: "btn-small btn btn-grouped", title: 'Remove user from group' do
               %i.icon-signout
               Leave
+
+          - if can?(current_user, :manage_group, group)
+            = link_to edit_group_path(group), class: "btn-small btn btn-grouped" do
+              %i.icon-cogs
+              Settings
 
         = link_to group, class: 'group-name' do
           %strong= group.name


### PR DESCRIPTION
**What does this MR do?**
This MR changes the position of the "Settings" button in the groups list of a user's profile. Very often you have the position of the "Leave" and the "Settings" switched throughout the list. The change makes the style of the page a bit more streamlined.

**Old look**
![changed_order_buttons_old](https://cloud.githubusercontent.com/assets/6304496/4090741/9694be9e-2f80-11e4-8b94-3771b739a9d5.jpg)

**New look**
![changed_order_buttons](https://cloud.githubusercontent.com/assets/6304496/4090742/9d1ddee4-2f80-11e4-9d6b-c747ba02c5e1.jpg)
