### PR TITLE
Adding ability to configure webhook timeout via gitlab.yml

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ v 7.3.0
   - Project wiki search (Ralf Seidler)
   - Enabled Shibboleth authentication support (Matus Banas)
   - Zen mode (fullscreen) for issues/MR/notes (Robert Schilling)
+  - Add ability to configure webhook timeout via gitlab.yml (Wes Gurney)
 
 v 7.2.1
   - Delete orphaned labels during label migration (James Brooks)

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -23,7 +23,7 @@ class WebHook < ActiveRecord::Base
   default_value_for :merge_requests_events, false
 
   # HTTParty timeout
-  default_timeout 10
+  default_timeout Gitlab.config.gitlab.webhook_timeout
 
   validates :url, presence: true,
                   format: { with: URI::regexp(%w(http https)), message: "should be a valid url" }

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -80,6 +80,10 @@ production: &base
       snippets: false
       visibility_level: "private"  # can be "private" | "internal" | "public"
 
+    ## Webhook settings
+    # Number of seconds to wait for HTTP response after sending webhook HTTP POST request (default: 10)
+    # webhook_timeout: 10
+
     ## Repository downloads directory
     # When a user clicks e.g. 'Download zip' on a project, a temporary zip file is created in the following directory.
     # The default is 'tmp/repositories' relative to the root of the Rails app.
@@ -263,9 +267,9 @@ test:
     port: 80
 
     # When you run tests we clone and setup gitlab-shell
-    # In order to setup it correctly you need to specify 
+    # In order to setup it correctly you need to specify
     # your system username you use to run GitLab
-    # user: YOUR_USERNAME 
+    # user: YOUR_USERNAME
   satellites:
     path: tmp/tests/gitlab-satellites/
   gitlab_shell:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -92,6 +92,7 @@ Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['issue_closing_pattern'] = '([Cc]lose[sd]|[Ff]ixe[sd]) #(\d+)' if Settings.gitlab['issue_closing_pattern'].nil?
 Settings.gitlab['default_projects_features'] ||= {}
+Settings.gitlab['webhook_timeout'] ||= 10
 Settings.gitlab.default_projects_features['issues']         = true if Settings.gitlab.default_projects_features['issues'].nil?
 Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.gitlab.default_projects_features['merge_requests'].nil?
 Settings.gitlab.default_projects_features['wiki']           = true if Settings.gitlab.default_projects_features['wiki'].nil?


### PR DESCRIPTION
We need the ability to configure the webhook timeout.

Creating fresh merge request that is mergable.  

This is referenced from pull request #6971.
