### PR TITLE
Also show diff tab while editing blob with preview [failure unrelated]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ v 7.7.0
   -
   - Mention notification level
   -
-  -
+  - Show both preview and diff on markdown blob edit (Ciro Santilli)
   - OAuth applications feature
   -
   -

--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -29,11 +29,13 @@ class Projects::EditTreeController < Projects::BaseTreeController
 
   def preview
     @content = params[:content]
+    render layout: false
+  end
 
-    diffy = Diffy::Diff.new(@blob.data, @content, diff: '-U 3',
+  def diff
+    diffy = Diffy::Diff.new(@blob.data, params[:content], diff: '-U 3',
                             include_diff_info: true)
     @diff_lines = Gitlab::Diff::Parser.new.parse(diffy.diff.scan(/.*\n/))
-
     render layout: false
   end
 

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -116,12 +116,4 @@ module TreeHelper
   def leave_edit_message
     "Leave edit mode?\nAll unsaved changes will be lost."
   end
-
-  def editing_preview_title(filename)
-    if Gitlab::MarkdownHelper.previewable?(filename)
-      'Preview'
-    else
-      'Diff'
-    end
-  end
 end

--- a/app/views/projects/edit_tree/diff.html.haml
+++ b/app/views/projects/edit_tree/diff.html.haml
@@ -1,0 +1,17 @@
+.diff-file
+  .diff-content
+    .file-content.code
+      - unless @diff_lines.empty?
+        %table.text-file
+          - @diff_lines.each do |line|
+            %tr.line_holder{ class: "#{line.type}" }
+              - if line.type == "match"
+                %td.old_line= "..."
+                %td.new_line= "..."
+                %td.line_content.matched= line.text
+              - else
+                %td.old_line
+                %td.new_line
+                %td.line_content{class: "#{line.type}"}= raw diff_line_content(line.text)
+      - else
+        .nothing-here-block No changes.

--- a/app/views/projects/edit_tree/preview.html.haml
+++ b/app/views/projects/edit_tree/preview.html.haml
@@ -1,25 +1,7 @@
-.diff-file
-  .diff-content
-    - if gitlab_markdown?(@blob.name)
-      .file-content.wiki
-        = preserve do
-          = markdown(@content)
-    - elsif markup?(@blob.name)
-      .file-content.wiki
-        = raw render_markup(@blob.name, @content)
-    - else
-      .file-content.code
-        - unless @diff_lines.empty?
-          %table.text-file
-            - @diff_lines.each do |line|
-              %tr.line_holder{ class: "#{line.type}" }
-                - if line.type == "match"
-                  %td.old_line= "..."
-                  %td.new_line= "..."
-                  %td.line_content.matched= line.text
-                - else
-                  %td.old_line
-                  %td.new_line
-                  %td.line_content{class: "#{line.type}"}= raw diff_line_content(line.text)
-        - else
-          .nothing-here-block No changes.
+- if gitlab_markdown?(@blob.name)
+  .file-content.wiki
+    = preserve do
+      = markdown(@content)
+- elsif markup?(@blob.name)
+  .file-content.wiki
+    = raw render_markup(@blob.name, @content)

--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -1,9 +1,14 @@
 .file-editor
   %ul.nav.nav-tabs.js-edit-mode
     %li.active
-      = link_to 'Edit', '#editor'
+      = link_to 'Edit', '#', data: { 'pane-id' => 'editor' }
+    - if Gitlab::MarkdownHelper.previewable?(@blob.name)
+      %li
+        = link_to 'Preview', '#', data: { 'pane-id' => 'preview',
+            'target-url' => preview_project_edit_tree_path(@project, @id) }
     %li
-      = link_to editing_preview_title(@blob.name), '#preview', 'data-preview-url' => preview_project_edit_tree_path(@project, @id)
+      = link_to 'Diff', '#', data: { 'pane-id' => 'preview',
+          'target-url' => diff_project_edit_tree_path(@project, @id) }
 
   = form_tag(project_edit_tree_path(@project, @id), method: :put, class: "form-horizontal") do
     .file-holder.file
@@ -18,9 +23,9 @@
       .file-content.code
         %pre.js-edit-mode-pane#editor
         .js-edit-mode-pane#preview.hide
-          .center
-            %h2
-              %i.fa.fa-spinner.fa-spin
+        .js-edit-mode-pane#loader.hide
+          %h2.center
+            %i.fa.fa-spinner.fa-spin
     = render 'shared/commit_message_container', params: params,
              placeholder: "Update #{@blob.name}"
     = hidden_field_tag 'last_commit', @last_commit
@@ -47,26 +52,31 @@
   });
 
   var editModePanes = $('.js-edit-mode-pane'),
