### PR TITLE
Fix fa-download icon

### DIFF
--- a/app/views/projects/blob/_download.html.haml
+++ b/app/views/projects/blob/_download.html.haml
@@ -2,6 +2,6 @@
   .center
     = link_to project_raw_path(@project, @id) do
       %h1.light
-        %i.fa.fa-arrow-circle-o-down-alt
+        %i.fa.fa-download
       %h4
         Download (#{number_to_human_size blob.size})

--- a/app/views/projects/commit/_commit_box.html.haml
+++ b/app/views/projects/commit/_commit_box.html.haml
@@ -6,7 +6,7 @@
         = @notes_count
     .pull-left.btn-group
       %a.btn.btn-grouped.dropdown-toggle{ data: {toggle: :dropdown} }
-        %i.fa.fa-arrow-circle-o-down-alt
+        %i.fa.fa-download
         Download as
         %span.caret
       %ul.dropdown-menu

--- a/app/views/projects/merge_requests/show/_mr_title.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_title.html.haml
@@ -6,7 +6,7 @@
       - if @merge_request.open?
         .btn-group.pull-left
           %a.btn.btn-grouped.dropdown-toggle{ data: {toggle: :dropdown} }
-            %i.fa.fa-arrow-circle-o-down-alt
+            %i.fa.fa-download
             Download as
             %span.caret
           %ul.dropdown-menu

--- a/app/views/projects/repositories/_download_archive.html.haml
+++ b/app/views/projects/repositories/_download_archive.html.haml
@@ -4,7 +4,7 @@
 - if split_button == true
   %span.btn-group{class: btn_class}
     = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn', rel: 'nofollow' do
-      %i.fa.fa-arrow-circle-o-down-alt
+      %i.fa.fa-download
       %span Download zip
     %a.btn.dropdown-toggle{ 'data-toggle' => 'dropdown' }
       %span.caret
@@ -13,25 +13,25 @@
     %ul.dropdown-menu{ role: 'menu' }
       %li
         = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), rel: 'nofollow' do
-          %i.fa.fa-arrow-circle-o-down-alt
+          %i.fa.fa-download
           %span Download zip
       %li
         = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz'), rel: 'nofollow' do
-          %i.fa.fa-arrow-circle-o-down-alt
+          %i.fa.fa-download
           %span Download tar.gz
       %li
         = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.bz2'), rel: 'nofollow' do
-          %i.fa.fa-arrow-circle-o-down-alt
+          %i.fa.fa-download
           %span Download tar.bz2
       %li
         = link_to archive_project_repository_path(@project, ref: ref, format: 'tar'), rel: 'nofollow' do
-          %i.fa.fa-arrow-circle-o-down-alt
+          %i.fa.fa-download
           %span Download tar
 - else
   %span.btn-group{class: btn_class}
     = link_to archive_project_repository_path(@project, ref: ref, format: 'zip'), class: 'btn', rel: 'nofollow' do
-      %i.fa.fa-arrow-circle-o-down-alt
+      %i.fa.fa-download
       %span zip
     = link_to archive_project_repository_path(@project, ref: ref, format: 'tar.gz'), class: 'btn', rel: 'nofollow' do
-      %i.fa.fa-arrow-circle-o-down-alt
+      %i.fa.fa-download
       %span tar.gz

--- a/app/views/projects/wikis/_nav.html.haml
+++ b/app/views/projects/wikis/_nav.html.haml
@@ -7,7 +7,7 @@
 
   = nav_link(path: 'wikis#git_access') do
     = link_to git_access_project_wikis_path(@project) do
-      %i.fa.fa-arrow-circle-o-down-alt
+      %i.fa.fa-download
       Git Access
 
   - if can?(current_user, :write_wiki, @project)


### PR DESCRIPTION
A bug about download icons was introduce since PR #7934.

`icon-download` was replaced by `fa-arrow-circle-o-down-alt`, that doesn't exist...

I don't know how the fuck happened but anyway, it's fixed now. :+1: 
