### PR TITLE
DRY mentioned in magic note constant

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -119,7 +119,7 @@ class NotificationService
 
     # ignore gitlab service messages
     return true if note.note =~ /\A_Status changed to closed_/
-    return true if note.note =~ /\A_mentioned in / && note.system == true
+    return true if note.cross_reference? && note.system == true
 
     opts = { noteable_type: note.noteable_type, project_id: note.project_id }
 


### PR DESCRIPTION
Magic string `_mentioned in` appeared 3 times.

@kemenaran, @mr-vinn, @randx: you may have written those lines: let's avoid repeating magic constants more than once, specially when they show on the UI. They break later with high probability.
