### PR TITLE
Fix serialize migration

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -17,7 +17,8 @@ class Service < ActiveRecord::Base
   serialize :properties, JSON
 
   default_value_for :active, false
-  default_value_for :properties, {}
+
+  after_initialize :initialize_properties
 
   belongs_to :project
   has_one :service_hook
@@ -30,6 +31,10 @@ class Service < ActiveRecord::Base
 
   def category
     :common
+  end
+
+  def initialize_properties
+    self.properties = {} if properties.nil?
   end
 
   def title

--- a/db/migrate/20140907220153_serialize_service_properties.rb
+++ b/db/migrate/20140907220153_serialize_service_properties.rb
@@ -1,6 +1,7 @@
 class SerializeServiceProperties < ActiveRecord::Migration
   def change
     add_column :services, :properties, :text
+    Service.reset_column_information
 
     associations =
     {
@@ -13,7 +14,7 @@ class SerializeServiceProperties < ActiveRecord::Migration
       HipchatService:         [:token, :room],
       PivotaltrackerService:  [:token],
       SlackService:           [:subdomain, :token, :room],
-      JenkinsService:         [:token, :subdomain],
+      JenkinsService:         [:project_url],
       JiraService:            [:project_url, :username, :password,
                                :api_version, :jira_issue_transition_id],
     }


### PR DESCRIPTION
This should fix all of the serialize migration issues. The key was `Service.reset_column_information` after adding the column.
