### PR TITLE
Remove unused filter from ProjectsController

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,6 @@ class ProjectsController < ApplicationController
   # Authorize
   before_filter :authorize_read_project!, except: [:index, :new, :create]
   before_filter :authorize_admin_project!, only: [:edit, :update, :destroy, :transfer, :archive, :unarchive, :retry_import]
-  before_filter :require_non_empty_project, only: [:blob, :tree, :graph]
 
   layout 'navless', only: [:new, :create, :fork]
   before_filter :set_title, only: [:new, :create]


### PR DESCRIPTION
Neither controller nor any of it's descendants have those actions.

Dead code :skull: 
