### PR TITLE
[WIP] Factor blob and blame [failure unrelated]

### DIFF
--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -39,6 +39,11 @@ class Projects::BlobController < Projects::ApplicationController
     render layout: false
   end
 
+  def blame
+    @blame = Gitlab::Git::Blame.new(project.repository, @commit.id, @path)
+    render :show
+  end
+
   private
 
   def blob

--- a/app/views/projects/blob/_blame.html.haml
+++ b/app/views/projects/blob/_blame.html.haml
@@ -1,0 +1,24 @@
+.file-content.blame.highlight
+  %table
+    - @blame.each do |commit, lines, since|
+      - commit = Commit.new(commit)
+      %tr
+        %td.blame-commit
+          %span.commit
+            = link_to commit.short_id, project_commit_path(@project, commit), class: "commit_short_id"
+            &nbsp;
+            = commit_author_link(commit, avatar: true, size: 16)
+            &nbsp;
+            = link_to_gfm truncate(commit.title, length: 20), project_commit_path(@project, commit.id), class: "row_title"
+        %td.lines.blame-numbers
+          %pre
+            - (since...(since + lines.count)).each do |i|
+              = i
+              \
+        %td.lines
+          %pre
+            %code{ class: highlightjs_class(@blob.name) }
+              :erb
+                <% lines.each do |line| %>
+                  <%= line %>
+                <% end %>

--- a/app/views/projects/blob/_blob.html.haml
+++ b/app/views/projects/blob/_blob.html.haml
@@ -27,9 +27,12 @@
         = blob.name
         %small= number_to_human_size blob.size
       %span.options.hidden-xs= render "actions"
-    - if blob.text?
-      = render "text", blob: blob
-    - elsif blob.image?
-      = render "image", blob: blob
+    - if @blame
+      = render 'blame'
     - else
-      = render "download", blob: blob
+      - if blob.text?
+        = render "text", blob: blob
+      - elsif blob.image?
+        = render "image", blob: blob
+      - else
+        = render "download", blob: blob

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,7 @@ Gitlab::Application.routes.draw do
       resources :blob, only: [:show, :destroy], constraints: { id: /.+/, format: false } do
         get :diff, on: :member
       end
+      get 'blame/:id' => 'blob#blame', constraints: { id: /.+/ }, as: :blame
       resources :raw,       only: [:show], constraints: {id: /.+/}
       resources :tree,      only: [:show], constraints: {id: /.+/, format: /(html|js)/ }
       resources :edit_tree, only: [:show, :update], constraints: { id: /.+/ }, path: 'edit' do
@@ -210,7 +211,6 @@ Gitlab::Application.routes.draw do
       resources :commit,    only: [:show], constraints: {id: /[[:alnum:]]{6,40}/}
       resources :commits,   only: [:show], constraints: {id: /(?:[^.]|\.(?!atom$))+/, format: /atom/}
       resources :compare,   only: [:index, :create]
-      resources :blame,     only: [:show], constraints: {id: /.+/}
       resources :network,   only: [:show], constraints: {id: /(?:[^.]|\.(?!json$))+/, format: /json/}
       resources :graphs,    only: [:show], constraints: {id: /(?:[^.]|\.(?!json$))+/, format: /json/} do
         member do

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -404,14 +404,6 @@ describe Projects::NotesController, "routing" do
   end
 end
 
-# project_blame GET    /:project_id/blame/:id(.:format) blame#show {id: /.+/, project_id: /[^\/]+/}
-describe Projects::BlameController, "routing" do
-  it "to #show" do
-    get("/gitlab/gitlabhq/blame/master/app/models/project.rb").should route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/project.rb')
-    get("/gitlab/gitlabhq/blame/master/files.scss").should route_to('projects/blame#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
-  end
-end
-
 # project_blob GET    /:project_id/blob/:id(.:format) blob#show {id: /.+/, project_id: /[^\/]+/}
 describe Projects::BlobController, "routing" do
   it "to #show" do
@@ -419,6 +411,12 @@ describe Projects::BlobController, "routing" do
     get("/gitlab/gitlabhq/blob/master/app/models/compare.rb").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/compare.rb')
     get("/gitlab/gitlabhq/blob/master/app/models/diff.js").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/app/models/diff.js')
     get("/gitlab/gitlabhq/blob/master/files.scss").should route_to('projects/blob#show', project_id: 'gitlab/gitlabhq', id: 'master/files.scss')
+    get('/gitlab/gitlabhq/blame/master/app/models/project.rb').
+      should route_to('projects/blob#blame', project_id: 'gitlab/gitlabhq',
+                                             id: 'master/app/models/project.rb')
+    get('/gitlab/gitlabhq/blame/master/files.scss').
+      should route_to('projects/blob#blame', project_id: 'gitlab/gitlabhq',
+                                             id: 'master/files.scss')
   end
 end
 


### PR DESCRIPTION
Philosophy: blame is just a type of view for a blob. There is even a toggle button to go between both.

This PR factors:
- the filename holder on blame and blob views
- controller logic for blame which is identical for blame by moving `blame` into the blob controller

It makes the following UI modifications which increases uniformity between blobs and blames:
- show the branch / path breadcrumb and last commit to the top of the blame
- remove the "blame view" title, since this is already obvious from the view itself, and from the "normal view" toggle button. Same rationale why the show view does not have a "Show view" title.

New:

![screenshot from 2014-09-28 00 18 17 blob blame new](https://cloud.githubusercontent.com/assets/1429315/4432445/f8bda826-4694-11e4-8088-3301225af0f1.png)

Old:

![screenshot from 2014-09-28 00 18 32 blob blame old](https://cloud.githubusercontent.com/assets/1429315/4432444/f0f9013a-4694-11e4-92b9-6f35d72a6005.png)

We now have more functionality and uniformity with less lines of code.

TODO: the only implementation detail I'm not satisfied with is the route. Can anyone propose a shorter, DRYer way of writing it, possibly as a `member` of the `:blob` resource? 
