### PR TITLE
update public snippets subtitle

### DIFF
--- a/app/views/snippets/index.html.haml
+++ b/app/views/snippets/index.html.haml
@@ -8,7 +8,7 @@
       My snippets
 
 %p.light
-  Public snippets created by you and other users are listed here
+  Public snippets created by you and other users.
 
 %hr
 = render 'snippets'


### PR DESCRIPTION
Remove unnecessary `are listed here` wording.
