### PR TITLE
Factor commit message textareas

### DIFF
--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -15,7 +15,7 @@ class MergeRequest
 
     modal = $('#modal_merge_info').modal(show: false)
 
-    disableButtonIfEmptyField '#merge_commit_message', '.accept_merge_request'
+    disableButtonIfEmptyField '#commit_message', '.accept_merge_request'
 
 
   # Local jQuery finder

--- a/app/controllers/projects/merge_requests_controller.rb
+++ b/app/controllers/projects/merge_requests_controller.rb
@@ -122,7 +122,7 @@ class Projects::MergeRequestsController < Projects::ApplicationController
 
     if @merge_request.open? && @merge_request.can_be_merged?
       @merge_request.should_remove_source_branch = params[:should_remove_source_branch]
-      @merge_request.automerge!(current_user, params[:merge_commit_message])
+      @merge_request.automerge!(current_user, params[:commit_message])
       @status = true
     else
       @status = false

--- a/app/views/projects/blob/_remove.html.haml
+++ b/app/views/projects/blob/_remove.html.haml
@@ -10,12 +10,8 @@
 
       .modal-body
         = form_tag project_blob_path(@project, @id), method: :delete, class: 'form-horizontal' do
-          .form-group.commit_message-group
-            = label_tag 'commit_message', class: "control-label" do
-              Commit message
-            .col-sm-10
-              = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
-                  params[:commit_message], placeholder: "Removed this file because...", required: true, rows: 3, class: 'form-control')}
+          = render 'shared/commit_message_container', params: params,
+                   placeholder: 'Removed this file because...'
           .form-group
             .col-sm-2
             .col-sm-10

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -21,13 +21,8 @@
           .center
             %h2
               %i.icon-spinner.icon-spin
-
-    .form-group.commit_message-group
-      = label_tag 'commit_message', class: "control-label" do
-        Commit message
-      .col-sm-10
-        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message', '',
-            placeholder: "Update #{@blob.name}", required: true, rows: 3, class: 'form-control')}
+    = render 'shared/commit_message_container', params: params,
+             placeholder: "Update #{@blob.name}"
     .form-actions
       = hidden_field_tag 'last_commit', @last_commit
       = hidden_field_tag 'content', '', id: "file-content"

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -22,15 +22,9 @@
               %strong= link_to "modify merge commit message", "#", class: "modify-merge-commit-link js-toggle-button", title: "Modify merge commit message"
               before accepting merge request
             .js-toggle-content.hide
-              .form-group
-                = label_tag :merge_commit_message, "Commit message", class: 'control-label'
-                .col-sm-10
-                  = render 'shared/commit_message_container', {textarea: text_area_tag(:merge_commit_message,
-                      @merge_request.merge_commit_message, class: "form-control js-gfm-input", rows: 14, required: true)}
-                  %p.hint
-                    Try to keep the first line under 52 characters
-                    and the others under 72.
-
+              = render 'shared/commit_message_container', params: params,
+                  text: @merge_request.merge_commit_message,
+                  rows: 14, hint: true
           .accept-group
             .pull-left
               = f.submit "Accept Merge Request", class: "btn btn-create accept_merge_request"

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -19,15 +19,8 @@
         Encoding
       .col-sm-10
         = select_tag :encoding, options_for_select([ "base64", "text" ], "text"), class: 'form-control'
-
-    .form-group.commit_message-group
-      = label_tag 'commit_message', class: "control-label" do
-        Commit message
-      .col-sm-10
-        = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
-            params[:commit_message], placeholder: 'Add new file',
-            required: true, rows: 3, class: 'form-control')}
-
+    = render 'shared/commit_message_container', params: params,
+             placeholder: 'Add new file'
     .file-holder
       .file-title
         %i.icon-file

--- a/app/views/shared/_commit_message_container.html.haml
+++ b/app/views/shared/_commit_message_container.html.haml
@@ -1,3 +1,14 @@
-.commit-message-container
-  .max-width-marker
-  = textarea
+.form-group.commit_message-group
+  = label_tag 'commit_message', class: 'control-label' do
+    Commit message
+  .col-sm-10
+    .commit-message-container
+      .max-width-marker
+      = text_area_tag 'commit_message',
+          (params[:commit_message] || local_assigns[:text]),
+          class: 'form-control', placeholder: local_assigns[:placeholder],
+          required: true, rows: (local_assigns[:rows] || 3)
+    - if local_assigns[:hint]
+      %p.hint
+        Try to keep the first line under 52 characters
+        and the others under 72.

--- a/features/steps/project/merge_requests.rb
+++ b/features/steps/project/merge_requests.rb
@@ -154,7 +154,7 @@ class Spinach::Features::ProjectMergeRequests < Spinach::FeatureSteps
 
   step 'I modify merge commit message' do
     find('.modify-merge-commit-link').click
-    fill_in 'merge_commit_message', with: "wow such merge"
+    fill_in 'commit_message', with: 'wow such merge'
   end
 
   step 'merge request "Bug NS-05" is mergeable' do


### PR DESCRIPTION
Same thing as before in less lines. ;)

Factors out the commit message textareas from new file, edit file, remove file and merge request custom msg.

The only change in HTML is not noticeable for end users: merge_commit_message was moved to `commit_message` to match other textareas and be DRYer.
