### PR TITLE
Add web UI file CRUD tests.

### DIFF
--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -25,10 +25,30 @@ Feature: Project Browse files
     Then I can see new file page
 
   @javascript
+  Scenario: I can create and commit file
+    Given I click on "new file" link in repo
+    And I edit code
+    And I fill the new file name
+    And I fill the commit message
+    And I click on "Commit changes"
+    Then I am redirected to the new file
+    And I should see its new content
+
+  @javascript
   Scenario: I can edit file
     Given I click on ".gitignore" file in repo
     And I click button "edit"
     Then I can edit code
+
+  @javascript
+  Scenario: I can edit and commit file
+    Given I click on ".gitignore" file in repo
+    And I click button "edit"
+    And I edit code
+    And I fill the commit message
+    And I click on "Commit changes"
+    Then I am redirected to the ".gitignore"
+    And I should see its new content
 
   @javascript
   Scenario: I can see editing preview
@@ -37,6 +57,16 @@ Feature: Project Browse files
     And I edit code
     And I click link "Diff"
     Then I see diff
+
+  @javascript
+  Scenario: I can remove file and commit
+    Given I click on ".gitignore" file in repo
+    And I see the ".gitignore"
+    And I click on "remove"
+    And I fill the commit message
+    And I click on "Remove file"
+    Then I am redirected to the files URL
+    And I don't see the ".gitignore"
 
   Scenario: I can browse directory with Browse Dir
     Given I click on files directory

--- a/features/steps/project/browse_files.rb
+++ b/features/steps/project/browse_files.rb
@@ -16,12 +16,24 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     page.should have_content "LICENSE"
   end
 
+  step 'I see the ".gitignore"' do
+    page.should have_content '.gitignore'
+  end
+
+  step 'I don\'t see the ".gitignore"' do
+    page.should_not have_content '.gitignore'
+  end
+
   step 'I click on ".gitignore" file in repo' do
     click_link ".gitignore"
   end
 
   step 'I should see its content' do
-    page.should have_content "*.rbc"
+    page.should have_content old_gitignore_content
+  end
+
+  step 'I should see its new content' do
+    page.should have_content new_gitignore_content
   end
 
   step 'I click link "raw"' do
@@ -37,16 +49,36 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
   end
 
   step 'I can edit code' do
-    execute_script('editor.setValue("GitlabFileEditor")')
-    evaluate_script('editor.getValue()').should == "GitlabFileEditor"
+    set_new_content
+    evaluate_script('editor.getValue()').should == new_gitignore_content
   end
 
   step 'I edit code' do
-    execute_script('editor.setValue("GitlabFileEditor")')
+    set_new_content
+  end
+
+  step 'I fill the new file name' do
+    fill_in :file_name, with: new_file_name
+  end
+
+  step 'I fill the commit message' do
+    fill_in :commit_message, with: 'Not yet a commit message.'
   end
 
   step 'I click link "Diff"' do
     click_link 'Diff'
+  end
+
+  step 'I click on "Commit changes"' do
+    click_button 'Commit changes'
+  end
+
+  step 'I click on "remove"' do
+    click_link 'remove'
+  end
+
+  step 'I click on "Remove file"' do
+    click_button 'Remove file'
   end
 
   step 'I see diff' do
@@ -97,12 +129,48 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     click_link 'permalink'
   end
 
+  step 'I am redirected to the files URL' do
+    current_path.should == project_tree_path(@project, 'master')
+  end
+
+  step 'I am redirected to the ".gitignore"' do
+    expect(current_path).to eq(project_blob_path(@project, 'master/.gitignore'))
+  end
+
   step 'I am redirected to the permalink URL' do
     expect(current_path).to eq(project_blob_path(
       @project, @project.repository.commit.sha + '/.gitignore'))
   end
 
+  step 'I am redirected to the new file' do
+    expect(current_path).to eq(project_blob_path(
+      @project, 'master/' + new_file_name))
+  end
+
   step "I don't see the permalink link" do
     expect(page).not_to have_link('permalink')
+  end
+
+  private
+
+  def set_new_content
+    execute_script("editor.setValue('#{new_gitignore_content}')")
+  end
+
+  # Content of the gitignore file on the seed repository.
+  def old_gitignore_content
+    '*.rbc'
+  end
+
+  # Constant value that differs from the content
+  # of the gitignore of the seed repository.
+  def new_gitignore_content
+    old_gitignore_content + 'a'
+  end
+
+  # Constant value that is a valid filename and
+  # not a filename present at root of the seed repository.
+  def new_file_name
+    'not_a_file.md'
   end
 end


### PR DESCRIPTION
This PR adds the first file modification operations (create, edit and delete).

They were currently undertested, and this has already lead me to not notice bugs during refactoring at: https://github.com/gitlabhq/gitlabhq/pull/7856

This is probably the case because the ability to edit repositories on tests was only recently added.
