### PR TITLE
Replace testme with gitlab-test.

### DIFF
--- a/db/fixtures/development/04_project.rb
+++ b/db/fixtures/development/04_project.rb
@@ -7,7 +7,7 @@ Sidekiq::Testing.inline! do
       'https://gitlab.com/gitlab-org/gitlab-ce.git',
       'https://gitlab.com/gitlab-org/gitlab-ci.git',
       'https://gitlab.com/gitlab-org/gitlab-shell.git',
-      'https://gitlab.com/gitlab-org/testme.git',
+      'https://gitlab.com/gitlab-org/gitlab-test.git',
       'https://github.com/twitter/flight.git',
       'https://github.com/twitter/typeahead.js.git',
       'https://github.com/h5bp/html5-boilerplate.git',

--- a/spec/support/test_env.rb
+++ b/spec/support/test_env.rb
@@ -46,17 +46,16 @@ module TestEnv
   end
 
   def setup_factory_repo
-    repo_path = repos_path + "/root/testme.git"
-    clone_url = 'https://gitlab.com/gitlab-org/gitlab-test.git'
+    clone_url = "https://gitlab.com/gitlab-org/#{factory_repo_name}.git"
 
-    unless File.directory?(repo_path)
-      git_cmd = %W(git clone --bare #{clone_url} #{repo_path})
+    unless File.directory?(factory_repo_path)
+      git_cmd = %W(git clone --bare #{clone_url} #{factory_repo_path})
       system(*git_cmd)
     end
   end
 
   def copy_repo(project)
-    base_repo_path = File.expand_path(repos_path + "/root/testme.git")
+    base_repo_path = File.expand_path(factory_repo_path)
     target_repo_path = File.expand_path(repos_path + "/#{project.namespace.path}/#{project.path}.git")
     FileUtils.mkdir_p(target_repo_path)
     FileUtils.cp_r("#{base_repo_path}/.", target_repo_path)
@@ -65,5 +64,15 @@ module TestEnv
 
   def repos_path
     Gitlab.config.gitlab_shell.repos_path
+  end
+
+  private
+
+  def factory_repo_path
+    @factory_repo_path ||= repos_path + "/root/#{factory_repo_name}.git"
+  end
+
+  def factory_repo_name
+    'gitlab-test'
   end
 end


### PR DESCRIPTION
This PR:
- replaces testme with gitlab-test on the development env
- renames the local testme to gitlab-test on the test env to match the new repo name, and DRYes it up

RIP tesme. :skull:

Long live gitlab-test!
