### PR TITLE
Prevent email sending on admin dev seed.

### DIFF
--- a/db/fixtures/development/01_admin.rb
+++ b/db/fixtures/development/01_admin.rb
@@ -1,11 +1,13 @@
-User.seed do |s|
-  s.id = 1
-  s.name = "Administrator"
-  s.email = "admin@example.com"
-  s.username = 'root'
-  s.password = "5iveL!fe"
-  s.password_confirmation = "5iveL!fe"
-  s.admin = true
-  s.projects_limit = 100
-  s.confirmed_at = DateTime.now
+Gitlab::Seeder.quiet do
+  User.seed do |s|
+    s.id = 1
+    s.name = 'Administrator'
+    s.email = 'admin@example.com'
+    s.username = 'root'
+    s.password = '5iveL!fe'
+    s.password_confirmation = '5iveL!fe'
+    s.admin = true
+    s.projects_limit = 100
+    s.confirmed_at = DateTime.now
+  end
 end


### PR DESCRIPTION
The only advantage of having emails is for first time developers to find the password more easily... but I think it is not worth it because:
- it forces every dev (large majority of which not a first time dev) to close those email tabs on every `gitlab:setup`
- it is already well documented on the dev install

So let's nuke them.
