### PR TITLE
Adding in snippet search functionality

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,6 +5,7 @@ class SearchController < ApplicationController
     @project = Project.find_by(id: params[:project_id]) if params[:project_id].present?
     @group = Group.find_by(id: params[:group_id]) if params[:group_id].present?
     @scope = params[:scope]
+    @show_snippets = params[:snippets].eql? 'true'
 
     @search_results = if @project
                         return access_denied! unless can?(current_user, :download_code, @project)
@@ -14,7 +15,7 @@ class SearchController < ApplicationController
                         end
 
                         Search::ProjectService.new(@project, current_user, params).execute
-                      elsif params[:snippets].eql? 'true'
+                      elsif @show_snippets
                         unless %w(snippet_blobs snippet_titles).include?(@scope)
                           @scope = 'snippet_blobs'
                         end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -14,6 +14,12 @@ class SearchController < ApplicationController
                         end
 
                         Search::ProjectService.new(@project, current_user, params).execute
+                      elsif params[:snippets].eql? 'true'
+                        unless %w(snippet_blobs snippet_titles).include?(@scope)
+                          @scope = 'snippet_blobs'
+                        end
+
+                        Search::SnippetService.new(current_user, params).execute
                       else
                         unless %w(projects issues merge_requests).include?(@scope)
                           @scope = 'projects'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -178,7 +178,7 @@ module ApplicationHelper
   def search_placeholder
     if @project && @project.persisted?
       "Search in this project"
-    elsif @snippet || @snippets || (params && params[:snippets] == 'true')
+    elsif @snippet || @snippets || @show_snippets
       'Search snippets'
     elsif @group && @group.persisted?
       "Search in this group"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -178,6 +178,8 @@ module ApplicationHelper
   def search_placeholder
     if @project && @project.persisted?
       "Search in this project"
+    elsif @snippet || @snippets || (params && params[:snippets] == 'true')
+      'Search snippets'
     elsif @group && @group.persisted?
       "Search in this group"
     else

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -65,4 +65,18 @@ class Snippet < ActiveRecord::Base
   def expired?
     expires_at && expires_at < Time.current
   end
+
+  class << self
+    def search(query)
+      where('(title LIKE :query OR file_name LIKE :query)', query: "%#{query}%")
+    end
+
+    def search_code(query)
+      where('(content LIKE :query)', query: "%#{query}%")
+    end
+
+    def accessible_to(user)
+      where('private = ? OR author_id = ?', false, user)
+    end
+  end
 end

--- a/app/services/search/snippet_service.rb
+++ b/app/services/search/snippet_service.rb
@@ -1,0 +1,14 @@
+module Search
+  class SnippetService
+    attr_accessor :current_user, :params
+
+    def initialize(user, params)
+      @current_user, @params = user, params.dup
+    end
+
+    def execute
+      snippet_ids = Snippet.accessible_to(current_user).pluck(:id)
+      Gitlab::SnippetSearchResults.new(snippet_ids, params[:search])
+    end
+  end
+end

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -5,6 +5,8 @@
     - if @project && @project.persisted?
       = hidden_field_tag :project_id, @project.id
       = hidden_field_tag :search_code, true
+    - if @snippet || @snippets
+      = hidden_field_tag :snippets, true
     = hidden_field_tag :repository_ref, @ref
     = submit_tag 'Go' if ENV['RAILS_ENV'] == 'test'
     .search-autocomplete-opts.hide{:'data-autocomplete-path' => search_autocomplete_path, :'data-autocomplete-project-id' => @project.try(:id), :'data-autocomplete-project-ref' => @ref }

--- a/app/views/search/_filter.html.haml
+++ b/app/views/search/_filter.html.haml
@@ -1,35 +1,36 @@
-.dropdown.inline
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-    %i.icon-tags
-    %span.light Group:
-    - if @group.present?
-      %strong= @group.name
-    - else
-      Any
-    %b.caret
-  %ul.dropdown-menu
-    %li
-      = link_to search_filter_path(group_id: nil) do
+- unless params[:snippets]
+  .dropdown.inline
+    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+      %i.icon-tags
+      %span.light Group:
+      - if @group.present?
+        %strong= @group.name
+      - else
         Any
