### PR TITLE
Added search wiki feature

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,7 +9,8 @@ class SearchController < ApplicationController
     @search_results = if @project
                         return access_denied! unless can?(current_user, :download_code, @project)
 
-                        unless %w(blobs notes issues merge_requests wiki_blobs).include?(@scope)
+                        unless %w(blobs notes issues merge_requests wiki_blobs).
+                                 include?(@scope)
                           @scope = 'blobs'
                         end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,7 +9,7 @@ class SearchController < ApplicationController
     @search_results = if @project
                         return access_denied! unless can?(current_user, :download_code, @project)
 
-                        unless %w(blobs notes issues merge_requests).include?(@scope)
+                        unless %w(blobs notes issues merge_requests wiki_blobs).include?(@scope)
                           @scope = 'blobs'
                         end
 

--- a/app/views/search/_project_filter.html.haml
+++ b/app/views/search/_project_filter.html.haml
@@ -23,3 +23,9 @@
       Comments
       .pull-right
         = @search_results.notes_count
+  %li{class: ("active" if @scope == 'wiki_blobs')}
+    = link_to search_filter_path(scope: 'wiki_blobs') do
+      Wiki
+      .pull-right
+        = @search_results.wiki_blobs_count
+

--- a/app/views/search/results/_wiki_blob.html.haml
+++ b/app/views/search/results/_wiki_blob.html.haml
@@ -1,0 +1,9 @@
+.blob-result
+  .file-holder
+    .file-title
+      = link_to project_wiki_path(@project, wiki_blob.filename) do
+        %i.icon-file
+        %strong
+          = wiki_blob.filename
+    .file-content.code.term
+      = render 'shared/file_hljs', blob: wiki_blob, first_line_number: wiki_blob.startline

--- a/lib/gitlab/project_search_results.rb
+++ b/lib/gitlab/project_search_results.rb
@@ -14,13 +14,15 @@ module Gitlab
         notes.page(page).per(per_page)
       when 'blobs'
         Kaminari.paginate_array(blobs).page(page).per(per_page)
+      when 'wiki_blobs'
+        Kaminari.paginate_array(wiki_blobs).page(page).per(per_page)
       else
         super
       end
     end
 
     def total_count
-      @total_count ||= issues_count + merge_requests_count + blobs_count + notes_count
+      @total_count ||= issues_count + merge_requests_count + blobs_count + notes_count + wiki_blobs_count
     end
 
     def blobs_count
@@ -31,6 +33,10 @@ module Gitlab
       @notes_count ||= notes.count
     end
 
+    def wiki_blobs_count
+      @wiki_blobs_count ||= wiki_blobs.count
+    end
+
     private
 
     def blobs
@@ -38,6 +44,14 @@ module Gitlab
         []
       else
         project.repository.search_files(query, repository_ref)
+      end
+    end
+
+    def wiki_blobs
+      if !project.wiki_enabled?
+        []
+      else
+        Repository.new(ProjectWiki.new(project).path_with_namespace).search_files(query)
       end
     end
 

--- a/lib/gitlab/project_search_results.rb
+++ b/lib/gitlab/project_search_results.rb
@@ -22,7 +22,7 @@ module Gitlab
     end
 
     def total_count
-      @total_count ||= issues_count + merge_requests_count + blobs_count + 
+      @total_count ||= issues_count + merge_requests_count + blobs_count +
                        notes_count + wiki_blobs_count
     end
 

--- a/lib/gitlab/project_search_results.rb
+++ b/lib/gitlab/project_search_results.rb
@@ -22,7 +22,8 @@ module Gitlab
     end
 
     def total_count
-      @total_count ||= issues_count + merge_requests_count + blobs_count + notes_count + wiki_blobs_count
+      @total_count ||= issues_count + merge_requests_count + blobs_count + 
+                       notes_count + wiki_blobs_count
     end
 
     def blobs_count
@@ -51,7 +52,8 @@ module Gitlab
       if !project.wiki_enabled?
         []
       else
-        Repository.new(ProjectWiki.new(project).path_with_namespace).search_files(query)
+        Repository.new(ProjectWiki.new(project).path_with_namespace).
+           search_files(query)
       end
     end
 


### PR DESCRIPTION
As a lot of people requested, I implemented the search in wiki pages.(again), hope this time I followed the style guid and contributing guidlines... 
Refers to:
http://feedback.gitlab.com/forums/176466-general/suggestions/4078088-add-wiki-search-function

Comments:
Since the structure of gitlab has massively improved since the last time, it was now much easier to implement the search feature. I simply added a new filter to project_filter called Wiki which calls the search engine with a new scope 'wiki_blobs'. This is evaluated in ProjectSearchResults, where a new method works straight on the ProjectWiki repository to search files.

New UI:
![image](https://cloud.githubusercontent.com/assets/4696860/4163659/0ee2e6dc-34ea-11e4-9b34-b143e1333184.png)

Affected files:
app/controllers/search_controller.rb
app/views/search/_project_filter.html.haml
 lib/gitlab/project_search_results.rb
New file:
app/views/search/results/_wiki_blob.html.haml
