### PR TITLE
Use Gitlab.config instead of Settings everywhere

### DIFF
--- a/app/controllers/admin/background_jobs_controller.rb
+++ b/app/controllers/admin/background_jobs_controller.rb
@@ -1,6 +1,6 @@
 class Admin::BackgroundJobsController < Admin::ApplicationController
   def show
-    ps_output, _ = Gitlab::Popen.popen(%W(ps -U #{Settings.gitlab.user} -o pid,pcpu,pmem,stat,start,command))
+    ps_output, _ = Gitlab::Popen.popen(%W(ps -U #{Gitlab.config.gitlab.user} -o pid,pcpu,pmem,stat,start,command))
     @sidekiq_processes = ps_output.split("\n").grep(/sidekiq/)
   end
 end

--- a/app/views/admin/background_jobs/show.html.haml
+++ b/app/views/admin/background_jobs/show.html.haml
@@ -25,7 +25,7 @@
             - next unless process.match(/(sidekiq \d+\.\d+\.\d+.+$)/)
             - data = process.strip.split(' ')
             %tr
-              %td= Settings.gitlab.user
+              %td= gitlab_config.user
               - 5.times do
                 %td= data.shift
               %td= data.join(' ')
@@ -36,7 +36,7 @@
           If '[25 of 25 busy]' is shown, restart GitLab with 'sudo service gitlab reload'.
         %p
           %i.fa.fa-exclamation-circle
-          If more than one sidekiq process is listed, stop GitLab, kill the remaining sidekiq processes (sudo pkill -u #{Settings.gitlab.user} -f sidekiq) and restart GitLab.
+          If more than one sidekiq process is listed, stop GitLab, kill the remaining sidekiq processes (sudo pkill -u #{gitlab_config.user} -f sidekiq) and restart GitLab.
 
 
 

--- a/lib/gitlab/url_builder.rb
+++ b/lib/gitlab/url_builder.rb
@@ -19,7 +19,7 @@ module Gitlab
       issue = Issue.find(id)
       project_issue_url(id: issue.iid,
                         project_id: issue.project,
-                        host: Settings.gitlab['url'])
+                        host: Gitlab.config.gitlab['url'])
     end
   end
 end

--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -7,9 +7,9 @@ namespace :gitlab do
       default_version = File.read(File.join(Rails.root, "GITLAB_SHELL_VERSION")).strip
       args.with_defaults(tag: 'v' + default_version, repo: "https://gitlab.com/gitlab-org/gitlab-shell.git")
 
-      user = Settings.gitlab.user
-      home_dir = Rails.env.test? ? Rails.root.join('tmp/tests') : Settings.gitlab.user_home
-      gitlab_url = Settings.gitlab.url
+      user = Gitlab.config.gitlab.user
+      home_dir = Rails.env.test? ? Rails.root.join('tmp/tests') : Gitlab.config.gitlab.user_home
+      gitlab_url = Gitlab.config.gitlab.url
       # gitlab-shell requires a / at the end of the url
       gitlab_url += "/" unless gitlab_url.match(/\/$/)
       repos_path = Gitlab.config.gitlab_shell.repos_path


### PR DESCRIPTION
They are the same because of https://github.com/gitlabhq/gitlabhq/blob/2b816075dc71dfe8f6f9e5349fdff7f03ad9dad0/config/initializers/2_app.rb#L5, but `Gitlab.config` is used far more than `Settings`, so let's use it everywhere.

I wonder why though: `Settings` is shorter, easier to understand since it is the same for every app that uses settings logic. Took me a while to find that 2_app.rb file.
