### PR TITLE
Cleanup MySQL database

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -1,0 +1,68 @@
+# From 7.3 to 7.4
+
+## GitLab 7.4 has not been released yet!
+
+This document currently just serves as a place to keep track of updates that will be needed for the 7.4 update.
+
+## Update config files
+
+* Add `collation: utf8_general_ci` to config/database.yml as seen in [config/database.yml.mysql](config/database.yml.mysql)
+
+## Optional optimizations for GitLab setups with MySQL databases
+
+Only applies if running MySQL database created with GitLab 6.7 or earlier. If you are not experiencing any issues you may not need the following instructions however following them will bring your database in line with the latest recommended installation configuration and help avoid future issues. Be sure to follow these directions exactly. These directions should be safe for any MySQL instance but to be sure take a current MySQL database backup beforehand.
+
+```
+# Secure your MySQL installation (added in GitLab 6.2)
+sudo mysql_secure_installation
+
+# Login to MySQL
+mysql -u root -p
+
+# do not type the 'mysql>', this is part of the prompt
+
+# Convert all tables to use the InnoDB storage engine (added in GitLab 6.8)
+SELECT CONCAT('ALTER TABLE gitlabhq_production.', table_name, ' ENGINE=InnoDB;') AS 'Copy & run these SQL statements:' FROM information_schema.tables WHERE table_schema = 'gitlabhq_production' AND `ENGINE` <> 'InnoDB' AND `TABLE_TYPE` = 'BASE TABLE';
+
+# If previous query returned results, copy & run all outputed SQL statements
+
+# Find MySQL users
+mysql> SELECT user FROM mysql.user WHERE user LIKE '%git%';
+
+# If git user exists and gitlab user does not exist 
+# you are done with the database cleanup tasks
+mysql> \q
+
+# If both users exist skip to Delete gitlab user
+
+# Create new user for GitLab (changed in GitLab 6.4)
+# change $password in the command below to a real password you pick
+mysql> CREATE USER 'git'@'localhost' IDENTIFIED BY '$password';
+
+# Grant the git user necessary permissions on the database
+mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER, LOCK TABLES ON `gitlabhq_production`.* TO 'git'@'localhost';
+
+# Delete the old gitlab user
+mysql> DELETE FROM mysql.user WHERE user='gitlab';
+
+# Quit the database session
+mysql> \q
+
+# Try connecting to the new database with the new user
+sudo -u git -H mysql -u git -p -D gitlabhq_production
+
+# Type the password you replaced $password with earlier
+
+# You should now see a 'mysql>' prompt
+
+# Quit the database session
+mysql> \q
+
+# Update database configuration details
+# See config/database.yml.mysql for latest recommended configuration details
+#   Remove the reaping_frequency setting line if it exists (removed in GitLab 6.8)
+#   Set production -> pool: 10 (updated in GitLab 5.3 & 6.2)
+#   Set production -> username: git
+#   Set production -> password: the password your replaced $password with earlier
+sudo -u git -H editor /home/git/gitlab/config/database.yml
+```


### PR DESCRIPTION
Addresses changes made to installation guide and config files but never applied in update process. Relevant changes to installation guide and config files were made in https://github.com/gitlabhq/gitlabhq/commit/cbb5b000c0c7593673683c08a402ea01a3a7f369, https://github.com/gitlabhq/gitlabhq/commit/498a4e6b0c8b7cc9266f71dd3337669a9442934d, https://github.com/gitlabhq/gitlabhq/commit/c33d5e16fe5f5dde4f270adaf7fb6fe5b9552018, https://github.com/gitlabhq/gitlabhq/commit/485162ec608784dc1cbafe70b3ba3201b0f74098#diff-e1059d0fa0437ffad94facff86210603, https://github.com/gitlabhq/gitlabhq/commit/72e2fe2c8a48fae4ec72d9d25b1742187afa0c92#diff-d1b4ff7de834bae6008dd49550413a6f, https://github.com/gitlabhq/gitlabhq/commit/5163a8fcb9cfd63435560fda00173b76df2ccc93#diff-e1059d0fa0437ffad94facff86210603, https://github.com/gitlabhq/gitlabhq/commit/993af5d0d2d596040195c4109c531c33deeac026#diff-e1059d0fa0437ffad94facff86210603, & https://github.com/gitlabhq/gitlabhq/commit/d3f5a0c67f029441537d4f64040bf6454b999120.

Doesn't make sense to add this to old install guides as most users have already passed those install guides and this doesn't address specific issues they would have encountered during upgrading.

Main purpose of these instructions are to get old installations more up to speed with latest recommended setup as per installation.md and database_mysql.md.
