### PR TITLE
[WIP] Make issue assigned filters more uniform across group and project [Can be updated]

### DIFF
--- a/app/finders/issuable_finder.rb
+++ b/app/finders/issuable_finder.rb
@@ -6,7 +6,7 @@
 #   klass - actual class like Issue or MergeRequest
 #   current_user - which user use
 #   params:
-#     scope: 'created-by-me' or 'assigned-to-me' or 'all'
+#     scope: 'authored' or 'assigned-to-me' or 'all'
 #     state: 'open' or 'closed' or 'all'
 #     group_id: integer
 #     project_id: integer
@@ -58,7 +58,7 @@ class IssuableFinder
 
   def by_scope(items)
     case params[:scope]
-    when 'created-by-me', 'authored' then
+    when 'authored' then
       items.where(author_id: current_user.id)
     when 'all' then
       items

--- a/app/finders/issues_finder.rb
+++ b/app/finders/issues_finder.rb
@@ -5,7 +5,7 @@
 # Arguments:
 #   current_user - which user use
 #   params:
-#     scope: 'created-by-me' or 'assigned-to-me' or 'all'
+#     scope: 'authored' or 'assigned-to-me' or 'all'
 #     state: 'open' or 'closed' or 'all'
 #     group_id: integer
 #     project_id: integer

--- a/app/finders/merge_requests_finder.rb
+++ b/app/finders/merge_requests_finder.rb
@@ -5,7 +5,7 @@
 # Arguments:
 #   current_user - which user use
 #   params:
-#     scope: 'created-by-me' or 'assigned-to-me' or 'all'
+#     scope: 'authored' or 'assigned-to-me' or 'all'
 #     state: 'open' or 'closed' or 'all'
 #     group_id: integer
 #     project_id: integer

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,4 +1,27 @@
 module DashboardHelper
