### PR TITLE
Factor out Emoji parsing using html-pipeline-gitlab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,9 @@ gem "six"
 # Seed data
 gem "seed-fu"
 
+# Markup pipeline for GitLab
+gem 'html-pipeline-gitlab', '~> 0.1.0'
+
 # Markdown to HTML
 gem "github-markup"
 
@@ -157,7 +160,7 @@ gem "rack-attack"
 # Ace editor
 gem 'ace-rails-ap'
 
-# Keyboard shortcuts 
+# Keyboard shortcuts
 gem 'mousetrap-rails'
 
 # Semantic UI Sass for Sidebar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,12 @@ GEM
     hipchat (0.14.0)
       httparty
       httparty
+    html-pipeline (1.11.0)
+      activesupport (>= 2)
+      nokogiri (~> 1.4)
+    html-pipeline-gitlab (0.1.0)
+      gitlab_emoji (~> 0.0.1.1)
+      html-pipeline (~> 1.11.0)
     http_parser.rb (0.5.3)
     httparty (0.13.0)
       json (~> 1.8)
@@ -629,6 +635,7 @@ DEPENDENCIES
   guard-spinach
   haml-rails
   hipchat (~> 0.14.0)
+  html-pipeline-gitlab (~> 0.1.0)
   httparty
   jasmine (= 2.0.2)
   jquery-atwho-rails (~> 0.3.3)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,12 +151,6 @@ module ApplicationHelper
     sanitize(str, tags: %w(a span))
   end
 
-  def image_url(source)
-    # prevent relative_root_path being added twice (it's part of root_url and path_to_image)
-    root_url.sub(/#{root_path}$/, path_to_image(source))
-  end
-
-  alias_method :url_to_image, :image_url
 
   def body_data_page
     path = controller.controller_path.split('/')

--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -14,6 +14,10 @@ describe GitlabMarkdownHelper do
   let(:snippet)       { create(:project_snippet, project: project) }
   let(:member)        { project.project_members.where(user_id: user).first }
 
+  def url_helper(image_name)
+    File.join(root_url, 'assets', image_name)
+  end
+
   before do
     # Helper expects a @project instance variable
     @project = project
@@ -38,8 +42,8 @@ describe GitlabMarkdownHelper do
 
     it "should not touch HTML entities" do
       @project.issues.stub(:where).with(id: '39').and_return([issue])
-      actual = expected = "We&#39;ll accept good pull requests."
-      gfm(actual).should == expected
+      actual = 'We&#39;ll accept good pull requests.'
+      gfm(actual).should == "We'll accept good pull requests."
     end
 
     it "should forward HTML options to links" do
@@ -330,7 +334,8 @@ describe GitlabMarkdownHelper do
       end
 
       it "keeps whitespace intact" do
-        gfm("This deserves a :+1: big time.").should match(/deserves a <img.+\/> big time/)
+        gfm('This deserves a :+1: big time.').
+          should match(/deserves a <img.+> big time/)
       end
 
       it "ignores invalid emoji" do
@@ -448,7 +453,8 @@ describe GitlabMarkdownHelper do
     end
 
     it "should leave inline code untouched" do
-      markdown("\nDon't use `$#{snippet.id}` here.\n").should == "<p>Don&#39;t use <code>$#{snippet.id}</code> here.</p>\n"
+      markdown("\nDon't use `$#{snippet.id}` here.\n").should ==
+        "<p>Don't use <code>$#{snippet.id}</code> here.</p>\n"
     end
 
     it "should leave ref-like autolinks untouched" do
@@ -468,7 +474,7 @@ describe GitlabMarkdownHelper do
     end
 
     it "should generate absolute urls for emoji" do
-      markdown(":smile:").should include("src=\"#{url_to_image("emoji/smile")}")
+      markdown(":smile:").should include("src=\"#{url_helper('emoji/smile')}")
     end
 
     it "should handle relative urls for a file in master" do


### PR DESCRIPTION
This PR is one of the first PRs refactoring the markup handling. As discussed with @randx, I'll do this with small PRs, to keep changes detectable.
### What it does?

It removes parsing emoji references, such as `:+1:`, from GitLab and calls instead `HTML::Pipeline::GitLab::MarkdownPipeline.` This pipeline currently only contains the  EmojiFilter.

In future we need to separate the markdown handling, by introducing different pipelines for different context. Eg.  for issues/MRs, dashboard...
