### PR TITLE
Remove unneeded password_confirmation from seed.

### DIFF
--- a/db/fixtures/development/01_admin.rb
+++ b/db/fixtures/development/01_admin.rb
@@ -5,7 +5,6 @@ Gitlab::Seeder.quiet do
     s.email = 'admin@example.com'
     s.username = 'root'
     s.password = '5iveL!fe'
-    s.password_confirmation = '5iveL!fe'
     s.admin = true
     s.projects_limit = 100
     s.confirmed_at = DateTime.now

--- a/db/fixtures/production/001_admin.rb
+++ b/db/fixtures/production/001_admin.rb
@@ -11,7 +11,6 @@ admin = User.create(
   name: "Administrator",
   username: 'root',
   password: password,
-  password_confirmation: password,
   password_expires_at: expire_time,
   theme_id: Gitlab::Theme::MARS
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,7 +20,6 @@ FactoryGirl.define do
     name
     sequence(:username) { |n| "#{Faker::Internet.user_name}#{n}" }
     password "12345678"
-    password_confirmation { password }
     confirmed_at { Time.now }
     confirmation_token { nil }
 


### PR DESCRIPTION
Not validated if not present: https://github.com/plataformatec/devise/issues/2796

Already works like that for the user development seeds.
