### PR TITLE
Factor new issue and edit MR forms.

### DIFF
--- a/app/views/projects/_issuable_form.html.haml
+++ b/app/views/projects/_issuable_form.html.haml
@@ -1,0 +1,39 @@
+.form-group
+  = f.label :title, class: 'control-label' do
+    %strong= 'Title *'
+  .col-sm-10
+    = f.text_field :title, maxlength: 255, autofocus: true,
+        class: 'form-control pad js-gfm-input', required: true
+.form-group
+  = f.label :description, 'Description', class: 'control-label'
+  .col-sm-10
+    = f.text_area :description, rows: 14,
+        class: 'form-control js-gfm-input markdown-area'
+    .col-sm-12.hint
+      .pull-left
+        Parsed with
+        #{link_to 'GitLab Flavored Markdown', help_page_path('markdown', 'markdown'), target: '_blank'}.
+      .pull-right
+        Attach images (JPG, PNG, GIF) by dragging &amp; dropping
+        or #{link_to 'selecting them', '#', class: 'markdown-selector' }.
+    .clearfix
+    .error-alert
+%hr
+.form-group
+  .issue-assignee
+    = f.label :assignee_id, class: 'control-label' do
+      %i.icon-user
+      Assign to
+    .col-sm-10
+      = project_users_select_tag("#{issuable.class.model_name.param_key}[assignee_id]",
+          placeholder: 'Select a user', class: 'custom-form-control',
+          selected: issuable.assignee_id)
+      &nbsp;
+      = link_to 'Assign to me', '#', class: 'btn assign-to-me-link'
+.form-group
+  .issue-milestone
+    = f.label :milestone_id, class: 'control-label' do
+      %i.icon-time
+      Milestone
+    .col-sm-10= f.select(:milestone_id, milestone_options(issuable),
+        { include_blank: 'Select milestone' }, { class: 'select2' })

--- a/app/views/projects/issues/_form.html.haml
+++ b/app/views/projects/issues/_form.html.haml
@@ -16,37 +16,7 @@
             - @issue.errors.full_messages.each do |msg|
               %span= msg
               %br
-    .form-group
-      = f.label :title, class: 'control-label' do
-        %strong= 'Title *'
-      .col-sm-10
-        = f.text_field :title, maxlength: 255, class: "form-control js-gfm-input", autofocus: true, required: true
-    .form-group
-      = f.label :description, 'Description', class: 'control-label'
-      .col-sm-10
-        = f.text_area :description, class: 'form-control js-gfm-input markdown-area', rows: 14
-        .col-sm-12.hint
-          .pull-left Issues are parsed with #{link_to "GitLab Flavored Markdown", help_page_path("markdown", "markdown"), target: '_blank'}.
-          .pull-right Attach images (JPG, PNG, GIF) by dragging &amp; dropping or #{link_to "selecting them", '#', class: 'markdown-selector' }.
-        .clearfix
-        .error-alert
-    %hr
-    .form-group
-      .issue-assignee
-        = f.label :assignee_id, class: 'control-label' do
-          %i.icon-user
-          Assign to
-        .col-sm-10
-          = project_users_select_tag('issue[assignee_id]', placeholder: 'Select a user', class: 'custom-form-control', selected: @issue.assignee_id)
-          &nbsp;
-          = link_to 'Assign to me', '#', class: 'btn assign-to-me-link'
-    .form-group
-      .issue-milestone
-        = f.label :milestone_id, class: 'control-label' do
-          %i.icon-time
-          Milestone
-        .col-sm-10= f.select(:milestone_id, milestone_options(@issue), { include_blank: "Select milestone" }, {class: 'select2'})
-
+    = render 'projects/issuable_form', f: f, issuable: @issue
     .form-group
       = f.label :label_ids, class: 'control-label' do
         %i.icon-tag

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -15,37 +15,7 @@
             %div= msg
 
   .merge-request-form-info
-    .form-group
-      = f.label :title, class: 'control-label' do
-        %strong= "Title *"
-      .col-sm-10= f.text_field :title, class: "form-control pad js-gfm-input", maxlength: 255, rows: 5, required: true
-    .form-group
-      = f.label :description, "Description", class: 'control-label'
-      .col-sm-10
-        = f.text_area :description, class: "form-control js-gfm-input markdown-area", rows: 14
-        .col-sm-12.hint
-          .pull-left Description is parsed with #{link_to "GitLab Flavored Markdown", help_page_path("markdown", "markdown"), target: '_blank'}.
-          .pull-right Attach images (JPG, PNG, GIF) by dragging &amp; dropping or #{link_to "selecting them", '#', class: 'markdown-selector' }.
-        .clearfix
-        .error-alert
-    %hr
-    .form-group
-      .issue-assignee
-        = f.label :assignee_id, class: 'control-label' do
-          %i.icon-user
-          Assign to
-        .col-sm-10
-          = project_users_select_tag('merge_request[assignee_id]', placeholder: 'Select a user', class: 'custom-form-control', selected: @merge_request.assignee_id)
-          &nbsp;
-          = link_to 'Assign to me', '#', class: 'btn assign-to-me-link'
-    .form-group
-      .issue-milestone
-        = f.label :milestone_id, class: 'control-label' do
-          %i.icon-time
-          Milestone
-        .col-sm-10= f.select(:milestone_id, milestone_options(@merge_request), { include_blank: "Select milestone" }, {class: 'select2'})
-
-
+    = render 'projects/issuable_form', f: f, issuable: @merge_request
     .form-group
       = f.label :label_ids, class: 'control-label' do
         %i.icon-tag


### PR DESCRIPTION
There was a lot of code duplication here.

There is also a third copy which has diverged more and which we should DRY out as well: the new MR form. It probably has the best visual style of the three and should be the one to copy. Opened an issue for that at: https://github.com/gitlabhq/gitlabhq/issues/7679 so we won't forget.

The issue edit and new were already factored.

Minor visible changes:
- "Issue is parsed with GFM" message changed to: "Parsed with GFM". Shorter, DRYer, and it is obvious that we are talking about the description that corresponds to the textarea above.

I cannot see any other behavior / UI changes.

Non-visible changes:
- title input element:
  - remove rows attribute. Does nothing on `input type="text"`.
  - remove class `"pad"` from the merge request form. Not used anywhere in the app.

TODO in future merge requests: DRY those forms even further on the points they diverged more:
- errors
- labels
- submit

Found using https://github.com/UncleGene/flay-haml
