### PR TITLE
Edit labels from issues and merge requests show page.

### DIFF
--- a/app/assets/javascripts/open_labels_dropdown.js.coffee
+++ b/app/assets/javascripts/open_labels_dropdown.js.coffee
@@ -1,0 +1,7 @@
+@openLabelsDropdown =
+  init: ->
+    $(".labels-display-none").on "click",  ->
+      $(this).select2("open")
+
+$ ->
+  openLabelsDropdown.init()

--- a/app/assets/javascripts/remove_label.js.coffee
+++ b/app/assets/javascripts/remove_label.js.coffee
@@ -1,0 +1,16 @@
+@removeLabel =
+  init: ->
+    removeLabel.remove 'issue'
+    removeLabel.remove 'merge-request'
+
+  remove: (type) ->
+    $('.' + type + '-show-labels').on "click", ".label-choice-close", (e) ->
+      e.preventDefault()
+      label_id = $(this).attr("label_id")
+      type = type.replace(/\-/,'_')
+      $('#' + type + '_label_ids option[value="' + label_id + '"]').removeAttr("selected")
+      $('#' + type + '_label_ids').trigger("change")
+      return false
+
+$ ->
+  removeLabel.init()

--- a/app/assets/stylesheets/generic/issue_box.scss
+++ b/app/assets/stylesheets/generic/issue_box.scss
@@ -85,6 +85,7 @@
     @media (max-width: $screen-xs-max) {
       // Don't right align on mobile
       .text-right { text-align: left; }
+      .text-center { text-align: left; }
 
       .row .col-md-6 {
         padding-top: 5px;

--- a/app/assets/stylesheets/generic/selects.scss
+++ b/app/assets/stylesheets/generic/selects.scss
@@ -19,6 +19,10 @@
   @include border-radius(4px)
 }
 
+.labels-display-none .select2-search-choice{
+  display: none;
+}
+
 .select2-container-multi .select2-choices .select2-search-field input {
   padding: 6px 12px;
   font-size: 13px;

--- a/app/assets/stylesheets/sections/merge_requests.scss
+++ b/app/assets/stylesheets/sections/merge_requests.scss
@@ -161,7 +161,7 @@
   }
 }
 
