### PR TITLE
Factor issue and MR edit form error list.

### DIFF
--- a/app/views/projects/_issuable_form.html.haml
+++ b/app/views/projects/_issuable_form.html.haml
@@ -1,3 +1,10 @@
+- if issuable.errors.any?
+  .row
+    .col-sm-10.col-sm-offset-2
+      .alert.alert-danger
+        - issuable.errors.full_messages.each do |msg|
+          %span= msg
+          %br
 .form-group
   = f.label :title, class: 'control-label' do
     %strong= 'Title *'

--- a/app/views/projects/issues/_form.html.haml
+++ b/app/views/projects/issues/_form.html.haml
@@ -9,13 +9,6 @@
           = "Please review the <strong>#{link_to "guidelines for contribution", contribution_guide_url}</strong> to this repository.".html_safe
 
   = form_for [@project, @issue], html: { class: 'form-horizontal issue-form' } do |f|
-    -if @issue.errors.any?
-      .row
-        .col-sm-10.col-sm-offset-2
-          .alert.alert-danger
-            - @issue.errors.full_messages.each do |msg|
-              %span= msg
-              %br
     = render 'projects/issuable_form', f: f, issuable: @issue
     .form-group
       = f.label :label_ids, class: 'control-label' do

--- a/app/views/projects/merge_requests/_form.html.haml
+++ b/app/views/projects/merge_requests/_form.html.haml
@@ -9,11 +9,6 @@
           %strong #{link_to "guidelines for contribution", contribution_guide_url}
           to this repository.
 
-      -if @merge_request.errors.any?
-        .alert.alert-danger
-          - @merge_request.errors.full_messages.each do |msg|
-            %div= msg
-
   .merge-request-form-info
     = render 'projects/issuable_form', f: f, issuable: @merge_request
     .form-group


### PR DESCRIPTION
Direct continuation to https://github.com/gitlabhq/gitlabhq/pull/7678

This one factors the error messages.

Note: I am unable to view the error messages, because the only thing that could generate an error, an empty title, is not allowed by the browser because of the "required: true", so I could not test it the CSS looks good.

If anyone knows of a way to do this test, please tell me.

In any case, that is basically dead code, and now it is factored dead code.
