### PR TITLE
Only run avatar chooser Js on pages that need it [failure unrelated]

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -67,6 +67,8 @@ class Dispatcher
         new TeamMembers()
       when 'groups:members'
         new GroupMembers()
+      when 'groups:new', 'groups:edit', 'admin:groups:edit'
+        new GroupAvatar()
       when 'projects:tree:show'
         new TreeView()
         shortcut_handler = new ShortcutsNavigation()

--- a/app/assets/javascripts/group_avatar.js.coffee
+++ b/app/assets/javascripts/group_avatar.js.coffee
@@ -1,0 +1,9 @@
+class @GroupAvatar
+  constructor: ->
+    $('.js-choose-group-avatar-button').bind "click", ->
+      form = $(this).closest("form")
+      form.find(".js-group-avatar-input").click()
+    $('.js-group-avatar-input').bind "change", ->
+      form = $(this).closest("form")
+      filename = $(this).val().replace(/^.*[\\\/]/, '')
+      form.find(".js-avatar-filename").text(filename)

--- a/app/assets/javascripts/groups.js.coffee
+++ b/app/assets/javascripts/groups.js.coffee
@@ -2,14 +2,3 @@ class @GroupMembers
   constructor: ->
     $('li.group_member').bind 'ajax:success', ->
       $(this).fadeOut()
-
-$ ->
-  # avatar
-  $('.js-choose-group-avatar-button').bind "click", ->
-    form = $(this).closest("form")
-    form.find(".js-group-avatar-input").click()
-
-  $('.js-group-avatar-input').bind "change", ->
-    form = $(this).closest("form")
-    filename = $(this).val().replace(/^.*[\\\/]/, '')
-    form.find(".js-avatar-filename").text(filename)


### PR DESCRIPTION
Before this PR, that code was run on all pages, making our app slower =(

 Now it uses the dispatch system to run only when needed! Yay.

`$ ->` is evil.
