### PR TITLE
tweak title to match other setting tab titles

### DIFF
--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -3,7 +3,7 @@
   .project-edit-content
     %div
       %h3.page-title
-        Project settings:
+        Project settings
       %p.light Some settings, such as "Transfer Project", are hidden inside the danger area below.
       %hr
       .panel-body


### PR DESCRIPTION
Changes `Project settings:` title to `Project settings` to match format of other settings tab titles.
