### PR TITLE
Fix log rotate permission error

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -159,7 +159,7 @@ We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](da
     # Make sure GitLab can write to the log/ and tmp/ directories
     sudo chown -R git log/
     sudo chown -R git tmp/
-    sudo chmod -R u+rwX log/
+    sudo chmod -R u+rwX,go-w log/
     sudo chmod -R u+rwX tmp/
 
     # Create directory for satellites


### PR DESCRIPTION
As described in #7651, logrotate produces errors with the current logrotate config shipped with gitlab.
This error showed up on my debian wheezy machine. Although I'm not sure I anyone else has encountert the same problem I found a solution for this problem:

Logrotate needs to know which permissions (user/group) it has to use when rotationg log files. The su directive has to be used to set correct permissions. Man page of logrotate:

su user group
        Rotate  log files set under this user and group
        instead of using default user/group (usually root).
        user specifies the user name used for rotation and group
        specifies the group used for rotation.

Please consider for pulling into master.
