### PR TITLE
[7.4 rc fix] [doc] stop gitlab before mysql optimizations, run checks

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -134,6 +134,9 @@ More details can be found at the [integration documentation](../integration/goog
 Only applies if running MySQL database created with GitLab 6.7 or earlier. If you are not experiencing any issues you may not need the following instructions however following them will bring your database in line with the latest recommended installation configuration and help avoid future issues. Be sure to follow these directions exactly. These directions should be safe for any MySQL instance but to be sure make a current MySQL database backup beforehand.
 
 ```
+# Stop GitLab
+sudo service gitlab stop
+
 # Secure your MySQL installation (added in GitLab 6.2)
 sudo mysql_secure_installation
 
@@ -195,6 +198,9 @@ mysql> \q
 #   Set production -> username: git
 #   Set production -> password: the password your replaced $password with earlier
 sudo -u git -H editor /home/git/gitlab/config/database.yml
+
+# Run thorough check
+sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production
 ```
 
 


### PR DESCRIPTION
Update MySQL optimizations to reflect doing updates after GitLab has already been started back up.
