### PR TITLE
Remove outdated comment on the project test seed

### DIFF
--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -47,16 +47,6 @@ FactoryGirl.define do
     end
   end
 
-  # Generates a test repository from the repository stored under `spec/seed_project.tar.gz`.
-  # Once you run `rake gitlab:setup`, you can see what the repository looks like under `tmp/repositories/gitlabhq`.
-  # In order to modify files in the repository, you must untar the seed, modify and remake the tar.
-  # Before recompressing, do not forget to `git checkout master`.
-  # After recompressing, you need to run `RAILS_ENV=test bundle exec rake gitlab:setup` to regenerate the seeds under tmp.
-  #
-  # If you want to modify the repository only for an specific type of tests, e.g., markdown tests,
-  # consider using a feature branch to reduce the chances of collision with other tests.
-  # Create a new commit, and use the same commit message that you will use for the change in the main repo.
-  # Changing the commig message and SHA of branch `master` may break tests.
   factory :project, parent: :empty_project do
     path { 'gitlabhq' }
 


### PR DESCRIPTION
We are now using gitlab-test, so this comment makes no sense anymore.

When the situation settles down (hopefully after https://github.com/gitlabhq/gitlabhq/pull/7903) we should document that somewhere else for devs.
