### PR TITLE
Add tests for tree edit routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,7 @@ Gitlab::Application.routes.draw do
       resources :raw,       only: [:show], constraints: {id: /.+/}
       resources :tree,      only: [:show], constraints: {id: /.+/, format: /(html|js)/ }
       resources :edit_tree, only: [:show, :update], constraints: { id: /.+/ }, path: 'edit' do
+        # Cannot be GET to differentiate from GET paths that end in preview.
         post :preview, on: :member
       end
       resources :new_tree,  only: [:show, :update], constraints: {id: /.+/}, path: 'new'

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -432,6 +432,26 @@ describe Projects::TreeController, "routing" do
   end
 end
 
+describe Projects::EditTreeController, 'routing' do
+  it 'to #show' do
+    get('/gitlab/gitlabhq/edit/master/app/models/project.rb').should(
+      route_to('projects/edit_tree#show',
+               project_id: 'gitlab/gitlabhq',
+               id: 'master/app/models/project.rb'))
+    get('/gitlab/gitlabhq/edit/master/app/models/project.rb/preview').should(
+      route_to('projects/edit_tree#show',
+               project_id: 'gitlab/gitlabhq',
+               id: 'master/app/models/project.rb/preview'))
+  end
+
+  it 'to #preview' do
+    post('/gitlab/gitlabhq/edit/master/app/models/project.rb/preview').should(
+      route_to('projects/edit_tree#preview',
+               project_id: 'gitlab/gitlabhq',
+               id: 'master/app/models/project.rb'))
+  end
+end
+
 # project_compare_index GET    /:project_id/compare(.:format)             compare#index {id: /[^\/]+/, project_id: /[^\/]+/}
 #                       POST   /:project_id/compare(.:format)             compare#create {id: /[^\/]+/, project_id: /[^\/]+/}
 #       project_compare        /:project_id/compare/:from...:to(.:format) compare#show {from: /.+/, to: /.+/, id: /[^\/]+/, project_id: /[^\/]+/}


### PR DESCRIPTION
Critical because of possible confusion between /:id/preview
and /:id for a path that ends in preview.

The goal it to prevent a bug analogous to: https://github.com/gitlabhq/gitlabhq/pull/7977
