### PR TITLE
Only redirect project path.git to path on #show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,15 +83,6 @@ class ApplicationController < ActionController::Base
   def project
     id = params[:project_id] || params[:id]
 
-    # Redirect from
-    #   localhost/group/project.git
-    # to
-    #   localhost/group/project
-    #
-    if id =~ /\.git\Z/
-      redirect_to request.original_url.gsub(/\.git\Z/, '') and return
-    end
-
     @project = Project.find_with_namespace(id)
 
     if @project and can?(current_user, :read_project, @project)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,6 @@
 class ProjectsController < ApplicationController
   skip_before_filter :authenticate_user!, only: [:show]
+  before_filter :show_redirect_git, only: [:show]
   before_filter :project, except: [:new, :create]
   before_filter :repository, except: [:new, :create]
 
@@ -208,5 +209,15 @@ class ProjectsController < ApplicationController
       :issues_enabled, :merge_requests_enabled, :snippets_enabled, :issues_tracker_id, :default_branch,
       :wiki_enabled, :visibility_level, :import_url, :last_activity_at, :namespace_id
     )
+  end
+
+  # Redirect from
+  #   localhost/group/project.git
+  # to
+  #   localhost/group/project
+  def show_redirect_git
+    if params[:id].end_with?('.git')
+      redirect_to request.original_url.chomp('.git') and return
+    end
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -7,6 +7,12 @@ describe ProjectsController do
   let(:jpg)     { fixture_file_upload(Rails.root + 'spec/fixtures/rails_sample.jpg', 'image/jpg') }
   let(:txt)     { fixture_file_upload(Rails.root + 'spec/fixtures/doc_sample.txt', 'text/plain') }
 
+  it 'GET #show .git redirection' do
+    get :show, id: project.to_param + '.git'
+
+    expect(response).to redirect_to(project_path(project))
+  end
+
   describe "POST #upload_image" do
     before do
       sign_in(user)

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -86,6 +86,11 @@ describe ProjectsController, "routing" do
     get("/gitlab/gitlabhq").should route_to('projects#show', id: 'gitlab/gitlabhq')
   end
 
+  it 'to #show .git redirect' do
+    get('/gitlab/gitlabhq.git').should(
+      route_to('projects#show', id: 'gitlab/gitlabhq.git'))
+  end
+
   it "to #update" do
     put("/gitlab/gitlabhq").should route_to('projects#update', id: 'gitlab/gitlabhq')
   end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -15,7 +15,7 @@ describe "Mounted Apps", "routing" do
   end
 
   it "to Grack" do
-    get("/gitlab/gitlabhq.git").should be_routable
+    get('/gitlab/gitlabhq.git/foo').should be_routable
   end
 end
 


### PR DESCRIPTION
- POST path.git should not be allowed
- path.git/some/path currently already redirects to Grack

Makes the all project controllers faster by removing that check from all actions to only project#show.

Also added some tests.

This works because before hooks on base classes are run BEFORE those of parents, so the redirect is done before the `:project` before filter of `ApplicationController`.
