### PR TITLE
[7.4 rc fix] [doc] clarify when database.yml needs to be updated

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -101,7 +101,7 @@ timeout 60
 
 * HTTPS setups: Make `/etc/nginx/sites-available/nginx-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab-ssl but with your setting
 
-#### Update database.yml config file(for mysql only) if needed (basically it is required for old gitlab installations)
+#### MySQL Databases: Update database.yml config file
 
 * Add `collation: utf8_general_ci` to config/database.yml as seen in [config/database.yml.mysql](config/database.yml.mysql)
 


### PR DESCRIPTION
Clarify that database.yml should be updated if you are running a MySQL Database. Remove wording that de-emphasises importance of update.
