### PR TITLE
Remove test line without effect because no should.

### DIFF
--- a/features/steps/project/issues.rb
+++ b/features/steps/project/issues.rb
@@ -232,9 +232,6 @@ class Spinach::Features::ProjectIssues < Spinach::FeatureSteps
 
   def filter_issue(text)
     fill_in 'issue_search', with: text
-
-    # make sure AJAX request finished
-    URI.parse(current_url).request_uri == project_issues_path(project, issue_search: text)
   end
 
   def project


### PR DESCRIPTION
I think the `should ==` was forgotten, as the return value is never used, and the function is only used in intermediate steps, not on the conclusions.

If I add the should, tests start to fail. Not sure if Poltergeist can handle `window.location` stuff.

Even if it could, tests should still fail, because when you edit the issue search all possible parameters get added to the URL, not just the `issue_search`.

So let's just remove this.
