### PR TITLE
Disallow POST to compare as it does not create objects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,8 @@ Gitlab::Application.routes.draw do
         end
       end
 
-      match "/compare/:from...:to" => "compare#show", as: "compare", via: [:get, :post], constraints: {from: /.+/, to: /.+/}
+      get '/compare/:from...:to' => 'compare#show', :as => 'compare',
+          :constraints => {from: /.+/, to: /.+/}
 
         resources :snippets, constraints: {id: /\d+/} do
           member do


### PR DESCRIPTION
Also does not seem to be used anywhere in the app: tests pass, and I've quickly checked the occurrences manually.
