### PR TITLE
Use FileUtils to delete instead of File

### DIFF
--- a/spec/lib/gitlab/satellite/action_spec.rb
+++ b/spec/lib/gitlab/satellite/action_spec.rb
@@ -59,7 +59,7 @@ describe 'Gitlab::Satellite::Action' do
       called = false
 
       #set assumptions
-      File.rm(project.satellite.lock_file) unless !File.exists? project.satellite.lock_file
+      FileUtils.rm_f(project.satellite.lock_file)
 
       File.exists?(project.satellite.lock_file).should be_false
 


### PR DESCRIPTION
File.rm should be FileUtils.rm.  The test fails with an error if the satellite lock file exists.
