### PR TITLE
Disable / hide MR edit blob button if cannot edit.

### DIFF
--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -1,11 +1,5 @@
 .btn-group.tree-btn-group
-  -# only show edit link for text files
-  - if @blob.text?
-    - if allowed_tree_edit?
-      = link_to 'Edit', project_edit_tree_path(@project, @id),
-          class: 'btn btn-small'
-    - else
-      %span.btn.btn-small.disabled Edit
+  = edit_blob_link(@project, @ref, @path)
   = link_to 'Raw', project_raw_path(@project, @id),
       class: 'btn btn-small', target: '_blank'
   -# only show normal/blame view links for text files

--- a/app/views/projects/diffs/_file.html.haml
+++ b/app/views/projects/diffs/_file.html.haml
@@ -27,9 +27,9 @@
           &nbsp;
 
         - if @merge_request && @merge_request.source_project
-          = link_to project_edit_tree_path(@merge_request.source_project, tree_join(@merge_request.source_branch, diff_file.new_path), from_merge_request_id: @merge_request.id), { class: 'btn btn-small' } do
-            Edit
-          &nbsp;
+          = edit_blob_link(@merge_request.source_project,
+              @merge_request.source_branch, diff_file.new_path,
+              after: '&nbsp;', from_merge_request_id: @merge_request.id)
 
         = view_file_btn(@commit.id, diff_file, project)
 


### PR DESCRIPTION
UI changes on the merge request diff view:
- if the user does not have permission to edit the blob, disable the link
- if the blob is not text, hide the link

This is the same behavior as for the blob show edit button. Both buttons have been factored out.

The blob show edit button is unchanged.

Before this, there would be a clickable link to a 404 or to edit binary files as text on the page.

Screenshot of disabled Edit link:

![screenshot from 2014-09-28 11 00 53 disable edit mr after](https://cloud.githubusercontent.com/assets/1429315/4433779/97c20602-46ee-11e4-8d7b-8e1c85a6416f.png)

This solves half of: https://github.com/gitlabhq/gitlabhq/issues/7310
