### PR TITLE
Change keyboard shortcut for activity to project

### DIFF
--- a/app/assets/javascripts/shortcuts_navigation.coffee
+++ b/app/assets/javascripts/shortcuts_navigation.coffee
@@ -3,7 +3,7 @@
 class @ShortcutsNavigation extends Shortcuts
   constructor: ->
     super()
-    Mousetrap.bind('g a', -> ShortcutsNavigation.findAndollowLink('.shortcuts-activity'))
+    Mousetrap.bind('g p', -> ShortcutsNavigation.findAndollowLink('.shortcuts-project'))
     Mousetrap.bind('g f', -> ShortcutsNavigation.findAndollowLink('.shortcuts-tree'))
     Mousetrap.bind('g c', -> ShortcutsNavigation.findAndollowLink('.shortcuts-commits'))
     Mousetrap.bind('g n', -> ShortcutsNavigation.findAndollowLink('.shortcuts-network'))

--- a/app/views/help/_shortcuts.html.haml
+++ b/app/views/help/_shortcuts.html.haml
@@ -78,9 +78,9 @@
               %tr
                 %td.shortcut 
                   .key g
-                  .key a
+                  .key p
                 %td
-                  Go to the activity feed
+                  Go to the project's activity feed
               %tr
                 %td.shortcut 
                   .key g

--- a/app/views/layouts/nav/_project.html.haml
+++ b/app/views/layouts/nav/_project.html.haml
@@ -1,6 +1,6 @@
 %ul.project-navigation
   = nav_link(path: 'projects#show', html_options: {class: "home"}) do
-    = link_to project_path(@project), title: 'Project', class: 'shortcuts-activity' do
+    = link_to project_path(@project), title: 'Project', class: 'shortcuts-project' do
       Project
   - if project_nav_tab? :files
     = nav_link(controller: %w(tree blob blame edit_tree new_tree)) do

--- a/features/project/shortcuts.feature
+++ b/features/project/shortcuts.feature
@@ -44,3 +44,9 @@ Feature: Project shortcuts
   Scenario: Navigate to wiki tab
     Given I press "g" and "w"
     Then the active main tab should be Wiki
+
+  @javascript
+  Scenario: Navigate to project feed
+    Given I visit my project's files page
+    Given I press "g" and "p"
+    Then the active main tab should be Home


### PR DESCRIPTION
#### What does this to?

It changes the shortcut to the project's activity feed from `a` to `p`.
This is needed, because the navbar has changed from `Activity` to `Project`.
