### PR TITLE
Change always passing visible false tests.

### DIFF
--- a/features/project/commits/comments.feature
+++ b/features/project/commits/comments.feature
@@ -14,11 +14,6 @@ Feature: Project Commits Comments
     Then I should not see the cancel comment button
 
   @javascript
-  Scenario: I can't preview without text
-    Given I haven't written any comment text
-    Then The comment preview tab should say there is nothing to do
-
-  @javascript
   Scenario: I can preview with text
     Given I write a comment like ":+1: Nice"
     Then The comment preview tab should be display rendered Markdown

--- a/features/project/commits/diff_comments.feature
+++ b/features/project/commits/diff_comments.feature
@@ -55,12 +55,6 @@ Feature: Project Commits Diff Comments
     Then I should see a discussion reply button
 
   @javascript
-  Scenario: I can't preview without text
-    Given I open a diff comment form
-    And I haven't written any diff comment text
-    Then The diff comment preview tab should say there is nothing to do
-
-  @javascript
   Scenario: I can preview with text
     Given I open a diff comment form
     And I write a diff comment like ":-1: I don't like this"

--- a/features/steps/shared/diff_note.rb
+++ b/features/steps/shared/diff_note.rb
@@ -80,7 +80,7 @@ module SharedDiffNote
 
   step 'I should not see the diff comment text field' do
     within(diff_file_selector) do
-      page.should have_css(".js-note-text", visible: false)
+      expect(find('.js-note-text')).not_to be_visible
     end
   end
 
@@ -115,7 +115,7 @@ module SharedDiffNote
   end
 
   step 'I should see add a diff comment button' do
-    page.should have_css(".js-add-diff-note-button", visible: false)
+    page.should have_css('.js-add-diff-note-button', visible: true)
   end
 
   step 'I should see an empty diff comment form' do

--- a/features/steps/shared/note.rb
+++ b/features/steps/shared/note.rb
@@ -64,7 +64,7 @@ module SharedNote
 
   step 'I should not see the comment text field' do
     within(".js-main-target-form") do
-      page.should have_css(".js-note-text", visible: false)
+      expect(find('.js-note-text')).not_to be_visible
     end
   end
 


### PR DESCRIPTION
Many usages of `visible: false` are wrong since `visible: false` matches _both_ visible and invisible elements: http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Finders#all-instance_method

The correct way to check that an element is present but not visible is:

```
expect(find(...)).not_to be_visible
```

The two "I can't preview without text" scenarios are not true anymore: now you can preview without text, so I removed then. They only passed because of the misuse. Screenshot:

![screenshot from 2014-09-30 15 56 00 js not preview visible without text](https://cloud.githubusercontent.com/assets/1429315/4459298/fe22b61e-48a9-11e4-8dc8-fb722792d719.png)

`'I should see add a diff comment button'` is simply wrong: it should be `visible: true` instead of `visible: false`.
