### PR TITLE
[UX] Disable buttons if form is empty

### DIFF
--- a/app/views/projects/blob/_remove.html.haml
+++ b/app/views/projects/blob/_remove.html.haml
@@ -19,5 +19,8 @@
           .form-group
             .col-sm-2
             .col-sm-10
-              = submit_tag 'Remove file', class: 'btn btn-remove'
+              = submit_tag 'Remove file', class: 'btn btn-remove btn-remove-file'
               = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+
+:javascript
+  disableButtonIfEmptyField('#commit_message', '.btn-remove-file')

--- a/app/views/projects/network/show.html.haml
+++ b/app/views/projects/network/show.html.haml
@@ -2,8 +2,8 @@
 .project-network
   .controls
     = form_tag project_network_path(@project, @id), method: :get, class: 'form-inline network-form' do |f|
-      = text_field_tag :extended_sha1, @options[:extended_sha1], placeholder: "Input an extended SHA1 syntax", class: "search-input form-control input-mx-250"
-      = button_tag type: 'submit', class: 'btn btn-success' do
+      = text_field_tag :extended_sha1, @options[:extended_sha1], placeholder: "Input an extended SHA1 syntax", class: 'search-input form-control input-mx-250 search-sha'
+      = button_tag type: 'submit', class: 'btn btn-success btn-search-sha' do
         %i.icon-search
       .inline.prepend-left-20
         .checkbox.light
@@ -15,6 +15,8 @@
     = spinner nil, true
 
 :javascript
+  disableButtonIfEmptyField('#extended_sha1', '.btn-search-sha')
+
   network_graph = new Network({
     url: '#{project_network_path(@project, @ref, @options.merge(format: :json))}',
     commit_url: '#{project_commit_path(@project, 'ae45ca32').gsub("ae45ca32", "%s")}',

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -1,9 +1,9 @@
 %h3.page-title New file
 %hr
 .file-editor
-  = form_tag(project_new_tree_path(@project, @id), method: :put, class: "form-horizontal") do
+  = form_tag(project_new_tree_path(@project, @id), method: :put, class: 'form-horizontal form-new-file') do
     .form-group.commit_message-group
-      = label_tag 'file_name', class: "control-label" do
+      = label_tag 'file_name', class: 'control-label' do
         File name
       .col-sm-10
         .input-group
@@ -24,7 +24,7 @@
       = label_tag 'commit_message', class: "control-label" do
         Commit message
       .col-sm-10
-        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
+        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message form-control',
             params[:commit_message], placeholder: "Added new file", required: true, rows: 3, class: 'form-control')}
 
     .file-holder
@@ -46,7 +46,7 @@
   ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")
   var editor = ace.edit("editor");
 
-  disableButtonIfEmptyField("#commit_message", ".js-commit-button");
+  disableButtonIfAnyEmptyField($('.form-new-file'), '.form-control', '.btn-create')
 
   $(".js-commit-button").click(function(){
     $("#file-content").val(editor.getValue());


### PR DESCRIPTION
#### What does this PR do?

This PR disables buttons if form input is empty on various places:
- Do not search on network graph for empty SHA
- Do not remove file when no commit message
- For a new file, both commit message and filename need to be entered

Currently, on all these places a stale UI happens because these actions are not allowed
