### PR TITLE
add xss security vulnerability warnings

### DIFF
--- a/doc/update/6.5-to-6.6.md
+++ b/doc/update/6.5-to-6.6.md
@@ -1,5 +1,9 @@
 # From 6.5 to 6.6
 
+## Warning
+
+GitLab 6.6 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ## 0. Backup
 
 ```bash

--- a/doc/update/6.6-to-6.7.md
+++ b/doc/update/6.6-to-6.7.md
@@ -1,5 +1,9 @@
 # From 6.6 to 6.7
 
+## Warning
+
+GitLab 6.7 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ## 0. Backup
 
 ```bash

--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -1,5 +1,9 @@
 # From 6.7 to 6.8
 
+## Warning
+
+GitLab 6.8 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ## 0. Backup
 
 ```bash

--- a/doc/update/6.8-to-6.9.md
+++ b/doc/update/6.8-to-6.9.md
@@ -1,5 +1,9 @@
 # From 6.8 to 6.9
 
+## Warning
+
+GitLab 6.9 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ### 0. Backup
 
 ```bash

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -1,5 +1,9 @@
 # From 6.9 to 7.0
 
+## Warning
+
+GitLab 7.0 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ### 0. Backup
 
 ```bash

--- a/doc/update/7.0-to-7.1.md
+++ b/doc/update/7.0-to-7.1.md
@@ -1,5 +1,9 @@
 # From 7.0 to 7.1
 
+## Warning
+
+GitLab 7.1 is affected by a [XSS security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/).
+
 ### 0. Backup
 
 ```bash


### PR DESCRIPTION
Add [security vulnerability](https://about.gitlab.com/2014/08/28/gitlab-7-dot-2-1-security-release/) warning to 7.1 upgrade notes.
