### PR TITLE
Convert blob edit preview route from POST to GET

### DIFF
--- a/app/views/projects/edit_tree/show.html.haml
+++ b/app/views/projects/edit_tree/show.html.haml
@@ -67,7 +67,7 @@
 
     if (paneId == '#preview') {
       currentPane.fadeIn(200);
-      $.post(currentLink.data('preview-url'), { content: editor.getValue() }, function(response) {
+      $.get(currentLink.data('preview-url'), { content: editor.getValue() }, function(response) {
         currentPane.empty().append(response);
       })
     } else {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,7 +198,7 @@ Gitlab::Application.routes.draw do
       resources :raw,       only: [:show], constraints: {id: /.+/}
       resources :tree,      only: [:show], constraints: {id: /.+/, format: /(html|js)/ }
       resources :edit_tree, only: [:show, :update], constraints: { id: /.+/ }, path: 'edit' do
-        post :preview, on: :member
+        get :preview, on: :member
       end
       resources :new_tree,  only: [:show, :update], constraints: {id: /.+/}, path: 'new'
       resources :commit,    only: [:show], constraints: {id: /[[:alnum:]]{6,40}/}


### PR DESCRIPTION
Use GET because it does not alter the application state.

cc @skv-headless you may have written that line. If yes, please check if this PR makes sense.
