### PR TITLE
Fix grammatical error in 'not merged changes' msg

### DIFF
--- a/app/views/projects/merge_requests/show/_state_widget.html.haml
+++ b/app/views/projects/merge_requests/show/_state_widget.html.haml
@@ -13,7 +13,7 @@
       %h4
         Closed by #{link_to_member(@project, @merge_request.closed_event.author, avatar: false)}
         #{time_ago_with_tooltip(@merge_request.closed_event.created_at)}
-      %p Changes was not merged into target branch
+      %p Changes were not merged into target branch
 
     - if @merge_request.merged?
       %h4


### PR DESCRIPTION
Not quite an English Language expert, but should't it be "changes were" instead of "changes was" ?
