### PR TITLE
Replace :erb filter with plain HAML.

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -18,8 +18,7 @@
   = javascript_include_tag "application"
   = csrf_meta_tags
   = include_gon
-  :erb
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
 
   = render 'layouts/google_analytics' if extra_config.has_key?('google_analytics_id')
   = render 'layouts/piwik' if extra_config.has_key?('piwik_url') && extra_config.has_key?('piwik_site_id')


### PR DESCRIPTION
Rendered HTML is the same.

We use HAML exactly avoid ERB or pure HTML, so let's not use `:erb`.

There is another occurrence which I cannot get rid of at: https://github.com/gitlabhq/gitlabhq/blob/c2c41fb2d3b6b5934ff26cec77c15f6c45351018/app/views/projects/blame/show.html.haml#L31 because of https://github.com/haml/haml/issues/648
