### PR TITLE
Fix missing flash on file edit error from web UI.

### DIFF
--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -20,7 +20,7 @@ class Projects::BlobController < Projects::ApplicationController
       flash[:notice] = "Your changes have been successfully committed"
       redirect_to project_tree_path(@project, @ref)
     else
-      flash[:alert] = result[:error]
+      flash[:alert] = result[:message]
       render :show
     end
   end

--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -22,7 +22,7 @@ class Projects::EditTreeController < Projects::BaseTreeController
 
       redirect_to after_edit_path
     else
-      flash[:alert] = result[:error]
+      flash[:alert] = result[:message]
       render :show
     end
   end

--- a/app/services/files/base_service.rb
+++ b/app/services/files/base_service.rb
@@ -10,12 +10,6 @@ module Files
 
     private
 
-    def success
-      out = super()
-      out[:error] = ''
-      out
-    end
-
     def repository
       project.repository
     end

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -35,6 +35,16 @@ Feature: Project Source Browse Files
     And I should see its new content
 
   @javascript
+  Scenario: If I enter an illegal file name I see an error message
+    Given I click on "new file" link in repo
+    And I fill the new file name with an illegal name
+    And I edit code
+    And I fill the commit message
+    And I click on "Commit changes"
+    Then I am on the new file page
+    And I see a commit error message
+
+  @javascript
   Scenario: I can edit file
     Given I click on ".gitignore" file in repo
     And I click button "Edit"
@@ -49,6 +59,16 @@ Feature: Project Source Browse Files
     And I click on "Commit Changes"
     Then I am redirected to the ".gitignore"
     And I should see its new content
+
+  @javascript  @wip
+  Scenario: If I don't change the content of the file I see an error message
+    Given I click on ".gitignore" file in repo
+    And I click button "edit"
+    And I fill the commit message
+    And I click on "Commit changes"
+    # Test fails because carriage returns are added to the file.
+    Then I am on the ".gitignore" edit file page
+    And I see a commit error message
 
   @javascript
   Scenario: I can see editing preview

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -61,6 +61,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     fill_in :file_name, with: new_file_name
   end
 
+  step 'I fill the new file name with an illegal name' do
+    fill_in :file_name, with: '.git'
+  end
+
   step 'I fill the commit message' do
     fill_in :commit_message, with: 'Not yet a commit message.'
   end
@@ -149,6 +153,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
 
   step "I don't see the permalink link" do
     expect(page).not_to have_link('permalink')
+  end
+
+  step 'I see a commit error message' do
+    expect(page).to have_content('Your changes could not be committed')
   end
 
   private

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -265,6 +265,15 @@ module SharedPaths
     visit project_blob_path(@project, File.join(root_ref, '.gitignore'))
   end
 
+  step 'I am on the new file page' do
+    current_path.should eq(project_new_tree_path(@project, root_ref))
+  end
+
+  step 'I am on the ".gitignore" edit file page' do
+    current_path.should eq(project_edit_tree_path(
+      @project, File.join(root_ref, '.gitignore')))
+  end
+
   step 'I visit project source page for "6d39438"' do
     visit project_tree_path(@project, "6d39438")
   end

--- a/lib/api/files.rb
+++ b/lib/api/files.rb
@@ -85,7 +85,7 @@ module API
             branch_name: branch_name
           }
         else
-          render_api_error!(result[:error], 400)
+          render_api_error!(result[:message], 400)
         end
       end
 
@@ -117,7 +117,7 @@ module API
             branch_name: branch_name
           }
         else
-          render_api_error!(result[:error], 400)
+          render_api_error!(result[:message], 400)
         end
       end
 
@@ -149,7 +149,7 @@ module API
             branch_name: branch_name
           }
         else
-          render_api_error!(result[:error], 400)
+          render_api_error!(result[:message], 400)
         end
       end
     end


### PR DESCRIPTION
These bugs were introduced by myself at https://github.com/gitlabhq/gitlabhq/pull/7807

The fact that the refactoring lead to bugs means we should add more tests for those error cases =)

Also removed the `out[:error] = ''` which never happens: every place of the app first checks for `success`.

Added tests that would have prevented me from generating this bug.

**Needs to be double checked**

One of the tests is `@wip` as explained on the source: I can't get it working no matter what. Still it shows the behavior and does an initial step to point to the cause of the problem.

This seems to be an unrelated bug in GitLab, so I've opened a separate report at: https://github.com/gitlabhq/gitlabhq/issues/7950

**Update**

This was partially fixed after this PR at: https://github.com/gitlabhq/gitlabhq/commit/184e0f , but only partially since the blob destroy, edit and API messages were not fixed, only the new blob case.