-    - current_user.authorized_groups.sort_by(&:name).each do |group|
+      %b.caret
+    %ul.dropdown-menu
       %li
-        = link_to search_filter_path(group_id: group.id, project_id: nil) do
-          = group.name
+        = link_to search_filter_path(group_id: nil) do
+          Any
+      - current_user.authorized_groups.sort_by(&:name).each do |group|
+        %li
+          = link_to search_filter_path(group_id: group.id, project_id: nil) do
+            = group.name
 
-.dropdown.inline.prepend-left-10.project-filter
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-    %i.icon-tags
-    %span.light Project:
-    - if @project.present?
-      %strong= @project.name_with_namespace
-    - else
-      Any
-    %b.caret
-  %ul.dropdown-menu
-    %li
-      = link_to search_filter_path(project_id: nil) do
+  .dropdown.inline.prepend-left-10.project-filter
+    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+      %i.icon-tags
+      %span.light Project:
+      - if @project.present?
+        %strong= @project.name_with_namespace
+      - else
         Any
-    - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
+      %b.caret
+    %ul.dropdown-menu
       %li
-        = link_to search_filter_path(project_id: project.id, group_id: nil) do
-          = project.name_with_namespace
+        = link_to search_filter_path(project_id: nil) do
+          Any
+      - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
+        %li
+          = link_to search_filter_path(project_id: project.id, group_id: nil) do
+            = project.name_with_namespace

--- a/app/views/search/_filter.html.haml
+++ b/app/views/search/_filter.html.haml
@@ -1,36 +1,35 @@
-- unless params[:snippets]
-  .dropdown.inline
-    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-      %i.icon-tags
-      %span.light Group:
-      - if @group.present?
-        %strong= @group.name
-      - else
+.dropdown.inline
+  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+    %i.icon-tags
+    %span.light Group:
+    - if @group.present?
+      %strong= @group.name
+    - else
+      Any
+    %b.caret
+  %ul.dropdown-menu
+    %li
+      = link_to search_filter_path(group_id: nil) do
         Any
-      %b.caret
-    %ul.dropdown-menu
+    - current_user.authorized_groups.sort_by(&:name).each do |group|
       %li
-        = link_to search_filter_path(group_id: nil) do
-          Any
-      - current_user.authorized_groups.sort_by(&:name).each do |group|
-        %li
-          = link_to search_filter_path(group_id: group.id, project_id: nil) do
-            = group.name
+        = link_to search_filter_path(group_id: group.id, project_id: nil) do
+          = group.name
 
-  .dropdown.inline.prepend-left-10.project-filter
-    %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
-      %i.icon-tags
-      %span.light Project:
-      - if @project.present?
-        %strong= @project.name_with_namespace
-      - else
+.dropdown.inline.prepend-left-10.project-filter
+  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+    %i.icon-tags
+    %span.light Project:
+    - if @project.present?
+      %strong= @project.name_with_namespace
+    - else
+      Any
+    %b.caret
+  %ul.dropdown-menu
+    %li
+      = link_to search_filter_path(project_id: nil) do
         Any
-      %b.caret
-    %ul.dropdown-menu
+    - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
       %li
-        = link_to search_filter_path(project_id: nil) do
-          Any
-      - current_user.authorized_projects.sort_by(&:name_with_namespace).each do |project|
-        %li
-          = link_to search_filter_path(project_id: project.id, group_id: nil) do
-            = project.name_with_namespace
+        = link_to search_filter_path(project_id: project.id, group_id: nil) do
+          = project.name_with_namespace

--- a/app/views/search/_results.html.haml
+++ b/app/views/search/_results.html.haml
@@ -1,9 +1,10 @@
 %h4
   #{@search_results.total_count} results found
