### PR TITLE
remove unnecessary chmod

### DIFF
--- a/doc/update/6.0-to-6.1.md
+++ b/doc/update/6.0-to-6.1.md
@@ -73,7 +73,6 @@ sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
 ```bash
 sudo rm /etc/init.d/gitlab
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ## 7. Start application

--- a/doc/update/6.1-to-6.2.md
+++ b/doc/update/6.1-to-6.2.md
@@ -88,7 +88,6 @@ sudo cp lib/support/logrotate/gitlab /etc/logrotate.d/gitlab
 ```bash
 sudo rm /etc/init.d/gitlab
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ## 8. Start application

--- a/doc/update/6.2-to-6.3.md
+++ b/doc/update/6.2-to-6.3.md
@@ -74,7 +74,6 @@ sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers
 
 ```bash
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ## 7. Start application

--- a/doc/update/6.7-to-6.8.md
+++ b/doc/update/6.7-to-6.8.md
@@ -62,7 +62,6 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 
 # Update init.d script
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 
 # Close access to gitlab-satellites for others
 sudo chmod u+rwx,g=rx,o-rwx /home/git/gitlab-satellites

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -93,7 +93,6 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 
 # Update init.d script
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ### 6. Update config files

--- a/doc/update/7.0-to-7.1.md
+++ b/doc/update/7.0-to-7.1.md
@@ -93,7 +93,6 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 
 # Update init.d script
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ### 6. Update config files

--- a/doc/update/7.1-to-7.2.md
+++ b/doc/update/7.1-to-7.2.md
@@ -77,7 +77,6 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 
 # Update init.d script
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
-sudo chmod +x /etc/init.d/gitlab
 ```
 
 ### 6. Update config files


### PR DESCRIPTION
`lib/support/init.d/gitlab` was set as executable in the repo as of the 6.1 release so `chmod` is not needed after that. See https://github.com/gitlabhq/gitlabhq/pull/7586/files#r16885445.
