### PR TITLE
Add timezone configuration to gitlab.yml

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 7.5.0
+  - Add time zone configuration on gitlab.yml (Sullivan Senechal)
+
 v 7.4.0
   - Refactored membership logic
   - Improve error reporting on users API (Julien Bianchi)

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module Gitlab
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+    # NOTE: Please prefer set time zone on config/gitlab.yml configuration file.
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -33,6 +33,11 @@ production: &base
     # Uncomment and customize if you can't use the default user to run GitLab (default: 'git')
     # user: git
 
+    ## Date & Time settings
+    # Uncomment and customize if you want to change the default time zone of GitLab application.
+    # To see all available zones, run `bundle exec rake time:zones:all`
+    # time_zone: 'UTC'
+
     ## Email settings
     # Email address used in the "From" field in mails sent by GitLab
     email_from: example@example.com

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -103,6 +103,7 @@ Settings.gitlab['user_home']  ||= begin
 rescue ArgumentError # no user configured
   '/home/' + Settings.gitlab['user']
 end
+Settings.gitlab['time_zone']  ||= nil
 Settings.gitlab['signup_enabled'] ||= false
 Settings.gitlab['signin_enabled'] ||= true if Settings.gitlab['signin_enabled'].nil?
 Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant_array, Gitlab::VisibilityLevel, Settings.gitlab['restricted_visibility_levels'], [])

--- a/config/initializers/time_zone.rb
+++ b/config/initializers/time_zone.rb
@@ -1,0 +1,1 @@
+Time.zone = Gitlab.config.gitlab.time_zone || Time.zone


### PR DESCRIPTION
This pull request refer to this suggestion: http://feedback.gitlab.com/forums/176466-general/suggestions/5890076-add-timezone-configuration-to-gitlab-yml

It's now possible to set time zone form gitlab.yml configuration file by adding a little time_zone initializer.
