### PR TITLE
Skip OmniAuth init when LDAP is disabled

### DIFF
--- a/config/initializers/7_omniauth.rb
+++ b/config/initializers/7_omniauth.rb
@@ -1,9 +1,11 @@
-module OmniAuth::Strategies
-  server = Gitlab.config.ldap.servers.values.first
-  const_set(server['provider_class'], Class.new(LDAP))
-end
+if Settings.ldap['enabled'] || Rails.env.test?
+  module OmniAuth::Strategies
+    server = Gitlab.config.ldap.servers.values.first
+    const_set(server['provider_class'], Class.new(LDAP))
+  end
 
-OmniauthCallbacksController.class_eval do
-  server = Gitlab.config.ldap.servers.values.first
-  alias_method server['provider_name'], :ldap
+  OmniauthCallbacksController.class_eval do
+    server = Gitlab.config.ldap.servers.values.first
+    alias_method server['provider_name'], :ldap
+  end
 end


### PR DESCRIPTION
The OmniAuth initializer uses config settings that are only assigned when LDAP is enabled or when GitLab is run in the test environment, so those same conditions should be applied to the initializer itself.
