### PR TITLE
Fix typo in link title

### DIFF
--- a/app/views/projects/_home_panel.html.haml
+++ b/app/views/projects/_home_panel.html.haml
@@ -17,7 +17,7 @@
         .fork-buttons
           - if current_user && can?(current_user, :fork_project, @project) && @project.namespace != current_user.namespace
             - if current_user.already_forked?(@project)
-              = link_to project_path(current_user.fork_of(@project)), title: 'Got to my fork' do
+              = link_to project_path(current_user.fork_of(@project)), title: 'Go to my fork' do
                 = link_to_toggle_fork
             - else
               = link_to fork_project_path(@project), title: "Fork project", method: "POST" do


### PR DESCRIPTION
"Got to my fork" should be "Go to my fork".
