### PR TITLE
Use ruby1.8 compatible syntax for hooks-receiver service

### DIFF
--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -124,12 +124,14 @@ Save the following file as `print_http_body.rb`.
 ```ruby
 require 'webrick'
 
-server = WEBrick::HTTPServer.new(Port: ARGV.first)
+server = WEBrick::HTTPServer.new(:Port => ARGV.first)
 server.mount_proc '/' do |req, res|
   puts req.body
 end
 
-trap 'INT' do server.shutdown end
+trap 'INT' do 
+  server.shutdown 
+end
 server.start
 ```
 


### PR DESCRIPTION
Adds support for ruby 1.8 by using the hash rocket syntax for port creation. Maintains ruby 1.9 and ruby 2.0 compatibility.
Fixes incorrect do .. else. They either need to be surrounded in {} if on 1 line, or moved to separate lines.
Additional information http://stackoverflow.com/questions/25899476/webrick-gives-error-unexpected-expecting-end