-  - if @project
-    for #{link_to @project.name_with_namespace, @project}
-  - elsif @group
-    for #{link_to @group.name, @group}
+  - unless params[:snippets].eql? 'true'
+    - if @project
+      for #{link_to @project.name_with_namespace, @project}
+    - elsif @group
+      for #{link_to @group.name, @group}
 
 %hr
 
@@ -11,6 +12,8 @@
   .col-sm-3
     - if @project
       = render "project_filter"
+    - elsif params[:snippets].eql? 'true'
+      = render 'snippet_filter'
     - else
       = render "global_filter"
   .col-sm-9

--- a/app/views/search/_results.html.haml
+++ b/app/views/search/_results.html.haml
@@ -1,6 +1,6 @@
 %h4
   #{@search_results.total_count} results found
-  - unless params[:snippets].eql? 'true'
+  - unless @show_snippets
     - if @project
       for #{link_to @project.name_with_namespace, @project}
     - elsif @group
@@ -12,7 +12,7 @@
   .col-sm-3
     - if @project
       = render "project_filter"
-    - elsif params[:snippets].eql? 'true'
+    - elsif @show_snippets
       = render 'snippet_filter'
     - else
       = render "global_filter"

--- a/app/views/search/_snippet_filter.html.haml
+++ b/app/views/search/_snippet_filter.html.haml
@@ -2,7 +2,7 @@
   %li{class: ("active" if @scope == 'snippet_blobs')}
     = link_to search_filter_path(scope: 'snippet_blobs', snippets: true, group_id: nil, project_id: nil) do
       %i.icon-code
-      Code
+      Snippet Contents
       .pull-right
         = @search_results.snippet_blobs_count
   %li{class: ("active" if @scope == 'snippet_titles')}

--- a/app/views/search/_snippet_filter.html.haml
+++ b/app/views/search/_snippet_filter.html.haml
@@ -1,0 +1,13 @@
+%ul.nav.nav-pills.nav-stacked.search-filter
+  %li{class: ("active" if @scope == 'snippet_blobs')}
+    = link_to search_filter_path(scope: 'snippet_blobs', snippets: true, group_id: nil, project_id: nil) do
+      %i.icon-code
+      Code
+      .pull-right
+        = @search_results.snippet_blobs_count
+  %li{class: ("active" if @scope == 'snippet_titles')}
+    = link_to search_filter_path(scope: 'snippet_titles', snippets: true, group_id: nil, project_id: nil) do
+      %i.icon-book
+      Titles and Filenames
+      .pull-right
+        = @search_results.snippet_titles_count

