### PR TITLE
Display renamed files in diff views

### DIFF
--- a/app/views/projects/diffs/_file.html.haml
+++ b/app/views/projects/diffs/_file.html.haml
@@ -10,7 +10,10 @@
         - if @commit.parent_ids.present?
           = view_file_btn(@commit.parent_id, diff_file, project)
     - else
-      %span= diff_file.new_path
+      - if diff_file.renamed_file
+        %span= "#{diff_file.old_path} renamed to #{diff_file.new_path}"
+      - else
+        %span= diff_file.new_path
       - if diff_file.mode_changed?
         %span.file-mode= "#{diff_file.diff.a_mode} → #{diff_file.diff.b_mode}"
 


### PR DESCRIPTION
Show both the old and new filenames when viewing the diff for a renamed file, as suggested on [feedback.gitlab.com](http://feedback.gitlab.com/forums/176466-general/suggestions/4130669-display-moved-files-with-a-single-line-instead-of).

This depends on a change to gitlab_git; file rename detection is enabled there in [merge request 6](https://gitlab.com/gitlab-org/gitlab_git/merge_requests/6) on gitlab.com.  However, this change shouldn't break the existing diff view in the meantime.

Here are screen prints of some commits from the gitlab-shell repo.  The "before" view is the same with either of these combinations of gitlab and gitlab_git:
- `gitlabhq/master` gitlab and `gitlabhq/master` gitlab_git
- `mr-vinn/diff-renames` gitlab and `gitlabhq/master` gitlab_git

The "after" view requires `mr-vinn/diff-renames` gitlab and `mr-vinn/rugged-diff-options` gitlab_git
### Before

![diff_without_rename](https://cloud.githubusercontent.com/assets/2551678/4688449/0b60b052-5678-11e4-8fe0-07da00546e7b.png)
### After

![diff_rename_enabled](https://cloud.githubusercontent.com/assets/2551678/4688451/185a7126-5678-11e4-8d0a-f14acd78e0bb.png)
