### PR TITLE
Add tests for disabled blob edit button cases [Can be updated]

### DIFF
--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -50,6 +50,16 @@ Feature: Project Source Browse Files
     And I click button "Edit"
     Then I can edit code
 
+  Scenario: If the file is binary the edit link is hidden
+    Given I visit a binary file in the repo
+    Then I cannot see the edit button
+
+  Scenario: If I don't have edit permission the edit link is disabled
+    Given public project "Community"
+    And I visit project "Community" source page
+    And I click on ".gitignore" file in repo
+    Then The edit button is disabled
+
   @javascript
   Scenario: I can edit and commit file
     Given I click on ".gitignore" file in repo

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -48,6 +48,14 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     click_link 'Edit'
   end
 
+  step 'I cannot see the edit button' do
+    page.should_not have_link 'edit'
+  end
+
+  step 'The edit button is disabled' do
+    page.should have_css '.disabled', text: 'edit'
+  end
+
   step 'I can edit code' do
     set_new_content
     evaluate_script('editor.getValue()').should == new_gitignore_content

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -178,6 +178,11 @@ module SharedPaths
     visit project_tree_path(@project, root_ref)
   end
 
+  step 'I visit a binary file in the repo' do
+    visit project_blob_path(@project, File.join(
+      root_ref, 'files/images/logo-black.png'))
+  end
+
   step "I visit my project's commits page" do
     visit project_commits_path(@project, root_ref, {limit: 5})
   end
@@ -378,6 +383,11 @@ module SharedPaths
   step 'I visit project "Community" page' do
     project = Project.find_by(name: "Community")
     visit project_path(project)
+  end
+
+  step 'I visit project "Community" source page' do
+    project = Project.find_by(name: 'Community')
+    visit project_tree_path(project, root_ref)
   end
 
   step 'I visit project "Internal" page' do


### PR DESCRIPTION
This PR adds 2 tests for the blob edit link state:
- If the file is binary the edit link is hidden
- If I don't have edit permission the edit link is disabled

I felt the need for that while doing: https://github.com/gitlabhq/gitlabhq/pull/7886
