### PR TITLE
Use blob local instead of instance.

### DIFF
--- a/app/views/projects/blob/_blob.html.haml
+++ b/app/views/projects/blob/_blob.html.haml
@@ -16,7 +16,7 @@
         = link_to title, '#'
 
 %ul.blob-commit-info.bs-callout.bs-callout-info.hidden-xs
-  - blob_commit = @repository.last_commit_for_path(@commit.id, @blob.path)
+  - blob_commit = @repository.last_commit_for_path(@commit.id, blob.path)
   = render blob_commit, project: @project
 
 %div#tree-content-holder.tree-content-holder


### PR DESCRIPTION
It is open to discussion which is the better style, to use instance variables `@blob` on partials or only locals, but mixing both like here is definitely not the way to go.

http://stackoverflow.com/questions/2503838/rails-should-partials-be-aware-of-instance-variables

Modified to a local since it is the only occurrence of `@blob`, and there are many other `blob` in the same file.

Other variables however are predominantly instance.
