### PR TITLE
Prevent Hound from checking InlineComment.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,3 +2,6 @@
 StringLiterals:
   EnforcedStyle: single_quotes
   Enabled: true
+
+InlineComment:
+  Enabled: false


### PR DESCRIPTION
Prevent it from checking stuff like: https://github.com/gitlabhq/gitlabhq/pull/7641#discussion_r16910378

Or else, can someone explain what is wrong there (what is an inline comment in Ruby?), and what would be the better way of doing it?
