### PR TITLE
More information in merge request hook

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -88,6 +88,21 @@ class Commit
     description.present?
   end
 
+  def hook_attrs(project)
+    path_with_namespace = project.path_with_namespace
+
+    {
+      id: id,
+      message: safe_message,
+      timestamp: committed_date.xmlschema,
+      url: "#{Gitlab.config.gitlab.url}/#{path_with_namespace}/commit/#{id}",
+      author: {
+        name: author_name,
+        email: author_email
+      }
+    }
+  end
+
   # Discover issues should be closed when this commit is pushed to a project's
   # default branch.
   def closes_issues project

--- a/app/models/concerns/issuable.rb
+++ b/app/models/concerns/issuable.rb
@@ -134,7 +134,7 @@ module Issuable
   def to_hook_data
     {
       object_kind: self.class.name.underscore,
-      object_attributes: self.attributes
+      object_attributes: hook_attrs
     }
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -48,6 +48,10 @@ class Issue < ActiveRecord::Base
     state :closed
   end
 
+  def hook_attrs
+    attributes
+  end
+
   # Mentionable overrides.
 
   def gfm_reference

--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -211,6 +211,20 @@ class MergeRequest < ActiveRecord::Base
     Gitlab::Satellite::MergeAction.new(current_user, self).format_patch
   end
 
+  def hook_attrs
+    attrs = {
+      source: source_project.hook_attrs,
+      target: target_project.hook_attrs,
+      last_commit: nil
+    }
+
+    unless last_commit.nil?
+      attrs.merge!(last_commit: last_commit.hook_attrs(source_project))
+    end
+
+    attributes.merge!(attrs)
+  end
+
   def for_fork?
     target_project != source_project
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -544,6 +544,16 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def hook_attrs
+    {
+      name: name,
+      ssh_url: ssh_url_to_repo,
+      http_url: http_url_to_repo,
+      namespace: namespace.name,
+      visibility_level: visibility_level
+    }
+  end
+
   # Reset events cache related to this project
   #
   # Since we do cache @event we need to reset cache in special cases:

--- a/app/services/git_push_service.rb
+++ b/app/services/git_push_service.rb
@@ -150,16 +150,7 @@ class GitPushService
     # will be passed as post receive hook data.
     #
     push_commits_limited.each do |commit|
-      data[:commits] << {
-        id: commit.id,
-        message: commit.safe_message,
-        timestamp: commit.committed_date.xmlschema,
-        url: "#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}/commit/#{commit.id}",
-        author: {
-          name: commit.author_name,
-          email: commit.author_email
-        }
-      }
+      data[:commits] << commit.hook_attrs(project)
     end
 
     data

--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -109,7 +109,31 @@ Triggered when a new merge request is created or an existing merge request was u
     "merge_status": "unchecked",
     "target_project_id": 14,
     "iid": 1,
-    "description": ""
+    "description": "",
+    "source": {
+      "name": "awesome_project",
+      "ssh_url": "ssh://git@example.com/awesome_space/awesome_project.git",
+      "http_url": "http://example.com/awesome_space/awesome_project.git",
+      "visibility_level": 20,
+      "namespace": "awesome_space"
+    },
+    "target": {
+      "name": "awesome_project",
+      "ssh_url": "ssh://git@example.com/awesome_space/awesome_project.git",
+      "http_url": "http://example.com/awesome_space/awesome_project.git",
+      "visibility_level": 20,
+      "namespace": "awesome_space"
+    },
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
**What does this MR do?**
This MR allow send more information about merge request via web hook: source project, target project and last commit.

Hook example:

``` json
{
  "object_kind": "merge_request",
  "object_attributes": {
    "id": 99,
    "target_branch": "master",
    "source_branch": "ms-viewport",
    "source_project_id": 14,
    "author_id": 51,
    "assignee_id": 6,
    "title": "MS-Viewport",
    "created_at": "2013-12-03T17:23:34Z",
    "updated_at": "2013-12-03T17:23:34Z",
    "st_commits": null,
    "st_diffs": null,
    "milestone_id": null,
    "state": "opened",
    "merge_status": "unchecked",
    "target_project_id": 14,
    "iid": 1,
    "description": "",
    "source": {
      "name": "awesome_project",
      "ssh_url": "ssh://git@example.com/awesome_space/awesome_project.git",
      "http_url": "http://example.com/awesome_space/awesome_project.git",
      "visibility_level": 20,
      "namespace": "awesome_space"
    },
    "target": {
      "name": "awesome_project",
      "ssh_url": "ssh://git@example.com/awesome_space/awesome_project.git",
      "http_url": "http://example.com/awesome_space/awesome_project.git",
      "visibility_level": 20,
      "namespace": "awesome_space"
    },
    "last_commit": {
      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
      "message": "fixed readme",
      "timestamp": "2012-01-03T23:36:29+02:00",
      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
      "author": {
        "name": "GitLab dev user",
        "email": "gitlabdev@dv6700.(none)"
      }
    }
  }
}
```

Was also affected by a piece of code responsible for the push event, as now has a certain common code base with Merga request

**Are there points in the code the reviewer needs to double check?**
- https://github.com/Bugagazavr/gitlabhq/blob/hooks/app/models/merge_request.rb#L211-L223
- https://github.com/Bugagazavr/gitlabhq/blob/hooks/app/services/git_push_service.rb#L154

**Why was this MR needed?**
- For many Continius Integration services, because now to get last commit sha, source remote ( if source is fork ) need work with API.
- GitLab doesn't have API to get last commits related with current PR, only project/branch.
- Also, I need this functionality to allow Drone to work with GitLab Merge Requests ( https://github.com/drone/drone/blob/exp/plugin/remote/gitlab/gitlab.go#L159-L162 )
