### PR TITLE
Remove param[:project_id] at admin controller

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -31,9 +31,7 @@ class Admin::ProjectsController < Admin::ApplicationController
   protected
 
   def project
-    id = params[:project_id] || params[:id]
-
-    @project = Project.find_with_namespace(id)
+    @project = Project.find_with_namespace(params[:id])
     @project || render_404
   end
 


### PR DESCRIPTION
The route never passes that parameter to the helpers, only :id 
