### PR TITLE
Remove blame lines added leading whitespace.

### DIFF
--- a/app/views/projects/blame/show.html.haml
+++ b/app/views/projects/blame/show.html.haml
@@ -30,5 +30,5 @@
                 %code{ class: highlightjs_class(@blob.name) }
                   :erb
                     <% lines.each do |line| %>
-                      <%= line %>
+                    <%= line %>
                     <% end %>


### PR DESCRIPTION
This was adding 2 extra spaces to the blame.

Before: (there are two whitespaces before every line content)

![screenshot from 2014-09-27 16 47 19 blame whitespace before](https://cloud.githubusercontent.com/assets/1429315/4431050/6bf0e104-4655-11e4-9988-0c10b415cc91.png)

After:

![screenshot from 2014-09-27 16 47 34 blame whitespace after](https://cloud.githubusercontent.com/assets/1429315/4431051/7148e804-4655-11e4-8413-225cb42321b4.png)

I think the new spacing is fine: if we want to control it let's do it with CSS.

I really wanted to get rid of that `:erb` block but I was not able to as mentioned in https://github.com/gitlabhq/gitlabhq/pull/7880