+  def filter_path(options = {})
+    exist_opts = {
+      state: params[:state],
+      scope: params[:scope],
+      project_id: params[:project_id],
+    }
+
+    options = exist_opts.merge(options)
+
+    path = request.path
+    path << "?#{options.to_param}"
+    path
+  end
+
+  def entities_per_project(project, entity)
+    case entity.to_sym
+    when :issue then @issues.where(project_id: project.id)
+    when :merge_request then @merge_requests.where(target_project_id: project.id)
+    else
+      []
+    end.count
+  end
+
   def projects_dashboard_filter_path(options={})
     exist_opts = {
       sort: params[:sort],
@@ -13,11 +36,41 @@ module DashboardHelper
     path
   end
 
-  def assigned_issues_dashboard_path
-    issues_dashboard_path(assignee_id: current_user.id)
+  def assigned_entities_count(current_user, entity, scope = nil)
+    items = current_user.send("assigned_" + entity.pluralize).opened
+
+    if scope.kind_of?(Group)
+      items = items.of_group(scope)
+    elsif scope.kind_of?(Project)
+      items = items.of_projects(scope)
+    end
+
+    items.count
   end
 
-  def assigned_mrs_dashboard_path
-    merge_requests_dashboard_path(assignee_id: current_user.id)
+  def authored_entities_count(current_user, entity, scope = nil)
+    items = current_user.send(entity.pluralize).opened
+
+    if scope.kind_of?(Group)
+      items = items.of_group(scope)
+    elsif scope.kind_of?(Project)
+      items = items.of_projects(scope)
+    end
+
+    items.count
+  end
+
+  def authorized_entities_count(current_user, entity, scope = nil)
+    items = entity.classify.constantize.opened
+
+    if scope.kind_of?(Group)
+      items = items.of_group(scope)
+    elsif scope.kind_of?(Project)
+      items = items.of_projects(scope)
+    else
+      items = items.of_projects(current_user.authorized_projects)
+    end
+
+    items.count
   end
 end

--- a/app/views/shared/_filter.html.haml
+++ b/app/views/shared/_filter.html.haml
@@ -1,0 +1,21 @@
+.side-filters
+  = form_tag filter_path, method: 'get' do
+    = render 'shared/state_filter', filter_path: :filter_path,
+        entity: entity, scope: @group
+
+    %fieldset
+      %legend Projects
+      %ul.nav.nav-pills.nav-stacked.nav-small
+        - @projects.each do |project|
+          - unless entities_per_project(project, entity).zero?
+            %li{class: ("active" if params[:project_id] == project.id.to_s)}
+              = link_to filter_path(project_id: project.id) do
+                = project.name_with_namespace
+                %small.pull-right= entities_per_project(project, entity)
+
+    %fieldset
+      - if params[:state].present? || params[:project_id].present?
+        = link_to filter_path(state: nil, project_id: nil), class: 'pull-right cgray' do
+          %i.icon-remove
+          %strong Clear filter
+

--- a/app/views/shared/_project_filter.html.haml
+++ b/app/views/shared/_project_filter.html.haml
@@ -1,0 +1,35 @@
+.side-filters
+  = form_tag project_entities_path, method: 'get' do
+    = render 'shared/state_filter', filter_path: :project_filter_path,
+        entity: entity, scope: @project
+
+    - if defined?(labels)
+      %fieldset
+        %legend
+          Labels
+          %small.pull-right
+            = link_to project_labels_path(@project), class: 'light' do
+              %i.icon-edit
+        %ul.nav.nav-pills.nav-stacked.nav-small.labels-filter
+          - @project.labels.order_by_name.each do |label|
+            %li{class: label_filter_class(label.name)}
+              = link_to labels_filter_path(label.name) do
+                = render_colored_label(label)
+                - if selected_label?(label.name)
+                  .pull-right
+                    %i.icon-remove
+
+        - if @project.labels.empty?
+          .light-well
+            Create first label at
+            = link_to 'labels page', project_labels_path(@project)
+            %br
+            or #{link_to 'generate', generate_project_labels_path(@project, redirect: redirect), method: :post} default set of labels
+
+    %fieldset
+      - if %w(state scope milestone_id assignee_id label_name).select { |k| params[k].present? }.any?
+        = link_to project_entities_path, class: 'cgray pull-right' do
+          %i.icon-remove
+          %strong Clear filter
+
+

--- a/app/views/shared/_state_filter.html.haml
+++ b/app/views/shared/_state_filter.html.haml
@@ -1,0 +1,18 @@
+- if current_user
+  %fieldset
+    %ul.nav.nav-pills.nav-stacked
+      - [['all',            "Everyone's",     :authorized_entities_count],
+         ['assigned-to-me', 'Assigned to me', :assigned_entities_count],
+         ['authored',       'Created by me', :authored_entities_count]].each do |key, label, count|
+        %li{class: ('active' if params[:scope] == key)}
+          = link_to send(:filter_path, scope: key) do
+            = label
+            %span.pull-right
+              = send(count, current_user, entity, scope)
+%fieldset
+  %legend State
+  %ul.nav.nav-pills
+    - [['opened', 'Open'], ['closed', 'Closed'], ['all', 'All']].each do |key, label|
+      %li{class: ('active' if params[:state] == key)}
+        = link_to send(filter_path, state: key) do
+          = label

--- a/features/steps/dashboard/issues.rb
+++ b/features/steps/dashboard/issues.rb
@@ -1,5 +1,6 @@
 class Spinach::Features::DashboardIssues < Spinach::FeatureSteps
   include SharedAuthentication
+  include SharedDashboard
   include SharedPaths
 
   step 'I should see issues assigned to me' do
@@ -32,24 +33,6 @@ class Spinach::Features::DashboardIssues < Spinach::FeatureSteps
 
   step 'I have other issues' do
     other_issue
-  end
-
-  step 'I click "Authored by me" link' do
-    within ".assignee-filter" do
-      click_link "Any"
-    end
-    within ".author-filter" do
-      click_link current_user.name
-    end
-  end
-
-  step 'I click "All" link' do
-    within ".author-filter" do
-      click_link "Any"
-    end
-    within ".assignee-filter" do
-      click_link "Any"
-    end
   end
 
   def should_see(issue)

--- a/features/steps/dashboard/merge_requests.rb
+++ b/features/steps/dashboard/merge_requests.rb
@@ -1,5 +1,6 @@
 class Spinach::Features::DashboardMergeRequests < Spinach::FeatureSteps
   include SharedAuthentication
+  include SharedDashboard
   include SharedPaths
 
   step 'I should see merge requests assigned to me' do
@@ -36,24 +37,6 @@ class Spinach::Features::DashboardMergeRequests < Spinach::FeatureSteps
 
   step 'I have other merge requests' do
     other_merge_request
-  end
-
-  step 'I click "Authored by me" link' do
-    within ".assignee-filter" do
-      click_link "Any"
-    end
-    within ".author-filter" do
-      click_link current_user.name
-    end
-  end
-
-  step 'I click "All" link' do
-    within ".author-filter" do
-      click_link "Any"
-    end
-    within ".assignee-filter" do
-      click_link "Any"
-    end
   end
 
   def should_see(merge_request)

--- a/features/steps/shared/dashboard.rb
+++ b/features/steps/shared/dashboard.rb
@@ -1,0 +1,21 @@
+module SharedDashboard
+  include Spinach::DSL
+
+  step 'I click "Authored by me" link' do
+    within ".assignee-filter" do
+      click_link "Any"
+    end
+    within ".author-filter" do
+      click_link current_user.name
+    end
+  end
+
+  step 'I click "All" link' do
+    within ".author-filter" do
+      click_link "Any"
+    end
+    within ".assignee-filter" do
+      click_link "Any"
+    end
+  end
+end


### PR DESCRIPTION
This PR makes the `Assigned to me / created by me / everyone's` issue filter more uniform between project, dashboard and group issues.

The only UI change is that for the dashboard and group, the order changed from:
- `assigned to me`
- `created by me`
- `everyone's`

to:
- `everyone's`
- `assigned to me`
- `created by me`

which matches the order under projects. Those two should have the same order: it makes the UI more uniform.

Note that the default values for those attributes is different between views and has not been changed: for dashboard it is `assigned to me`, for groups depends on signed in or not, and for project issues it is always everyone's.

The greater uniformity also allowed a large factorization. 

![screenshot from 2014-10-02 11 11 14 factor filter state assigned](https://cloud.githubusercontent.com/assets/1429315/4488887/202d0122-4a14-11e4-9719-1a03bf13135a.png)

Implementation notes:
- removed the  `.scope-filter` class which is not used anywhere
- removed the unused `entity` argument to facilitate polymorphism 
