### PR TITLE
Fix missing to on reassign Merge Request email to unassigned.

### DIFF
--- a/app/views/notify/_reassigned_issuable_email.html.haml
+++ b/app/views/notify/_reassigned_issuable_email.html.haml
@@ -1,0 +1,10 @@
+%p
+  Assignee changed
+  - if @previous_assignee
+    from
+    %strong #{@previous_assignee.name}
+  to
+  - if issuable.assignee_id
+    %strong #{issuable.assignee_name}
+  - else
+    %strong Unassigned

--- a/app/views/notify/reassigned_issue_email.html.haml
+++ b/app/views/notify/reassigned_issue_email.html.haml
@@ -1,11 +1,1 @@
-%p
-  Assignee changed
-  - if @previous_assignee
-    from
-    %strong #{@previous_assignee.name}
-  to
-  - if @issue.assignee_id
-    %strong #{@issue.assignee_name}
-  - else
-    %strong Unassigned
-
+= render 'reassigned_issuable_email', issuable: @issue

--- a/app/views/notify/reassigned_merge_request_email.html.haml
+++ b/app/views/notify/reassigned_merge_request_email.html.haml
@@ -1,7 +1,1 @@
-%p
-  Assignee changed
-  - if @previous_assignee
-    from
-    %strong #{@previous_assignee.name}
-  to
-  %strong #{@merge_request.assignee_name}
+= render 'reassigned_issuable_email', issuable: @merge_request


### PR DESCRIPTION
Factors out MR and issue email.

Before this, when you reassign to unassigned, it said on the email "reassigned to " (empty).

Now it says: "reassigned to unassigned", just like it does for issues.

This started out as a refactor but ended on a bug fix: it had already been fixed for issues at https://github.com/cirosantilli/gitlabhq/commit/39f82b7 but not for MRs because of duplication.

Found using https://github.com/UncleGene/flay-haml
