### PR TITLE
Proof of concept: recommend that user adds README, LICENSE, and .gitignore files

### DIFF
--- a/app/views/projects/empty.html.haml
+++ b/app/views/projects/empty.html.haml
@@ -1,6 +1,8 @@
 = render "home_panel"
 
 %div.git-empty
+  %p.slead
+    We recommend every repository include #{link_to "README", project_path(@project)/new/master?file_name=README.md}, #{link_to "LICENSE", project_path(@project)/new/master?file_name=LICENSE.md}, and #{link_to ".gitignore", project_path(@project)/new/master?file_name=.gitignore} files. You may also be interested in including #{link_to ".gitattributes", project_path(@project)/new/master?file_name=.gitattributes}, #{link_to "CONTRIBUTING", project_path(@project)/new/master?file_name=CONTRIBUTING.md}, and #{link_to "VERSION", project_path(@project)/new/master?file_name=VERSION} files.
   %fieldset
     %legend Git global setup:
     %pre.dark


### PR DESCRIPTION
Would like to see the empty repo page recommend that the user add README, LICENSE, and .gitignore files.

![image](https://cloud.githubusercontent.com/assets/1192780/4299119/980d139c-3e31-11e4-87d5-4f173541e013.png)

What's needed to make this happen:
- [x] GitLab needs to be able to init repo without someone pushing an inited repo (started at https://github.com/gitlabhq/gitlabhq/pull/7069 & https://github.com/gitlabhq/gitlab-shell/pull/153)
- [x] `/new/master?file_name=README.md` needs to open an editor to create a new file of the specified name
- [x] Visiting `/new/master?file_name=README.md` in an empty repo should return the new file page rather than a 404
- [x] Selecting commit from `/new/master?file_name=README.md` when the repo is empty should init the repo and make the commit
- [ ] Test haml code (I just threw this together without testing the links) and styling

Eventually it would be nice to have these key files created via the add project page. README could create a blank file with the project file and LICENSE & .gitignore could be dropdowns pulling info from http://choosealicense.com/ & https://github.com/github/gitignore.
