### PR TITLE
Impossible to show a blob named `diff` [failure unrelated]

### DIFF
--- a/app/assets/javascripts/diff.js.coffee
+++ b/app/assets/javascripts/diff.js.coffee
@@ -31,7 +31,7 @@ class @Diff
         offset: offset
         unfold: unfold
 
-      $.get(link, params, (response) =>
+      $.post(link, params, (response) =>
         target.parent().replaceWith(response)
       )
     )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,8 @@ Gitlab::Application.routes.draw do
 
     scope module: :projects do
       resources :blob, only: [:show, :destroy], constraints: { id: /.+/, format: false } do
-        get :diff, on: :member
+        # Cannot be GET to differentiate from GET paths that end in diff.
+        post :diff, on: :member
       end
       resources :raw,       only: [:show], constraints: {id: /.+/}
       resources :tree,      only: [:show], constraints: {id: /.+/, format: /(html|js)/ }

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -450,6 +450,23 @@ describe Projects::EditTreeController, 'routing' do
   end
 end
 
+describe Projects::BlobController, 'routing' do
+  it 'to #show' do
+    get('/gitlab/gitlabhq/blob/master/app/models/project.rb').should(
+      route_to('projects/blob#show', project_id: 'gitlab/gitlabhq',
+                                     id: 'master/app/models/project.rb'))
+    get('/gitlab/gitlabhq/blob/master/app/models/project.rb/diff').should(
+      route_to('projects/blob#show', project_id: 'gitlab/gitlabhq',
+                                     id: 'master/app/models/project.rb/diff'))
+  end
+
+  it 'to #diff' do
+    post('/gitlab/gitlabhq/blob/master/app/models/project.rb/diff').should(
+      route_to('projects/blob#diff', project_id: 'gitlab/gitlabhq',
+                                     id: 'master/app/models/project.rb'))
+  end
+end
+
 # project_compare_index GET    /:project_id/compare(.:format)             compare#index {id: /[^\/]+/, project_id: /[^\/]+/}
 #                       POST   /:project_id/compare(.:format)             compare#create {id: /[^\/]+/, project_id: /[^\/]+/}
 #       project_compare        /:project_id/compare/:from...:to(.:format) compare#show {from: /.+/, to: /.+/, id: /[^\/]+/, project_id: /[^\/]+/}


### PR DESCRIPTION
Before this commit, it was impossible to see a blob whose filename ends in `diff` because GET `path/to/diff` routed to `blob#diff`.

Currently live on GitLab: https://gitlab.com/cirosantilli/test/blob/master/diff

You will get redirected to https://gitlab.com/cirosantilli/test/tree/master/ where you can see the the file named `diff` does in fact exist!

This is an ugly fix that replaces the  GET with a POST to resolve the ambiguity but for something that does not change system state, but it is the simplest DRY strategy I could find, and the same strategy is currently used for blob edit preview at: https://github.com/gitlabhq/gitlabhq/blob/30c447ed2f35a0d1f4eb0f6200aa9ab952c46768/config/routes.rb#L201

To solve the problem beautifully, we must instead use a route like `diff_blob/:id`, and to do that nicely someone must answer: http://stackoverflow.com/questions/26223317/how-to-put-a-member-of-a-routing-resource-outside-of-its-parent-namespace
