### PR TITLE
Remove unused admin/projects#repository method

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -38,8 +38,4 @@ class Admin::ProjectsController < Admin::ApplicationController
   def group
     @group ||= @project.group
   end
-
-  def repository
-    @repository ||= @project.repository
-  end
 end


### PR DESCRIPTION
Already defined on the ApplicationController base class at: https://github.com/gitlabhq/gitlabhq/blob/3880bb61760ef1f69b0df49148202ff6b4208f01/app/controllers/application_controller.rb#L108
