### PR TITLE
update rack_attack link to history page

### DIFF
--- a/doc/release/monthly.md
+++ b/doc/release/monthly.md
@@ -113,7 +113,7 @@ Check if any of these changed since last release:
 - <https://gitlab.com/gitlab-org/gitlab-ce/commits/master/config/unicorn.rb.example>
 - <https://gitlab.com/gitlab-org/gitlab-ce/commits/master/config/database.yml.mysql>
 - <https://gitlab.com/gitlab-org/gitlab-ce/commits/master/config/database.yml.postgresql>
-- <https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/initializers/rack_attack.rb.example>
+- <https://gitlab.com/gitlab-org/gitlab-ce/commits/master/config/initializers/rack_attack.rb.example>
 - <https://gitlab.com/gitlab-org/gitlab-ce/commits/master/config/resque.yml.example>
 
 #### 8. Need to update init script?


### PR DESCRIPTION
For release process look at history page to see if file has been updated. Replaces https://github.com/gitlabhq/gitlabhq/pull/7766.

/cc @dosire 
