### PR TITLE
Factor zen mode.

### DIFF
--- a/app/assets/stylesheets/generic/issuable.scss
+++ b/app/assets/stylesheets/generic/issuable.scss
@@ -1,0 +1,9 @@
+/**
+ * Styles that apply to both issues and merge requests.
+ */
+
+.issue-form, .merge-request-form {
+  .description {
+    height: 20em;
+  }
+}

--- a/app/views/projects/_issuable_form.html.haml
+++ b/app/views/projects/_issuable_form.html.haml
@@ -7,12 +7,8 @@
 .form-group.issuable-description
   = f.label :description, 'Description', class: 'control-label'
   .col-sm-10
-    .zennable
-      %input#zen-toggle-comment{ tabindex: '-1', type: 'checkbox' }
-      .zen-backdrop
-        = f.text_area :description, rows: 14, class: 'form-control js-gfm-input markdown-area', placeholder: 'Leave a comment'
-        %label{ for: 'zen-toggle-comment', class: 'expand' } Edit in fullscreen
-        %label{ for: 'zen-toggle-comment', class: 'collapse' }
+    = render 'projects/zen', f: f, attr: :description,
+                             classes: 'description form-control'
     .col-sm-12.hint
       .pull-left
         Parsed with

--- a/app/views/projects/_zen.html.haml
+++ b/app/views/projects/_zen.html.haml
@@ -1,0 +1,7 @@
+.zennable
+  %input#zen-toggle-comment{ tabindex: '-1', type: 'checkbox' }
+  .zen-backdrop
+    - classes << ' js-gfm-input markdown-area'
+    = f.text_area attr, class: classes, placeholder: 'Leave a comment'
+    %label{ for: 'zen-toggle-comment', class: 'expand' } Edit in fullscreen
+    %label{ for: 'zen-toggle-comment', class: 'collapse' }

--- a/app/views/projects/merge_requests/_new_submit.html.haml
+++ b/app/views/projects/merge_requests/_new_submit.html.haml
@@ -21,12 +21,8 @@
       .form-group
         .light
           = f.label :description, "Description"
-        .zennable
-          %input#zen-toggle-comment{ tabindex: '-1', type: 'checkbox' }
-          .zen-backdrop
-            = f.text_area :description, class: 'form-control js-gfm-input markdown-area', rows: 10, placeholder: 'Leave a comment'
-            %label{ for: 'zen-toggle-comment', class: 'expand' } Edit in fullscreen
-            %label{ for: 'zen-toggle-comment', class: 'collapse' }
+        = render 'projects/zen', f: f, attr: :description,
+                                 classes: 'description form-control'
         .clearfix.hint
           .pull-left Description is parsed with #{link_to "GitLab Flavored Markdown", help_page_path("markdown", "markdown"), target: '_blank'}.
           .pull-right Attach images (JPG, PNG, GIF) by dragging & dropping or #{link_to "selecting them", '#', class: 'markdown-selector' }.

--- a/app/views/projects/notes/_form.html.haml
+++ b/app/views/projects/notes/_form.html.haml
@@ -14,13 +14,8 @@
         Preview
   %div
     .note-write-holder
-      .zennable
-        %input#zen-toggle-comment{ tabindex: '-1', type: 'checkbox' }
-        .zen-backdrop
-          = f.text_area :note, size: 255, class: 'note_text js-note-text js-gfm-input markdown-area', placeholder: 'Leave a comment'
-          %label{ for: 'zen-toggle-comment', class: 'expand' } Edit in fullscreen
-          %label{ for: 'zen-toggle-comment', class: 'collapse' }
-
+      = render 'projects/zen', f: f, attr: :note,
+                               classes: 'note_text js-note-text'
       .light.clearfix
         .pull-left Comments are parsed with #{link_to "GitLab Flavored Markdown", help_page_path("markdown", "markdown"),{ target: '_blank', tabindex: -1 }}
         .pull-right Attach images (JPG, PNG, GIF) by dragging &amp; dropping or #{link_to "selecting them", '#', class: 'markdown-selector', tabindex: -1 }.


### PR DESCRIPTION
Almost the same code was on 3 different places. 

Minor UI change: both new issue and merge request description textarea are now the same size. They were different sizes, so I picked an intermediate new size. The change is almost unnoticeable.

The pages that could be affected are: new / edit issue and merge request, diff notes and comments.

This continues the move for form DRYness as in https://github.com/gitlabhq/gitlabhq/pull/7678

cc. @Razer6 if you get the time please check that I didn't break the feature =) A good indicator of non-DRYness are strings shown on the UI: when I saw that there were two occurrences of "Edit in fullscreen", I immediately `git grep -C2 'Edit in` and found this opportunity for DRYing.
