### PR TITLE
Add predictable merge requests on dev seed.

### DIFF
--- a/db/fixtures/development/10_merge_requests.rb
+++ b/db/fixtures/development/10_merge_requests.rb
@@ -20,4 +20,22 @@ Gitlab::Seeder.quiet do
       print '.'
     end
   end
+
+  project = Project.find_with_namespace('gitlab-org/testme')
+
+  params = {
+    source_branch: 'feature',
+    target_branch: 'master',
+    title: 'Can be automatically merged'
+  }
+  MergeRequests::CreateService.new(project, User.admins.first, params).execute
+  print '.'
+
+  params = {
+    source_branch: 'feature_conflict',
+    target_branch: 'feature',
+    title: 'Cannot be automatically merged'
+  }
+  MergeRequests::CreateService.new(project, User.admins.first, params).execute
+  print '.'
 end


### PR DESCRIPTION
Create 2 predictable merge requests on the `gitlab-org/testme` repository:
- between `feature` and `master`, which has no conflict
- between `feature_conflict` and `feature`, which has conflicts

This would be a huge help when devving merge request related features.
