### PR TITLE
Fix pasting images into browser

### DIFF
--- a/app/assets/javascripts/markdown_area.js.coffee
+++ b/app/assets/javascripts/markdown_area.js.coffee
@@ -13,7 +13,9 @@ $(document).ready ->
   project_image_path_upload = window.project_image_path_upload or null
 
   $("textarea.markdown-area").wrap "<div class=\"div-dropzone\"></div>"
-
+  $("textarea.markdown-area").bind 'paste', (event) =>
+    handlePaste(event)
+  
   $(".div-dropzone").parent().addClass "div-dropzone-wrapper"
 
   $(".div-dropzone").append divHover
@@ -137,7 +139,7 @@ $(document).ready ->
     e.preventDefault()
     my_event = e.originalEvent
 
-    if my_event.clipboardData and my_event.clipboardData.items
+    if my_event.clipboardData
       processItem(my_event)
 
   processItem = (e) ->
@@ -152,10 +154,13 @@ $(document).ready ->
       text = e.clipboardData.getData("text/plain")
       pasteText(text)
 
-  isImage = (data) ->
+  isImage = (e) ->
+    if not e.clipboardData.items
+      return false
+
     i = 0
-    while i < data.clipboardData.items.length
-      item = data.clipboardData.items[i]
+    while i < e.clipboardData.items.length
+      item = e.clipboardData.items[i]
       if item.type.indexOf("image") isnt -1
         return item
       i++


### PR DESCRIPTION
This patch binds the handlePaste() function to the clipboardData paste event.

Currently firefox/safari do not fully support clipboardData. Therefore
on those browsers the clipboard contents is pasted as plain/text and a
message is displayed within the alert area.

This is a possible solution for #7392

I only tested on:
Firefox (linux) -> NOT working
Chrome (linux) -> working
Firefox (Mac) -> NOT working
Safari (Mac) -> NOT working

Tomorrow I will test on Windows (Firefox, Chrome, IE 10)

For Firefox there is currently some work in progress to get it working too:
https://bugzilla.mozilla.org/show_bug.cgi?id=891247

Before this will be merged I probably have to change something.
Please review and comment. It would be great to get this merged because the pasting of images is a great feature.
