### PR TITLE
[WIP] Add services Install Notes system

### DIFF
--- a/app/views/projects/services/_form.html.haml
+++ b/app/views/projects/services/_form.html.haml
@@ -10,6 +10,11 @@
 
 %hr
 
+%h3 Install Notes
+= render "projects/services_notes/#{@service.to_param}"
+
+%hr
+
 = form_for(@service, as: :service, url: project_service_path(@project, @service.to_param), method: :put, html: { class: 'form-horizontal' }) do |f|
   - if @service.errors.any?
     .alert.alert-danger

--- a/app/views/projects/services_notes/_assembla.md
+++ b/app/views/projects/services_notes/_assembla.md
@@ -1,0 +1,1 @@
+This is **Assembla** setup notes.

--- a/config/initializers/template_handlers.rb
+++ b/config/initializers/template_handlers.rb
@@ -1,0 +1,23 @@
+module ActionView
+  module Template::Handlers
+    class Markdown
+      class_attribute :default_format
+      self.default_format = Mime::HTML
+
+      def call(template)
+        @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+                                              no_intra_emphasis: true,
+                                              tables: true,
+                                              fenced_code_blocks: true,
+                                              autolink: true,
+                                              strikethrough: true,
+                                              lax_spacing: true,
+                                              space_after_headers: true,
+                                              superscript: true)
+        "#{@markdown.render(template.source).inspect}.html_safe"
+      end
+    end
+  end
+end
+
+ActionView::Template.register_template_handler(:md, ActionView::Template::Handlers::Markdown.new)


### PR DESCRIPTION
I think attaching install notes to services will be more user-friendly.

We often have to know more than just an one line description of the app, this should simplify services installation procedure for users.

This PR, not finished yet, is an experiment and a proposition for this moment.

Feel free to let your thinking about this idea and don't hesitate to give me advice for the code flow (methods, file emplacement, tests to be written, UI etc...).

I will attach some screenshots later.

Thanks!
