### PR TITLE
Correctly pluralize participants on issue show page

### DIFF
--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -62,7 +62,8 @@
       = link_to 'Close Issue', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn btn-grouped btn-close js-note-target-close", title: "Close Issue"
 
 .participants
-  %cite.cgray #{@issue.participants.count} participants
+  %cite.cgray
+    = pluralize(@issue.participants.count, 'participant')
   - @issue.participants.each do |participant|
     = link_to_member(@project, participant, name: false, size: 24)
 


### PR DESCRIPTION
Right now, if there is only one participants, the issue show page says "1 participants" instead of "1 participant."  This commit uses pluralize() to fix that.
