### PR TITLE
API: Implement edit via API for projects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ v 7.4.0
   - Fail harder in the backup script
   - Changes to Slack service structure, only webhook url needed
   - Zen mode for wiki and milestones (Robert Schilling)
+  - API: Add support for editing an existing project (Mika Mäenpää)
   - Move Emoji parsing to html-pipeline-gitlab (Robert Schilling)
   - Font Awesome 4.2 integration (Sullivan Senechal)
   - Add Pushover service integration (Sullivan Senechal)

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -281,6 +281,31 @@ Parameters:
 - `visibility_level` (optional)
 - `import_url` (optional)
 
+### Edit project
+
+Updates an existing project
+
+```
+PUT /projects/:id
+```
+
+Parameters:
+
+- `id` (required) - The ID of a project
+- `name` (optional) - project name
+- `path` (optional) - repository name for project
+- `description` (optional) - short project description
+- `default_branch` (optional)
+- `issues_enabled` (optional)
+- `merge_requests_enabled` (optional)
+- `wiki_enabled` (optional)
+- `snippets_enabled` (optional)
+- `public` (optional) - if `true` same as setting visibility_level = 20
+- `visibility_level` (optional)
+
+On success, method returns 200 with the updated project. If parameters are 
+invalid, 400 is returned.
+
 ### Fork project
 
 Forks a project into the user namespace of the authenticated user.

--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -170,6 +170,49 @@ module API
         end
       end
 
+      # Update an existing project
+      #
+      # Parameters:
+      #   id (required) - the id of a project
+      #   name (optional) - name of a project
+      #   path (optional) - path of a project
+      #   description (optional) - short project description
+      #   issues_enabled (optional)
+      #   merge_requests_enabled (optional)
+      #   wiki_enabled (optional)
+      #   snippets_enabled (optional)
+      #   public (optional) - if true same as setting visibility_level = 20
+      #   visibility_level (optional) - visibility level of a project
+      # Example Request
+      #   PUT /projects/:id
+      put ':id' do
+        attrs = attributes_for_keys [:name,
+                                     :path,
+                                     :description,
+                                     :default_branch,
+                                     :issues_enabled,
+                                     :merge_requests_enabled,
+                                     :wiki_enabled,
+                                     :snippets_enabled,
+                                     :public,
+                                     :visibility_level]
+        attrs = map_public_to_visibility_level(attrs)
+        authorize_admin_project
+        authorize! :rename_project, user_project if attrs[:name].present?
+        if attrs[:visibility_level].present?
+          authorize! :change_visibility_level, user_project
+        end
+
+        ::Projects::UpdateService.new(user_project,
+                                      current_user, attrs).execute
+
+        if user_project.valid?
+          present user_project, with: Entities::Project
+        else
+          render_validation_error!(user_project)
+        end
+      end
+
       # Remove project
       #
       # Parameters:


### PR DESCRIPTION
Implements edit via API for projects. Edit was part of missing features in feature request Full CRUD operations via API for projects. 
http://feedback.gitlab.com/forums/176466-general/suggestions/3904506-full-crud-operations-via-api-for-projects

Feature is implemented using existing UpdateService for projects. Permission to change visibility level and name are checked in addition to check for permission to administer project.

Doesn't allow updating project namespace id, because there was existing API-method for transferring project to a group.

Documentation added to doc/api/projects.md. Uses API request _PUT /projects/:id_ .

Tests included for:
  1) Success for changing path
  2) Success for changing name
  3) Success for changing visibility level
  4) Success for changing all other attributes
  5) Success for changing name & path to existing name & path but in different namespace
  6) Failure if not authenticated
  7) Failure if path exists in project's namespace
  8) Failure if name exists in project's namespace
  9) Failure if not sufficient permission to change name
  10) Failure if not sufficient permission to change visibility level
  11) Failure if not sufficient permission to change other attributes

Allows updating following parameters:
- name
- path
- visibility_level
- public
- default_branch
- issues_enabled
- wiki_enabled
- snippets_enabled
- merge_requests_enabled
- description
