### PR TITLE
rake:import:repos: fix exclude wiki regex for importing repositories

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -34,7 +34,7 @@ namespace :gitlab do
 
         puts "Processing #{repo_path}".yellow
 
-        if path =~ /.wiki\Z/
+        if path =~ /\.wiki\Z/
           puts " * Skipping wiki repo"
           next
         end


### PR DESCRIPTION
fix typo

the old regex exluded all repositories with its name ending in wiki

the new regex allows importing repositories with repository name ending with wiki but still exclude gitlab wiki repositories
