### PR TITLE
Remove unneeded app/finders config.autoload path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ module Gitlab
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib
-                                #{config.root}/app/finders
                                 #{config.root}/app/models/hooks
                                 #{config.root}/app/models/concerns
                                 #{config.root}/app/models/project_services


### PR DESCRIPTION
Every directory directly under app/ is already searched by default because it is under `eager_load_path` as mentioned at: http://edgeguides.rubyonrails.org/configuring.html

> config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled. Defaults to every folder in the app directory of the application.

and empirically verified.

This is for example why services can be used from controllers magically.
