### PR TITLE
Add syntax colors to diffs in email-on-push notifications

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ v 7.3.0
   - Don't allow edit of system notes
   - Project wiki search (Ralf Seidler)
   - Enabled Shibboleth authentication support (Matus Banas)
+  - Add diff syntax highlighting in email-on-push service notifications
 
 v 7.2.1
   - Delete orphaned labels during label migration (James Brooks)

--- a/Gemfile
+++ b/Gemfile
@@ -183,6 +183,7 @@ gem "gon", '~> 5.0.0'
 gem 'nprogress-rails'
 gem 'request_store'
 gem "virtus"
+gem 'rouge'
 
 group :development do
   gem "annotate", "~> 2.6.0.beta2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,6 +665,7 @@ DEPENDENCIES
   redcarpet (~> 3.1.2)
   redis-rails
   request_store
+  rouge
   rspec-rails
   sanitize (~> 2.0)
   sass-rails (~> 4.0.2)

--- a/app/views/layouts/notify.html.haml
+++ b/app/views/layouts/notify.html.haml
@@ -3,19 +3,15 @@
     %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}
       %title
         GitLab
-  :css
-    img {
-      max-width: 100%;
-      height: auto;
-    }
-    p.details {
-      font-style:italic;
-      color:#777
-    }
-    .footer p {
-      font-size:small;
-      color:#777
-    }
+  :ruby
+    require 'rouge'
+    stock_style = 'p.details { font-style:italic; color:#777 }'
+    stock_style2 = '.footer p { font-size:small; color:#777 }'
+    haml_io.puts '<style>'
+    haml_io.puts stock_style
+    haml_io.puts stock_style2
+    haml_io.puts Rouge::Themes::Github.render(:scope => '.highlight')
+    haml_io.puts '</style>'
 
   %body
     %div.content

--- a/app/views/notify/repository_push_email.html.haml
+++ b/app/views/notify/repository_push_email.html.haml
@@ -20,8 +20,11 @@
       - else
         = diff.new_path || diff.old_path
     %hr
-    %pre
-      = diff.diff
+    :ruby
+      require 'rouge'
+      formatter = Rouge::Formatters::HTML.new(:css_class => 'highlight')
+      lexer = Rouge::Lexers::Diff.new
+      haml_io.puts formatter.format(lexer.lex(diff.diff))
     %br
 
 - if @compare.timeout


### PR DESCRIPTION
Closes Issue #6994 ... Diff syntax colors for email-on-push-service
Also closes feature request [5802256-add-color-to-diffs-in-email-on-push-service-to-html](http://feedback.gitlab.com/forums/176466-general/suggestions/5802256-add-color-to-diffs-in-email-on-push-service-to-htm)

![screenshot_mergereq](https://cloud.githubusercontent.com/assets/242848/4242251/d3f9ec34-39fb-11e4-9fc5-6813979598fe.png)

@oracle
@rodrigo-lima