--- a/app/views/search/results/_snippet_blob.html.haml
+++ b/app/views/search/results/_snippet_blob.html.haml
@@ -1,0 +1,65 @@
+.search-result-row
+  %span
+    = snippet_blob[:snippet_object].title
+    by
+    = link_to user_snippets_path(snippet_blob[:snippet_object].author) do
+      = image_tag avatar_icon(snippet_blob[:snippet_object].author_email), class: "avatar avatar-inline s16", alt: ''
+      = snippet_blob[:snippet_object].author_name
+    %span.light #{time_ago_with_tooltip(snippet_blob[:snippet_object].created_at)}
+  %h4.snippet-title
+  - snippet_path = reliable_snippet_path(snippet_blob[:snippet_object])
+  = link_to snippet_path do
+    .file-holder
+      .file-title
+        %i.icon-file
+        %strong= snippet_blob[:snippet_object].file_name
+        %span.options
+          .btn-group.tree-btn-group.pull-right
+            - if snippet_blob[:snippet_object].author == current_user
+              = link_to "Edit", edit_snippet_path(snippet_blob[:snippet_object]), class: "btn btn-tiny", title: 'Edit Snippet'
+              = link_to "Delete", snippet_path(snippet_blob[:snippet_object]), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-tiny", title: 'Delete Snippet'
+            = link_to "Raw", raw_snippet_path(snippet_blob[:snippet_object]), class: "btn btn-tiny", target: "_blank"
+      - if gitlab_markdown?(snippet_blob[:snippet_object].file_name)
+        .file-content.wiki
+          - snippet_blob[:snippet_chunks].each do |snippet|
+            - unless snippet[:data].empty?
+              = preserve do
+                = markdown(snippet[:data])
+            - else
+              .file-content.code
+                .nothing-here-block Empty file
+      - elsif markup?(snippet_blob[:snippet_object].file_name)
+        .file-content.wiki
+          - snippet_blob[:snippet_chunks].each do |snippet|
+            - unless snippet[:data].empty?
+              = render_markup(snippet_blob[:snippet_object].file_name, snippet[:data])
+            - else
+              .file-content.code
+                .nothing-here-block Empty file
+      - else
+        .file-content.code
+          %div.highlighted-data{class: user_color_scheme_class}
+            .line-numbers
+              - snippet_blob[:snippet_chunks].each do |snippet|
+                - unless snippet[:data].empty?
+                  - snippet[:data].lines.to_a.size.times do |index|
+                    - offset = defined?(snippet[:start_line]) ? snippet[:start_line] : 1
+                    - i = index + offset
+                    = link_to snippet_path+"#L#{i}", id: "L#{i}", rel: "#L#{i}" do
+                      %i.icon-link
+                      = i
+                  - unless snippet == snippet_blob[:snippet_chunks].last
+                    %a
+                      = "."
+            .highlight.term
+              %pre
+                %code
+                  - snippet_blob[:snippet_chunks].each do |snippet|
+                    - unless snippet[:data].empty?
+                      = snippet[:data]
+                      - unless snippet == snippet_blob[:snippet_chunks].last
+                        %a
+                          = "..."
+                    - else
+                      .file-content.code
+                        .nothing-here-block Empty file

--- a/app/views/search/results/_snippet_title.html.haml
+++ b/app/views/search/results/_snippet_title.html.haml
@@ -1,0 +1,23 @@
+.search-result-row
+  %h4.snippet-title.term
+    = link_to reliable_snippet_path(snippet_title) do
+      = truncate(snippet_title.title, length: 60)
+      - if snippet_title.private?
+        %span.label.label-gray
+          %i.icon-lock
+          private
+    %span.cgray.monospace.tiny.pull-right.term
+      = snippet_title.file_name
+
+  %small.pull-right.cgray
+    - if snippet_title.project_id?
+      = link_to snippet_title.project.name_with_namespace, project_path(snippet_title.project)
+
+  .snippet-info
+    = "##{snippet_title.id}"
+    %span
+      by
+      = link_to user_snippets_path(snippet_title.author) do
+        = image_tag avatar_icon(snippet_title.author_email), class: "avatar avatar-inline s16", alt: ''
+        = snippet_title.author_name
+      %span.light #{time_ago_with_tooltip(snippet_title.created_at)}

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -9,8 +9,9 @@
         = submit_tag 'Search', class: "btn btn-create"
     .form-group
       .col-sm-2
-      .col-sm-10
-        = render 'filter', f: f
+      - unless params[:snippets].eql? 'true'
+        .col-sm-10
+          = render 'filter', f: f
       = hidden_field_tag :project_id, params[:project_id]
       = hidden_field_tag :group_id, params[:group_id]
       = hidden_field_tag :snippets, params[:snippets]

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -13,6 +13,7 @@
         = render 'filter', f: f
       = hidden_field_tag :project_id, params[:project_id]
       = hidden_field_tag :group_id, params[:group_id]
+      = hidden_field_tag :snippets, params[:snippets]
       = hidden_field_tag :scope, params[:scope]
 
   .results.prepend-top-10

--- a/features/snippet_search.feature
+++ b/features/snippet_search.feature
@@ -1,0 +1,20 @@
+@dashboard
+Feature: Snippet Search
+  Background:
+    Given I sign in as a user
+    And I have public "Personal snippet one" snippet
+    And I have private "Personal snippet private" snippet
+    And I have a public many lined snippet
+
+  Scenario: I should see my public and private snippets
+    When I search for "snippet" in snippet titles
+    Then I should see "Personal snippet one" in results
+    And I should see "Personal snippet private" in results
+
+  Scenario: I should see three surrounding lines on either side of a matching snippet line
+    When I search for "line seven" in snippet contents
+    Then I should see "line four" in results
+    And I should see "line seven" in results
+    And I should see "line ten" in results
+    And I should not see "line three" in results
+    And I should not see "line eleven" in results

