### PR TITLE
Replace match via get with get on routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,8 +143,8 @@ Gitlab::Application.routes.draw do
     end
   end
 
-  match "/u/:username" => "users#show", as: :user,
-    constraints: {username: /(?:[^.]|\.(?!atom$))+/, format: /atom/}, via: :get
+  get '/u/:username' => 'users#show', as: :user,
+      constraints: { username: /(?:[^.]|\.(?!atom$))+/, format: /atom/ }
 
   #
   # Dashboard Area


### PR DESCRIPTION
Shorter, matches the style of the rest of the routes, and `match` raises red flags for me because of the possibility of routing multiple methods to a single action with it: http://guides.rubyonrails.org/routing.html#http-verb-constraints
