### PR TITLE
Remove extra git describe on Rake shell install.

### DIFF
--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -24,7 +24,7 @@ namespace :gitlab do
       Dir.chdir(target_dir) do
         # First try to checkout without fetching
         # to avoid stalling tests if the Internet is down.
-        reset = "git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"
+        reset = "git reset --hard $(git describe #{args.tag})"
         sh "#{reset} || git fetch origin && #{reset}"
 
         config = {


### PR DESCRIPTION
I'm sure there is a good reason for this, but I'm just too curious to know why =)

IIUC:
- `man gitrevisions` says that refnames are already searched under `refs/heads/<name>` and then `refs/remotes/<name>` in that order by default. So saying `git checkout branch` will find `remote/origin/branch` already if `heads/branch` does not exist.
- no other type of revision name is stored under `refs/heads/remote`

cc @crohr you may have written that line, sorry if not.

Actually , what I really wanted to do is to remove the `describe` entirely: if I give a ref from the command line, it is simpler to use it directly instead of `describe ref`. People should never install the latest stable and always give the version that corresponds to their gitlab instance.
