### PR TITLE
[7.4 rc fix] [doc] remove configure Redis to use sockets

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -56,30 +56,6 @@ sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS
 sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 ```
 
-
-### 4. Configure Redis to use sockets
-
-    # Configure redis to use sockets
-    sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.orig
-    # Disable Redis listening on TCP by setting 'port' to 0
-    sed 's/^port .*/port 0/' /etc/redis/redis.conf.orig | sudo tee /etc/redis/redis.conf
-    # Enable Redis socket for default Debian / Ubuntu path
-    echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis/redis.conf
-    # Be sure redis group can write to the socket, enable only if supported (>= redis 2.4.0).
-    sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0775/' /etc/redis/redis.conf
-    # Activate the changes to redis.conf
-    sudo service redis-server restart
-    # Add git to the redis group
-    sudo usermod -aG redis git
-
-    # Configure Redis connection settings
-    sudo -u git -H cp config/resque.yml.example config/resque.yml
-    # Change the Redis socket path if you are not using the default Debian / Ubuntu configuration
-    sudo -u git -H editor config/resque.yml
-
-    # Configure gitlab-shell to use Redis sockets
-    sudo -u git -H sed -i 's|^  # socket.*|  socket: /var/run/redis/redis.sock|' /home/git/gitlab-shell/config.yml
-
 ### 5. Update config files
 
 #### New configuration options for gitlab.yml


### PR DESCRIPTION
This was completed in the 7.2 to 7.3 guide and is not needed again in 7.3 to 7.4 guide.
