### PR TITLE
Add tag push events to project hook api

### DIFF
--- a/app/models/hooks/web_hook.rb
+++ b/app/models/hooks/web_hook.rb
@@ -21,6 +21,7 @@ class WebHook < ActiveRecord::Base
   default_value_for :push_events, true
   default_value_for :issues_events, false
   default_value_for :merge_requests_events, false
+  default_value_for :tag_push_events, false
 
   # HTTParty timeout
   default_timeout Gitlab.config.gitlab.webhook_timeout

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -447,6 +447,7 @@ Parameters:
 - `push_events` - Trigger hook on push events
 - `issues_events` - Trigger hook on issues events
 - `merge_requests_events` - Trigger hook on merge_requests events
+- `tag_push_events` - Trigger hook on push_tag events
 
 ### Edit project hook
 
@@ -464,6 +465,7 @@ Parameters:
 - `push_events` - Trigger hook on push events
 - `issues_events` - Trigger hook on issues events
 - `merge_requests_events` - Trigger hook on merge_requests events
+- `tag_push_events` - Trigger hook on push_tag events
 
 ### Delete project hook
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -30,7 +30,8 @@ module API
     end
 
     class ProjectHook < Hook
-      expose :project_id, :push_events, :issues_events, :merge_requests_events
+      expose :project_id, :push_events
+      expose :issues_events, :merge_requests_events, :tag_push_events
     end
 
     class ForkedFromProject < Grape::Entity

--- a/lib/api/project_hooks.rb
+++ b/lib/api/project_hooks.rb
@@ -38,7 +38,13 @@ module API
       #   POST /projects/:id/hooks
       post ":id/hooks" do
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
         @hook = user_project.hooks.new(attrs)
 
         if @hook.save
@@ -62,7 +68,13 @@ module API
       put ":id/hooks/:hook_id" do
         @hook = user_project.hooks.find(params[:hook_id])
         required_attributes! [:url]
-        attrs = attributes_for_keys [:url, :push_events, :issues_events, :merge_requests_events]
+        attrs = attributes_for_keys [
+          :url,
+          :push_events,
+          :issues_events,
+          :merge_requests_events,
+          :tag_push_events
+        ]
 
         if @hook.update_attributes attrs
           present @hook, with: Entities::ProjectHook


### PR DESCRIPTION
**What does this MR do?**
Allow add push tag event via API
**Are there points in the code the reviewer needs to double check?**
No
**Why was this MR needed?**
Catch tag push event on external services to build release
