### PR TITLE
Only clone GitLab Shell on tests if necessary.

### DIFF
--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -22,7 +22,10 @@ namespace :gitlab do
 
       # Make sure we're on the right tag
       Dir.chdir(target_dir) do
-        sh "git fetch origin && git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"
+        # First try to checkout without fetching
+        # to avoid stalling tests if the Internet is down.
+        reset = "git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"
+        sh "#{reset} || git fetch origin && #{reset}"
 
         redis_url = URI.parse(ENV['REDIS_URL'] || "redis://localhost:6379")
 

--- a/spec/support/test_env.rb
+++ b/spec/support/test_env.rb
@@ -17,7 +17,11 @@ module TestEnv
     tmp_test_path = Rails.root.join('tmp', 'tests')
 
     if File.directory?(tmp_test_path)
-      FileUtils.rm_r(tmp_test_path)
+      Dir.entries(tmp_test_path).each do |entry|
+        unless ['.', '..', 'gitlab-shell'].include?(entry)
+          FileUtils.rm_r(File.join(tmp_test_path, entry))
+        end
+      end
     end
 
     FileUtils.mkdir_p(tmp_test_path)
@@ -38,9 +42,7 @@ module TestEnv
   end
 
   def setup_gitlab_shell
-    unless File.directory?(Gitlab.config.gitlab_shell.path)
-      %x[rake gitlab:shell:install]
-    end
+    `rake gitlab:shell:install`
   end
 
   def setup_factory_repo


### PR DESCRIPTION
Before this change, `tmp/test` got removed before every time we started running tests, and we had to clone GitLab Shell again.

Now:
- `tmp/test/gitlab-shell` is not removed before tests, only the other siblings
- it only gets cloned if the repo does not exist already
- if the repo and the correct shell version exist, it only checks out
- otherwise do a git fetch instead of a clone

Use case: allow to run tests without the Internet (airplane, commuting, internet problems, GitLab.com downtime, etc.)

There is only one more Internet dependency: cloning `gitlab-test`, but that one is harder to deal with since all branches must be synced.

Still, this change already makes testing a bit faster and walks towards that goal.

Implementation notes:
- `unless File.directory?`: removed because was never used because `rm_rf` always removed `tests`, and should not be used in theory either, since if the repository is there we might want to fetch.
