### PR TITLE
add HSTS Policy warning

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -83,6 +83,8 @@ server {
 
   ssl_prefer_server_ciphers   on;
 
+  ## [WARNING] The following header states that the browser should only communicate 
+  ## with your server over a secure connection for the next 24 months.
   add_header Strict-Transport-Security max-age=63072000;
   add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
Add warning about HSTS header as it means user will need to provide secure connection access to site for next 24 months from page view. See https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security for more details.
