### PR TITLE
remove rack attack middleware update

### DIFF
--- a/doc/update/7.2-to-7.3.md
+++ b/doc/update/7.2-to-7.3.md
@@ -99,12 +99,6 @@ git diff 7-2-stable:config/gitlab.yml.example 7-3-stable:config/gitlab.yml.examp
 * HTTP setups: Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab but with your settings.
 * HTTPS setups: Make `/etc/nginx/sites-available/nginx-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab-ssl but with your setting
 
-Update rack attack middleware config
-
-```
-sudo -u git -H cp config/initializers/rack_attack.rb.example config/initializers/rack_attack.rb
-```
-
 ### 7. Start application
 
     sudo service gitlab start


### PR DESCRIPTION
Hasn't changed since 7.2 release: https://github.com/gitlabhq/gitlabhq/commits/master/config/initializers/rack_attack.rb.example
