### PR TITLE
Improve zen mode internals.

### DIFF
--- a/app/assets/javascripts/zen_mode.js.coffee
+++ b/app/assets/javascripts/zen_mode.js.coffee
@@ -1,13 +1,12 @@
 class @ZenMode
   @fullscreen_prefix = 'fullscreen_'
-  @ESC = 27
 
   constructor: ->
     @active_zen_area = null
     @active_checkbox = null
 
     $('body').on 'change', '.zennable input[type=checkbox]', (e) =>
-      checkbox = e.currentTarget;
+      checkbox = e.currentTarget
       if checkbox.checked
         Mousetrap.pause()
         @udpateActiveZenArea(checkbox)
@@ -15,8 +14,7 @@ class @ZenMode
         @exitZenMode()
 
     $(document).on 'keydown', (e) =>
-      console.log("esc")
-      if e.keyCode is ZenMode.ESC
+      if e.keyCode is $.ui.keyCode.ESCAPE
         @exitZenMode()
 
     $(window).on 'hashchange', @updateZenModeFromLocationHash
@@ -27,7 +25,7 @@ class @ZenMode
     @active_zen_area = @active_checkbox.parent().find('textarea')
     @active_zen_area.focus()
     window.location.hash = ZenMode.fullscreen_prefix + @active_checkbox.prop('id')
-  
+
   exitZenMode: =>
     if @active_zen_area isnt null
       Mousetrap.unpause()
@@ -48,4 +46,4 @@ class @ZenMode
     if checkbox
       @udpateActiveZenArea(checkbox)
     else
-      @exitZenMode()      
+      @exitZenMode()


### PR DESCRIPTION
- remove the `console`. Probably for testing. It shows up on my `rspec` and spinach, cluttering them.
- ESC exists on jQuery UI.
- remove trailing whitespace. Use Vim with http://stackoverflow.com/questions/4617059/showing-trailing-spaces-in-vim
- remove `;`. Becomes bright red on Vim with https://github.com/kchmck/vim-coffee-script/

cc @Razer6 
