### PR TITLE
Convert many JavaScript # links to buttons [failure unrelated]

### DIFF
--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -44,7 +44,7 @@
         Projects (#{@projects.total_count})
         .panel-head-actions
           .dropdown.inline
-            %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+            %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
               %span.light sort:
               - if @sort.present?
                 = @sort.humanize

--- a/app/views/explore/groups/index.html.haml
+++ b/app/views/explore/groups/index.html.haml
@@ -8,7 +8,7 @@
 
   .pull-right
     .dropdown.inline
-      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+      %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
         %span.light sort:
         - if @sort.present?
           = @sort.humanize

--- a/app/views/explore/projects/index.html.haml
+++ b/app/views/explore/projects/index.html.haml
@@ -8,7 +8,7 @@
 
   .pull-right
     .dropdown.inline
-      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+      %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
         %span.light sort:
         - if @sort.present?
           = @sort.humanize

--- a/app/views/groups/group_members/_group_member.html.haml
+++ b/app/views/groups/group_members/_group_member.html.haml
@@ -14,7 +14,8 @@
       %strong= member.human_access
       - if show_controls
         - if can?(current_user, :modify, member)
-          = link_to '#', class: "btn-tiny btn js-toggle-button", title: 'Edit access level' do
+          = button_tag class: "btn-tiny btn js-toggle-button",
+                       title: 'Edit access level', type: 'button' do
             %i.fa.fa-pencil-square-o
         - if can?(current_user, :destroy, member)
           - if current_user == member.user

--- a/app/views/groups/members.html.haml
+++ b/app/views/groups/members.html.haml
@@ -17,7 +17,7 @@
 
   - if current_user && current_user.can?(:manage_group, @group)
     .pull-right
-      = link_to '#', class: 'btn btn-new js-toggle-button' do
+      = button_tag class: 'btn btn-new js-toggle-button', type: 'button' do
         Add members
         %i.fa.fa-chevron-down
 

--- a/app/views/projects/branches/index.html.haml
+++ b/app/views/projects/branches/index.html.haml
@@ -8,7 +8,7 @@
         New branch
       &nbsp;
     .dropdown.inline
-      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+      %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
         %span.light sort:
         - if @sort.present?
           = @sort.humanize

--- a/app/views/search/_filter.html.haml
+++ b/app/views/search/_filter.html.haml
@@ -1,5 +1,5 @@
 .dropdown.inline
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+  %button.dropdown-toggle.btn.btn-small{type: 'button', 'data-toggle' => 'dropdown'}
     %i.fa.fa-tags
     %span.light Group:
     - if @group.present?
@@ -17,7 +17,7 @@
           = group.name
 
 .dropdown.inline.prepend-left-10.project-filter
-  %a.dropdown-toggle.btn.btn-small{href: '#', "data-toggle" => "dropdown"}
+  %button.dropdown-toggle.btn.btn-small{type: 'button', 'data-toggle' => 'dropdown'}
     %i.fa.fa-tags
     %span.light Project:
     - if @project.present?

--- a/app/views/shared/_issuable_filter.html.haml
+++ b/app/views/shared/_issuable_filter.html.haml
@@ -15,7 +15,7 @@
           All
 
   .dropdown.inline.assignee-filter
-    %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+    %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
       %i.fa.fa-user
       %span.light assignee:
       - if @assignee.present?
@@ -38,7 +38,7 @@
             = user.name
 
   .dropdown.inline.prepend-left-10.author-filter
-    %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+    %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
       %i.fa.fa-user
       %span.light author:
       - if @author.present?
@@ -61,7 +61,7 @@
             = user.name
 
   .dropdown.inline.prepend-left-10.milestone-filter
-    %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+    %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
       %i.fa.fa-clock-o
       %span.light milestone:
       - if @milestone.present?
@@ -85,7 +85,7 @@
 
   - if @project
     .dropdown.inline.prepend-left-10.labels-filter
-      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+      %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
         %i.fa.fa-tags
         %span.light label:
         - if params[:label_name].present?

--- a/app/views/shared/_sort_dropdown.html.haml
+++ b/app/views/shared/_sort_dropdown.html.haml
@@ -1,5 +1,5 @@
 .dropdown.inline.prepend-left-10
-  %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+  %button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}
     %span.light sort:
     - if @sort.present?
       = @sort

--- a/features/steps/groups.rb
+++ b/features/steps/groups.rb
@@ -29,7 +29,7 @@ class Spinach::Features::Groups < Spinach::FeatureSteps
 
   step 'I select user "Mary Jane" from list with role "Reporter"' do
     user = User.find_by(name: "Mary Jane") || create(:user, name: "Mary Jane")
-    click_link 'Add members'
+    click_button 'Add members'
     within ".users-group-form" do
       select2(user.id, from: "#user_ids", multiple: true)
       select "Reporter", from: "access_level"


### PR DESCRIPTION
Same rationale as: https://github.com/gitlabhq/gitlabhq/pull/7863

Found with `git grep "'#'"`.

Refactored for every place except projects.

Only touched buttons that look like buttons, not links. Those should work with `.btn.btn-link` but for some reason didn't.

There were several dropdown ones factored with:

```
find . -iname '*.haml' | xargs perl -lapi -e "s/%a.dropdown-toggle.btn{href: '#', \"data-toggle\" => \"dropdown\"}/%button.dropdown-toggle.btn{type: 'button', 'data-toggle' => 'dropdown'}/"
```

We should really DRY up those dropboxes before they start diverging.
