### PR TITLE
Improve remove file commit message textarea placeholder.

### DIFF
--- a/app/views/projects/blob/_remove.html.haml
+++ b/app/views/projects/blob/_remove.html.haml
@@ -15,7 +15,8 @@
               Commit message
             .col-sm-10
               = render 'shared/commit_message_container', {textarea: text_area_tag('commit_message',
-                  params[:commit_message], placeholder: "Removed this file because...", required: true, rows: 3, class: 'form-control')}
+                  params[:commit_message], placeholder: "Remove #{@blob.name}",
+                  required: true, rows: 3, class: 'form-control')}
           .form-group
             .col-sm-2
             .col-sm-10


### PR DESCRIPTION
Advantages:
- imperative `Remove`, which is the more common practice
- add filename, which makes it clear what is being done, and matches the update placeholder which says `Update filename`
