### PR TITLE
Document Markdown table formatting issue

### DIFF
--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -510,6 +510,10 @@ Code above produces next output:
 | cell 1   | cell 2   |
 | cell 3   | cell 4   |
 
+**Note**
+
+The row of dashes between the table header and body must have at least three dashes in each column.
+
 ## References
 
 - This document leveraged heavily from the [Markdown-Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).


### PR DESCRIPTION
Add a note to the Markdown documentation about a quirk of Redcarpet's table parsing.  See issue #3651 
