### PR TITLE
Extend user add api to allow adding users like from admin panel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v 7.5.0
   - API: Add support for Hipchat (Kevin Houdebert)
   - Add time zone configuration on gitlab.yml (Sullivan Senechal)
+  - Add force_random_password option to user POST api
   - Fix LDAP authentication for Git HTTP access
   - Fix LDAP config lookup for provider 'ldap'
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -45,7 +45,6 @@ class Admin::UsersController < Admin::ApplicationController
 
     @user = User.new(user_params.merge(opts))
     @user.created_by_id = current_user.id
-    @user.generate_password
     @user.generate_reset_token
     @user.skip_confirmation!
 

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -146,7 +146,7 @@ Parameters:
 
 ## User creation
 
-Creates a new user. Note only administrators can create new users.
+Creates a new user. Note only administrators can create new users. If `force_random_password` is set, user is created as if done from the admin control panel.
 
 ```
 POST /users
@@ -154,20 +154,21 @@ POST /users
 
 Parameters:
 
-- `email` (required)            - Email
-- `password` (required)         - Password
-- `username` (required)         - Username
-- `name` (required)             - Name
-- `skype` (optional)            - Skype ID
-- `linkedin` (optional)         - LinkedIn
-- `twitter` (optional)          - Twitter account
-- `website_url` (optional)      - Website URL
-- `projects_limit` (optional)   - Number of projects user can create
-- `extern_uid` (optional)       - External UID
-- `provider` (optional)         - External provider name
-- `bio` (optional)              - User's biography
-- `admin` (optional)            - User is admin - true or false (default)
-- `can_create_group` (optional) - User can create groups - true or false
+- `email` (required)                                                    - Email
+- `password` (required unless force_random_password is set)             - Password
+- `force_random_password` (true/false; required unless password is set) - generate random password for user
+- `username` (required)                                                 - Username
+- `name` (required)                                                     - Name
+- `skype` (optional)                                                    - Skype ID
+- `linkedin` (optional)                                                 - LinkedIn
+- `twitter` (optional)                                                  - Twitter account
+- `website_url` (optional)                                              - Website URL
+- `projects_limit` (optional)                                           - Number of projects user can create
+- `extern_uid` (optional)                                               - External UID
+- `provider` (optional)                                                 - External provider name
+- `bio` (optional)                                                      - User's biography
+- `admin` (optional)                                                    - User is admin - true or false (default)
+- `can_create_group` (optional)                                         - User can create groups - true or false
 
 ## User modification
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -145,8 +145,8 @@ describe API::API, api: true  do
           '\'_\', optionally preceeded by \'.\'. It must not end in \'.git\'.']
     end
 
-    it "shouldn't available for non admin users" do
-      post api("/users", user), attributes_for(:user)
+    it "shouldn't be available for non admin users" do
+      post api('/users', user), attributes_for(:user)
       response.status.should == 403
     end
 


### PR DESCRIPTION
- Add force_random_password parameter to have password of new user set
  randomly and expired
- Update docs
- Update tests

Rationale:
- When adding a user from the admin panel (Admin Area -> New user), the user is created with a random, expired password and in the welcome email, is directed to (re)set their password
- The user creation API call right now only allows for a password to be set that is supplied by the API caller
- Creating a user with a random expired password from the API is a desireable feature for e.g. batch-adding users without handling password distribution
- This PR adds that feature

This is a remake of my [old PR](https://github.com/gitlabhq/gitlabhq/pull/4805) that was abandoned since things about how user registration/signup works were expected to change soon. Since it's been a year and the PR is still applicable, I'm resubmitting it. I've heavily polished and simplified it.

It simply adds a new parameter to the /users POST api call that allows to trigger identical behaviour to adding users from the admin panel: Setting the newly signed up user as already confirmed and with an expired password, resulting in a "You have been added to Gitlab, click here to set a password" email.

As a bonus, I've also fixed two tests for that API call that were succeeding for the wrong reasons.
