### PR TITLE
Fix missing to on reassign Merge Request text email to unassigned.

### DIFF
--- a/app/views/notify/_reassigned_issuable_email.text.erb
+++ b/app/views/notify/_reassigned_issuable_email.text.erb
@@ -1,0 +1,6 @@
+Reassigned <%= issuable.class.model_name.human.titleize %> <%= issuable.iid %>
+
+<%= url_for([issuable.project, issuable, {only_path: false}]) %>
+
+Assignee changed <%= "from #{@previous_assignee.name}" if @previous_assignee -%>
+ to <%= "#{issuable.assignee_id ? issuable.assignee_name : 'Unassigned'}" %>

--- a/app/views/notify/reassigned_issue_email.text.erb
+++ b/app/views/notify/reassigned_issue_email.text.erb
@@ -1,5 +1,1 @@
-Reassigned Issue <%= @issue.iid %>
-
-<%= url_for(project_issue_url(@issue.project, @issue)) %>
-
-Assignee changed <%= "from #{@previous_assignee.name}" if @previous_assignee %> to <%= "#{@issue.assignee_id ? @issue.assignee_name : 'Unassigned'}" %>
+<%= render 'reassigned_issuable_email', issuable: @issue %>

--- a/app/views/notify/reassigned_merge_request_email.text.erb
+++ b/app/views/notify/reassigned_merge_request_email.text.erb
@@ -1,7 +1,1 @@
-Reassigned Merge Request #<%= @merge_request.iid %>
-
-<%= url_for(project_merge_request_url(@merge_request.target_project, @merge_request)) %>
-
-
-Assignee changed <%= "from #{@previous_assignee.name}" if @previous_assignee %> to <%= @merge_request.assignee_name %>
-
+<%= render 'reassigned_issuable_email', issuable: @merge_request %>


### PR DESCRIPTION
Factors out text MR and issue email.

Same as: https://github.com/gitlabhq/gitlabhq/pull/7661 but for the text version instead of HTML.
