### PR TITLE
update gitlab shell to 1.9.8 for gitlab 7.2.2

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -238,7 +238,7 @@ GitLab Shell is an SSH access and repository management software developed speci
     cd /home/git/gitlab
 
     # Run the installation task for gitlab-shell (replace `REDIS_URL` if needed):
-    sudo -u git -H bundle exec rake gitlab:shell:install[v1.9.7] REDIS_URL=redis://localhost:6379 RAILS_ENV=production
+    sudo -u git -H bundle exec rake gitlab:shell:install[v1.9.8] REDIS_URL=redis://localhost:6379 RAILS_ENV=production
 
     # By default, the gitlab-shell config is generated from your main gitlab config.
     #


### PR DESCRIPTION
As committed in https://github.com/gitlabhq/gitlabhq/commit/873acfd9aa54e801d5786c32b05c4f8ad21af72a GitLab 7.2.2 requires GitLab Shell 1.9.8. Related to https://github.com/gitlabhq/gitlabhq/pull/7806 & https://github.com/gitlabhq/gitlabhq/pull/7809.
