### PR TITLE
Factor abilities methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   before_filter :authenticate_user!
   before_filter :reject_blocked!
   before_filter :check_password_expiration
-  before_filter :add_abilities
   before_filter :ldap_security_check
   before_filter :dev_tools if Rails.env == 'development'
   before_filter :default_headers
@@ -73,7 +72,7 @@ class ApplicationController < ActionController::Base
   end
 
   def abilities
-    @abilities ||= Six.new
+    Ability.abilities
   end
 
   def can?(object, action, subject)
@@ -109,10 +108,6 @@ class ApplicationController < ActionController::Base
     @repository ||= project.repository
   rescue Grit::NoSuchPathError
     nil
-  end
-
-  def add_abilities
-    abilities << Ability
   end
 
   def authorize_project!(action)

--- a/app/controllers/explore/groups_controller.rb
+++ b/app/controllers/explore/groups_controller.rb
@@ -1,7 +1,6 @@
 class Explore::GroupsController < ApplicationController
   skip_before_filter :authenticate_user!,
-                     :reject_blocked, :set_current_user_for_observers,
-                     :add_abilities
+                     :reject_blocked, :set_current_user_for_observers
 
   layout "explore"
 

--- a/app/controllers/explore/projects_controller.rb
+++ b/app/controllers/explore/projects_controller.rb
@@ -1,7 +1,6 @@
 class Explore::ProjectsController < ApplicationController
   skip_before_filter :authenticate_user!,
-    :reject_blocked,
-    :add_abilities
+                     :reject_blocked
 
   layout 'explore'
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -262,5 +262,13 @@ class Ability
       end
       rules
     end
+
+    def abilities
+      @abilities ||= begin
+                       abilities = Six.new
+                       abilities << self
+                       abilities
+                     end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -330,11 +330,7 @@ class User < ActiveRecord::Base
   end
 
   def abilities
-    @abilities ||= begin
-                     abilities = Six.new
-                     abilities << Ability
-                     abilities
-                   end
+    Ability.abilities
   end
 
   def can_select_namespace?

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -6,11 +6,7 @@ class BaseService
   end
 
   def abilities
-    @abilities ||= begin
-                     abilities = Six.new
-                     abilities << Ability
-                     abilities
-                   end
+    Ability.abilities
   end
 
   def can?(object, action, subject)


### PR DESCRIPTION
in app controller, user model and services.

Same code repeated 3 times.

Same behavior, less lines, and slightly more time efficient since:
- a single `@abilities` is constructed once for the entire app
- no more `add_abilities` filter before every action of the app, yay!
