### PR TITLE
Improve new file commit message textarea placeholder.

### DIFF
--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -25,7 +25,8 @@
         Commit message
       .col-sm-10
         = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
-            params[:commit_message], placeholder: "Added new file", required: true, rows: 3, class: 'form-control')}
+            params[:commit_message], placeholder: 'Add new file',
+            required: true, rows: 3, class: 'form-control')}
 
     .file-holder
       .file-title


### PR DESCRIPTION
Imperative `Add` is the more common standard than `Added`.
