### PR TITLE
Factor authorize_push! and authorize_code_access!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,14 +119,6 @@ class ApplicationController < ActionController::Base
     return access_denied! unless can?(current_user, action, project)
   end
 
-  def authorize_code_access!
-    return access_denied! unless can?(current_user, :download_code, project)
-  end
-
-  def authorize_push!
-    return access_denied! unless can?(current_user, :push_code, project)
-  end
-
   def authorize_labels!
     # Labels should be accessible for issues and/or merge requests
     authorize_read_issue! || authorize_read_merge_request!

--- a/app/controllers/projects/base_tree_controller.rb
+++ b/app/controllers/projects/base_tree_controller.rb
@@ -2,7 +2,7 @@ class Projects::BaseTreeController < Projects::ApplicationController
   include ExtractsPath
 
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 end
 

--- a/app/controllers/projects/blame_controller.rb
+++ b/app/controllers/projects/blame_controller.rb
@@ -4,7 +4,7 @@ class Projects::BlameController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def show

--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -4,9 +4,9 @@ class Projects::BlobController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
-  before_filter :authorize_push!, only: [:destroy]
+  before_filter :authorize_push_code!, only: [:destroy]
 
   before_filter :blob
 

--- a/app/controllers/projects/branches_controller.rb
+++ b/app/controllers/projects/branches_controller.rb
@@ -3,8 +3,8 @@ class Projects::BranchesController < Projects::ApplicationController
   before_filter :authorize_read_project!
   before_filter :require_non_empty_project
 
-  before_filter :authorize_code_access!
-  before_filter :authorize_push!, only: [:create, :destroy]
+  before_filter :authorize_download_code!
+  before_filter :authorize_push_code!, only: [:create, :destroy]
 
   def index
     @sort = params[:sort] || 'name'

--- a/app/controllers/projects/commit_controller.rb
+++ b/app/controllers/projects/commit_controller.rb
@@ -4,7 +4,7 @@
 class Projects::CommitController < Projects::ApplicationController
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
   before_filter :commit
 

--- a/app/controllers/projects/commits_controller.rb
+++ b/app/controllers/projects/commits_controller.rb
@@ -5,7 +5,7 @@ class Projects::CommitsController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def show

--- a/app/controllers/projects/compare_controller.rb
+++ b/app/controllers/projects/compare_controller.rb
@@ -1,7 +1,7 @@
 class Projects::CompareController < Projects::ApplicationController
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def index

--- a/app/controllers/projects/edit_tree_controller.rb
+++ b/app/controllers/projects/edit_tree_controller.rb
@@ -1,7 +1,7 @@
 class Projects::EditTreeController < Projects::BaseTreeController
   before_filter :require_branch_head
   before_filter :blob
-  before_filter :authorize_push!
+  before_filter :authorize_push_code!
   before_filter :from_merge_request
   before_filter :after_edit_path
 

--- a/app/controllers/projects/graphs_controller.rb
+++ b/app/controllers/projects/graphs_controller.rb
@@ -1,7 +1,7 @@
 class Projects::GraphsController < Projects::ApplicationController
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def show

--- a/app/controllers/projects/network_controller.rb
+++ b/app/controllers/projects/network_controller.rb
@@ -4,7 +4,7 @@ class Projects::NetworkController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def show

--- a/app/controllers/projects/new_tree_controller.rb
+++ b/app/controllers/projects/new_tree_controller.rb
@@ -1,6 +1,6 @@
 class Projects::NewTreeController < Projects::BaseTreeController
   before_filter :require_branch_head
-  before_filter :authorize_push!
+  before_filter :authorize_push_code!
 
   def show
   end

--- a/app/controllers/projects/raw_controller.rb
+++ b/app/controllers/projects/raw_controller.rb
@@ -4,7 +4,7 @@ class Projects::RawController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def show

--- a/app/controllers/projects/refs_controller.rb
+++ b/app/controllers/projects/refs_controller.rb
@@ -3,7 +3,7 @@ class Projects::RefsController < Projects::ApplicationController
 
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def switch

--- a/app/controllers/projects/repositories_controller.rb
+++ b/app/controllers/projects/repositories_controller.rb
@@ -1,7 +1,7 @@
 class Projects::RepositoriesController < Projects::ApplicationController
   # Authorize
   before_filter :authorize_read_project!
-  before_filter :authorize_code_access!
+  before_filter :authorize_download_code!
   before_filter :require_non_empty_project
 
   def archive

--- a/app/controllers/projects/tags_controller.rb
+++ b/app/controllers/projects/tags_controller.rb
@@ -3,8 +3,8 @@ class Projects::TagsController < Projects::ApplicationController
   before_filter :authorize_read_project!
   before_filter :require_non_empty_project
 
-  before_filter :authorize_code_access!
-  before_filter :authorize_push!, only: [:create]
+  before_filter :authorize_download_code!
+  before_filter :authorize_push_code!, only: [:create]
   before_filter :authorize_admin_project!, only: [:destroy]
 
   def index


### PR DESCRIPTION
with existing `method_missing` in the same controller.

The pattern of leaving standard named methods like `authorize_` to `method_missing` is already used extensively, so let's be consistent and use it everywhere.

```
git ls-files | xargs perl -lapi -e 's/authorize_code_access!/authorize_download_code!/g'
git ls-files | xargs perl -lapi -e 's/authorize_push!/authorize_push_code!/g'
```
