### PR TITLE
Replacing invalid characters in LDAP username

### DIFF
--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -27,8 +27,8 @@ module Gitlab
               email: email,
               password: password,
               password_confirmation: password,
-            }  
-          else 
+            }
+          else
             opts = {
               extern_uid: uid,
               provider: provider,

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -21,7 +21,7 @@ module Gitlab
             extern_uid: uid,
             provider: provider,
             name: name,
-            username: username,
+            username: username.gsub( /[^\w\d\.-]/, "." ),
             email: email,
             password: password,
             password_confirmation: password,

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -19,6 +19,7 @@ module Gitlab
           password = Devise.friendly_token[0, 8].downcase
           
           if username.nil?
+          # Use the old behavior if no username is present
             opts = {
               extern_uid: uid,
               provider: provider,
@@ -29,7 +30,8 @@ module Gitlab
               password_confirmation: password,
             }
           else
-            opts = {
+          # Otherwise clean username with regex
+          opts = {
               extern_uid: uid,
               provider: provider,
               name: name,

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -17,7 +17,7 @@ module Gitlab
         def create(auth)
           @auth = auth
           password = Devise.friendly_token[0, 8].downcase
-          
+
           if username.nil?
           # Use the old behavior if no username is present
             opts = {

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -21,7 +21,7 @@ module Gitlab
             extern_uid: uid,
             provider: provider,
             name: name,
-            username: username.gsub( /[^\w\d\.-]/, "." ),
+            username: username.gsub(/[^\w\d\.-]/, '.'),
             email: email,
             password: password,
             password_confirmation: password,

--- a/lib/gitlab/oauth/user.rb
+++ b/lib/gitlab/oauth/user.rb
@@ -17,15 +17,28 @@ module Gitlab
         def create(auth)
           @auth = auth
           password = Devise.friendly_token[0, 8].downcase
-          opts = {
-            extern_uid: uid,
-            provider: provider,
-            name: name,
-            username: username.gsub(/[^\w\d\.-]/, '.'),
-            email: email,
-            password: password,
-            password_confirmation: password,
-          }
+          
+          if username.nil?
+            opts = {
+              extern_uid: uid,
+              provider: provider,
+              name: name,
+              username: username,
+              email: email,
+              password: password,
+              password_confirmation: password,
+            }  
+          else 
+            opts = {
+              extern_uid: uid,
+              provider: provider,
+              name: name,
+              username: username.gsub(/[^\w\d\.-]/, '.'),
+              email: email,
+              password: password,
+              password_confirmation: password,
+            }
+          end
 
           user = model.build_user(opts)
           user.skip_confirmation!


### PR DESCRIPTION
Allowing users with blank spaces in LDAP username to login / create a new user.
