### PR TITLE
Make new and edit file submit more uniform

### DIFF
--- a/app/views/projects/_commit_button.html.haml
+++ b/app/views/projects/_commit_button.html.haml
@@ -1,0 +1,9 @@
+.form-actions
+  .commit-button-annotation
+    = button_tag 'Commit Changes',
+                 class: 'btn commit-btn js-commit-button btn-create'
+    .message
+      to branch
+      %strong= ref
+  = link_to 'Cancel', cancel_path,
+            class: 'btn btn-cancel', data: {confirm: leave_edit_message}

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -23,16 +23,11 @@
               %i.fa.fa-spinner.fa-spin
     = render 'shared/commit_message_container', params: params,
              placeholder: "Update #{@blob.name}"
-    .form-actions
-      = hidden_field_tag 'last_commit', @last_commit
-      = hidden_field_tag 'content', '', id: "file-content"
-      = hidden_field_tag 'from_merge_request_id', params[:from_merge_request_id]
-      .commit-button-annotation
-        = button_tag "Commit changes", class: 'btn commit-btn js-commit-button btn-primary'
-        .message
-          to branch
-          %strong= @ref
-      = link_to "Cancel", @after_edit_path, class: "btn btn-cancel", data: { confirm: leave_edit_message}
+    = hidden_field_tag 'last_commit', @last_commit
+    = hidden_field_tag 'content', '', id: "file-content"
+    = hidden_field_tag 'from_merge_request_id', params[:from_merge_request_id]
+    = render 'projects/commit_button', ref: @ref,
+              cancel_path: @after_edit_path
 
 :javascript
   ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace")

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -27,14 +27,9 @@
       .file-content.code
         %pre#editor= params[:content]
 
-    .form-actions
-      = hidden_field_tag 'content', '', id: "file-content"
-      .commit-button-annotation
-        = button_tag "Commit changes", class: 'btn commit-btn js-commit-button btn-create'
-        .message
-          to branch
-          %strong= @ref
-      = link_to "Cancel", project_tree_path(@project, @id), class: "btn btn-cancel", data: { confirm: leave_edit_message}
+    = hidden_field_tag 'content', '', id: 'file-content'
+    = render 'projects/commit_button', ref: @ref,
+              cancel_path: project_tree_path(@project, @id)
 
 :javascript
   ace.config.set("modePath", gon.relative_url_root + "#{Gitlab::Application.config.assets.prefix}/ace-src-noconflict")

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -30,7 +30,7 @@ Feature: Project Source Browse files
     And I edit code
     And I fill the new file name
     And I fill the commit message
-    And I click on "Commit changes"
+    And I click on "Commit Changes"
     Then I am redirected to the new file
     And I should see its new content
 
@@ -46,7 +46,7 @@ Feature: Project Source Browse files
     And I click button "Edit"
     And I edit code
     And I fill the commit message
-    And I click on "Commit changes"
+    And I click on "Commit Changes"
     Then I am redirected to the ".gitignore"
     And I should see its new content
 

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -69,8 +69,8 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     click_link 'Diff'
   end
 
-  step 'I click on "Commit changes"' do
-    click_button 'Commit changes'
+  step 'I click on "Commit Changes"' do
+    click_button 'Commit Changes'
   end
 
   step 'I click on "Remove"' do


### PR DESCRIPTION
DRY them up. UI changes:
- uppercased `Commit changes` to `Commit Changes` on both forms as per https://github.com/gitlabhq/gitlabhq/issues/7789
- change color from blue to green on the edit form (which differed from the new one: it shouldn't)

After:

![screenshot from 2014-10-03 00 12 33 commit changes new](https://cloud.githubusercontent.com/assets/1429315/4499383/b86fc894-4a81-11e4-8b4c-1cae8639e401.png)

Before:

![screenshot from 2014-10-02 23 54 19 commit changes before](https://cloud.githubusercontent.com/assets/1429315/4499384/c1c12690-4a81-11e4-8b34-2fcd28babb8e.png)
