### PR TITLE
[WIP] Remove authentication logic from project filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,27 +82,7 @@ class ApplicationController < ActionController::Base
 
   def project
     id = params[:project_id] || params[:id]
-
-    # Redirect from
-    #   localhost/group/project.git
-    # to
-    #   localhost/group/project
-    #
-    if id =~ /\.git\Z/
-      redirect_to request.original_url.gsub(/\.git\Z/, '') and return
-    end
-
     @project = Project.find_with_namespace(id)
-
-    if @project and can?(current_user, :read_project, @project)
-      @project
-    elsif current_user.nil?
-      @project = nil
-      authenticate_user!
-    else
-      @project = nil
-      render_404 and return
-    end
   end
 
   def repository

--- a/app/controllers/projects/application_controller.rb
+++ b/app/controllers/projects/application_controller.rb
@@ -6,13 +6,7 @@ class Projects::ApplicationController < ApplicationController
   def authenticate_user!
     # Restrict access to Projects area only
     # for non-signed users
-    if !current_user
-      id = params[:project_id] || params[:id]
-      @project = Project.find_with_namespace(id)
-
-      return if @project && @project.public?
-    end
-
+    return if can?(current_user, :read_project, @project)
     super
   end
 


### PR DESCRIPTION
It is confusing to have a setter method also do authorization:
all authorization methods should start with authorize_

This is a better alternative than https://github.com/gitlabhq/gitlabhq/pull/8099, but harder to make sure that it is correct.
