### PR TITLE
[7.4 rc fix] [doc] add missing configure Redis to use sockets

### DIFF
--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -99,6 +99,8 @@ sudo apt-get install pkg-config cmake
     sed 's/^port .*/port 0/' /etc/redis/redis.conf.orig | sudo tee /etc/redis/redis.conf
     # Enable Redis socket for default Debian / Ubuntu path
     echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis/redis.conf
+    # Be sure redis group can write to the socket, enable only if supported (>= redis 2.4.0).
+    sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0775/' /etc/redis/redis.conf
     # Activate the changes to redis.conf
     sudo service redis-server restart
     # Add git to the redis group


### PR DESCRIPTION
Add details from 7.2-to-7.3.md. Replaces https://github.com/gitlabhq/gitlabhq/pull/8047.
