### PR TITLE
Remove unnecessary service requires [passes locally, always fails on CI]

### DIFF
--- a/app/services/create_branch_service.rb
+++ b/app/services/create_branch_service.rb
@@ -1,5 +1,3 @@
-require_relative 'base_service'
-
 class CreateBranchService < BaseService
   def execute(branch_name, ref)
     valid_branch = Gitlab::GitRefValidator.validate(branch_name)

--- a/app/services/create_tag_service.rb
+++ b/app/services/create_tag_service.rb
@@ -1,5 +1,3 @@
-require_relative 'base_service'
-
 class CreateTagService < BaseService
   def execute(tag_name, ref, message)
     valid_tag = Gitlab::GitRefValidator.validate(tag_name)

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -1,5 +1,3 @@
-require_relative "base_service"
-
 module Files
   class CreateService < BaseService
     def execute

--- a/app/services/files/delete_service.rb
+++ b/app/services/files/delete_service.rb
@@ -1,5 +1,3 @@
-require_relative "base_service"
-
 module Files
   class DeleteService < BaseService
     def execute

--- a/app/services/files/update_service.rb
+++ b/app/services/files/update_service.rb
@@ -1,5 +1,3 @@
-require_relative "base_service"
-
 module Files
   class UpdateService < BaseService
     def execute

--- a/app/services/merge_requests/update_service.rb
+++ b/app/services/merge_requests/update_service.rb
@@ -1,9 +1,5 @@
-require_relative 'base_service'
-require_relative 'reopen_service'
-require_relative 'close_service'
-
 module MergeRequests
-  class UpdateService < MergeRequests::BaseService
+  class UpdateService < BaseService
     def execute(merge_request)
       # We dont allow change of source/target projects
       # after merge request was created
@@ -14,9 +10,9 @@ module MergeRequests
 
       case state
       when 'reopen'
-        MergeRequests::ReopenService.new(project, current_user, {}).execute(merge_request)
+        ReopenService.new(project, current_user, {}).execute(merge_request)
       when 'close'
-        MergeRequests::CloseService.new(project, current_user, {}).execute(merge_request)
+        CloseService.new(project, current_user, {}).execute(merge_request)
       when 'task_check'
         merge_request.update_nth_task(params[:task_num].to_i, true)
       when 'task_uncheck'


### PR DESCRIPTION
and explicit modules MergeRequests::

Rails does magic autoloading based on file paths and we already use it extensively.

I don't understand why but this always passes locally and always fails on CI because of the new edit and remove blob actions.

From the errors it is clear that the file services are loading the wrong base service (base instead of file/base) on the CI because of the wrong number of arguments.

I don't understand why this is so: according to this blog post http://urbanautomaton.com/blog/2013/08/27/rails-autoloading-hell/ `Files::BaseService` should be searched first.

As it stands it cannot be merged because it would break the CI, but I'd really like to know why it fails only on the CI and not locally...
