### PR TITLE
evaluate -> execute_script when return not needed.

### DIFF
--- a/features/steps/project/multiselect_blob.rb
+++ b/features/steps/project/multiselect_blob.rb
@@ -12,7 +12,7 @@ class Spinach::Features::ProjectMultiselectBlob < Spinach::FeatureSteps
 
         step "I shift-click line #{line_number} in file" do
           script = "$('#L#{line_number}').trigger($.Event('click', { shiftKey: true }));"
-          page.evaluate_script(script)
+          execute_script(script)
         end
       end
     end


### PR DESCRIPTION
execute does not fetch the return value. It is therefore faster and should be used when the return is not needed.

The two other occurrences on the page were factored out in https://github.com/gitlabhq/gitlabhq/pull/7837
