### PR TITLE
Remove unnecessary authorize_user! filter [can be updated]

### DIFF
--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -1,20 +1,8 @@
 class Projects::ApplicationController < ApplicationController
+  skip_before_filter :authenticate_user!
   before_filter :project
   before_filter :repository
   layout :determine_layout
-
-  def authenticate_user!
-    # Restrict access to Projects area only
-    # for non-signed users
-    if !current_user
-      id = params[:project_id] || params[:id]
-      @project = Project.find_with_namespace(id)
-
-      return if @project && @project.public?
-    end
-
-    super
-  end
 
   def determine_layout
     if current_user


### PR DESCRIPTION
from Project controllers. The filter is already implied by
[ApplicationController#project](https://github.com/gitlabhq/gitlabhq/blob/47f157a535b63a3ed732d6256b4ce6ae9bfce696/app/controllers/application_controller.rb#L83) which is used as a before_filter.

Faster because one less helper, less redundant code.

It is implied because:
- authorization is skipped iff user can `read_project`, which is checked in `def project`
- other cases lead to either authorize_user! or 404 as expected
- the project filter is not skipped in any project controller