--- a/features/steps/shared/search.rb
+++ b/features/steps/shared/search.rb
@@ -1,0 +1,11 @@
+module SharedSearch
+  include Spinach::DSL
+
+  def search_snippet_contents(query)
+    visit "/search?search=#{URI::encode(query)}&snippets=true&scope=snippet_blobs"
+  end
+
+  def search_snippet_titles(query)
+    visit "/search?search=#{URI::encode(query)}&snippets=true&scope=snippet_titles"
+  end
+end

--- a/features/steps/shared/snippet.rb
+++ b/features/steps/shared/snippet.rb
@@ -20,9 +20,24 @@ module SharedSnippet
   end
   And 'I have a public many lined snippet' do
     create(:personal_snippet,
-           title: "Many lined snippet",
-           content: "line one\nline two\nline three\nline four\nline five\nline six\nline seven\nline eight\nline nine\nline ten\nline eleven\nline twelve\nline thirteen\nline fourteen",
-           file_name: "many_lined_snippet.rb",
+           title: 'Many lined snippet',
+           content: <<-END.gsub(/^\s+\|/, ''),
+             |line one
+             |line two
+             |line three
+             |line four
+             |line five
+             |line six
+             |line seven
+             |line eight
+             |line nine
+             |line ten
+             |line eleven
+             |line twelve
+             |line thirteen
+             |line fourteen
+           END
+           file_name: 'many_lined_snippet.rb',
            private: true,
            author: current_user)
   end

--- a/features/steps/shared/snippet.rb
+++ b/features/steps/shared/snippet.rb
@@ -18,4 +18,12 @@ module SharedSnippet
            private: true,
            author: current_user)
   end
+  And 'I have a public many lined snippet' do
+    create(:personal_snippet,
+           title: "Many lined snippet",
+           content: "line one\nline two\nline three\nline four\nline five\nline six\nline seven\nline eight\nline nine\nline ten\nline eleven\nline twelve\nline thirteen\nline fourteen",
+           file_name: "many_lined_snippet.rb",
+           private: true,
+           author: current_user)
+  end
 end

--- a/features/steps/snippet_search.rb
+++ b/features/steps/snippet_search.rb
@@ -6,51 +6,51 @@ class Spinach::Features::SnippetSearch < Spinach::FeatureSteps
   include SharedSearch
 
   step 'I search for "snippet" in snippet titles' do
-    search_snippet_titles "snippet"
+    search_snippet_titles 'snippet'
   end
 
   step 'I search for "snippet private" in snippet titles' do
-    search_snippet_titles "snippet private"
+    search_snippet_titles 'snippet private'
   end
 
   step 'I search for "line seven" in snippet contents' do
-    search_snippet_contents "line seven"
+    search_snippet_contents 'line seven'
   end
 
   step 'I should see "line seven" in results' do
-    page.should have_content "line seven"
+    page.should have_content 'line seven'
   end
 
   step 'I should see "line four" in results' do
-    page.should have_content "line four"
+    page.should have_content 'line four'
   end
 
   step 'I should see "line ten" in results' do
-    page.should have_content "line ten"
+    page.should have_content 'line ten'
   end
 
   step 'I should not see "line eleven" in results' do
-    page.should_not have_content "line eleven"
+    page.should_not have_content 'line eleven'
   end
 
   step 'I should not see "line three" in results' do
-    page.should_not have_content "line three"
+    page.should_not have_content 'line three'
   end
 
   Then 'I should see "Personal snippet one" in results' do
-    page.should have_content "Personal snippet one"
+    page.should have_content 'Personal snippet one'
   end
 
   And 'I should see "Personal snippet private" in results' do
