### PR TITLE
Finish up work on annotated tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v 7.5.0
   - Fix LDAP authentication for Git HTTP access
   - Fix LDAP config lookup for provider 'ldap'
   - Add Atlassian Bamboo CI service (Drew Blessing)
+  - Tie up loose ends with annotated tags: API & UI (Sean Edge)
 
 v 7.4.2
   - Fix internal snippet exposing for unauthenticated users

--- a/app/views/projects/tags/_tag.html.haml
+++ b/app/views/projects/tags/_tag.html.haml
@@ -4,6 +4,9 @@
     = link_to project_commits_path(@project, tag.name), class: "" do
       %i.fa.fa-tag
       = tag.name
+    - if tag.message.present?
+      &nbsp;
+      = tag.message
     .pull-right
       - if can? current_user, :download_code, @project
         = render 'projects/repositories/download_archive', ref: tag.name, btn_class: 'btn-grouped btn-group-small'

--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -56,6 +56,7 @@ Parameters:
 [
   {
     "name": "v1.0.0",
+    "message": "Release 1.0.0",
     "commit": {
       "id": "2695effb5807a22ff3d138d593fd856244e155e7",
       "parents": [],
@@ -67,10 +68,11 @@ Parameters:
       "committed_date": "2012-05-28T04:42:42-07:00",
       "committer_email": "jack@example.com"
     },
-    "protected": false
   }
 ]
 ```
+The message will be `nil` when creating a lightweight tag otherwise
+it will contain the annotation.
 
 It returns 200 if the operation succeed. In case of an error,
 405 with an explaining error message is returned.

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -73,6 +73,25 @@ module API
       end
     end
 
+    class RepoTag < Grape::Entity
+      expose :name
+      expose :message do |repo_obj, _options|
+        if repo_obj.respond_to?(:message)
+          repo_obj.message
+        else
+          nil
+        end
+      end
+
+      expose :commit do |repo_obj, options|
+        if repo_obj.respond_to?(:commit)
+          repo_obj.commit
+        elsif options[:project]
+          options[:project].repository.commit(repo_obj.target)
+        end
+      end
+    end
+
     class RepoObject < Grape::Entity
       expose :name
 

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -23,7 +23,8 @@ module API
       # Example Request:
       #   GET /projects/:id/repository/tags
       get ":id/repository/tags" do
-        present user_project.repo.tags.sort_by(&:name).reverse, with: Entities::RepoObject, project: user_project
+        present user_project.repo.tags.sort_by(&:name).reverse,
+                with: Entities::RepoTag, project: user_project
       end
 
       # Create tag
@@ -43,7 +44,7 @@ module API
 
         if result[:status] == :success
           present result[:tag],
-                  with: Entities::RepoObject,
+                  with: Entities::RepoTag,
                   project: user_project
         else
           render_api_error!(result[:message], 400)

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -34,21 +34,24 @@ describe API::API, api: true  do
       end
     end
 
-    # TODO: fix this test for CI
-    #context 'annotated tag' do
-      #it 'should create a new annotated tag' do
-        #post api("/projects/#{project.id}/repository/tags", user),
-             #tag_name: 'v7.1.0',
-             #ref: 'master',
-             #message: 'tag message'
+    context 'annotated tag' do
+      it 'should create a new annotated tag' do
+        # Identity must be set in .gitconfig to create annotated tag.
+        repo_path = File.join(Gitlab.config.gitlab_shell.repos_path,
+                              project.path_with_namespace + '.git')
+        system(*%W(git --git-dir=#{repo_path} config user.name #{user.name}))
+        system(*%W(git --git-dir=#{repo_path} config user.email #{user.email}))
 
-        #response.status.should == 201
-        #json_response['name'].should == 'v7.1.0'
-        # The message is not part of the JSON response.
-        # Additional changes to the gitlab_git gem may be required.
-        # json_response['message'].should == 'tag message'
-      #end
-    #end
+        post api("/projects/#{project.id}/repository/tags", user),
+             tag_name: 'v7.1.0',
+             ref: 'master',
+             message: 'Release 7.1.0'
+
+        response.status.should == 201
+        json_response['name'].should == 'v7.1.0'
+        json_response['message'].should == 'Release 7.1.0'
+      end
+    end
 
     it 'should deny for user without push access' do
       post api("/projects/#{project.id}/repository/tags", user2),


### PR DESCRIPTION
After screwing up the first attempt at this PR, here it is again.
- Fixed up JSON response for tags, now includes the `message` and changed API doc to reflect the change.
- Re-added spec for annotated tag creation with the API. Can now verify the `message`.
- Added tag's `message` to tag list. I think the style used for the `message` can be improved, maybe it's not desirable to be displayed at all. I'm hoping for a suggestion here:

![tag_list_with_message](https://cloud.githubusercontent.com/assets/4359059/4398798/beb13a6e-445d-11e4-868f-47fdf0580a44.png)
