### PR TITLE
Remove def project from tests that inherit it.

### DIFF
--- a/features/steps/dashboard/dashboard.rb
+++ b/features/steps/dashboard/dashboard.rb
@@ -82,8 +82,4 @@ class Spinach::Features::Dashboard < Spinach::FeatureSteps
   step 'I should see 1 project at group list' do
     find('span.last_activity/span').should have_content('1')
   end
-
-  def project
-    @project ||= Project.find_by(name: "Shop")
-  end
 end

--- a/features/steps/project/forked_merge_requests.rb
+++ b/features/steps/project/forked_merge_requests.rb
@@ -128,10 +128,6 @@ class Spinach::Features::ProjectForkedMergeRequests < Spinach::FeatureSteps
     page.should have_select("merge_request_target_project_id", selected: project.path_with_namespace)
   end
 
-  def project
-    @project ||= Project.find_by!(name: "Shop")
-  end
-
   # Verify a link is generated against the correct project
   def verify_commit_link(container_div, container_project)
     # This should force a wait for the javascript to execute

--- a/features/steps/project/issues.rb
+++ b/features/steps/project/issues.rb
@@ -236,8 +236,4 @@ class Spinach::Features::ProjectIssues < Spinach::FeatureSteps
     # make sure AJAX request finished
     URI.parse(current_url).request_uri == project_issues_path(project, issue_search: text)
   end
-
-  def project
-    @project ||= Project.find_by(name: 'Shop')
-  end
 end

--- a/features/steps/project/merge_requests.rb
+++ b/features/steps/project/merge_requests.rb
@@ -261,10 +261,6 @@ class Spinach::Features::ProjectMergeRequests < Spinach::FeatureSteps
     end
   end
 
-  def project
-    @project ||= Project.find_by!(name: "Shop")
-  end
-
   def merge_request
     @merge_request ||= MergeRequest.find_by!(title: "Bug NS-05")
   end

--- a/features/steps/project/snippets.rb
+++ b/features/steps/project/snippets.rb
@@ -89,10 +89,6 @@ class Spinach::Features::ProjectSnippets < Spinach::FeatureSteps
     visit project_snippet_path(project, project_snippet)
   end
 
-  def project
-    @project ||= Project.find_by!(name: "Shop")
-  end
-
   def project_snippet
     @project_snippet ||= ProjectSnippet.find_by!(title: "Snippet one")
   end

--- a/features/steps/search.rb
+++ b/features/steps/search.rb
@@ -66,8 +66,4 @@ class Spinach::Features::Search < Spinach::FeatureSteps
   step 'I should not see "Bar" link' do
     page.should_not have_link "Bar"
   end
-
-  def project
-    @project ||= Project.find_by(name: "Shop")
-  end
 end


### PR DESCRIPTION
It's already defined on `SharedPath` at https://github.com/gitlabhq/gitlabhq/blob/c2c41fb2d3b6b5934ff26cec77c15f6c45351018/features/steps/shared/paths.rb#L413 which basically every test inherits.
