### PR TITLE
Finish up work on annotated tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v 7.4.0
   - Improve error reporting on users API (Julien Bianchi)
   - Refactor test coverage tools usage. Use SIMPLECOV=true to generate it locally
   - Increase unicorn timeout to 60 seconds
+  - Tie up loose ends with annotated tags: API & UI (Sean Edge)
 
 v 7.3.1
   - Fix ref parsing in Gitlab::GitAccess

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'omniauth-shibboleth'
 
 # Extracting information from a git repository
 # Provide access to Gitlab::Git library
-gem "gitlab_git", '~> 6.0'
+gem "gitlab_git", '~> 6.3.0'
 
 # Ruby/Rack Git Smart-HTTP Server Handler
 gem 'gitlab-grack', '~> 2.0.0.pre', require: 'grack'

--- a/app/views/projects/tags/_tag.html.haml
+++ b/app/views/projects/tags/_tag.html.haml
@@ -4,6 +4,9 @@
     = link_to project_commits_path(@project, tag.name), class: "" do
       %i.icon-tag
       = tag.name
+      - if not tag.message.nil?
+        &nbsp;
+        = tag.message
     .pull-right
       - if can? current_user, :download_code, @project
         = render 'projects/repositories/download_archive', ref: tag.name, btn_class: 'btn-grouped btn-group-small'

--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -56,6 +56,7 @@ Parameters:
 [
   {
     "name": "v1.0.0",
+    "message": "Release 1.0.0",
     "commit": {
       "id": "2695effb5807a22ff3d138d593fd856244e155e7",
       "parents": [],
@@ -67,10 +68,11 @@ Parameters:
       "committed_date": "2012-05-28T04:42:42-07:00",
       "committer_email": "jack@example.com"
     },
-    "protected": false
   }
 ]
 ```
+The message will be `nil` when creating a lightweight tag otherwise
+it will contain the annotation.
 
 It returns 200 if the operation succeed. In case of an error,
 405 with an explaining error message is returned.

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -23,7 +23,7 @@ module API
       # Example Request:
       #   GET /projects/:id/repository/tags
       get ":id/repository/tags" do
-        present user_project.repo.tags.sort_by(&:name).reverse, with: Entities::RepoObject, project: user_project
+        present user_project.repo.tags.sort_by(&:name).reverse, with: Entities::RepoTag, project: user_project
       end
 
       # Create tag
@@ -38,12 +38,13 @@ module API
       post ':id/repository/tags' do
         authorize_push_project
         message = params[:message] || nil
-        result = CreateTagService.new(user_project, current_user).
-          execute(params[:tag_name], params[:ref], message)
+        result = CreateTagService.new.execute(user_project, params[:tag_name],
+                                              params[:ref], message,
+                                              current_user)
 
         if result[:status] == :success
           present result[:tag],
-                  with: Entities::RepoObject,
+                  with: Entities::RepoTag,
                   project: user_project
         else
           render_api_error!(result[:message], 400)

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -34,21 +34,18 @@ describe API::API, api: true  do
       end
     end
 
-    # TODO: fix this test for CI
-    #context 'annotated tag' do
-      #it 'should create a new annotated tag' do
-        #post api("/projects/#{project.id}/repository/tags", user),
-             #tag_name: 'v7.1.0',
-             #ref: 'master',
-             #message: 'tag message'
+    context 'annotated tag' do
+      it 'should create a new annotated tag' do
+        post api("/projects/#{project.id}/repository/tags", user),
+             tag_name: 'v7.1.0',
+             ref: 'master',
+             message: 'Release 7.1.0'
 
-        #response.status.should == 201
-        #json_response['name'].should == 'v7.1.0'
-        # The message is not part of the JSON response.
-        # Additional changes to the gitlab_git gem may be required.
-        # json_response['message'].should == 'tag message'
-      #end
-    #end
+        response.status.should == 201
+        json_response['name'].should == 'v7.1.0'
+        json_response['message'].should == 'Release 7.1.0'
+      end
+    end
 
     it 'should deny for user without push access' do
       post api("/projects/#{project.id}/repository/tags", user2),


### PR DESCRIPTION
- Fixed up JSON response for tags, now includes the `message` and changed API doc to reflect the change.
- Re-added spec for annotated tag creation with the API.  Can now verify the `message`.
- Added tag's message to tag list.  I think the style used for the message can be improved, maybe it's not desirable to be displayed at all.  I'm hoping for a suggestion here:

![tag_list_with_message](https://cloud.githubusercontent.com/assets/4359059/4398576/1b2fe114-4459-11e4-9c94-954ddd62c17b.png)
