### PR TITLE
Import - Display message when skipping repo

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -27,7 +27,10 @@ namespace :gitlab do
         group_name = nil if group_name == '.'
 
         # Skip if group or user
-        next if namespaces.include?(name)
+        if namespaces.include?(name)
+          puts "Skipping #{project.name} due to namespace conflict with group or user".yellow
+          next
+        end
 
         puts "Processing #{repo_path}".yellow
 


### PR DESCRIPTION
We've searched a while why our repo was not imported and finally found out in the code the reason why. There was no error, no nothing. We could've used an info message saying that the repo was skipped and why.
