### PR TITLE
support latest firefox esr release

### DIFF
--- a/doc/install/requirements.md
+++ b/doc/install/requirements.md
@@ -90,7 +90,7 @@ On a very active server (10.000 active users) the Sidekiq process can use 1GB+ o
 ## Supported webbrowsers
 
 - Chrome (Latest stable version)
-- Firefox (Latest released version) 
+- Firefox (Latest released version and [latest ESR version](https://www.mozilla.org/en-US/firefox/organizations/)) 
 - Safari 7+ (known problem: required fields in html5 do not work)
 - Opera (Latest released version)
 - IE 10+


### PR DESCRIPTION
Propose that GitLab should formally support the latest [Firefox ESR release](https://www.mozilla.org/en-US/firefox/organizations/) ([more details](https://en.wikipedia.org/wiki/Firefox#Extended_Support_Release)). ESR releases are based on the rapid releases but supported for 1 year. New ESR releases appear to come out about every 9 months.
