### PR TITLE
Improve event note display in dashboard and project activity views

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -136,9 +136,8 @@ module EventsHelper
   end
 
   def event_note(text)
-    text = first_line_in_markdown(text)
-    text = truncate(text, length: 150)
-    sanitize(markdown(text), tags: %w(a img b pre p))
+    text = first_line_in_markdown(text, 150)
+    sanitize(text, tags: %w(a img b pre p))
   end
 
   def event_commit_title(message)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -137,7 +137,7 @@ module EventsHelper
 
   def event_note(text)
     text = first_line_in_markdown(text, 150)
-    sanitize(text, tags: %w(a img b pre p))
+    sanitize(text, tags: %w(a img b pre code p))
   end
 
   def event_commit_title(message)

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe EventsHelper do
+  include ApplicationHelper
+  include GitlabMarkdownHelper
+
+  it 'should display one line of plain text without alteration' do
+    input = 'A short, plain note'
+    expect(event_note(input)).to match(input)
+    expect(event_note(input)).not_to match(/\.\.\.\z/)
+  end
+
+  it 'should display inline code' do
+    input = 'A note with `inline code`'
+    expected = 'A note with <code>inline code</code>'
+
+    expect(event_note(input)).to match(expected)
+  end
+
+  it 'should truncate a note with multiple paragraphs' do
+    input = "Paragraph 1\n\nParagraph 2"
+    expected = 'Paragraph 1...'
+
+    expect(event_note(input)).to match(expected)
+  end
+
+  it 'should display the first line of a code block' do
+    input = "```\nCode block\nwith two lines\n```"
+    expected = '<pre><code class="">Code block...</code></pre>'
+
+    expect(event_note(input)).to match(expected)
+  end
+
+  it 'should truncate a single long line of text' do
+    text = 'The quick brown fox jumped over the lazy dog twice' # 50 chars
+    input = "#{text}#{text}#{text}#{text}" # 200 chars
+    expected = "#{text}#{text}".sub(/.{3}/, '...')
+
+    expect(event_note(input)).to match(expected)
+  end
+
+  it 'should preserve a link href when link text is truncated' do
+    text = 'The quick brown fox jumped over the lazy dog' # 44 chars
+    input = "#{text}#{text}#{text} " # 133 chars
+    link_url = 'http://example.com/foo/bar/baz' # 30 chars
+    input << link_url
+    expected_link_text = 'http://example...</a>'
+
+    expect(event_note(input)).to match(link_url)
+    expect(event_note(input)).to match(expected_link_text)
+  end
+end


### PR DESCRIPTION
Fixes #3910 

This change improves the event note display in dashboard and project activity views:
- Preserve link href values when the link text is truncated.
- Display inline code in the first line of a note.
- Only display "..." when the note contents are truncated.
- If the note starts with a code block, display the first line instead of an empty `<pre/>` element.
### Examples
#### Old
## ![truncated_link_old](https://cloud.githubusercontent.com/assets/2551678/4609238/8e47f9f4-5299-11e4-8283-aac0d64bd58a.png)
## ![inline_code_old](https://cloud.githubusercontent.com/assets/2551678/4609240/969e7772-5299-11e4-9e5e-8051ac074d33.png)
## ![plain_old](https://cloud.githubusercontent.com/assets/2551678/4609241/9b7c9648-5299-11e4-9e64-b29c199f9495.png)

![code_block_old](https://cloud.githubusercontent.com/assets/2551678/4609243/9fb3dcda-5299-11e4-9b17-d2f1783d4a7b.png)
#### New
## ![truncated_link_new](https://cloud.githubusercontent.com/assets/2551678/4609272/36feca50-529a-11e4-8712-51ae5f2a5e58.png)
## ![inline_code_new](https://cloud.githubusercontent.com/assets/2551678/4609273/3fb6bfa4-529a-11e4-8109-1670bbdc058e.png)
## ![plain_new](https://cloud.githubusercontent.com/assets/2551678/4609276/4485838a-529a-11e4-8574-7034eab88f68.png)

![code_block_new](https://cloud.githubusercontent.com/assets/2551678/4609277/490b53ee-529a-11e4-95c2-3ad0657b2e19.png)
