### PR TITLE
Adds support for ruby 1.8 in webhook example

### DIFF
--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -124,12 +124,14 @@ Save the following file as `print_http_body.rb`.
 ```ruby
 require 'webrick'
 
-server = WEBrick::HTTPServer.new(Port: ARGV.first)
+server = WEBrick::HTTPServer.new(:Port => ARGV.first)
 server.mount_proc '/' do |req, res|
   puts req.body
 end
 
-trap 'INT' do server.shutdown end
+trap 'INT' do 
+  server.shutdown 
+end
 server.start
 ```
 


### PR DESCRIPTION
By using the hash rocket syntax, the web hook will work on older versions of ruby (1.8) in addition to 1.9, 2.0 ect..
Moves do .. end to separate lines for ruby-lint.

Additional Information:
http://stackoverflow.com/questions/25899476/webrick-gives-error-unexpected-expecting-end
https://github.com/spuder/r10k_gitlab_webhook
