### PR TITLE
Bump org-mode to 0.9.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem "github-markup"
 gem 'redcarpet', '~> 3.1.2'
 gem 'RedCloth'
 gem 'rdoc', '~>3.6'
-gem 'org-ruby'
+gem 'org-ruby', '= 0.9.9'
 gem 'creole', '~>0.3.6'
 gem 'wikicloth', '=0.8.1'
 gem 'asciidoctor', '= 0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
     omniauth-twitter (1.0.1)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
-    org-ruby (0.9.8)
+    org-ruby (0.9.9)
       rubypants (~> 0.2)
     orm_adapter (0.5.0)
     pg (0.15.1)
@@ -655,7 +655,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-shibboleth
   omniauth-twitter
-  org-ruby
+  org-ruby (= 0.9.9)
   pg
   poltergeist (~> 1.5.1)
   pry


### PR DESCRIPTION
This PR updates `org-mode` gem to 0.9.9. `org-mode` is used for markdown rendering. 
This version fixes problems parsing comments.

This is also the recommended version from [github/markup](https://github.com/github/markup) as shown in https://github.com/github/markup/blob/master/Gemfile
