### PR TITLE
Fixed gitlab.org issue #633 (Forced all OAuth UserSpec properties to be encoded as UTF-8)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ Note: The upcoming release contains empty lines to reduce the number of merge co
 v 7.8.0
   - Replace highlight.js with rouge-fork rugments (Stefan Tatschner)
   - Make project search case insensitive (Hannes Rosenögger)
-  - 
+  - Forced all OAuth UserSpec properties to be encoded as UTF-8
   - Expose description in groups API
   - 
   - 

--- a/lib/gitlab/oauth/auth_hash.rb
+++ b/lib/gitlab/oauth/auth_hash.rb
@@ -9,11 +9,11 @@ module Gitlab
       end
 
       def uid
-        auth_hash.uid.to_s
+        Gitlab::Utils.encode_utf8(auth_hash.uid.to_s)
       end
 
       def provider
-        auth_hash.provider
+        Gitlab::Utils.encode_utf8(auth_hash.provider.to_s)
       end
 
       def info
@@ -21,23 +21,23 @@ module Gitlab
       end
 
       def name
-        (info.try(:name) || full_name).to_s.force_encoding('utf-8')
+        Gitlab::Utils.encode_utf8((info.try(:name) || full_name).to_s)
       end
 
       def full_name
-        "#{info.first_name} #{info.last_name}"
+        Gitlab::Utils.encode_utf8("#{info.first_name} #{info.last_name}")
       end
 
       def username
-        (info.try(:nickname) || generate_username).to_s.force_encoding('utf-8')
+        Gitlab::Utils.encode_utf8((info.try(:nickname) || generate_username).to_s)
       end
 
       def email
-        (info.try(:email) || generate_temporarily_email).downcase
+        Gitlab::Utils.encode_utf8((info.try(:email) || generate_temporarily_email).downcase)
       end
 
       def password
-        @password ||= Devise.friendly_token[0, 8].downcase
+        @password ||= Gitlab::Utils.encode_utf8(Devise.friendly_token[0, 8].downcase)
       end
 
       # Get the first part of the email address (before @)

--- a/lib/gitlab/utils.rb
+++ b/lib/gitlab/utils.rb
@@ -9,5 +9,9 @@ module Gitlab
     def system_silent(cmd)
       Popen::popen(cmd).last.zero?
     end
+
+    def encode_utf8(str)
+      str.force_encoding(Encoding::UTF_8)
+    end
   end
 end

--- a/spec/lib/gitlab/oauth/auth_hash_spec.rb
+++ b/spec/lib/gitlab/oauth/auth_hash_spec.rb
@@ -3,53 +3,97 @@ require 'spec_helper'
 describe Gitlab::OAuth::AuthHash do
   let(:auth_hash) do
     Gitlab::OAuth::AuthHash.new(double({
-      provider: 'twitter',
-      uid: uid,
+      provider: provider_ascii,
+      uid: uid_ascii,
       info: double(info_hash)
     }))
   end
-  let(:uid) { 'my-uid' }
-  let(:email) { 'my-email@example.com' }
-  let(:nickname) { 'my-nickname' }
+
+  let(:provider_ascii) { 'ldap'.force_encoding(Encoding::ASCII_8BIT) }
+  let(:uid_ascii) { "CN=John B\xC4\x99ben,OU=Test,DC=company,DC=org".force_encoding(Encoding::ASCII_8BIT) }
+  let(:email_ascii) { "john.b\xC4\x99ben@company.org".force_encoding(Encoding::ASCII_8BIT) }
+  let(:nickname_ascii) { "jb\xC4\x99ben".force_encoding(Encoding::ASCII_8BIT) }
+  let(:first_name_ascii) { 'John'.force_encoding(Encoding::ASCII_8BIT) }
+  let(:last_name_ascii) { "B\xC4\x99ben".force_encoding(Encoding::ASCII_8BIT) }
+  let(:name_ascii) { "John B\xC4\x99ben".force_encoding(Encoding::ASCII_8BIT) }
+
+  let(:provider_utf8) { provider_ascii.force_encoding(Encoding::UTF_8) }
+  let(:uid_utf8) { uid_ascii.force_encoding(Encoding::UTF_8) }
+  let(:email_utf8) { email_ascii.force_encoding(Encoding::UTF_8) }
+  let(:nickname_utf8) { nickname_ascii.force_encoding(Encoding::UTF_8) }
+  let(:name_utf8) { name_ascii.force_encoding(Encoding::UTF_8) }
+
   let(:info_hash) {
     {
-      email: email,
-      nickname: nickname,
-      name: 'John',
-      first_name: "John",
-      last_name: "Who"
+      email: email_ascii,
+      first_name: first_name_ascii,
+      last_name: last_name_ascii,
+      name: name_ascii,
+      nickname: nickname_ascii,
+      uid: uid_ascii
     }
   }
 
-  context "defaults" do
-    it { expect(auth_hash.provider).to eql 'twitter' }
-    it { expect(auth_hash.uid).to eql uid }
-    it { expect(auth_hash.email).to eql email }
-    it { expect(auth_hash.username).to eql nickname }
-    it { expect(auth_hash.name).to eql "John" }
+  context 'defaults' do
+    it { expect(auth_hash.provider).to eql provider_utf8 }
+    it { expect(auth_hash.uid).to eql uid_utf8 }
+    it { expect(auth_hash.email).to eql email_utf8 }
+    it { expect(auth_hash.username).to eql nickname_utf8 }
+    it { expect(auth_hash.name).to eql name_utf8 }
     it { expect(auth_hash.password).to_not be_empty }
   end
 
-  context "email not provided" do
+  context 'email not provided' do
     before { info_hash.delete(:email) }
-    it "generates a temp email" do
+
+    it 'generates a temp email' do
       expect( auth_hash.email).to start_with('temp-email-for-oauth')
     end
   end
 
-  context "username not provided" do
+  context 'username not provided' do
     before { info_hash.delete(:nickname) }
 
-    it "takes the first part of the email as username" do
-      expect( auth_hash.username ).to eql "my-email"
+    it 'takes the first part of the email as username' do
+      expect( auth_hash.username ).to eql 'john-beben'
     end
   end
 
-  context "name not provided" do
+  context 'name not provided' do
     before { info_hash.delete(:name) }
 
-    it "concats first and lastname as the name" do
-      expect( auth_hash.name ).to eql "John Who"
+    it 'concats first and lastname as the name' do
+      expect( auth_hash.name ).to eql name_utf8
+    end
+  end
+
+  context 'auth_hash constructed with ASCII-8BIT encoding' do
+    it 'forces utf8 encoding on uid' do
+      auth_hash.uid.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on provider' do
+      auth_hash.provider.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on name' do
+      auth_hash.name.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on full_name' do
+      auth_hash.full_name.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on username' do
+      auth_hash.username.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on email' do
+      auth_hash.email.encoding.should == Encoding::UTF_8
+    end
+
+    it 'forces utf8 encoding on password' do
+      auth_hash.password.encoding.should == Encoding::UTF_8
     end
   end
 end


### PR DESCRIPTION
I've found that some omniauth properties are still causing trouble when not forced to be UTF-8.

This commit is forcing every property of Gitlab::OAuth::AuthHash to be UTF-8.
