### PR TITLE
[7.4 rc fix] [doc] remove google OmniAuth update

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -123,12 +123,6 @@ To make sure you didn't miss anything run a more thorough check with:
 
 If all items are green, then congratulations upgrade is complete!
 
-### 8. Update OmniAuth configuration
-
-When using Google omniauth login, changes of the Google account required.
-Ensure that `Contacts API` and the `Google+ API` are enabled in the [Google Developers Console](https://console.developers.google.com/).
-More details can be found at the [integration documentation](../integration/google.md).
-
 ### 9. Optional optimizations for GitLab setups with MySQL databases
 
 Only applies if running MySQL database created with GitLab 6.7 or earlier. If you are not experiencing any issues you may not need the following instructions however following them will bring your database in line with the latest recommended installation configuration and help avoid future issues. Be sure to follow these directions exactly. These directions should be safe for any MySQL instance but to be sure make a current MySQL database backup beforehand.


### PR DESCRIPTION
This change has been in the last few upgrade guides, believe it is not a new change since previous version.
