### PR TITLE
update gitlab shell to 1.9.8 for gitlab 7.2.2

### DIFF
--- a/doc/update/7.1-to-7.2.md
+++ b/doc/update/7.1-to-7.2.md
@@ -46,7 +46,7 @@ sudo -u git -H git checkout 7-2-stable-ee
 ```bash
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
-sudo -u git -H git checkout v1.9.7
+sudo -u git -H git checkout v1.9.8
 ```
 
 ### 4. Install new system dependencies


### PR DESCRIPTION
As committed in https://github.com/gitlabhq/gitlabhq/commit/873acfd9aa54e801d5786c32b05c4f8ad21af72a GitLab 7.2.2 requires GitLab Shell 1.9.8. Fixes https://github.com/gitlabhq/gitlabhq/issues/7806.
