### PR TITLE
[refactor] Factor out commit list from compare and new MR.

### DIFF
--- a/app/views/projects/commits/_commit_list.html.haml
+++ b/app/views/projects/commits/_commit_list.html.haml
@@ -1,0 +1,11 @@
+%div.panel.panel-default
+  .panel-heading
+    Commits (#{@commits.count})
+  - if @commits.size > MergeRequestDiff::COMMITS_SAFE_SIZE
+    %ul.well-list
+      - Commit.decorate(@commits.first(MergeRequestDiff::COMMITS_SAFE_SIZE)).each do |commit|
+        = render "projects/commits/inline_commit", commit: commit, project: @project
+      %li.warning-row.unstyled
+        other #{@commits.size - MergeRequestDiff::COMMITS_SAFE_SIZE} commits hidden to prevent performance issues.
+  - else
+    %ul.well-list= render Commit.decorate(@commits), project: @project

--- a/app/views/projects/compare/show.html.haml
+++ b/app/views/projects/compare/show.html.haml
@@ -6,20 +6,8 @@
 = render "form"
 
 - if @commits.present?
-  %div.panel.panel-default
-    .panel-heading
-      Commits (#{@commits.count})
-    - if @commits.size > MergeRequestDiff::COMMITS_SAFE_SIZE
-      %ul.well-list
-        - Commit.decorate(@commits.first(MergeRequestDiff::COMMITS_SAFE_SIZE)).each do |commit|
-          = render "projects/commits/inline_commit", commit: commit, project: @project
-        %li.warning-row.unstyled
-          other #{@commits.size - MergeRequestDiff::COMMITS_SAFE_SIZE} commits hidden to prevent performance issues.
-    - else
-      %ul.well-list= render Commit.decorate(@commits), project: @project
-
+  = render "projects/commits/commit_list"
   = render "projects/diffs/diffs", diffs: @diffs, project: @project
-
 - else
   .light-well
     .center

--- a/app/views/projects/merge_requests/_new_submit.html.haml
+++ b/app/views/projects/merge_requests/_new_submit.html.haml
@@ -66,17 +66,7 @@
       = f.submit 'Submit merge request', class: "btn btn-create"
 
 .mr-compare
-  %div.panel.panel-default
-    .panel-heading
-      Commits (#{@commits.count})
-    - if @commits.size > MergeRequestDiff::COMMITS_SAFE_SIZE
-      %ul.well-list
-        - Commit.decorate(@commits.first(MergeRequestDiff::COMMITS_SAFE_SIZE)).each do |commit|
-          = render "projects/commits/inline_commit", commit: commit, project: @project
-        %li.warning-row.unstyled
-          other #{@commits.size - MergeRequestDiff::COMMITS_SAFE_SIZE} commits hidden to prevent performance issues.
-    - else
-      %ul.well-list= render Commit.decorate(@commits), project: @project
+  = render "projects/commits/commit_list"
 
   %h4 Changes
   - if @diffs.present?


### PR DESCRIPTION
The exact same piece of code was copied twice.

Besides those, there is also a third very similar copy which has started to diverge for the merge requests show view at: https://github.com/gitlabhq/gitlabhq/blob/174c00cf2c026a3bdc61d94b45195a5e5c99202f/app/views/projects/merge_requests/show/_commits.html.haml#L6 .  It has diverged as it now:
- has a list icon
- hides to 8 items on page load

I propose all of those 3 cases be made the same. If not, at least we should further refactor part of the MR show with the other 2 occurrences.

Just to show clearly what is the object in question:

![screenshot from 2014-08-31 13 07 27 commit list](https://cloud.githubusercontent.com/assets/1429315/4101701/d996c5d6-30ff-11e4-850f-8c9c00a272d3.png)