-      editModeLinks = $('.js-edit-mode a');
+      editModeLinks = $('.js-edit-mode a'),
+      loaderPane = $('#loader');
 
   editModeLinks.click(function(event) {
     event.preventDefault();
 
     var currentLink = $(this),
-        paneId = currentLink.attr('href'),
-        currentPane = editModePanes.filter(paneId);
+        paneId = currentLink.data('pane-id'),
+        currentPane = editModePanes.filter('#' + paneId);
 
     editModeLinks.parent().removeClass('active hover');
     currentLink.parent().addClass('active hover');
     editModePanes.hide();
+    loaderPane.show();
 
-    if (paneId == '#preview') {
+    if (paneId == 'editor') {
       currentPane.fadeIn(200);
-      $.post(currentLink.data('preview-url'), { content: editor.getValue() }, function(response) {
-        currentPane.empty().append(response);
-      })
-    } else {
-      currentPane.fadeIn(200);
+      loaderPane.hide();
       editor.focus()
+    } else {
+      $.post(currentLink.data('target-url'), { content: editor.getValue() },
+             function(response) {
+        currentPane.html(response);
+        loaderPane.hide();
+        currentPane.fadeIn(200);
+      })
     }
   })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,8 +204,12 @@ Gitlab::Application.routes.draw do
       resources :raw,       only: [:show], constraints: {id: /.+/}
       resources :tree,      only: [:show], constraints: {id: /.+/, format: /(html|js)/ }
       resources :edit_tree, only: [:show, :update], constraints: { id: /.+/ }, path: 'edit' do
-        # Cannot be GET to differentiate from GET paths that end in preview.
-        post :preview, on: :member
+        # Cannot be GET to differentiate from GET paths
+        # that end in those suffixes.
+        member do
+          post :diff
+          post :preview
+        end
       end
       resources :new_tree,  only: [:show, :update], constraints: {id: /.+/}, path: 'new'
       resources :commit,    only: [:show], constraints: {id: /[[:alnum:]]{6,40}/}

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -71,12 +71,27 @@ Feature: Project Source Browse Files
     And I see a commit error message
 
   @javascript
-  Scenario: I can see editing preview
+  Scenario: I can see the diff
     Given I click on ".gitignore" file in repo
     And I click button "Edit"
     And I edit code
     And I click link "Diff"
     Then I see diff
+
+  @javascript
+  Scenario: I don't see the preview button for a file type that has no preview
+    Given I click on ".gitignore" file in repo
+    And I click button "Edit"
+    And I edit code
+    Then I don't see the "Preview" button
+
+  @javascript
+  Scenario: I can see the preview for a file type that has preview
+    Given I click on readme file
+    And I click button "Edit"
+    And I enter new markdown content
+    And I click on "Preview"
+    Then I see the preview
 
   @javascript
   Scenario: I can remove file and commit

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -57,6 +57,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     set_new_content
   end
 
+  step 'I enter new markdown content' do
+    set_editor_new_markdown_content
+  end
+
   step 'I fill the new file name' do
     fill_in :file_name, with: new_file_name
   end
@@ -87,6 +91,18 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
 
   step 'I see diff' do
     page.should have_css '.line_holder.new'
+  end
+
+  step 'I see the preview' do
+    expect(page).to have_css(*rendered_editor_new_markdown_content_matcher)
+  end
+
+  step 'I don\'t see the "Preview" button' do
+    expect(page).not_to have_selector(:link_or_button, 'Preview')
+  end
+
+  step 'I click on "Preview"' do
+    click_link 'Preview'
   end
 
   step 'I click on "new file" link in repo' do
@@ -162,7 +178,7 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
   private
 
   def set_new_content
-    execute_script("editor.setValue('#{new_gitignore_content}')")
+    set_editor_content(new_gitignore_content)
   end
 
   # Content of the gitignore file on the seed repository.

--- a/spec/support/repo_helpers.rb
+++ b/spec/support/repo_helpers.rb
@@ -96,4 +96,22 @@ eos
       commits: commits
     )
   end
+
+  def set_editor_content(content)
+    execute_script("editor.setValue('#{content}')")
+  end
+
+  def set_editor_new_markdown_content
+    set_editor_content("**#{editor_new_markdown_inner_content}**")
+  end
+
+  def rendered_editor_new_markdown_content_matcher
+    ['strong', editor_new_markdown_inner_content]
+  end
+
+  private
+
+  def editor_new_markdown_inner_content
+    'New markdown content'
+  end
 end


### PR DESCRIPTION
Before this PR, you cannot see the diff if the blob you are editing has a preview, like Markdown: the Diff button would be replaced with Preview instead.

Now you can: both buttons have been split up. Diff always shows, and Preview only shows if there is a preview available.

The diff is equally useful whether there is preview or not.

Fixes: http://feedback.gitlab.com/forums/176466-general/suggestions/5855625-show-both-diff-and-preview-when-editing-markdown-f

![screenshot from 2014-10-05 13 47 21 diff preview after](https://cloud.githubusercontent.com/assets/1429315/4518354/e3e76eae-4c85-11e4-9375-eead5cb6e36b.png)

![screenshot from 2014-10-05 13 51 20 edit preview diff](https://cloud.githubusercontent.com/assets/1429315/4518355/fb057fcc-4c85-11e4-9745-f983045b74a4.png)
