### PR TITLE
Alternative project id api format

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -186,6 +186,7 @@ class Project < ActiveRecord::Base
     end
 
     def find_with_namespace(id)
+      id = id.sub(":", "/")
       return nil unless id.include?("/")
 
       id = id.split("/")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -186,7 +186,7 @@ class Project < ActiveRecord::Base
     end
 
     def find_with_namespace(id)
-      id = id.sub(":", "/")
+      id = id.sub(':', '/')
       return nil unless id.include?("/")
 
       id = id.split("/")

--- a/app/views/projects/merge_requests/show/_how_to_merge.html.haml
+++ b/app/views/projects/merge_requests/show/_how_to_merge.html.haml
@@ -34,6 +34,7 @@
           %p
             %strong Step 2.
             Merge the branch and push the changes to GitLab
+            NB: This will not be allowed on protected branches by default, and you should rather accept the merge request through gitlab. If this is not possible, you may use vote-for-push; the push failure message will instruct you on how to do this
           %pre.dark
             :preserve
               git checkout #{@merge_request.target_branch}

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -105,8 +105,9 @@ GET /projects/all
 
 ### Get single project
 
-Get a specific project, identified by project ID or NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
-If using namespaced projects call make sure that the NAMESPACE/PROJECT_NAME is URL-encoded, eg. `/api/v3/projects/diaspora%2Fdiaspora` (where `/` is represented by `%2F`).
+Get a specific project, identified by project ID or NAMESPACE:PROJECT_NAME, which is owned by the authenticated user.
+Note that the syntax of NAMESPACE/PROJECT_NAME is also supported, but requires the name to be URL-encoded, eg. `/api/v3/projects/diaspora%2Fdiaspora` (where `/` is represented by `%2F`).
+This also applies to all other project ID calls with namespaces below
 
 ```
 GET /projects/:id
@@ -114,7 +115,7 @@ GET /projects/:id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 
 ```json
 {
@@ -175,7 +176,7 @@ GET /projects/:id/events
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 
 ```json
 [
@@ -304,7 +305,7 @@ GET /projects/:id/members
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `query` (optional) - Query string to search for members
 
 ### Get project team member
@@ -317,7 +318,7 @@ GET /projects/:id/members/:user_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `user_id` (required) - The ID of a user
 
 ```json
@@ -344,7 +345,7 @@ POST /projects/:id/members
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `user_id` (required) - The ID of a user to add
 - `access_level` (required) - Project access level
 
@@ -358,7 +359,7 @@ PUT /projects/:id/members/:user_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `user_id` (required) - The ID of a team member
 - `access_level` (required) - Project access level
 
@@ -372,7 +373,7 @@ DELETE /projects/:id/members/:user_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `user_id` (required) - The ID of a team member
 
 This method is idempotent and can be called multiple times with the same parameters.
@@ -392,7 +393,7 @@ GET /projects/:id/hooks
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 
 ### Get project hook
 
@@ -404,7 +405,7 @@ GET /projects/:id/hooks/:hook_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `hook_id` (required) - The ID of a project hook
 
 ```json
@@ -429,7 +430,7 @@ POST /projects/:id/hooks
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `url` (required) - The hook URL
 - `push_events` - Trigger hook on push events
 - `issues_events` - Trigger hook on issues events
@@ -445,7 +446,7 @@ PUT /projects/:id/hooks/:hook_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `hook_id` (required) - The ID of a project hook
 - `url` (required) - The hook URL
 - `push_events` - Trigger hook on push events
@@ -463,7 +464,7 @@ DELETE /projects/:id/hooks/:hook_id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `hook_id` (required) - The ID of hook to delete
 
 Note the JSON response differs if the hook is available or not. If the project hook
@@ -481,7 +482,7 @@ GET /projects/:id/repository/branches
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 
 ```json
 [
@@ -546,7 +547,7 @@ GET /projects/:id/repository/branches/:branch
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `branch` (required) - The name of the branch.
 
 ### Protect single branch
@@ -559,7 +560,7 @@ PUT /projects/:id/repository/branches/:branch/protect
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `branch` (required) - The name of the branch.
 
 ### Unprotect single branch
@@ -572,7 +573,7 @@ PUT /projects/:id/repository/branches/:branch/unprotect
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE:PROJECT_NAME of a project
 - `branch` (required) - The name of the branch.
 
 ## Admin fork relation


### PR DESCRIPTION
Simplify the API for project IDs by supporting a `:` as the separator between `NAMESPACE` and `PROJECT_NAME` - see #7644 
