### PR TITLE
Remove ununsed CONTRIBUTING link on edit MR form.

### DIFF
--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -1,14 +1,4 @@
 = form_for [@project, @merge_request], html: { class: "merge-request-form form-horizontal" } do |f|
-  .row
-    .col-sm-2
-    .col-sm-10
-      - if @repository.contribution_guide && !@merge_request.persisted?
-        - contribution_guide_url = project_blob_path(@project, tree_join(@repository.root_ref, @repository.contribution_guide.name))
-        .alert.alert-info
-          Please review the
-          %strong #{link_to "guidelines for contribution", contribution_guide_url}
-          to this repository.
-
   .merge-request-form-info
     = render 'projects/issuable_form', f: f, issuable: @merge_request
     .form-group


### PR DESCRIPTION
The code is never reached because the new and edit MR forms have diverged,
and the CONTRIBUTING link is not shown when editing MRs (because of the `!@merge_request.persisted?`).

Dead code :skull:
