### PR TITLE
Remove empty query params from many filters [failure unrelated]

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,4 +305,10 @@ module ApplicationHelper
       profile_key_path(key)
     end
   end
+
+  # Generate a path to the current URL with given url_for options.
+  # Existing whitelisted params are used as defaults if missing.
+  def merge_params_path(options, whitelist)
+    url_for(params.slice(*whitelist).merge(options))
+  end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,16 +1,17 @@
 module DashboardHelper
-  def projects_dashboard_filter_path(options={})
-    exist_opts = {
-      sort: params[:sort],
-      scope: params[:scope],
-      group: params[:group],
-    }
+  def entities_per_project(project, entity)
+    case entity.to_sym
+    when :issue
+      @issues.where(project_id: project.id)
+    when :merge_request
+      @merge_requests.where(target_project_id: project.id)
+    else
+      []
+    end.count
+  end
 
-    options = exist_opts.merge(options)
-
-    path = request.path
-    path << "?#{options.to_param}"
-    path
+  def projects_dashboard_filter_path(options = {})
+    merge_params_path(options, [:sort, :scope, :group])
   end
 
   def assigned_issues_dashboard_path

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -34,15 +34,7 @@ module GroupsHelper
   end
 
   def group_filter_path(entity, options={})
-    exist_opts = {
-      status: params[:status]
-    }
-
-    options = exist_opts.merge(options)
-
-    path = request.path
-    path << "?#{options.to_param}"
-    path
+    merge_params_path(options, [:status])
   end
 
   def group_settings_page?

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -68,6 +68,36 @@ module ProjectsHelper
     project_nav_tabs.include? name
   end
 
+  def selected_label?(label_name)
+    params[:label_name].to_s.split(',').include?(label_name)
+  end
+
+  def labels_filter_path(label_name)
+    label_name =
+      if selected_label?(label_name)
+        params[:label_name].split(',').reject { |l| l == label_name }.join(',')
+      elsif params[:label_name].present?
+        "#{params[:label_name]},#{label_name}"
+      else
+        label_name
+      end
+
+    project_filter_path(label_name: label_name)
+  end
+
+  def label_filter_class(label_name)
+    if selected_label?(label_name)
+      'label-filter-item active'
+    else
+      'label-filter-item light'
+    end
+  end
+
+  def project_filter_path(options = {})
+    merge_params_path(options, [:state, :scope, :label_name,
+                                :milestone_id, :assignee_id, :sort])
+  end
+
   def project_active_milestones
     @project.milestones.active.order("due_date, title ASC")
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -94,15 +94,7 @@ module SearchHelper
   end
 
   def search_filter_path(options={})
-    exist_opts = {
-      search: params[:search],
-      project_id: params[:project_id],
-      group_id: params[:group_id],
-      scope: params[:scope]
-    }
-
-    options = exist_opts.merge(options)
-    search_path(options)
+    merge_params_path(options, [:search, :project_id, :group_id, :scope])
   end
 
   # Sanitize html generated after parsing markdown from issue description or comment


### PR DESCRIPTION
Before this PR, clicking on filters like `sort` at the issues index would give a URL with many empty parameters like:

```
assignee_id=&label_name=&milestone_id=&scope=all&sort=newest&state=opened
```

Now, `assignee_id=&label_name=&milestone_id=` only show if explicitly set, so the URL would be:

```
scope=all&sort=oldest&state=opened
```

The change should affect issues and merge request in indexes, group and global searches.

This works because we were using the built-in helper `url_for`, which removes keys which have nil values from params, while before params was being built with `to_params` which does not.

`scope` and `state` should also be removed if not set, but implementation there is more delicate because those params are always being set from controller and used in the logic as in https://github.com/gitlabhq/gitlabhq/blob/0f12e051c072521460fadfce2cec4e9768bc35ba/app/controllers/projects/issues_controller.rb#L131