-    page.should have_content "Personal snippet private"
+    page.should have_content 'Personal snippet private'
   end
 
   Then 'I should not see "Personal snippet one" in results' do
-    page.should_not have_content "Personal snippet one"
+    page.should_not have_content 'Personal snippet one'
   end
 
   And 'I should not see "Personal snippet private" in results' do
-    page.should_not have_content "Personal snippet private"
+    page.should_not have_content 'Personal snippet private'
   end
 
 end

--- a/features/steps/snippet_search.rb
+++ b/features/steps/snippet_search.rb
@@ -1,0 +1,56 @@
+class Spinach::Features::SnippetSearch < Spinach::FeatureSteps
+  include SharedAuthentication
+  include SharedPaths
+  include SharedSnippet
+  include SharedUser
+  include SharedSearch
+
+  step 'I search for "snippet" in snippet titles' do
+    search_snippet_titles "snippet"
+  end
+
+  step 'I search for "snippet private" in snippet titles' do
+    search_snippet_titles "snippet private"
+  end
+
+  step 'I search for "line seven" in snippet contents' do
+    search_snippet_contents "line seven"
+  end
+
+  step 'I should see "line seven" in results' do
+    page.should have_content "line seven"
+  end
+
+  step 'I should see "line four" in results' do
+    page.should have_content "line four"
+  end
+
+  step 'I should see "line ten" in results' do
+    page.should have_content "line ten"
+  end
+
+  step 'I should not see "line eleven" in results' do
+    page.should_not have_content "line eleven"
+  end
+
+  step 'I should not see "line three" in results' do
+    page.should_not have_content "line three"
+  end
+
+  Then 'I should see "Personal snippet one" in results' do
+    page.should have_content "Personal snippet one"
+  end
+
+  And 'I should see "Personal snippet private" in results' do
+    page.should have_content "Personal snippet private"
+  end
+
+  Then 'I should not see "Personal snippet one" in results' do
+    page.should_not have_content "Personal snippet one"
+  end
+
+  And 'I should not see "Personal snippet private" in results' do
+    page.should_not have_content "Personal snippet private"
+  end
+
+end

--- a/lib/gitlab/snippet_search_results.rb
+++ b/lib/gitlab/snippet_search_results.rb
@@ -1,0 +1,100 @@
+module Gitlab
+  class SnippetSearchResults < SearchResults
+    attr_reader :limit_snippet_ids
+
+    def initialize(limit_snippet_ids, query)
+      @limit_snippet_ids = limit_snippet_ids
+      @query = query
+    end
+
+    def objects(scope, page = nil)
+      case scope
+      when 'snippet_titles'
+        Kaminari.paginate_array(snippet_titles).page(page).per(per_page)
+      when 'snippet_blobs'
+        Kaminari.paginate_array(snippet_blobs).page(page).per(per_page)
+      else
+        super
+      end
+    end
+
+    def total_count
+      @total_count ||= snippet_titles_count + snippet_blobs_count
+    end
+
+    def snippet_titles_count
+      @snippet_titles_count ||= snippet_titles.count
+    end
+
+    def snippet_blobs_count
+      @snippet_blobs_count ||= snippet_blobs.count
+    end
+
+    private
+
+    def snippet_titles
+      Snippet.where(id: limit_snippet_ids).search(query).order('updated_at DESC')
+    end
+
+    def snippet_blobs
+      matching_snippets = Snippet.where(id: limit_snippet_ids).search_code(query).order('updated_at DESC')
+      matching_snippets = matching_snippets.to_a
+      snippets = []
+      matching_snippets.each { |e| snippets << chunk_snippet(e) }
+      snippets
+    end
+
+    def default_scope
+      'snippet_blobs'
+    end
+
+    def bounded_line_numbers(line, min, max, surrounding_lines)
+      lower = line - surrounding_lines > min ? line - surrounding_lines : min
+      upper = line + surrounding_lines < max ? line + surrounding_lines : max
+      (lower..upper).to_a
+    end
+
+    def chunk_snippet(snippet)
+      surrounding_lines = 3
+      used_lines = []
+      lined_content = snippet.content.split("\n")
+      lined_content.each_with_index { |line, line_number|
+        used_lines.concat bounded_line_numbers(
+          line_number,
+          0,
+          lined_content.size,
+          surrounding_lines
+        ) if line.include?(query)
+      }
+
+      used_lines = used_lines.uniq.sort
+
+      snippet_chunk = []
+      snippet_chunks = []
+      snippet_start_line = 0
+      last_line = -1
+      used_lines.each { |line_number|
+        if last_line < 0
+          snippet_start_line = line_number
+          snippet_chunk << lined_content[line_number]
+        elsif last_line == line_number - 1
+          snippet_chunk << lined_content[line_number]
+        else
+          snippet_chunks << {
+            data: snippet_chunk.join("\n"),
+            start_line: snippet_start_line + 1
+          }
+          snippet_chunk = [lined_content[line_number]]
+          snippet_start_line = line_number
+        end
+        last_line = line_number
+      }
+      snippet_chunks << {
+        data: snippet_chunk.join("\n"),
+        start_line: snippet_start_line + 1
+      }
+
+      { snippet_object: snippet, snippet_chunks: snippet_chunks }
+    end
+  end
+end

