### PR TITLE
Remove unused authenticate_user from project#show

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,8 +53,6 @@ class ProjectsController < ApplicationController
       return
     end
 
-    return authenticate_user! unless @project.public? || current_user
-
     limit = (params[:limit] || 20).to_i
     @events = @project.events.recent
     @events = event_filter.apply_filter(@events)


### PR DESCRIPTION
Redundant with the authorize_read_project! filter of the same controller.

@jhollingsworth you may have written that line. The red flag for me was the `public?`, which generally duplicates Ability logic.
