### PR TITLE
Remove unused method

### DIFF
--- a/app/services/issues/update_service.rb
+++ b/app/services/issues/update_service.rb
@@ -33,12 +33,5 @@ module Issues
 
       issue
     end
-
-    private
-
-    def update_task(issue, params, checked)
-      issue.update_nth_task(params[:task_num].to_i, checked)
-      params.except!(:task_num)
-    end
   end
 end


### PR DESCRIPTION
The private `#update_task` method is not used by `Issues::UpdateService` (and should have been removed before I pushed the task list feature).
