### PR TITLE
Make project title link to project homepage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v 7.5.0
   - Add time zone configuration on gitlab.yml (Sullivan Senechal)
   - Fix LDAP authentication for Git HTTP access
   - Fix LDAP config lookup for provider 'ldap'
+  - Project title links to project homepage (Ben Bodenmiller)
   - Add Atlassian Bamboo CI service (Drew Blessing)
   - Mentioned @user will receive email even if he is not participating in issue or commit
   - Session API: Use case-insensitive authentication like in UI (Andrey Krivko)

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -42,12 +42,12 @@ module ProjectsHelper
   def project_title(project)
     if project.group
       content_tag :span do
-        link_to(simple_sanitize(project.group.name), group_path(project.group)) + " / " + project.name
+        link_to(simple_sanitize(project.group.name), group_path(project.group)) + ' / ' + link_to(simple_sanitize(project.name), project_path(project))
       end
     else
       owner = project.namespace.owner
       content_tag :span do
-        link_to(simple_sanitize(owner.name), user_path(owner)) + " / " + project.name
+        link_to(simple_sanitize(owner.name), user_path(owner)) + ' / ' + link_to(simple_sanitize(project.name), project_path(project))
       end
     end
   end


### PR DESCRIPTION
Implements feature request: http://feedback.gitlab.com/forums/176466-general/suggestions/5491715-please-small-fix-click-on-title-of-repo-to-go-to

Make project title link to project homepage. Minor edit that does not appear to negatively affect [any pages used on](https://github.com/gitlabhq/gitlabhq/search?utf8=%E2%9C%93&q=project_title&type=Code).
