### PR TITLE
Remove unnecessary page. from tests.

### DIFF
--- a/features/steps/dashboard/dashboard.rb
+++ b/features/steps/dashboard/dashboard.rb
@@ -80,7 +80,7 @@ class Spinach::Features::Dashboard < Spinach::FeatureSteps
   end
 
   step 'I should see 1 project at group list' do
-    page.find('span.last_activity/span').should have_content('1')
+    find('span.last_activity/span').should have_content('1')
   end
 
   def project

--- a/features/steps/explore/groups_feature.rb
+++ b/features/steps/explore/groups_feature.rb
@@ -63,7 +63,7 @@ class Spinach::Features::ExploreGroupsFeature < Spinach::FeatureSteps
   end
 
   step 'I should not see member roles' do
-    page.body.should_not match(%r{owner|developer|reporter|guest}i)
+    body.should_not match(%r{owner|developer|reporter|guest}i)
   end
 
   protected

--- a/features/steps/explore/projects.rb
+++ b/features/steps/explore/projects.rb
@@ -22,14 +22,14 @@ class Spinach::Features::ExploreProjectsFeature < Spinach::FeatureSteps
 
   step 'I should see empty public project details with http clone info' do
     project = Project.find_by(name: 'Empty Public Project')
-    page.all(:css, '.git-empty .clone').each do |element|
+    all(:css, '.git-empty .clone').each do |element|
       element.text.should include(project.http_url_to_repo)
     end
   end
 
   step 'I should see empty public project details with ssh clone info' do
     project = Project.find_by(name: 'Empty Public Project')
-    page.all(:css, '.git-empty .clone').each do |element|
+    all(:css, '.git-empty .clone').each do |element|
       element.text.should include(project.url_to_repo)
     end
   end

--- a/features/steps/project/browse_branches.rb
+++ b/features/steps/project/browse_branches.rb
@@ -80,6 +80,6 @@ class Spinach::Features::ProjectBrowseBranches < Spinach::FeatureSteps
   end
 
   step "I should not see branch 'improve/awesome'" do
-    page.all(visible: true).should_not have_content 'improve/awesome'
+    all(visible: true).should_not have_content 'improve/awesome'
   end
 end

--- a/features/steps/project/browse_commits.rb
+++ b/features/steps/project/browse_commits.rb
@@ -17,10 +17,10 @@ class Spinach::Features::ProjectBrowseCommits < Spinach::FeatureSteps
 
   step 'I see commits atom feed' do
     commit = @project.repository.commit
-    page.response_headers['Content-Type'].should have_content("application/atom+xml")
-    page.body.should have_selector("title", text: "Recent commits to #{@project.name}")
-    page.body.should have_selector("author email", text: commit.author_email)
-    page.body.should have_selector("entry summary", text: commit.description[0..10])
+    response_headers['Content-Type'].should have_content("application/atom+xml")
+    body.should have_selector("title", text: "Recent commits to #{@project.name}")
+    body.should have_selector("author email", text: commit.author_email)
+    body.should have_selector("entry summary", text: commit.description[0..10])
   end
 
   step 'I click on commit link' do
@@ -72,7 +72,7 @@ class Spinach::Features::ProjectBrowseCommits < Spinach::FeatureSteps
   end
 
   step 'The diff links to both the previous and current image' do
