### PR TITLE
Fix Rspec error when using non-default port

### DIFF
--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -594,7 +594,7 @@ describe GitlabMarkdownHelper do
     end
 
     it "should generate absolute urls for emoji" do
-      markdown(":smile:").should include("src=\"http://localhost/assets/emoji/smile.png")
+      markdown(':smile:').should match(%r{src="http://localhost(:\d+)?/assets/emoji/smile.png})
     end
 
     it "should generate absolute urls for emoji if relative url is present" do

--- a/spec/helpers/gitlab_markdown_helper_spec.rb
+++ b/spec/helpers/gitlab_markdown_helper_spec.rb
@@ -594,7 +594,9 @@ describe GitlabMarkdownHelper do
     end
 
     it "should generate absolute urls for emoji" do
-      markdown(':smile:').should match(%r{src="http://localhost(:\d+)?/assets/emoji/smile.png})
+      markdown(':smile:').should(
+        include(%(src="#{Gitlab.config.gitlab.url}/assets/emoji/smile.png))
+      )
     end
 
     it "should generate absolute urls for emoji if relative url is present" do


### PR DESCRIPTION
Prevent test failures when GitLab is configured to use a port other than 80.
