### PR TITLE
[UI] Set textarea resize:vertical by default.

### DIFF
--- a/app/assets/stylesheets/generic/forms.scss
+++ b/app/assets/stylesheets/generic/forms.scss
@@ -1,3 +1,7 @@
+textarea {
+  resize: vertical;
+}
+
 input[type='search'].search-text-input {
   background-image: image-url("icon-search.png");
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/sections/commits.scss
+++ b/app/assets/stylesheets/sections/commits.scss
@@ -244,7 +244,6 @@ li.commit {
     font-family: inherit;
     padding-left: $left;
     position: relative;
-    resize: vertical;
     z-index: 2;
   }
 }


### PR DESCRIPTION
Horizontal resize breaks every textarea in of the UI should never be allowed. 

Also, it is hard for users to resize vertically without resizing horizontally, so they are likely to do it by mistake.

This change intends to affect every textarea of the app.

This is an extension of: https://github.com/gitlabhq/gitlabhq/pull/7483

Sample breaks:

With a float right as in milestone:

![screenshot from 2014-09-19 08 59 38 gitlab text resize milestone](https://cloud.githubusercontent.com/assets/1429315/4331905/374fb996-3fcc-11e4-92d8-6945dc1565de.png)

If you stretch the textarea horizontally and then shrink the browser window, it does not resize and falls out:

![screenshot from 2014-09-19 09 00 54 gitlab textarea resize comment out of window](https://cloud.githubusercontent.com/assets/1429315/4331920/747e97ba-3fcc-11e4-900a-95738a73aea2.png)

And in general, it is ugly having the textarea not align with the rest of the UI:

![screenshot from 2014-09-19 09 01 33 gitlab textarea resize issue small](https://cloud.githubusercontent.com/assets/1429315/4331932/aa4058ca-3fcc-11e4-809c-7f271a327222.png)

Burninate!
