### PR TITLE
add cleanup section to 5.0 upgrade guide

### DIFF
--- a/doc/update/4.2-to-5.0.md
+++ b/doc/update/4.2-to-5.0.md
@@ -10,7 +10,7 @@ GitLab 5.0 is affected by critical security vulnerability CVE-2013-4490.
 - Self signed SSL certificates are not supported until GitLab 5.1
 - **requires ruby1.9.3**
 
-## 0. Stop gitlab
+## 0. Stop GitLab
 
     sudo service gitlab stop
 
@@ -41,7 +41,7 @@ git checkout v1.1.0
 # copy config
 cp config.yml.example config.yml
 
-# change url to gitlab instance
+# change url to GitLab instance
 # ! make sure url end with '/' like 'https://gitlab.example/'
 vim config.yml
 
@@ -49,14 +49,14 @@ vim config.yml
 ./support/rewrite-hooks.sh
 
 # check ruby version for git user ( 1.9 required!! )
-# gitlab shell requires system ruby 1.9
+# GitLab shell requires system ruby 1.9
 ruby -v
 
 # exit from git user
 exit
 ```
 
-## 4. Copy gitlab instance to git user
+## 4. Copy GitLab instance to git user
 
 ```bash
 sudo cp -R /home/gitlab/gitlab /home/git/gitlab
@@ -162,8 +162,43 @@ sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
 
 ```
 
-**P.S. If everything works as expected you can remove gitlab user from system**
+## 9. Cleanup
+
+**If everything works as expected you can cleanup some old things**
+Recommend you wait a bit and do a backup before completing the following.
 
 ```bash
+# remove GitLab user from system
 sudo userdel -r gitlab
+
+cd /home/git
+
+# cleanup .profile
+## remove text from .profile added during gitolite installation:
+##   PATH=\$PATH:/home/git/bin
+##   export PATH
+## to see what a clean .profile for new users on your system would look like see /etc/skel/.profile
+sudo -u git -H vim .profile
+
+# remove gitolite
+sudo rm -R bin
+sudo rm -Rf gitolite
+sudo rm -R .gitolite
+sudo rm .gitolite.rc
+sudo rm -f gitlab.pub
+sudo rm projects.list
+
+# reset tmp folders
+sudo service gitlab stop
+cd /home/git/gitlab
+sudo rm -R tmp
+sudo -u git -H mkdir tmp
+sudo chmod -R u+rwX  tmp/
+
+# reboot system
+sudo reboot
+
+# login, check that GitLab is running fine
+cd /home/git/gitlab
+sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
 ```


### PR DESCRIPTION
Add cleanup details to upgrade guide as gitolite and more is no longer used.
