### PR TITLE
Changed activity notes to display first MEANINGFUL line.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -187,13 +187,6 @@ module ApplicationHelper
     end
   end
 
-  def first_line(str)
-    lines = str.split("\n")
-    line = lines.first
-    line += "..." if lines.size > 1
-    line
-  end
-
   def broadcast_message
     BroadcastMessage.current
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -136,7 +136,7 @@ module EventsHelper
   end
 
   def event_note(text)
-    text = first_line(text)
+    text = first_line_in_markdown(text)
     text = truncate(text, length: 150)
     sanitize(markdown(text), tags: %w(a img b pre p))
   end

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -51,6 +51,14 @@ module GitlabMarkdownHelper
     @markdown.render(text).html_safe
   end
 
+  def first_line_in_markdown(text)
+    line = text.split("\n").detect do |i|
+      i.present? && markdown(i).present?
+    end
+    line += '...' unless line.nil?
+    line
+  end
+
   def render_wiki_content(wiki_page)
     if wiki_page.format == :markdown
       markdown(wiki_page.content)


### PR DESCRIPTION
This PR fixes displaying of notes in activity view, when a note starts with a markdown comment, like this:

```
[//]: This is a comment
```

Previous behavior: if comment is less than 150 chars, then an empty note would be displayed. Otherwise, the first 150 chars of comment would be displayed.
New behavior: 150 chars of first meaningful line will be displayed. Comments are ignored.
