### PR TITLE
Do not remove repository_downloads_path

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -228,7 +228,7 @@ class Repository
 
   # Remove archives older than 2 hours
   def clean_old_archives
-    Gitlab::Popen.popen(%W(find #{Gitlab.config.gitlab.repository_downloads_path} -mmin +120 -delete))
+    Gitlab::Popen.popen(%W(find #{Gitlab.config.gitlab.repository_downloads_path}/* -mmin +120 -delete))
   end
 
   def branches_sorted_by(value)


### PR DESCRIPTION
git@git.host:/~$ find /some/repository_downloads_path
/some/repository_downloads_path
/some/repository_downloads_path/gitlab.git
/some/repository_downloads_path/gitlab.git/gitlab-30052823d6209520975eef8a1ff78ed8e0551bf9.zip

vs

git@git.host:/~$ find /some/repository_downloads_path/*
/some/repository_downloads_path/gitlab.git
/some/repository_downloads_path/gitlab.git/gitlab-30052823d6209520975eef8a1ff78ed8e0551bf9.zip
