### PR TITLE
Backup compression option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ v 7.4.0
   - Add select field type for services options (Sullivan Senechal)
   - Add cross-project references to the Markdown parser (Vinnie Okada)
   - Add task lists to issue and merge request descriptions (Vinnie Okada)
+  - Add backup compression option for gzip, bzip2 and xz (Sullivan Senechal)
 
 v 7.3.2
   - Fix creating new file via web editor

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -218,6 +218,9 @@ production: &base
   backup:
     path: "tmp/backups"   # Relative paths are relative to Rails.root (default: tmp/backups/)
     # keep_time: 604800   # default: 0 (forever) (in seconds)
+    # compression:
+    #   command: gzip     # Working commands: [gzip, bzip2, xz]. Be sure to have associated compress utility installed.
+    #   level: 6          # 0..9. Level 0 only available for xz command. Default level will be used if not specified.
     # upload:
     #   # Fog storage connection settings, see http://fog.io/storage/ .
     #   connection:

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -128,9 +128,10 @@ Settings.gitlab_shell['ssh_path_prefix'] ||= Settings.send(:build_gitlab_shell_s
 # Backup
 #
 Settings['backup'] ||= Settingslogic.new({})
-Settings.backup['keep_time']  ||= 0
-Settings.backup['path']         = File.expand_path(Settings.backup['path'] || "tmp/backups/", Rails.root)
-Settings.backup['upload'] ||= Settingslogic.new({'remote_directory' => nil, 'connection' => nil})
+Settings.backup['keep_time']   ||= 0
+Settings.backup['path']          = File.expand_path(Settings.backup['path'] || 'tmp/backups/', Rails.root)
+Settings.backup['compression'] ||= Settingslogic.new({ 'command' => nil, 'level' => nil })
+Settings.backup['upload']      ||= Settingslogic.new({ 'remote_directory' => nil, 'connection' => nil })
 # Convert upload connection settings to use symbol keys, to make Fog happy
 if Settings.backup['upload']['connection']
   Settings.backup['upload']['connection'] = Hash[Settings.backup['upload']['connection'].map { |k, v| [k.to_sym, v] }]

--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -1,0 +1,99 @@
+# From 7.3 to 7.4
+
+### 0. Backup
+
+```bash
+cd /home/git/gitlab
+sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
+```
+
+### 1. Stop server
+
+```bash
+sudo service gitlab stop
+```
+
+### 2. Get latest code
+
+```bash
+cd /home/git/gitlab
+sudo -u git -H git fetch --all
+```
+
+For GitLab Community Edition:
+
+```bash
+sudo -u git -H git checkout -- db/schema.rb # local changes will be restored automatically
+sudo -u git -H git checkout 7-4-stable
+```
+
+OR
+
+For GitLab Enterprise Edition:
+
+```bash
+sudo -u git -H git checkout -- db/schema.rb # local changes will be restored automatically
+sudo -u git -H git checkout 7-4-stable-ee
+```
+
+### 3. Install libs, migrations, etc.
+
+```bash
+cd /home/git/gitlab
+
+# MySQL installations (note: the line below states '--without ... postgres')
+sudo -u git -H bundle install --without development test postgres --deployment
+
+# PostgreSQL installations (note: the line below states '--without ... mysql')
+sudo -u git -H bundle install --without development test mysql --deployment
+
+# Run database migrations
+sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
+
+# Clean up assets and cache
+sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS_ENV=production
+
+# Update init.d script
+sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+```
+
+### 4. Update config files
+
+#### New configuration options for gitlab.yml
+
+There are new configuration options available for gitlab.yml. View them with the command below and apply them to your current gitlab.yml.
+
+```
+git diff origin/7-3-stable:config/gitlab.yml.example origin/7-4-stable:config/gitlab.yml.example
+```
+
+### 5. Start application
+
+    sudo service gitlab start
+    sudo service nginx restart
+
+### 6. Check application status
+
+Check if GitLab and its environment are configured correctly:
+
+    sudo -u git -H bundle exec rake gitlab:env:info RAILS_ENV=production
+
+To make sure you didn't miss anything run a more thorough check with:
+
+    sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
+
+If all items are green, then congratulations upgrade is complete!
+
+## Things went south? Revert to previous version (7.3)
+
+### 1. Revert the code to the previous version
+Follow the [upgrade guide from 7.2 to 7.3](7.2-to-7.3.md), except for the database migration
+(The backup is already migrated to the previous version)
+
+### 2. Restore from the backup:
+
+```bash
+cd /home/git/gitlab
+sudo -u git -H bundle exec rake gitlab:backup:restore RAILS_ENV=production
+```
+If you have more than one backup *.tar file(s) please add `BACKUP=timestamp_of_backup` to the command above.

--- a/lib/backup/manager.rb
+++ b/lib/backup/manager.rb
@@ -20,13 +20,42 @@ module Backup
       # create archive
       print "Creating backup archive: #{tar_file} ... "
       if Kernel.system('tar', '-cf', tar_file, *BACKUP_CONTENTS)
-        puts "done".green
       else
         puts "failed".red
         abort 'Backup failed'
       end
+      puts 'done'.green
 
+      tar_file = compress(tar_file)
       upload(tar_file)
+    end
+
+    def compress(tar_file)
+      print "Compressing backup archive: #{tar_file} ... "
+
+      compression_extensions = {
+        gzip:     '.gz',
+        bzip2:    '.bz2',
+        xz:       '.xz'
+      }
+
+      compression_cmd = Gitlab.config.backup.compression[:command]
+      compression_lvl = Gitlab.config.backup.compression[:level]
+      if compression_cmd.blank?
+        puts 'skipped'.yellow
+        return tar_file
+      end
+
+      if Kernel.system(compression_cmd, compression_lvl.blank? ? '--' : "-#{compression_lvl}", tar_file)
+      else
+        puts 'failed'.red
+        abort 'Compression failed'
+      end
+      puts 'done'.green
+
+      # Return the new tar file name
+      compression_ext = compression_extensions[compression_cmd.to_sym]
+      "#{tar_file}#{compression_ext}"
     end
 
     def upload(tar_file)
@@ -67,11 +96,11 @@ module Backup
 
       if keep_time > 0
         removed = 0
-        file_list = Dir.glob(Rails.root.join(path, "*_gitlab_backup.tar"))
-        file_list.map! { |f| $1.to_i if f =~ /(\d+)_gitlab_backup.tar/ }
-        file_list.sort.each do |timestamp|
+        file_list = Dir.glob(Rails.root.join(path, '*_gitlab_backup.tar*'))
+        file_list.sort.each do |tar_file|
+          timestamp = $1.to_i if tar_file =~ /(\d+)_gitlab_backup.tar*/
           if Time.at(timestamp) < (Time.now - keep_time)
-            if Kernel.system(*%W(rm #{timestamp}_gitlab_backup.tar))
+            if Kernel.system('rm', tar_file)
               removed += 1
             end
           end
@@ -86,7 +115,7 @@ module Backup
       Dir.chdir(Gitlab.config.backup.path)
 
       # check for existing backups in the backup dir
-      file_list = Dir.glob("*_gitlab_backup.tar").each.map { |f| f.split(/_/).first.to_i }
+      file_list = Dir.glob('*_gitlab_backup.tar*').each.map { |f| f.split(/_/).first.to_i }
       puts "no backups found" if file_list.count == 0
       if file_list.count > 1 && ENV["BACKUP"].nil?
         puts "Found more than one backup, please specify which one you want to restore:"
@@ -96,17 +125,37 @@ module Backup
 
       tar_file = ENV["BACKUP"].nil? ? File.join("#{file_list.first}_gitlab_backup.tar") : File.join(ENV["BACKUP"] + "_gitlab_backup.tar")
 
+      was_compressed = false
+      ['.gz', '.bz2', '.xz'].each do |compress_ext|
+        compressed_file = "#{tar_file}#{compress_ext}"
+        if File.exists?(compressed_file)
+          uncompress compressed_file, compress_ext
+          was_compressed = true
+        end
+      end
+
+      puts tar_file
       unless File.exists?(tar_file)
         puts "The specified backup doesn't exist!"
         exit 1
       end
 
-      print "Unpacking backup ... "
+      print "Unpacking backup: #{tar_file} ... "
       unless Kernel.system(*%W(tar -xf #{tar_file}))
         puts "failed".red
         exit 1
       else
         puts "done".green
+      end
+
+      if was_compressed
+        print "Deleting uncompressed backup: #{tar_file} ... "
+        if Kernel.system('rm', '-f', tar_file)
+          puts 'done'.green
+        else
+          puts 'failed'.red
+          exit 1
+        end
       end
 
       settings = YAML.load_file("backup_information.yml")
@@ -120,6 +169,24 @@ module Backup
         puts "  version: #{settings[:gitlab_version]}".red
         puts
         puts "Hint: git checkout v#{settings[:gitlab_version]}"
+        exit 1
+      end
+    end
+
+    def uncompress(tar_file, compress_ext)
+      print "Uncompressing backup: #{tar_file} ... "
+
+      uncompression_commands = {
+        '.gz'     => 'gzip',
+        '.bz2'    => 'bzip2',
+        '.xz'     => 'xz'
+      }
+      uncompression_cmd = uncompression_commands[compress_ext]
+
+      if Kernel.system(uncompression_cmd, '-kd', tar_file)
+        puts 'done'.green
+      else
+        puts 'failed'.red
         exit 1
       end
     end


### PR DESCRIPTION
As requested [here](http://feedback.gitlab.com/forums/176466-general/suggestions/5667052-allow-compression-of-backups-using-bzip2-gzip-etc), this PR add a compression option for backup.

TODO list:
- [x] Compression settings on gitlab.yml
- [x] Implement compression commands on backup create
- [x] The restore method should guess compression type and extract it to avoid BC break
- [x] Improve clean old backups method to fetch compressed packs
- [x] Check backup upload method to fetch compressed packs
- [x] Check for backup test and update it
- [x] Check if docs could be updated (upgrade)
- [x] Give some benchmark with dev env
- [x] Update CHANGELOG

This feature would be useful to save some space especially for big Gitlab platforms.

Some benchmark, done on my workstation with default dev env and data:

| Extension | Time | Size |
| --- | --- | --- |
| .tar | 0m7.746s | 101M |
| .tar.gz | 0m10.158s | 96M |
| .tar.bz2 | 0m20.678s | 96M |
| .tar.xz | 0m35.414s | 80M |

This benchmark use default compression level.

Tell me if I missed some check on todo list!