-    links = page.all('.two-up span div a')
+    links = all('.two-up span div a')
     links[0]['href'].should =~ %r{blob/#{sample_image_commit.old_blob_id}}
     links[1]['href'].should =~ %r{blob/#{sample_image_commit.new_blob_id}}
   end

--- a/features/steps/project/browse_files.rb
+++ b/features/steps/project/browse_files.rb
@@ -29,7 +29,7 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
   end
 
   step 'I should see raw file content' do
-    page.source.should == sample_blob.data
+    source.should == sample_blob.data
   end
 
   step 'I click button "edit"' do
@@ -37,12 +37,12 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
   end
 
   step 'I can edit code' do
-    page.execute_script('editor.setValue("GitlabFileEditor")')
-    page.evaluate_script('editor.getValue()').should == "GitlabFileEditor"
+    execute_script('editor.setValue("GitlabFileEditor")')
+    evaluate_script('editor.getValue()').should == "GitlabFileEditor"
   end
 
   step 'I edit code' do
-    page.execute_script('editor.setValue("GitlabFileEditor")')
+    execute_script('editor.setValue("GitlabFileEditor")')
   end
 
   step 'I click link "Diff"' do

--- a/features/steps/project/browse_tags.rb
+++ b/features/steps/project/browse_tags.rb
@@ -61,7 +61,7 @@ class Spinach::Features::ProjectBrowseTags < Spinach::FeatureSteps
 
   step "I should not see tag 'v1.1.0'" do
     within '.tags' do
-      page.all(visible: true).should_not have_content 'v1.1.0'
+      all(visible: true).should_not have_content 'v1.1.0'
     end
   end
 

--- a/features/steps/project/hooks.rb
+++ b/features/steps/project/hooks.rb
@@ -29,7 +29,7 @@ class Spinach::Features::ProjectHooks < Spinach::FeatureSteps
   end
 
   step 'I should see newly created hook' do
-    page.current_path.should == project_hooks_path(current_project)
+    current_path.should == project_hooks_path(current_project)
     page.should have_content(@url)
   end
 
@@ -44,7 +44,7 @@ class Spinach::Features::ProjectHooks < Spinach::FeatureSteps
   end
 
   step 'hook should be triggered' do
-    page.current_path.should == project_hooks_path(current_project)
+    current_path.should == project_hooks_path(current_project)
     page.should have_selector '.flash-notice',
                               text: 'Hook successfully executed.'
   end

--- a/features/steps/project/issues.rb
+++ b/features/steps/project/issues.rb
@@ -113,7 +113,7 @@ class Spinach::Features::ProjectIssues < Spinach::FeatureSteps
 
   step 'I should see selected milestone with title "v3.0"' do
     issues_milestone_selector = "#issue_milestone_id_chzn > a"
-    page.find(issues_milestone_selector).should have_content("v3.0")
+    find(issues_milestone_selector).should have_content("v3.0")
   end
 
   When 'I select first assignee from "Shop" project' do
@@ -126,7 +126,7 @@ class Spinach::Features::ProjectIssues < Spinach::FeatureSteps
     issues_assignee_selector = "#issue_assignee_id_chzn > a"
 
     assignee_name = project.users.first.name
-    page.find(issues_assignee_selector).should have_content(assignee_name)
+    find(issues_assignee_selector).should have_content(assignee_name)
   end
 
   step 'project "Shop" have "Release 0.4" open issue' do
@@ -164,7 +164,7 @@ class Spinach::Features::ProjectIssues < Spinach::FeatureSteps
 
   step 'I see empty project details with ssh clone info' do
     project = Project.find_by(name: 'Empty Project')
-    page.all(:css, '.git-empty .clone').each do |element|
+    all(:css, '.git-empty .clone').each do |element|
       element.text.should include(project.url_to_repo)
     end
   end

--- a/features/steps/project/network_graph.rb
+++ b/features/steps/project/network_graph.rb
@@ -30,12 +30,12 @@ class Spinach::Features::ProjectNetworkGraph < Spinach::FeatureSteps
   end
 
   When 'I switch ref to "feature"' do
-    page.select 'feature', from: 'ref'
+    select 'feature', from: 'ref'
     sleep 2
   end
 
   When 'I switch ref to "v1.0.0"' do
-    page.select 'v1.0.0', from: 'ref'
+    select 'v1.0.0', from: 'ref'
     sleep 2
   end
 

--- a/features/steps/project/redirects.rb
+++ b/features/steps/project/redirects.rb
@@ -48,8 +48,8 @@ class Spinach::Features::ProjectRedirects < Spinach::FeatureSteps
 
   step 'I should be redirected to "Community" page' do
     project = Project.find_by(name: 'Community')
-    page.current_path.should == "/#{project.path_with_namespace}"
-    page.status_code.should == 200
+    current_path.should == "/#{project.path_with_namespace}"
+    status_code.should == 200
   end
 
   step 'I get redirected to signin page where I sign in' do
@@ -63,7 +63,7 @@ class Spinach::Features::ProjectRedirects < Spinach::FeatureSteps
 
   step 'I should be redirected to "Enterprise" page' do
     project = Project.find_by(name: 'Enterprise')
-    page.current_path.should == "/#{project.path_with_namespace}"
-    page.status_code.should == 200
+    current_path.should == "/#{project.path_with_namespace}"
+    status_code.should == 200
   end
 end

--- a/features/steps/project/star.rb
+++ b/features/steps/project/star.rb
@@ -22,7 +22,7 @@ class Spinach::Features::ProjectStar < Spinach::FeatureSteps
 
   # Requires @javascript
   step "I click on the star toggle button" do
-    page.find(".star .toggle", visible: true).click
+    find(".star .toggle", visible: true).click
   end
 
   protected

--- a/features/steps/shared/active_tab.rb
+++ b/features/steps/shared/active_tab.rb
@@ -2,15 +2,15 @@ module SharedActiveTab
   include Spinach::DSL
 
   def ensure_active_main_tab(content)
-    page.find('.main-nav li.active').should have_content(content)
+    find('.main-nav li.active').should have_content(content)
   end
 
   def ensure_active_sub_tab(content)
-    page.find('div.content ul.nav-tabs li.active').should have_content(content)
+    find('div.content ul.nav-tabs li.active').should have_content(content)
   end
 
   def ensure_active_sub_nav(content)
-    page.find('div.content ul.nav-stacked-menu li.active').should have_content(content)
+    find('div.content ul.nav-stacked-menu li.active').should have_content(content)
   end
 
   step 'no other main tabs should be active' do

--- a/features/steps/shared/markdown.rb
+++ b/features/steps/shared/markdown.rb
@@ -2,8 +2,8 @@ module SharedMarkdown
   include Spinach::DSL
 
   def header_should_have_correct_id_and_link(level, text, id, parent = ".wiki")
-    page.find(:css, "#{parent} h#{level}##{id}").text.should == text
-    page.find(:css, "#{parent} h#{level}##{id} > :last-child")[:href].should =~ /##{id}$/
+    find(:css, "#{parent} h#{level}##{id}").text.should == text
+    find(:css, "#{parent} h#{level}##{id} > :last-child")[:href].should =~ /##{id}$/
   end
 
   step 'Header "Description header" should have correct id and link' do

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -419,6 +419,6 @@ module SharedPaths
   # ----------------------------------------
 
   step 'page status code should be 404' do
-    page.status_code.should == 404
+    status_code.should == 404
   end
 end

--- a/features/steps/user.rb
+++ b/features/steps/user.rb
@@ -5,6 +5,6 @@ class Spinach::Features::User < Spinach::FeatureSteps
   include SharedProject
 
   step 'I should see user "John Doe" page' do
-    expect(page.title).to match(/^\s*John Doe/)
+    expect(title).to match(/^\s*John Doe/)
   end
 end

--- a/spec/features/admin/admin_hooks_spec.rb
+++ b/spec/features/admin/admin_hooks_spec.rb
@@ -33,7 +33,7 @@ describe "Admin::Hooks", feature: true do
     end
 
     it "should open new hook popup" do
-      page.current_path.should == admin_hooks_path
+      current_path.should == admin_hooks_path
       page.should have_content(@url)
     end
   end
@@ -45,7 +45,7 @@ describe "Admin::Hooks", feature: true do
       click_link "Test Hook"
     end
 
-    it { page.current_path.should == admin_hooks_path }
+    it { current_path.should == admin_hooks_path }
   end
 
 end

--- a/spec/features/atom/dashboard_issues_spec.rb
+++ b/spec/features/atom/dashboard_issues_spec.rb
@@ -17,12 +17,12 @@ describe "Dashboard Issues Feed", feature: true  do
       it "should render atom feed via private token" do
         visit issues_dashboard_path(:atom, private_token: user.private_token)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{user.name} issues")
-        page.body.should have_selector("author email", text: issue1.author_email)
-        page.body.should have_selector("entry summary", text: issue1.title)
-        page.body.should have_selector("author email", text: issue2.author_email)
-        page.body.should have_selector("entry summary", text: issue2.title)
+        response_headers['Content-Type'].should have_content("application/atom+xml")
+        body.should have_selector("title", text: "#{user.name} issues")
+        body.should have_selector("author email", text: issue1.author_email)
+        body.should have_selector("entry summary", text: issue1.title)
+        body.should have_selector("author email", text: issue2.author_email)
+        body.should have_selector("entry summary", text: issue2.title)
       end
     end
   end

--- a/spec/features/atom/dashboard_spec.rb
+++ b/spec/features/atom/dashboard_spec.rb
@@ -7,7 +7,7 @@ describe "Dashboard Feed", feature: true  do
     context "projects atom feed via private token" do
       it "should render projects atom feed" do
         visit dashboard_path(:atom, private_token: user.private_token)
-        page.body.should have_selector("feed title")
+        body.should have_selector("feed title")
       end
     end
 
@@ -24,11 +24,11 @@ describe "Dashboard Feed", feature: true  do
       end
 
       it "should have issue opened event" do
-        page.body.should have_content("#{user.name} opened issue ##{issue.iid}")
+        body.should have_content("#{user.name} opened issue ##{issue.iid}")
       end
 
       it "should have issue comment event" do
-        page.body.should have_content("#{user.name} commented on issue ##{issue.iid}")
+        body.should have_content("#{user.name} commented on issue ##{issue.iid}")
       end
     end
   end

--- a/spec/features/atom/issues_spec.rb
+++ b/spec/features/atom/issues_spec.rb
@@ -13,10 +13,10 @@ describe "Issues Feed", feature: true  do
         login_with user
         visit project_issues_path(project, :atom)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{project.name} issues")
-        page.body.should have_selector("author email", text: issue.author_email)
-        page.body.should have_selector("entry summary", text: issue.title)
+        response_headers['Content-Type'].should have_content("application/atom+xml")
+        body.should have_selector("title", text: "#{project.name} issues")
+        body.should have_selector("author email", text: issue.author_email)
+        body.should have_selector("entry summary", text: issue.title)
       end
     end
 
@@ -24,10 +24,10 @@ describe "Issues Feed", feature: true  do
       it "should render atom feed" do
         visit project_issues_path(project, :atom, private_token: user.private_token)
 
-        page.response_headers['Content-Type'].should have_content("application/atom+xml")
-        page.body.should have_selector("title", text: "#{project.name} issues")
-        page.body.should have_selector("author email", text: issue.author_email)
-        page.body.should have_selector("entry summary", text: issue.title)
+        response_headers['Content-Type'].should have_content("application/atom+xml")
+        body.should have_selector("title", text: "#{project.name} issues")
+        body.should have_selector("author email", text: issue.author_email)
+        body.should have_selector("entry summary", text: issue.title)
       end
     end
   end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -59,9 +59,9 @@ describe "Issues", feature: true do
 
       page.should have_content "Assign to #{@user.name}"
 
-      page.first('#s2id_issue_assignee_id').click
+      first('#s2id_issue_assignee_id').click
       sleep 2 # wait for ajax stuff to complete
-      page.first('.user-result').click
+      first('.user-result').click
 
       click_button "Save changes"
 
@@ -212,7 +212,7 @@ describe "Issues", feature: true do
         click_button 'Update Issue'
 
         page.should have_content "Assignee:"
-        page.has_select?('issue_assignee_id', :selected => project.team.members.first.name)
+        has_select?('issue_assignee_id', :selected => project.team.members.first.name)
       end
     end
 
@@ -249,7 +249,7 @@ describe "Issues", feature: true do
         click_button 'Update Issue'
 
         page.should have_content "Milestone changed to #{milestone.title}"
-        page.has_select?('issue_assignee_id', :selected => milestone.title)
+        has_select?('issue_assignee_id', :selected => milestone.title)
       end
     end
 
@@ -283,9 +283,9 @@ describe "Issues", feature: true do
         visit project_issue_path(project, issue)
         page.should have_content "Assignee: #{user2.name}"
 
-        page.first('#s2id_issue_assignee_id').click
+        first('#s2id_issue_assignee_id').click
         sleep 2 # wait for ajax stuff to complete
-        page.first('.user-result').click
+        first('.user-result').click
 
         page.should have_content "Assignee: Unassigned"
         sleep 2 # wait for ajax stuff to complete

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -21,6 +21,6 @@ module LoginHelpers
 
   # Requires Javascript driver.
   def logout
-    page.find(:css, ".icon-signout").click
+    find(:css, ".icon-signout").click
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -42,19 +42,19 @@ module UrlAccess
   def url_allowed?(user, url)
     emulate_user(user)
     visit url
-    (page.status_code != 404 && current_path != new_user_session_path)
+    (status_code != 404 && current_path != new_user_session_path)
   end
 
   def url_denied?(user, url)
     emulate_user(user)
     visit url
-    (page.status_code == 404 || current_path == new_user_session_path)
+    (status_code == 404 || current_path == new_user_session_path)
   end
 
   def url_404?(user, url)
     emulate_user(user)
     visit url
-    page.status_code == 404
+    status_code == 404
   end
 
   def emulate_user(user)

--- a/spec/support/select2_helper.rb
+++ b/spec/support/select2_helper.rb
@@ -17,9 +17,9 @@ module Select2Helper
     selector = options[:from]
 
     if options[:multiple]
-      page.execute_script("$('#{selector}').select2('val', ['#{value}']);")
+      execute_script("$('#{selector}').select2('val', ['#{value}']);")
     else
-      page.execute_script("$('#{selector}').select2('val', '#{value}');")
+      execute_script("$('#{selector}').select2('val', '#{value}');")
     end
   end
 end


### PR DESCRIPTION
```
find features/steps spec -iname '*.rb' | xargs perl -lapi -e 's/(?<=[ (])page\.(?!should)//'
```

I propose we forget the Hound warning for now since this is an automatic refactoring commit and manually fixing those would miss the automatic part.

Let's fix all of them on a separate refactor someday.
