### PR TITLE
webbrowsers -> web browsers

### DIFF
--- a/doc/install/requirements.md
+++ b/doc/install/requirements.md
@@ -87,7 +87,7 @@ Sidekiq processes the background jobs with a multithreaded process.
 This process starts with the entire Rails stack (200MB+) but it can grow over time due to memory leaks.
 On a very active server (10.000 active users) the Sidekiq process can use 1GB+ of memory.
 
-## Supported webbrowsers
+## Supported web browsers
 
 - Chrome (Latest stable version)
 - Firefox (Latest released version) 


### PR DESCRIPTION
More standard show as `web browsers` rather than `webbrowsers`.