--- a/lib/gitlab/snippet_search_results.rb
+++ b/lib/gitlab/snippet_search_results.rb
@@ -37,10 +37,10 @@ module Gitlab
     end
 
     def snippet_blobs
-      matching_snippets = Snippet.where(id: limit_snippet_ids).search_code(query).order('updated_at DESC')
-      matching_snippets = matching_snippets.to_a
+      search = Snippet.where(id: limit_snippet_ids).search_code(query)
+      search = search.order('updated_at DESC').to_a
       snippets = []
-      matching_snippets.each { |e| snippets << chunk_snippet(e) }
+      search.each { |e| snippets << chunk_snippet(e) }
       snippets
     end
 
@@ -58,14 +58,14 @@ module Gitlab
       surrounding_lines = 3
       used_lines = []
       lined_content = snippet.content.split("\n")
-      lined_content.each_with_index { |line, line_number|
+      lined_content.each_with_index do |line, line_number|
         used_lines.concat bounded_line_numbers(
           line_number,
           0,
           lined_content.size,
           surrounding_lines
         ) if line.include?(query)
-      }
+      end
 
       used_lines = used_lines.uniq.sort
 
@@ -73,7 +73,7 @@ module Gitlab
       snippet_chunks = []
       snippet_start_line = 0
       last_line = -1