-.merge-request-show-labels .label {
+.merge-request-show-labels .color-label {
   padding: 6px 10px;
 }
 

--- a/app/helpers/labels_helper.rb
+++ b/app/helpers/labels_helper.rb
@@ -3,13 +3,12 @@ module LabelsHelper
     @project.labels.pluck(:title)
   end
 
-  def render_colored_label(label)
-    label_color = label.color || Label::DEFAULT_COLOR
-    text_color = text_color_for_bg(label_color)
+  def label_color(label)
+    label.color || Label::DEFAULT_COLOR
+  end
 
-    content_tag :span, class: 'label color-label', style: "background:#{label_color};color:#{text_color}" do
-      label.name
-    end
+  def text_color(label_color)
+    text_color_for_bg(label_color)
   end
 
   def suggested_colors

--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -36,7 +36,7 @@
     .issue-labels
       - issue.labels.each do |label|
         = link_to project_issues_path(issue.project, label_name: label.name) do
-          = render_colored_label(label)
+          = render partial: 'shared/colored_label', locals: {label: label}
 
   .issue-actions
     - if can? current_user, :modify_issue, issue

--- a/app/views/projects/issues/_issue_context.html.haml
+++ b/app/views/projects/issues/_issue_context.html.haml
@@ -1,6 +1,6 @@
 = form_for [@project, @issue], remote: true, html: {class: 'edit-issue inline-update'} do |f|
   .row
-    .col-sm-6
+    .col-sm-4
       %strong.append-right-10
         Assignee:
 
@@ -11,7 +11,14 @@
       - else
         None
 
-    .col-sm-6.text-right
+    .col-sm-4.text-center
+      %strong.append-right-10
+        Labels:
+
+      - if can?(current_user, :modify_issue, @issue)
+        = f.collection_select :label_ids, @project.labels.all, :id, :name, { selected: @issue.label_ids }, multiple: true, class: 'select2 labels-display-none js-open-labels-dropdown'
+
+    .col-sm-4.text-right
       %strong.append-right-10
         Milestone:
       - if can?(current_user, :modify_issue, @issue)

--- a/app/views/projects/issues/_labels.html.haml
+++ b/app/views/projects/issues/_labels.html.haml
@@ -1,0 +1,2 @@
+- @issue.labels.each do |label|
+  = render partial: 'shared/colored_label_with_close', locals: {label: label, path: project_issues_path(@project, label_name: label.name)}

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -68,8 +68,6 @@
     = link_to_member(@project, participant, name: false, size: 24)
 
   .issue-show-labels.pull-right
-    - @issue.labels.each do |label|
-      = link_to project_issues_path(@project, label_name: label.name) do
-        = render_colored_label(label)
+    = render 'labels'
 
 .voting_notes#notes= render "projects/notes/notes_with_form"

--- a/app/views/projects/issues/update.js.haml
+++ b/app/views/projects/issues/update.js.haml
@@ -4,6 +4,7 @@
       $("##{dom_id(@issue)}").fadeOut();
 - elsif params[:issue_context]
   $('.issue-box .context').effect('highlight');
+  $('.issue-show-labels').empty().append(" #{ escape_javascript(render partial: "labels" ) }")
   - if @issue.milestone
     $('.milestone-nav-link').replaceWith("<span class='milestone-nav-link'>| <span class='light'>Milestone</span> #{escape_javascript(link_to @issue.milestone.title, project_milestone_path(@issue.project, @issue.milestone))}</span>")
   - else

--- a/app/views/projects/labels/_label.html.haml
+++ b/app/views/projects/labels/_label.html.haml
@@ -1,5 +1,5 @@
 %li{id: dom_id(label)}
-  = render_colored_label(label)
+  = render partial: 'shared/colored_label', locals: {label: label}
   .pull-right
     %strong.append-right-20
       = link_to project_issues_path(@project, label_name: label.name) do

--- a/app/views/projects/merge_requests/_labels.html.haml
+++ b/app/views/projects/merge_requests/_labels.html.haml
@@ -1,0 +1,2 @@
+- @merge_request.labels.each do |label|
+  = render partial: 'shared/colored_label_with_close', locals: {label: label, path: project_merge_requests_path(@project, label_name: label.name)}

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -37,4 +37,4 @@
     .merge-request-labels
       - merge_request.labels.each do |label|
         = link_to project_merge_requests_path(merge_request.project, label_name: label.name) do
-          = render_colored_label(label)
+          = render partial: 'shared/colored_label', locals: {label: label}

--- a/app/views/projects/merge_requests/show/_context.html.haml
+++ b/app/views/projects/merge_requests/show/_context.html.haml
@@ -1,6 +1,6 @@
 = form_for [@project, @merge_request], remote: true, html: {class: 'edit-merge_request inline-update'} do |f|
   .row
-    .col-sm-6
+    .col-sm-4
       %strong.append-right-10
         Assignee:
 
@@ -11,7 +11,14 @@
       - else
         None
 
-    .col-sm-6.text-right
+    .col-sm-4.text-center
+      %strong.append-right-10
+        Labels:
+
+      - if can?(current_user, :modify_merge_request, @merge_request)
+        = f.collection_select :label_ids, @merge_request.target_project.labels.all, :id, :name, { selected: @merge_request.label_ids }, multiple: true, class: 'select2 labels-display-none js-open-labels-dropdown'
+
+    .col-sm-4.text-right
       %strong.append-right-10
         Milestone:
       - if can?(current_user, :modify_merge_request, @merge_request)

--- a/app/views/projects/merge_requests/show/_participants.html.haml
+++ b/app/views/projects/merge_requests/show/_participants.html.haml
@@ -4,6 +4,4 @@
     = link_to_member(@project, participant, name: false, size: 24)
 
   .merge-request-show-labels.pull-right
-    - @merge_request.labels.each do |label|
-      = link_to project_merge_requests_path(@project, label_name: label.name) do
-        = render_colored_label(label)
+    = render partial: 'labels'

--- a/app/views/projects/merge_requests/update.js.haml
+++ b/app/views/projects/merge_requests/update.js.haml
@@ -1,2 +1,3 @@
 - if params[:merge_request_context]
   $('.issue-box .context').effect('highlight');
+  $('.merge-request-show-labels').empty().append(" #{ escape_javascript(render partial: "labels" ) }")

--- a/app/views/shared/_colored_label.html.haml
+++ b/app/views/shared/_colored_label.html.haml
@@ -1,0 +1,2 @@
+%span{class: 'label color-label', style: "background:#{label_color(label) };color:#{text_color(label_color(label))}"}
+  = label.name

--- a/app/views/shared/_colored_label_with_close.html.haml
+++ b/app/views/shared/_colored_label_with_close.html.haml
@@ -1,0 +1,6 @@
+%span.label.color-label{style: "background:#{label_color(label)}"}
+  = link_to label.name, class: "label-choice-close js-remove-label", remote: true, label_id: label.id, label_name: label.name do
+    %i.fa.fa-remove{style: "color:#{text_color(label_color(label))}"}
+  = link_to path do
+    %span.label{style: "color:#{text_color(label_color(label))}"}
+      = label.title

--- a/app/views/shared/_project_filter.html.haml
+++ b/app/views/shared/_project_filter.html.haml
@@ -43,7 +43,7 @@
           - @project.labels.order_by_name.each do |label|
             %li{class: label_filter_class(label.name)}
               = link_to labels_filter_path(label.name) do
-                = render_colored_label(label)
+                = render partial: 'shared/colored_label', locals: {label: label}
                 - if selected_label?(label.name)
                   .pull-right
                     %i.fa.fa-times

--- a/features/project/issues/edit_labels.feature
+++ b/features/project/issues/edit_labels.feature
@@ -1,0 +1,24 @@
+Feature: Project Edit Labels
+  Background:
+    Given I sign in as a user
+    And I own project "Shop"
+    And project "Shop" has labels: "bug", "feature", "enhancement"
+    And project "Shop" has issue "Bugfix1" with labels: "bug", "feature"
+    Given I visit project "Shop" issues page
+    Given I visit issue "Bugfix1" show page
+
+  Scenario: I should see issue labels
+    Then I should see "bug" in labels list
+    And I should see "feature" in labels list
+    And I should not see "enhancement" in labels list
+
+  @javascript
+  Scenario: I add one label
+    Given I select "enhancement" from select issue labels
+    Then I should see "enhancement" in labels list
+
+  @javascript
+  Scenario: I remove one label
+    Given I click on "bug" remove link
+    Then I should not see "bug" in labels list
+    And I should see "bug" in select issue labels

--- a/features/steps/project/edit_labels.rb
+++ b/features/steps/project/edit_labels.rb
@@ -1,0 +1,65 @@
+class Spinach::Features::ProjectEditLabels < Spinach::FeatureSteps
+  include SharedAuthentication
+  include SharedProject
+  include SharedPaths
+
+  step 'I should see "bug" in labels list' do
+    labels_list_should_have('bug')
+  end
+
+  step 'I should see "feature" in labels list' do
+    labels_list_should_have('feature')
+  end
+
+  step 'I select "enhancement" from select issue labels' do
+    select 'enhancement', from: 'issue_label_ids'
+  end
+
+  step 'I should see "enhancement" in labels list' do
+    labels_list_should_have('enhancement')
+  end
+
+  step 'I should not see "enhancement" in labels list' do
+    labels_list_should_not_have('enhancement')
+  end
+
+  step 'I should not see "bug" in labels list' do
+    labels_list_should_not_have('bug')
+  end
+
+  step 'I should see "bug" in select issue labels' do
+    within '#issue_label_ids' do
+      page.should have_content 'bug'
+    end
+  end
+
+  step 'I click on "bug" remove link' do
+    within '.issue-show-labels' do
+      page.find(:xpath, "//a[@label_name='bug']/i").trigger('click')
+    end
+  end
+
+  step 'project "Shop" has issue "Bugfix1" with labels: "bug", "feature"' do
+    project = Project.find_by(name: 'Shop')
+    issue = create(:issue, title: 'Bugfix1', project: project)
+    issue.labels << project.labels.find_by(title: 'bug')
+    issue.labels << project.labels.find_by(title: 'feature')
+  end
+
+  step 'I visit issue "Bugfix1" show page' do
+    issue = Issue.find_by(title: 'Bugfix1')
+    visit project_issue_path(issue.project, issue)
+  end
+
+  def labels_list_should_have(label)
+    within '.issue-show-labels' do
+      page.should have_content label
+    end
+  end
+
+  def labels_list_should_not_have(label)
+    within '.issue-show-labels' do
+      page.should_not have_content label
+    end
+  end
+end


### PR DESCRIPTION
The idea of this feature is to have the possibility of editing labels from the issues and merge requests show pages.
#### **User Interface**

The implementation consists of a modified UI for issues and merge requests show page:
- the project's labels which aren't selected are displayed in a dropdown between Asignee and Milestone
- the selected labels are shown underneath the issue/merge request box. They can be removed from there using the remove image which is contained in the left area of the label

Screenshot before:
![before-issue-page](https://cloud.githubusercontent.com/assets/4246830/4625784/6592ad38-537a-11e4-94b3-a6d2d3fee466.png)
Screenshot after:
![after-issue-page2](https://cloud.githubusercontent.com/assets/4246830/4625796/7996e614-537a-11e4-903f-d51f71b5ee5f.png)
Small screen:
![small-screen](https://cloud.githubusercontent.com/assets/4246830/4631391/34775916-53b5-11e4-9060-bf1c77d709b2.png)
#### **Implementation**
- selecting a label from dropdown will add it to the issue/merge request through Javascript and the updated label's list will be shown underneath the issue/merge request box
- in order to remove a label, a backend modification was required. The partial created for these labels contains two links: the first removes the label and the second has the basic functionality – to filter by label.
#### **Testing**

A Spinach feature was written to test the functionality for the issue, given the fact that it is similar to the merge request functionality.  
