### PR TITLE
improve project members page

### DIFF
--- a/app/views/projects/team_members/index.html.haml
+++ b/app/views/projects/team_members/index.html.haml
@@ -1,5 +1,5 @@
 %h3.page-title
-  Users with access to this project
+  Project members
 
   - if can? current_user, :admin_team_member, @project
     %span.pull-right
@@ -9,8 +9,7 @@
         Import members
 
 %p.light
-  Read more about project permissions
-  %strong= link_to "here", help_page_path("permissions", "permissions"), class: "vlink"
+  Manage project members and #{link_to "permissions", help_page_path("permissions", "permissions"), class: "vlink"}
 = render "team", members: @users_projects
 - if @group
   = render "group_members"

--- a/app/views/projects/team_members/index.html.haml
+++ b/app/views/projects/team_members/index.html.haml
@@ -4,9 +4,9 @@
   - if can? current_user, :admin_team_member, @project
     %span.pull-right
       = link_to new_project_team_member_path(@project), class: "btn btn-new btn-grouped", title: "New project member" do
-        New project member
+        New Project Member
       = link_to import_project_team_members_path(@project), class: "btn btn-grouped", title: "Import members from another project" do
-        Import members
+        Import Members
 
 %p.light
   Manage project members and #{link_to "permissions", help_page_path("permissions", "permissions"), class: "vlink"}


### PR DESCRIPTION
- Improve project members page by changing title to match format of other settings tabs. 
- Update subtitle to be more useful and remove the `here` reference. Click-here type links are a bad web development practice.
