### PR TITLE
Transform remove blob link into button.

### DIFF
--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -23,5 +23,6 @@
         tree_join(@commit.sha, @path)), class: 'btn btn-small'
 
 - if allowed_tree_edit?
-  = link_to '#modal-remove-blob', class: "remove-blob btn btn-small btn-remove", "data-toggle" => "modal" do
+  = button_tag class: 'remove-blob btn btn-small btn-remove',
+      'data-toggle' => 'modal', 'data-target' => '#modal-remove-blob' do
     Remove

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -78,7 +78,7 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
   end
 
   step 'I click on "Remove"' do
-    click_link 'Remove'
+    click_button 'Remove'
   end
 
   step 'I click on "Remove file"' do


### PR DESCRIPTION
The advantages of this are the same as of the merged https://github.com/gitlabhq/gitlabhq/pull/7793.

For example, middle clicking on the link would open a new tab without the modal since it is Javascript based.
