### PR TITLE
Make blob new and edit file editors more uniform

### DIFF
--- a/app/views/projects/_blob_editor.html.haml
+++ b/app/views/projects/_blob_editor.html.haml
@@ -1,0 +1,15 @@
+.file-holder.file
+  .file-title
+    %i.icon-file
+    %span.file_name
+      %span.monospace.light #{ref}
+      - if local_assigns[:path]
+        = ': ' + local_assigns[:path]
+  .file-content.code
+    %pre.js-edit-mode-pane#editor
+      = params[:content] || local_assigns[:blob_data]
+    - if local_assigns[:path]
+      .js-edit-mode-pane#preview.hide
+        .center
+          %h2
+            %i.icon-spinner.icon-spin

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -6,21 +6,7 @@
       = link_to editing_preview_title(@blob.name), '#preview', 'data-preview-url' => preview_project_edit_tree_path(@project, @id)
 
   = form_tag(project_edit_tree_path(@project, @id), method: :put, class: "form-horizontal") do
-    .file-holder.file
-      .file-title
-        %i.fa.fa-file
-        %span.file_name
-          %span.monospace.light #{@ref}:
-          = @path
-        %span.options
-          .btn-group.tree-btn-group
-            = link_to "Cancel", @after_edit_path, class: "btn btn-tiny btn-cancel", data: { confirm: leave_edit_message }
-      .file-content.code
-        %pre.js-edit-mode-pane#editor
-        .js-edit-mode-pane#preview.hide
-          .center
-            %h2
-              %i.fa.fa-spinner.fa-spin
+    = render 'projects/blob_editor', ref: @ref, path: @path, blob_data: @blob.data
     = render 'shared/commit_message_container', params: params,
              placeholder: "Update #{@blob.name}"
     = hidden_field_tag 'last_commit', @last_commit
@@ -34,7 +20,6 @@
   ace.config.loadModule("ace/ext/searchbox");
   var ace_mode = "#{@blob.language.try(:ace_mode)}";
   var editor = ace.edit("editor");
-  editor.setValue("#{escape_javascript(@blob.data)}");
   if (ace_mode) {
     editor.getSession().setMode('ace/mode/' + ace_mode);
   }

--- a/app/views/projects/new_tree/show.html.haml
+++ b/app/views/projects/new_tree/show.html.haml
@@ -19,12 +19,7 @@
         Encoding
       .col-sm-10
         = select_tag :encoding, options_for_select([ "base64", "text" ], "text"), class: 'form-control'
-    .file-holder
-      .file-title
-        %i.fa.fa-file
-      .file-content.code
-        %pre#editor= params[:content]
-
+    = render 'projects/blob_editor', ref: @ref
     = render 'shared/commit_message_container', params: params,
              placeholder: 'Add new file'
     = hidden_field_tag 'content', '', id: 'file-content'


### PR DESCRIPTION
DRY them up and make them uniform. UI changes:
- remove cancel button from file edit header: there is already a Cancel button the bottom of the page, which is the standard place for cancel buttons
- add branch to new file edit. Already present on the edit, so let's make it uniform.

After edit: no cancel:

![screenshot from 2014-10-03 14 17 30 factor editor after](https://cloud.githubusercontent.com/assets/1429315/4505639/716470e0-4af8-11e4-81ce-91f9512edc64.png)

Before edit:

![screenshot from 2014-10-03 14 25 18 blob edit before](https://cloud.githubusercontent.com/assets/1429315/4505642/782e0e68-4af8-11e4-8fda-b7a2ba55f445.png)

After new (has branch on header):

![screenshot from 2014-10-03 14 24 44 blob new after](https://cloud.githubusercontent.com/assets/1429315/4505647/7f92d10c-4af8-11e4-921a-ffc6854e13d9.png)

Before new:

![screenshot from 2014-10-03 14 25 29 blob new before](https://cloud.githubusercontent.com/assets/1429315/4505653/8663c40a-4af8-11e4-89f5-d8b730720683.png)
