### PR TITLE
set fail_timeout=0 as recommended by Unicorn

### DIFF
--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -28,7 +28,7 @@
 ##
 
 upstream gitlab {
-  server unix:/home/git/gitlab/tmp/sockets/gitlab.socket;
+  server unix:/home/git/gitlab/tmp/sockets/gitlab.socket fail_timeout=0;
 }
 
 ## Normal HTTP host

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -34,7 +34,7 @@
 ## See installation.md#using-https for additional HTTPS configuration details.
 
 upstream gitlab {
-  server unix:/home/git/gitlab/tmp/sockets/gitlab.socket;
+  server unix:/home/git/gitlab/tmp/sockets/gitlab.socket fail_timeout=0;
 }
 
 ## Normal HTTP host


### PR DESCRIPTION
Set's `fail_timeout=0` as recommended by http://unicorn.bogomips.org/Unicorn/Configurator.html#method-i-timeout when Unicorn is running behind nginx.

> For running Unicorn behind nginx, it is recommended to set `fail_timeout=0` for in your nginx configuration like this to have nginx always retry backends that may have had workers SIGKILL-ed due to timeouts.

From [Module ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server):

> `fail_timeout=time` sets
> - the time during which the specified number of unsuccessful attempts to communicate with the server should happen to consider the server unavailable;
> - and the period of time the server will be considered unavailable.
> 
> By default, the parameter is set to 10 seconds.

Courtesy of @phunehehe from https://github.com/gitlabhq/gitlabhq/issues/6621#issuecomment-44828050.
