### PR TITLE
Remove or prepend underscore _ to unused method arguments

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -15,11 +15,11 @@ class RegistrationsController < Devise::RegistrationsController
     super
   end
 
-  def after_sign_up_path_for(resource)
+  def after_sign_up_path_for(_resource)
     new_user_session_path
   end
 
-  def after_inactive_sign_up_path_for(resource)
+  def after_inactive_sign_up_path_for(_resource)
     new_user_session_path
   end
 

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -108,7 +108,7 @@ module TreeHelper
     end
   end
 
-  def up_dir_path(tree)
+  def up_dir_path
     file = File.join(@path, "..")
     tree_join(@ref, file)
   end

--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -35,7 +35,7 @@
     - if @path.present?
       %tr.tree-item
         %td.tree-item-file-name
-          = link_to "..", project_tree_path(@project, up_dir_path(tree)), class: 'prepend-left-10'
+          = link_to "..", project_tree_path(@project, up_dir_path), class: 'prepend-left-10'
         %td
         %td.hidden-xs
 


### PR DESCRIPTION
- remove `up_dir_path tree` which can be removed
- add underscore Devise callbacks to silence Hound in those cases where it cannot be omitted as mentioned at: https://github.com/gitlabhq/gitlabhq/pull/7858#discussion-diff-18063612
