### PR TITLE
Serialize service properties

### DIFF
--- a/app/models/project_services/assembla_service.rb
+++ b/app/models/project_services/assembla_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class AssemblaService < Service
   include HTTParty
 
+  prop_accessor :token, :subdomain
   validates :token, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/campfire_service.rb
+++ b/app/models/project_services/campfire_service.rb
@@ -5,19 +5,15 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class CampfireService < Service
+  prop_accessor :token, :subdomain, :room
   validates :token, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/ci_service.rb
+++ b/app/models/project_services/ci_service.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 # Base class for CI services

--- a/app/models/project_services/emails_on_push_service.rb
+++ b/app/models/project_services/emails_on_push_service.rb
@@ -5,19 +5,15 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class EmailsOnPushService < Service
+  prop_accessor :recipients
   validates :recipients, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/flowdock_service.rb
+++ b/app/models/project_services/flowdock_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require "flowdock-git-hook"
 
 class FlowdockService < Service
+  prop_accessor :token
   validates :token, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/gemnasium_service.rb
+++ b/app/models/project_services/gemnasium_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require "gemnasium/gitlab_service"
 
 class GemnasiumService < Service
+  prop_accessor :token, :api_key
   validates :token, :api_key, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/gitlab_ci_service.rb
+++ b/app/models/project_services/gitlab_ci_service.rb
@@ -5,19 +5,15 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  property    :text
 #
 
 class GitlabCiService < CiService
+  prop_accessor :project_url, :token
   validates :project_url, presence: true, if: :activated?
   validates :token, presence: true, if: :activated?
 

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class HipchatService < Service
   MAX_COMMITS = 3
 
+  prop_accessor :token, :room
   validates :token, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/pivotaltracker_service.rb
+++ b/app/models/project_services/pivotaltracker_service.rb
@@ -5,21 +5,17 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class PivotaltrackerService < Service
   include HTTParty
 
+  prop_accessor :token
   validates :token, presence: true, if: :activated?
 
   def title

--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -5,19 +5,15 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 class SlackService < Service
+  prop_accessor :room, :subdomain, :token
   validates :room, presence: true, if: :activated?
   validates :subdomain, presence: true, if: :activated?
   validates :token, presence: true, if: :activated?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,22 +5,19 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
-#
+#  properties  :text
 
 # To add new service you should build a class inherited from Service
 # and implement a set of methods
 class Service < ActiveRecord::Base
+  serialize :properties, JSON
+
   default_value_for :active, false
+  default_value_for :properties, {}
 
   belongs_to :project
   has_one :service_hook
@@ -62,5 +59,21 @@ class Service < ActiveRecord::Base
 
   def can_test?
     !project.empty_repo?
+  end
+
+  # Provide convenient accessor methods
+  # for each serialized property.
+  def self.prop_accessor(*args)
+    args.each do |arg|
+      class_eval %{
+        def #{arg}
+          properties['#{arg}']
+        end
+
+        def #{arg}=(value)
+          self.properties['#{arg}'] = value
+        end
+      }
+    end
   end
 end

--- a/db/migrate/20140907220153_serialize_service_properties.rb
+++ b/db/migrate/20140907220153_serialize_service_properties.rb
@@ -1,0 +1,35 @@
+class SerializeServiceProperties < ActiveRecord::Migration
+  def change
+    add_column :services, :properties, :text
+
+    associations =
+    {
+      AssemblaService:        [:token, :subdomain],
+      CampfireService:        [:token, :subdomain, :room],
+      EmailsOnPushService:    [:recipients],
+      FlowdockService:        [:token],
+      GemnasiumService:       [:api_key, :token],
+      GitlabCiService:        [:token, :project_url],
+      HipchatService:         [:token, :room],
+      PivotaltrackerService:  [:token],
+      SlackService:           [:subdomain, :token, :room],
+      JenkinsService:         [:token, :subdomain],
+      JiraService:            [:project_url, :username, :password,
+                               :api_version, :jira_issue_transition_id],
+    }
+
+    Service.all.each do |service|
+      associations[service.type.to_sym].each do |attribute|
+        service.send("#{attribute}=", service.attributes[attribute.to_s])
+      end
+      service.save!
+    end
+
+    remove_column :services, :project_url, :string
+    remove_column :services, :subdomain, :string
+    remove_column :services, :room, :string
+    remove_column :services, :recipients, :text
+    remove_column :services, :api_key, :string
+    remove_column :services, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140903115954) do
+ActiveRecord::Schema.define(version: 20140907220153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,16 +265,11 @@ ActiveRecord::Schema.define(version: 20140903115954) do
   create_table "services", force: true do |t|
     t.string   "type"
     t.string   "title"
-    t.string   "token"
-    t.integer  "project_id",                  null: false
+    t.integer  "project_id",                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "active",      default: false, null: false
-    t.string   "project_url"
-    t.string   "subdomain"
-    t.string   "room"
-    t.text     "recipients"
-    t.string   "api_key"
+    t.boolean  "active",     default: false, null: false
+    t.text     "properties"
   end
 
   add_index "services", ["project_id"], name: "index_services_on_project_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -165,7 +165,6 @@ FactoryGirl.define do
   factory :service do
     type ""
     title "GitLab CI"
-    token "x56olispAND34ng"
     project
   end
 

--- a/spec/models/assembla_service_spec.rb
+++ b/spec/models/assembla_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/flowdock_service_spec.rb
+++ b/spec/models/flowdock_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/gemnasium_service_spec.rb
+++ b/spec/models/gemnasium_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/gitlab_ci_service_spec.rb
+++ b/spec/models/gitlab_ci_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'

--- a/spec/models/slack_service_spec.rb
+++ b/spec/models/slack_service_spec.rb
@@ -5,16 +5,11 @@
 #  id          :integer          not null, primary key
 #  type        :string(255)
 #  title       :string(255)
-#  token       :string(255)
 #  project_id  :integer          not null
 #  created_at  :datetime
 #  updated_at  :datetime
 #  active      :boolean          default(FALSE), not null
-#  project_url :string(255)
-#  subdomain   :string(255)
-#  room        :string(255)
-#  recipients  :text
-#  api_key     :string(255)
+#  properties  :text
 #
 
 require 'spec_helper'


### PR DESCRIPTION
## What does this MR do?

Takes service 'properties' and serializes them in a single column. Anything that doesn't need to be queried directly and that may differ between different service types.

This is a straight across change - there are no UI changes or changes to the actual properties for a given service. That will come in other pull requests so this one stays simple and easy to review.
## Are there points in the code the reviewer needs to double check?

Please check/test the migration. It seems to work as far as I can tell. However, if something isn't right it could cause a lot of issues for users.

This doesn't appear to break any current tests (well, after some fixing) :smile:  Manual testing also shows identical behavior.
## Why was this MR needed?

Currently, any service type is limited to a number of attributes: `token`, `api_key`, `project_url`, `room`, and `subdomain`. 

When adding a new service the developer is faced with a decision to either work within the confines of the current attributes or create a new attribute. Creating a new attribute is overkill because not all services may use this attribute but it will be in the database anyway.

In the future this change could also improve user experience. For example, on some services users are forced to specify user/pass for a service in the `project_url`. This is ugly and unintuitive: `https://user:pass@service.example.com`. This also leads to lots of URL manipulation inside the service. After this change we could create properties on a whim: `user`, `pass`, and `project_url` and have a form field for each independently.
