### PR TITLE
Show labels help message if last label is deleted

### DIFF
--- a/app/controllers/projects/labels_controller.rb
+++ b/app/controllers/projects/labels_controller.rb
@@ -52,7 +52,7 @@ class Projects::LabelsController < Projects::ApplicationController
 
     respond_to do |format|
       format.html { redirect_to project_labels_path(@project), notice: 'Label was removed' }
-      format.js { render nothing: true }
+      format.js
     end
   end
 

--- a/app/views/projects/labels/destroy.js.haml
+++ b/app/views/projects/labels/destroy.js.haml
@@ -1,0 +1,2 @@
+- if @project.labels.size == 0
+  $('.labels').load(document.URL + ' .light-well').hide().fadeIn(1000)

--- a/app/views/projects/labels/index.html.haml
+++ b/app/views/projects/labels/index.html.haml
@@ -7,11 +7,11 @@
   Labels
 %hr
 
-- if @labels.present?
-  %ul.bordered-list.manage-labels-list
-    = render @labels
-  = paginate @labels, theme: 'gitlab'
-
-- else
-  .light-well
-    .nothing-here-block Create first label or #{link_to 'generate', generate_project_labels_path(@project), method: :post} default set of labels
+.labels
+  - if @labels.present?
+    %ul.bordered-list.manage-labels-list
+      = render @labels
+    = paginate @labels, theme: 'gitlab'
+  - else
+    .light-well
+      .nothing-here-block Create first label or #{link_to 'generate', generate_project_labels_path(@project), method: :post} default set of labels

--- a/features/project/issues/labels.feature
+++ b/features/project/issues/labels.feature
@@ -24,6 +24,11 @@ Feature: Project Labels
     When I remove label 'bug'
     Then I should not see label 'bug'
 
+  @javascript
+  Scenario: I remove all labels
+    When I delete all labels
+    Then I should see labels help message
+
   Scenario: I create a label with invalid color
     Given I visit project "Shop" new label page
     When I submit new label with invalid color

--- a/features/steps/project/labels.rb
+++ b/features/steps/project/labels.rb
@@ -25,6 +25,22 @@ class ProjectLabels < Spinach::FeatureSteps
     end
   end
 
+  step 'I delete all labels' do
+    within '.labels' do
+      all('.btn-remove').each do |remove|
+        remove.click
+        sleep 0.05
+      end
+    end
+  end
+
+  step 'I should see labels help message' do
+    within '.labels' do
+      page.should have_content 'Create first label or generate default set of '\
+                               'labels'
+    end
+  end
+
   step 'I submit new label \'support\'' do
     fill_in 'Title', with: 'support'
     fill_in 'Background Color', with: '#F95610'


### PR DESCRIPTION
#### What does this PR do?

If the last label is deleted, the label information message is shown again
#### Why is this needed?

Currently, if the last label is delated, an empty white page is shown. UX is better, to show instructions for labels again.
#### Related issues

This is related to #7522 which implements the same for tags.
