### PR TITLE
match latest config from https://cipherli.st/

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -60,18 +60,16 @@ server {
   client_max_body_size 20m;
 
   ## Strong SSL Security
-  ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+  ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html & https://cipherli.st/
   ssl on;
   ssl_certificate /etc/nginx/ssl/gitlab.crt;
   ssl_certificate_key /etc/nginx/ssl/gitlab.key;
 
   # GitLab needs backwards compatible ciphers to retain compatibility with Java IDEs
-  ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';
-
-  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-  ssl_session_cache  builtin:1000  shared:SSL:10m;
-
-  ssl_prefer_server_ciphers   on;
+  ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
 
   ## [WARNING] The following header states that the browser should only communicate
   ## with your server over a secure connection for the next 24 months.
@@ -88,7 +86,7 @@ server {
   # ssl_stapling_verify on;
   # ssl_trusted_certificate /etc/nginx/ssl/stapling.trusted.crt;
   # resolver 208.67.222.222 208.67.222.220 valid=300s; # Can change to your DNS resolver if desired
-  # resolver_timeout 10s;
+  # resolver_timeout 5s;
 
   ## [Optional] Generate a stronger DHE parameter:
   ##   cd /etc/ssl/certs


### PR DESCRIPTION
Updated ciphers and SSL settings to match latest recommendation by @RaymiiOrg on https://cipherli.st. Replaces https://github.com/gitlabhq/gitlabhq/pull/8019.

/cc @maxlazio @dosire
