### PR TITLE
Remove type submit from button_tag since default.

### DIFF
--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -22,7 +22,7 @@
       = form_tag admin_users_path, method: :get, class: 'form-inline' do
         .form-group
           = search_field_tag :name, params[:name], placeholder: 'Name, email or username', class: 'form-control'
-        = button_tag type: 'submit', class: 'btn btn-primary' do
+        = button_tag class: 'btn btn-primary' do
           %i.icon-search
       %hr
       = link_to 'Reset', admin_users_path, class: "btn btn-cancel"

--- a/app/views/projects/network/show.html.haml
+++ b/app/views/projects/network/show.html.haml
@@ -3,7 +3,7 @@
   .controls
     = form_tag project_network_path(@project, @id), method: :get, class: 'form-inline network-form' do |f|
       = text_field_tag :extended_sha1, @options[:extended_sha1], placeholder: "Input an extended SHA1 syntax", class: 'search-input form-control input-mx-250 search-sha'
-      = button_tag type: 'submit', class: 'btn btn-success btn-search-sha' do
+      = button_tag class: 'btn btn-success btn-search-sha' do
         %i.icon-search
       .inline.prepend-left-20
         .checkbox.light


### PR DESCRIPTION
The generated HTML is unchanged, becomes uniform with other button_tag usages.
