### PR TITLE
404 instead of 500 on inexistent paths for tree edit and blame show [failure unrelated]

### DIFF
--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -29,4 +29,16 @@ class Projects::ApplicationController < ApplicationController
       redirect_to project_tree_path(@project, @ref), notice: "This action is not allowed unless you are on top of a branch"
     end
   end
+
+  def blob
+    @blob ||= @repository.blob_at(@commit.id, @path)
+
+    if @blob
+      @blob
+    elsif tree.entries.any?
+      redirect_to project_tree_path(@project, File.join(@ref, @path)) and return
+    else
+      return not_found!
+    end
+  end
 end

--- a/app/controllers/projects/blame_controller.rb
+++ b/app/controllers/projects/blame_controller.rb
@@ -6,9 +6,9 @@ class Projects::BlameController < Projects::ApplicationController
   before_filter :authorize_read_project!
   before_filter :authorize_code_access!
   before_filter :require_non_empty_project
+  before_filter :blob
 
   def show
-    @blob = @repository.blob_at(@commit.id, @path)
     @blame = Gitlab::Git::Blame.new(project.repository, @commit.id, @path)
   end
 end

--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -39,18 +39,4 @@ class Projects::BlobController < Projects::ApplicationController
 
     render layout: false
   end
-
-  private
-
-  def blob
-    @blob ||= @repository.blob_at(@commit.id, @path)
-
-    if @blob
-      @blob
-    elsif tree.entries.any?
-      redirect_to project_tree_path(@project, File.join(@ref, @path)) and return
-    else
-      return not_found!
-    end
-  end
 end

--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -39,10 +39,6 @@ class Projects::EditTreeController < Projects::BaseTreeController
 
   private
 
-  def blob
-    @blob ||= @repository.blob_at(@commit.id, @path)
-  end
-
   def after_edit_path
     @after_edit_path ||=
       if from_merge_request

--- a/app/controllers/projects/raw_controller.rb
+++ b/app/controllers/projects/raw_controller.rb
@@ -6,24 +6,19 @@ class Projects::RawController < Projects::ApplicationController
   before_filter :authorize_read_project!
   before_filter :authorize_code_access!
   before_filter :require_non_empty_project
+  before_filter :blob
 
   def show
-    @blob = @repository.blob_at(@commit.id, @path)
+    type = get_blob_type
 
-    if @blob
-      type = get_blob_type
+    headers['X-Content-Type-Options'] = 'nosniff'
 
-      headers['X-Content-Type-Options'] = 'nosniff'
-
-      send_data(
-        @blob.data,
-        type: type,
-        disposition: 'inline',
-        filename: @blob.name
-      )
-    else
-      not_found!
-    end
+    send_data(
+      @blob.data,
+      type: type,
+      disposition: 'inline',
+      filename: @blob.name
+    )
   end
 
   private

--- a/spec/controllers/blame_controller_spec.rb
+++ b/spec/controllers/blame_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+include RepoHelpers
+
+describe Projects::BlameController do
+  let(:project) { create(:project) }
+  let(:user)    { create(:user) }
+
+  before do
+    sign_in(user)
+    project.team << [user, :developer]
+  end
+
+  describe 'GET show' do
+    it 'responds with success if branch / path pair exists' do
+      get :show, project_id: project.to_param, id: existing_path_id
+
+      assert_response :success
+    end
+
+    it 'responds with not found if branch / path pair does not exist' do
+      get :show, project_id: project.to_param, id: inexistent_path_id
+
+      assert_response :not_found
+    end
+  end
+end

--- a/spec/controllers/edit_tree_controller_spec.rb
+++ b/spec/controllers/edit_tree_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+include RepoHelpers
+
+describe Projects::EditTreeController do
+  let(:project) { create(:project) }
+  let(:user)    { create(:user) }
+
+  before do
+    sign_in(user)
+    project.team << [user, :developer]
+  end
+
+  describe 'GET show' do
+    it 'responds with success if branch / path pair exists' do
+      get :show, project_id: project.to_param, id: existing_path_id
+
+      assert_response :success
+    end
+
+    it 'responds with not found if branch / path pair does not exist' do
+      get :show, project_id: project.to_param, id: inexistent_path_id
+
+      assert_response :not_found
+    end
+  end
+end

--- a/spec/support/repo_helpers.rb
+++ b/spec/support/repo_helpers.rb
@@ -96,4 +96,24 @@ eos
       commits: commits
     )
   end
+
+  def root_ref
+    'master'
+  end
+
+  def existing_path
+    '.gitignore'
+  end
+
+  def existing_path_id
+    root_ref + '/' + existing_path
+  end
+
+  def inexistent_path
+    'new_file'
+  end
+
+  def inexistent_path_id
+    root_ref + '/' + inexistent_path
+  end
 end


### PR DESCRIPTION
Edit and blame on inexistent paths was giving 500 where it should be 404.

Live examples:
- https://gitlab.com/cirosantilli/test0/blame/master/README.mdqwer
- https://gitlab.com/cirosantilli/test0/edit/master/README.mdqwer

This was working for blob, tree and raw views.

Implementation: use the same mechanism currently used on the blob controller on all others by moving it to the parent `Projects::ApplicationController`.

The real cause of this however, is that the current controller design is bad IMHO: `blame`, `raw` and `edit` should be different actions of a single controller `blob` controller: this would make it easier to have uniformity.

The only reason they are not is probably because the `:id` can contain slashes which makes it harder to write DRY routes. See: http://stackoverflow.com/questions/26223317/how-to-put-a-member-of-a-routing-resource-outside-of-its-parent-namespace . But I'd rather have non DRY routes instead of non DRY controllers.
