### PR TITLE
Use @project on controllers, don't call method

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -38,10 +38,10 @@ class Admin::ProjectsController < Admin::ApplicationController
   end
 
   def group
-    @group ||= project.group
+    @group ||= @project.group
   end
 
   def repository
-    @repository ||= project.repository
+    @repository ||= @project.repository
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,28 +81,31 @@ class ApplicationController < ActionController::Base
   end
 
   def project
-    id = params[:project_id] || params[:id]
+    unless @project
+      id = params[:project_id] || params[:id]
 
-    # Redirect from
-    #   localhost/group/project.git
-    # to
-    #   localhost/group/project
-    #
-    if id =~ /\.git\Z/
-      redirect_to request.original_url.gsub(/\.git\Z/, '') and return
+      # Redirect from
+      #   localhost/group/project.git
+      # to
+      #   localhost/group/project
+      #
+      if id =~ /\.git\Z/
+        redirect_to request.original_url.gsub(/\.git\Z/, '') and return
+      end
+
+      @project = Project.find_with_namespace(id)
+
+      if @project and can?(current_user, :read_project, @project)
+        @project
+      elsif current_user.nil?
+        @project = nil
+        authenticate_user!
+      else
+        @project = nil
+        render_404 and return
+      end
     end
-
-    @project = Project.find_with_namespace(id)
-
-    if @project and can?(current_user, :read_project, @project)
-      @project
-    elsif current_user.nil?
-      @project = nil
-      authenticate_user!
-    else
-      @project = nil
-      render_404 and return
-    end
+    @project
   end
 
   def repository

--- a/app/controllers/projects/commit_controller.rb
+++ b/app/controllers/projects/commit_controller.rb
@@ -11,12 +11,12 @@ class Projects::CommitController < Projects::ApplicationController
   def show
     return git_not_found! unless @commit
 
-    @line_notes = project.notes.for_commit_id(commit.id).inline
-    @branches = project.repository.branch_names_contains(commit.id)
+    @line_notes = @project.notes.for_commit_id(commit.id).inline
+    @branches = @project.repository.branch_names_contains(commit.id)
     @diffs = @commit.diffs
-    @note = project.build_commit_note(commit)
-    @notes_count = project.notes.for_commit_id(commit.id).count
-    @notes = project.notes.for_commit_id(@commit.id).not_inline.fresh
+    @note = @project.build_commit_note(commit)
+    @notes_count = @project.notes.for_commit_id(commit.id).count
+    @notes = @project.notes.for_commit_id(@commit.id).not_inline.fresh
     @noteable = @commit
     @comments_allowed = @reply_allowed = true
     @comments_target  = {
@@ -32,6 +32,6 @@ class Projects::CommitController < Projects::ApplicationController
   end
 
   def commit
-    @commit ||= project.repository.commit(params[:id])
+    @commit ||= @project.repository.commit(params[:id])
   end
 end

--- a/app/controllers/projects/deploy_keys_controller.rb
+++ b/app/controllers/projects/deploy_keys_controller.rb
@@ -42,7 +42,7 @@ class Projects::DeployKeysController < Projects::ApplicationController
   end
 
   def enable
-    project.deploy_keys << available_keys.find(params[:id])
+    @project.deploy_keys << available_keys.find(params[:id])
 
     redirect_to project_deploy_keys_path(@project)
   end

--- a/app/controllers/projects/team_members_controller.rb
+++ b/app/controllers/projects/team_members_controller.rb
@@ -10,7 +10,7 @@ class Projects::TeamMembersController < Projects::ApplicationController
   end
 
   def new
-    @user_project_relation = project.project_members.new
+    @user_project_relation = @project.project_members.new
   end
 
   def create
@@ -26,7 +26,7 @@ class Projects::TeamMembersController < Projects::ApplicationController
   end
 
   def update
-    @user_project_relation = project.project_members.find_by(user_id: member)
+    @user_project_relation = @project.project_members.find_by(user_id: member)
     @user_project_relation.update_attributes(member_params)
 
     unless @user_project_relation.valid?
@@ -36,7 +36,7 @@ class Projects::TeamMembersController < Projects::ApplicationController
   end
 
   def destroy
-    @user_project_relation = project.project_members.find_by(user_id: member)
+    @user_project_relation = @project.project_members.find_by(user_id: member)
     @user_project_relation.destroy
 
     respond_to do |format|
@@ -46,7 +46,7 @@ class Projects::TeamMembersController < Projects::ApplicationController
   end
 
   def leave
-    project.project_members.find_by(user_id: current_user).destroy
+    @project.project_members.find_by(user_id: current_user).destroy
 
     respond_to do |format|
       format.html { redirect_to :back }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,7 +76,7 @@ class ProjectsController < ApplicationController
   end
 
   def import
-    if project.import_finished?
+    if @project.import_finished?
       redirect_to @project
       return
     end
@@ -98,7 +98,7 @@ class ProjectsController < ApplicationController
   end
 
   def destroy
-    return access_denied! unless can?(current_user, :remove_project, project)
+    return access_denied! unless can?(current_user, :remove_project, @project)
 
     ::Projects::DestroyService.new(@project, current_user, {}).execute
 
@@ -148,8 +148,8 @@ class ProjectsController < ApplicationController
   end
 
   def archive
-    return access_denied! unless can?(current_user, :archive_project, project)
-    project.archive!
+    return access_denied! unless can?(current_user, :archive_project, @project)
+    @project.archive!
 
     respond_to do |format|
       format.html { redirect_to @project }
@@ -157,8 +157,8 @@ class ProjectsController < ApplicationController
   end
 
   def unarchive
-    return access_denied! unless can?(current_user, :archive_project, project)
-    project.unarchive!
+    return access_denied! unless can?(current_user, :archive_project, @project)
+    @project.unarchive!
 
     respond_to do |format|
       format.html { redirect_to @project }


### PR DESCRIPTION
Also memoize the method through the `unless @project` line to ensure that other methods in
ApplicationController that rely on it can call it efficiently.

This PR makes things much more efficient: before it `def project` was already called as a filter before every project controller, setting `@project`, but many places in the controllers re-called `project`, which was not memoized, instead of using the instance.
