### PR TITLE
[7.4 rc fix] [doc] stop gitlab before backup

### DIFF
--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -13,7 +13,11 @@ possible to edit the label text and color. The characters `?`, `&` and `,` are
 no longer allowed however so those will be removed from your tags during the
 database migrations for GitLab 7.2.
 
-## 0. Backup
+## 0. Stop server
+
+    sudo service gitlab stop
+
+## 1. Backup
 
 It's useful to make a backup just in case things go south:
 (With MySQL, this may require granting "LOCK TABLES" privileges to the GitLab user on the database version)
@@ -22,10 +26,6 @@ It's useful to make a backup just in case things go south:
 cd /home/git/gitlab
 sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```
-
-## 1. Stop server
-
-    sudo service gitlab stop
 
 ## 2. Update Ruby
 

--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -1,22 +1,18 @@
 # From 7.3 to 7.4
 
-### 0. Backup
+### 0. Stop server
+
+    sudo service gitlab stop
+
+### 1. Backup
 
 ```bash
 cd /home/git/gitlab
 sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
-```
-
-### 1. Stop server
-
-```bash
-sudo service gitlab stop
-```
 
 ### 2. Get latest code
 
 ```bash
-cd /home/git/gitlab
 sudo -u git -H git fetch --all
 sudo -u git -H git checkout -- db/schema.rb # local changes will be restored automatically
 ```


### PR DESCRIPTION
Stopping gitlab before backup ensures that backup has everything before upgrade incase something goes wrong. Also remove extra cd.

Replaces https://github.com/gitlabhq/gitlabhq/pull/8042
