### PR TITLE
Titleize blob action buttons. [failure unrelated]

### DIFF
--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -2,21 +2,26 @@
   -# only show edit link for text files
   - if @blob.text?
     - if allowed_tree_edit?
-      = link_to "edit", project_edit_tree_path(@project, @id), class: "btn btn-small"
+      = link_to 'Edit', project_edit_tree_path(@project, @id),
+          class: 'btn btn-small'
     - else
-      %span.btn.btn-small.disabled edit
-  = link_to "raw", project_raw_path(@project, @id), class: "btn btn-small", target: "_blank"
+      %span.btn.btn-small.disabled Edit
+  = link_to 'Raw', project_raw_path(@project, @id),
+      class: 'btn btn-small', target: '_blank'
   -# only show normal/blame view links for text files
   - if @blob.text?
     - if current_page? project_blame_path(@project, @id)
-      = link_to "normal view", project_blob_path(@project, @id), class: "btn btn-small"
+      = link_to 'Normal View', project_blob_path(@project, @id),
+          class: 'btn btn-small'
     - else
-      = link_to "blame", project_blame_path(@project, @id), class: "btn btn-small" unless @blob.empty?
-  = link_to "history", project_commits_path(@project, @id), class: "btn btn-small"
+      = link_to 'Blame', project_blame_path(@project, @id),
+          class: 'btn btn-small' unless @blob.empty?
+  = link_to 'History', project_commits_path(@project, @id),
+      class: 'btn btn-small'
   - if @ref != @commit.sha
-    = link_to 'permalink', project_blob_path(@project,
+    = link_to 'Permalink', project_blob_path(@project,
         tree_join(@commit.sha, @path)), class: 'btn btn-small'
 
 - if allowed_tree_edit?
   = link_to '#modal-remove-blob', class: "remove-blob btn btn-small btn-remove", "data-toggle" => "modal" do
-    remove
+    Remove

--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -30,7 +30,7 @@
               = link_to @commit.short_id, project_commit_path(@project, @commit)
               &ndash;
               = truncate(@commit.title, length: 50)
-          = link_to "history", project_commits_path(@project, @id), class: "pull-right"
+          = link_to 'History', project_commits_path(@project, @id), class: 'pull-right'
 
     - if @path.present?
       %tr.tree-item

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -17,7 +17,7 @@ Feature: Project Browse files
 
   Scenario: I browse raw file
     Given I visit blob file from repo
-    And I click link "raw"
+    And I click link "Raw"
     Then I should see raw file content
 
   Scenario: I can create file
@@ -37,13 +37,13 @@ Feature: Project Browse files
   @javascript
   Scenario: I can edit file
     Given I click on ".gitignore" file in repo
-    And I click button "edit"
+    And I click button "Edit"
     Then I can edit code
 
   @javascript
   Scenario: I can edit and commit file
     Given I click on ".gitignore" file in repo
-    And I click button "edit"
+    And I click button "Edit"
     And I edit code
     And I fill the commit message
     And I click on "Commit changes"
@@ -53,7 +53,7 @@ Feature: Project Browse files
   @javascript
   Scenario: I can see editing preview
     Given I click on ".gitignore" file in repo
-    And I click button "edit"
+    And I click button "Edit"
     And I edit code
     And I click link "Diff"
     Then I see diff
@@ -62,7 +62,7 @@ Feature: Project Browse files
   Scenario: I can remove file and commit
     Given I click on ".gitignore" file in repo
     And I see the ".gitignore"
-    And I click on "remove"
+    And I click on "Remove"
     And I fill the commit message
     And I click on "Remove file"
     Then I am redirected to the files URL
@@ -70,23 +70,23 @@ Feature: Project Browse files
 
   Scenario: I can browse directory with Browse Dir
     Given I click on files directory
-    And I click on history link
+    And I click on History link
     Then I see Browse dir link
 
   Scenario: I can browse file with Browse File
     Given I click on readme file
-    And I click on history link
+    And I click on History link
     Then I see Browse file link
 
   Scenario: I can browse code with Browse Code
-    Given I click on history link
+    Given I click on History link
     Then I see Browse code link
 
   # Permalink
 
   Scenario: I click on the permalink link from a branch ref
     Given I click on ".gitignore" file in repo
-    And I click on permalink
+    And I click on Permalink
     Then I am redirected to the permalink URL
 
   Scenario: I don't see the permalink link from a SHA ref

--- a/features/project/source/git_blame.feature
+++ b/features/project/source/git_blame.feature
@@ -6,5 +6,5 @@ Feature: Project Browse git repo
 
   Scenario: I blame file
     Given I click on ".gitignore" file in repo
-    And I click blame button
+    And I click Blame button
     Then I should see git file blame

--- a/features/steps/project/browse_files.rb
+++ b/features/steps/project/browse_files.rb
@@ -36,16 +36,16 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     page.should have_content new_gitignore_content
   end
 
-  step 'I click link "raw"' do
-    click_link "raw"
+  step 'I click link "Raw"' do
+    click_link 'Raw'
   end
 
   step 'I should see raw file content' do
     source.should == sample_blob.data
   end
 
-  step 'I click button "edit"' do
-    click_link 'edit'
+  step 'I click button "Edit"' do
+    click_link 'Edit'
   end
 
   step 'I can edit code' do
@@ -73,8 +73,8 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     click_button 'Commit changes'
   end
 
-  step 'I click on "remove"' do
-    click_link 'remove'
+  step 'I click on "Remove"' do
+    click_link 'Remove'
   end
 
   step 'I click on "Remove file"' do
@@ -99,8 +99,8 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     click_link 'files'
   end
 
-  step 'I click on history link' do
-    click_link 'history'
+  step 'I click on History link' do
+    click_link 'History'
   end
 
   step 'I see Browse dir link' do
@@ -125,8 +125,8 @@ class Spinach::Features::ProjectBrowseFiles < Spinach::FeatureSteps
     page.should_not have_link 'Browse Dir »'
   end
 
-  step 'I click on permalink' do
-    click_link 'permalink'
+  step 'I click on Permalink' do
+    click_link 'Permalink'
   end
 
   step 'I am redirected to the files URL' do

--- a/features/steps/project/browse_git_repo.rb
+++ b/features/steps/project/browse_git_repo.rb
@@ -7,8 +7,8 @@ class Spinach::Features::ProjectBrowseGitRepo < Spinach::FeatureSteps
     click_link ".gitignore"
   end
 
-  step 'I click blame button' do
-    click_link "blame"
+  step 'I click Blame button' do
+    click_link 'Blame'
   end
 
   step 'I should see git file blame' do


### PR DESCRIPTION
As supported by dosire at: https://github.com/gitlabhq/gitlabhq/issues/7789#issuecomment-57126623

I think it looks better.

After:

![screenshot from 2014-09-29 23 10 14 upcase actions](https://cloud.githubusercontent.com/assets/1429315/4449602/7945114e-481d-11e4-8a54-9b0e783e6956.png)

Before:

![screenshot from 2014-09-29 23 12 03 titleize blob action before](https://cloud.githubusercontent.com/assets/1429315/4449605/80dcd586-481d-11e4-8975-88ee6af733aa.png)

In particular, those buttons being lower case already conflicts with the analogous buttons on merge request diffs.

Also titleized the history link on the tree view: it makes tests simpler, and would have to be done sooner or later. Screenshot (link on upper right):

![screenshot from 2014-09-30 23 30 15 project tree history](https://cloud.githubusercontent.com/assets/1429315/4466835/20a54d3e-48e9-11e4-9591-6147dead103b.png)
