### PR TITLE
Use button type=submit instead of input.

### DIFF
--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -10,7 +10,7 @@
 = form_tag admin_groups_path, method: :get, class: 'form-inline' do
   .form-group
     = text_field_tag :name, params[:name], class: "form-control input-mn-300"
-  = submit_tag "Search", class: "btn submit btn-primary"
+  = button_tag "Search", class: "btn submit btn-primary"
 
 %hr
 

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -64,7 +64,7 @@
           %div.prepend-top-10
             = select_tag :access_level, options_for_select(GroupMember.access_level_roles), class: "project-access-select select2"
           %hr
-          = submit_tag 'Add users into group', class: "btn btn-create"
+          = button_tag 'Add users into group', class: "btn btn-create"
     .panel.panel-default
       .panel-heading
         %h3.panel-title

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -35,7 +35,7 @@
                     = label
         %hr
         = hidden_field_tag :sort, params[:sort]
-        = submit_tag "Search", class: "btn submit btn-primary"
+        = button_tag "Search", class: "btn submit btn-primary"
         = link_to "Reset", admin_projects_path, class: "btn btn-cancel"
 
   .col-md-9

--- a/app/views/devise/sessions/_new_ldap.html.haml
+++ b/app/views/devise/sessions/_new_ldap.html.haml
@@ -2,4 +2,4 @@
   = text_field_tag :username, nil, {class: "form-control top", placeholder: "LDAP Login", autofocus: "autofocus"}
   = password_field_tag :password, nil, {class: "form-control bottom", placeholder: "Password"}
   %br/
-  = submit_tag "LDAP Sign in", class: "btn-save btn"
+  = button_tag "LDAP Sign in", class: "btn-save btn"

--- a/app/views/explore/groups/index.html.haml
+++ b/app/views/explore/groups/index.html.haml
@@ -4,7 +4,7 @@
       .form-group
         = search_field_tag :search, params[:search], placeholder: "Filter by name", class: "form-control search-text-input input-mn-300", id: "groups_search"
       .form-group
-        = submit_tag 'Search', class: "btn btn-primary wide"
+        = button_tag 'Search', class: "btn btn-primary wide"
 
   .pull-right
     .dropdown.inline

--- a/app/views/explore/projects/index.html.haml
+++ b/app/views/explore/projects/index.html.haml
@@ -4,7 +4,7 @@
       .form-group
         = search_field_tag :search, params[:search], placeholder: "Filter by name", class: "form-control search-text-input input-mn-300", id: "projects_search"
       .form-group
-        = submit_tag 'Search', class: "btn btn-primary wide"
+        = button_tag 'Search', class: "btn btn-primary wide"
 
   .pull-right
     .dropdown.inline

--- a/app/views/groups/members.html.haml
+++ b/app/views/groups/members.html.haml
@@ -13,7 +13,7 @@
   = form_tag members_group_path(@group), method: :get, class: 'form-inline member-search-form'  do
     .form-group
       = search_field_tag :search, params[:search], { placeholder: 'Find existing member by name', class: 'form-control search-text-input input-mn-300' }
-    = submit_tag 'Search', class: 'btn'
+    = button_tag 'Search', class: 'btn'
 
   - if current_user && current_user.can?(:manage_group, @group)
     .pull-right

--- a/app/views/layouts/_search.html.haml
+++ b/app/views/layouts/_search.html.haml
@@ -8,7 +8,7 @@
     - if @snippet || @snippets
       = hidden_field_tag :snippets, true
     = hidden_field_tag :repository_ref, @ref
-    = submit_tag 'Go' if ENV['RAILS_ENV'] == 'test'
+    = button_tag 'Go' if ENV['RAILS_ENV'] == 'test'
     .search-autocomplete-opts.hide{:'data-autocomplete-path' => search_autocomplete_path, :'data-autocomplete-project-id' => @project.try(:id), :'data-autocomplete-project-ref' => @ref }
 
 :javascript

--- a/app/views/projects/blob/_remove.html.haml
+++ b/app/views/projects/blob/_remove.html.haml
@@ -19,7 +19,7 @@
           .form-group
             .col-sm-2
             .col-sm-10
-              = submit_tag 'Remove file', class: 'btn btn-remove btn-remove-file'
+              = button_tag 'Remove file', class: 'btn btn-remove btn-remove-file'
               = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
 
 :javascript

--- a/app/views/projects/branches/new.html.haml
+++ b/app/views/projects/branches/new.html.haml
@@ -15,7 +15,7 @@
     .col-sm-10
       = text_field_tag :ref, params[:ref], placeholder: 'existing branch name, tag or commit SHA', required: true, tabindex: 2, class: 'form-control'
   .form-actions
-    = submit_tag 'Create branch', class: 'btn btn-create', tabindex: 3
+    = button_tag 'Create branch', class: 'btn btn-create', tabindex: 3
     = link_to 'Cancel', project_branches_path(@project), class: 'btn btn-cancel'
 
 :javascript

--- a/app/views/projects/compare/_form.html.haml
+++ b/app/views/projects/compare/_form.html.haml
@@ -12,7 +12,7 @@
         %span.input-group-addon to
         = text_field_tag :to, params[:to], class: "form-control"
     &nbsp;
-    = submit_tag "Compare", class: "btn btn-create commits-compare-btn"
+    = button_tag "Compare", class: "btn btn-create commits-compare-btn"
     - if compare_to_mr_button?
       = link_to compare_mr_path, class: 'prepend-left-10 btn' do
         %strong Make a merge request

--- a/app/views/projects/tags/new.html.haml
+++ b/app/views/projects/tags/new.html.haml
@@ -21,7 +21,7 @@
       = text_field_tag :message, nil, placeholder: 'Enter message.', required: false, tabindex: 3, class: 'form-control'
       .light (Optional) Entering a message will create an annotated tag.
   .form-actions
-    = submit_tag 'Create tag', class: 'btn btn-create', tabindex: 3
+    = button_tag 'Create tag', class: 'btn btn-create', tabindex: 3
     = link_to 'Cancel', project_tags_path(@project), class: 'btn btn-cancel'
 
 :javascript

--- a/app/views/projects/team_members/import.html.haml
+++ b/app/views/projects/team_members/import.html.haml
@@ -9,6 +9,6 @@
     .col-sm-10= select_tag(:source_project_id, options_from_collection_for_select(current_user.authorized_projects, :id, :name_with_namespace), prompt: "Select project", class: "select2 lg", required: true)
 
   .form-actions
-    = submit_tag 'Import project members', class: "btn btn-create"
+    = button_tag 'Import project members', class: "btn btn-create"
     = link_to "Cancel", project_team_index_path(@project), class: "btn btn-cancel"
 

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -6,7 +6,7 @@
       .col-sm-6
         = search_field_tag :search, params[:search], placeholder: "issue 143", class: "form-control search-text-input", id: "dashboard_search"
       .col-sm-4
-        = submit_tag 'Search', class: "btn btn-create"
+        = button_tag 'Search', class: "btn btn-create"
     .form-group
       .col-sm-2
       - unless params[:snippets].eql? 'true'


### PR DESCRIPTION
This PR replaces all `input type="submit"` (generated by `submit_tag`) with `button type="submit"`.

Starting from IE7 they are the same, and button is more flexible as it can contain HTML. Let's use button everywhere then: http://stackoverflow.com/questions/7117639/input-type-submit-vs-button-tag-are-they-interchangeable

Note: Rails adds `type="submit"` by default to `button_tag`.
