### PR TITLE
Prevent default action when closing zen mode

### DIFF
--- a/app/assets/javascripts/zen_mode.js.coffee
+++ b/app/assets/javascripts/zen_mode.js.coffee
@@ -16,6 +16,7 @@ class @ZenMode
     $(document).on 'keydown', (e) =>
       if e.keyCode is $.ui.keyCode.ESCAPE
         @exitZenMode()
+        e.preventDefault()
 
     $(window).on 'hashchange', @updateZenModeFromLocationHash
 


### PR DESCRIPTION
Otherwise `ESC` closes for example windows fullscreen mode on OSX when exiting Zen mode.
