### PR TITLE
Replace defined? in views with local_assigns

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -10,7 +10,7 @@
   %meta{content: "GitLab Community Edition", name: "description"}
 
   %title
-    = "#{title} | " if defined?(title)
+    = "#{local_assigns[:title]} | " if local_assigns[:title]
     GitLab
   = favicon_link_tag 'favicon.ico'
   = stylesheet_link_tag    "application", :media => "all"

--- a/app/views/projects/notes/_diff_notes_with_reply.html.haml
+++ b/app/views/projects/notes/_diff_notes_with_reply.html.haml
@@ -1,6 +1,6 @@
 - note = notes.first # example note
 -# Check if line want not changed since comment was left
-- if !defined?(line) || line == note.diff_line
+- if !local_assigns[:line] || line == note.diff_line
   %tr.notes_holder
     %td.notes_line{ colspan: 2 }
       %span.discussion-notes-count

--- a/app/views/search/results/_snippet_blob.html.haml
+++ b/app/views/search/results/_snippet_blob.html.haml
@@ -43,7 +43,7 @@
               - snippet_blob[:snippet_chunks].each do |snippet|
                 - unless snippet[:data].empty?
                   - snippet[:data].lines.to_a.size.times do |index|
-                    - offset = defined?(snippet[:start_line]) ? snippet[:start_line] : 1
+                    - offset = snippet[:start_line] || 1
                     - i = index + offset
                     = link_to snippet_path+"#L#{i}", id: "L#{i}", rel: "#L#{i}" do
                       %i.icon-link

--- a/app/views/shared/_file_hljs.html.haml
+++ b/app/views/shared/_file_hljs.html.haml
@@ -2,7 +2,7 @@
   .line-numbers
     - if blob.data.present?
       - blob.data.lines.to_a.size.times do |index|
-        - offset = defined?(first_line_number) ? first_line_number : 1
+        - offset = local_assigns[:first_line_number] || 1
         - i = index + offset
         = link_to "#L#{i}", id: "L#{i}", rel: "#L#{i}" do
           %i.icon-link

--- a/app/views/shared/_project_filter.html.haml
+++ b/app/views/shared/_project_filter.html.haml
@@ -32,7 +32,7 @@
           = link_to project_filter_path(state: 'all') do
             All
 
-    - if defined?(labels)
+    - if local_assigns[:labels]
       %fieldset
         %legend
           Labels

--- a/app/views/shared/_ref_switcher.html.haml
+++ b/app/views/shared/_ref_switcher.html.haml
@@ -1,7 +1,7 @@
 = form_tag switch_project_refs_path(@project), method: :get, class: "project-refs-form" do
   = select_tag "ref", grouped_options_refs, class: "project-refs-select select2 select2-sm"
   = hidden_field_tag :destination, destination
-  - if defined?(path)
+  - if local_assigns[:path]
     = hidden_field_tag :path, path
   - @options && @options.each do |key, value|
     = hidden_field_tag key, value, id: nil


### PR DESCRIPTION
`local_assigns` is the right way to do it: http://stackoverflow.com/questions/2060561/optional-local-variables-in-rails-partial-templates-how-do-i-get-out-of-the-de

One occurrence, `defined?(snippet[:start_line])`, is a bug, since `a = {}; defined? a[:b]` returns `"method"`, not `nil`.
