### PR TITLE
'all' is not a valid username

### DIFF
--- a/lib/gitlab/blacklist.rb
+++ b/lib/gitlab/blacklist.rb
@@ -26,6 +26,7 @@ module Gitlab
         hooks
         notes
         unsubscribes
+        all
       )
     end
   end


### PR DESCRIPTION
#### What does this PR do?

This PR adds `all` the blacklist. With the feature of mentioning all usernames of @maxlazio, this username is not valid anymore to avoid clashes between username lookup and mentioning all teammembers.
