### PR TITLE
Prevent graph spacing issue

### DIFF
--- a/app/models/network/graph.rb
+++ b/app/models/network/graph.rb
@@ -178,12 +178,6 @@ module Network
       space = find_free_space(time_range, 2, space_base)
       leaves.each do |l|
         l.spaces << space
-        # Also add space to parent
-        l.parents(@map).each do |parent|
-          if 0 < parent.space && parent.space < space
-            parent.spaces << space
-          end
-        end
       end
 
       # and mark it as reserved


### PR DESCRIPTION
As described in issue: https://github.com/gitlabhq/gitlabhq/issues/7505

Graph spacing doesn't work properly:
- Branch lines sometimes cross unnecessary
- Branch lines sometimes move to the left for no reason

The network graph is a lot easier to understand without the spacing and looks more like other git branch graphs.
