### PR TITLE
Only show text wrap and diff notes for text in merge requests.

### DIFF
--- a/app/views/projects/diffs/_file.html.haml
+++ b/app/views/projects/diffs/_file.html.haml
@@ -15,15 +15,16 @@
         %span.file-mode= "#{diff_file.diff.a_mode} → #{diff_file.diff.b_mode}"
 
       .diff-btn-group
-        - unless params[:view] == 'parallel'
-          %label
-            = check_box_tag nil, 1, false, class: "js-toggle-diff-line-wrap"
-            Wrap text
-        &nbsp;
-        = link_to "#", class: "js-toggle-diff-comments btn btn-small" do
-          %i.icon-chevron-down
-          Diff comments
-        &nbsp;
+        - if blob.text?
+          - unless params[:view] == 'parallel'
+            %label
+              = check_box_tag nil, 1, false, class: 'js-toggle-diff-line-wrap'
+              Wrap text
+          &nbsp;
+          = link_to '#', class: 'js-toggle-diff-comments btn btn-small' do
+            %i.icon-chevron-down
+            Diff comments
+          &nbsp;
 
         - if @merge_request && @merge_request.source_project
           = link_to project_edit_tree_path(@merge_request.source_project, tree_join(@merge_request.source_branch, diff_file.new_path), from_merge_request_id: @merge_request.id), { class: 'btn btn-small' } do


### PR DESCRIPTION
Before this PR those options also showed for binary files for which they don't apply:

![screenshot from 2014-09-29 14 46 31 wrap text diff comments binary](https://cloud.githubusercontent.com/assets/1429315/4441810/5c39411a-47d7-11e4-84ff-38f567a21ecf.png)

Now they only show for text files.
