### PR TITLE
Move new blob commit message textarea below editor

### DIFF
--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -19,14 +19,14 @@
         Encoding
       .col-sm-10
         = select_tag :encoding, options_for_select([ "base64", "text" ], "text"), class: 'form-control'
-    = render 'shared/commit_message_container', params: params,
-             placeholder: 'Add new file'
     .file-holder
       .file-title
         %i.fa.fa-file
       .file-content.code
         %pre#editor= params[:content]
 
+    = render 'shared/commit_message_container', params: params,
+             placeholder: 'Add new file'
     = hidden_field_tag 'content', '', id: 'file-content'
     = render 'projects/commit_button', ref: @ref,
               cancel_path: project_tree_path(@project, @id)


### PR DESCRIPTION
- match edit blob view
- you enter the commit message _after_ you make the modifications

After:

![screenshot from 2014-10-03 00 28 09 new blob commit below after](https://cloud.githubusercontent.com/assets/1429315/4499501/91e9d79e-4a83-11e4-9730-ecfbad5599ac.png)

Before:

![screenshot from 2014-10-03 00 27 49 new blob commit below before](https://cloud.githubusercontent.com/assets/1429315/4499503/995ec52a-4a83-11e4-8d46-a83a0eb60981.png)