-      used_lines.each { |line_number|
+      used_lines.each do |line_number|
         if last_line < 0
           snippet_start_line = line_number
           snippet_chunk << lined_content[line_number]
@@ -88,7 +88,7 @@ module Gitlab
           snippet_start_line = line_number
         end
         last_line = line_number
-      }
+      end
       snippet_chunks << {
         data: snippet_chunk.join("\n"),
         start_line: snippet_start_line + 1

--- a/lib/gitlab/snippet_search_results.rb
+++ b/lib/gitlab/snippet_search_results.rb
@@ -48,53 +48,84 @@ module Gitlab
       'snippet_blobs'
     end
 
-    def bounded_line_numbers(line, min, max, surrounding_lines)
+    # Get an array of line numbers surrounding a matching
+    # line, bounded by min/max.
+    #
+    # @returns Array of line numbers
+    def bounded_line_numbers(line, min, max)
       lower = line - surrounding_lines > min ? line - surrounding_lines : min
       upper = line + surrounding_lines < max ? line + surrounding_lines : max
       (lower..upper).to_a
     end
 
-    def chunk_snippet(snippet)
-      surrounding_lines = 3
+    # Returns a sorted set of lines to be included in a snippet preview.
+    # This ensures matching adjacent lines do not display duplicated
+    # surrounding code.
+    #
+    # @returns Array, unique and sorted.
+    def matching_lines(lined_content)
       used_lines = []
-      lined_content = snippet.content.split("\n")
       lined_content.each_with_index do |line, line_number|
         used_lines.concat bounded_line_numbers(
           line_number,
           0,
-          lined_content.size,
-          surrounding_lines
+          lined_content.size
         ) if line.include?(query)
       end
 
-      used_lines = used_lines.uniq.sort
+      used_lines.uniq.sort
+    end
+
+    # 'Chunkify' entire snippet.  Splits the snippet data into matching lines +
+    # surrounding_lines() worth of unmatching lines.
+    #
+    # @returns a hash with {snippet_object, snippet_chunks:{data,start_line}}
+    def chunk_snippet(snippet)
+      lined_content = snippet.content.split("\n")
+      used_lines = matching_lines(lined_content)
 
       snippet_chunk = []
       snippet_chunks = []
       snippet_start_line = 0
       last_line = -1
+
+      # Go through each used line, and add consecutive lines as a single chunk
+      # to the snippet chunk array.
       used_lines.each do |line_number|
         if last_line < 0
+          # Start a new chunk.
           snippet_start_line = line_number
           snippet_chunk << lined_content[line_number]
         elsif last_line == line_number - 1
+          # Consecutive line, continue chunk.
           snippet_chunk << lined_content[line_number]
         else
+          # Non-consecutive line, add chunk to chunk array.
           snippet_chunks << {
             data: snippet_chunk.join("\n"),
             start_line: snippet_start_line + 1
           }
+
+          # Start a new chunk.
           snippet_chunk = [lined_content[line_number]]
           snippet_start_line = line_number
         end
         last_line = line_number
       end
+      # Add final chunk to chunk array
       snippet_chunks << {
         data: snippet_chunk.join("\n"),
         start_line: snippet_start_line + 1
       }
 
+      # Return snippet with chunk array
       { snippet_object: snippet, snippet_chunks: snippet_chunks }
+    end
+
+    # Defines how many unmatching lines should be
+    # included around the matching lines in a snippet
+    def surrounding_lines
+      3
     end
   end
 end


### PR DESCRIPTION
This is a resubmit of the closed PR#7612.  While fixing some things, a refactor of search was pushed to master.  This PR is updating snippet-search for the refactor.

In reference to this merge request:

http://feedback.gitlab.com/forums/176466-general/suggestions/5529795-search-though-snippets
##### What does this MR do?

Adds the capability to search snippets.  This can be accessed  whenever viewing a snippet related page, such as personal snippets, snippet discovery, and search snippets.  There is a tab for searching just filenames and titles, and there is a tab for searching just the code of the snippet.  It searches all public snippets, as well as the private snippets of the user.
##### Are there points in the code the reviewer needs to double check?

The largest change outside of haml files is lib/gitlab/snippet_search_results.rb.  
##### Why was this MR needed?

This is something my users have been asking for, and it should add a great amount of collaborative capability and global discovery to the snippets feature.  In addition, there is a merge request already created with over 20 points.
##### What are the relevant issue numbers / Feature requests?

http://feedback.gitlab.com/forums/176466-general/suggestions/5529795-search-though-snippets
##### Screenshots (If appropiate)

![selection_014](https://cloud.githubusercontent.com/assets/236700/4096176/dbcb1d0e-2fbd-11e4-91bb-16835ba93e6b.png)
![selection_015](https://cloud.githubusercontent.com/assets/236700/4096178/dbce326e-2fbd-11e4-830f-f86f158491df.png)
![selection_016](https://cloud.githubusercontent.com/assets/236700/4096180/dbd1689e-2fbd-11e4-9ff9-3be0614ba718.png)
![selection_017](https://cloud.githubusercontent.com/assets/236700/4096177/dbcde70a-2fbd-11e4-91c0-108b0fab6aa5.png)
![selection_018](https://cloud.githubusercontent.com/assets/236700/4096179/dbcef47e-2fbd-11e4-986f-0d9f3bcb9c29.png)
![selection_019](https://cloud.githubusercontent.com/assets/236700/4096181/dbd8a17c-2fbd-11e4-8d02-fdcda553f1d9.png)
