### PR TITLE
Fix link_to_reply_diff.

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -69,9 +69,8 @@ module NotesHelper
 
     link_to "javascript:;", class: "btn reply-btn js-discussion-reply-button",
       data: data, title: "Add a reply" do
-      link_text = ""
-      link_text < content_tag(:i, nil, class: 'icon-comment')
-      link_text << "Reply"
-      end
+      link_text = content_tag(:i, nil, class: 'icon-comment')
+      link_text << ' Reply'
+    end
   end
 end


### PR DESCRIPTION
Came from a typo `<` instead of `<<`.

@randx consider using https://github.com/scrooloose/syntastic and `gem install ruby-lint`: it put a huge yellow marker next to that line saying statement without effect. (does some false positives too, but I think it's worth it).

Before:

![screenshot from 2014-09-19 14 06 51 gitlab reply diff before](https://cloud.githubusercontent.com/assets/1429315/4334966/5e524ca0-3ff6-11e4-843c-8692ac2291ed.png)

After:

![screenshot from 2014-09-19 14 06 32 gitlab reply diff](https://cloud.githubusercontent.com/assets/1429315/4334970/6a85a7d8-3ff6-11e4-8ef5-32d728800f79.png)
