### PR TITLE
change unicorn timeout to 300

### DIFF
--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -48,7 +48,7 @@ listen "127.0.0.1:8080", :tcp_nopush => true
 #
 # For more information see http://stackoverflow.com/a/21682112/752049
 #
-timeout 30
+timeout 300
 
 # feel free to point this anywhere accessible on the filesystem
 pid "/home/git/gitlab/tmp/pids/unicorn.pid"


### PR DESCRIPTION
I'm not entirely sure this is necessary however I've been getting lots of 502 errors recently that seem to relate to timeout values. Can someone elaborate on what other things could be affected by this timeout value being low or high?

Can someone explain why the Unicorn timeout does not match the `nginix` [`proxy_connect_timeout`](https://github.com/gitlabhq/gitlabhq/blob/0718d877b9b2ee9a8acd22e3c6d5abed2a5e9639/lib/support/nginx/gitlab#L64)?

Additionally can someone explain [`satellites` -> `timeout`](https://github.com/gitlabhq/gitlabhq/blob/0718d877b9b2ee9a8acd22e3c6d5abed2a5e9639/config/gitlab.yml.example#L201) in `gitlab/yml`?

/cc @Razer6 @randx @dosire 
