### PR TITLE
Remove whitespace link between user group avatars

### DIFF
--- a/app/views/users/_groups.html.haml
+++ b/app/views/users/_groups.html.haml
@@ -1,3 +1,3 @@
 - groups.each do |group|
   = link_to group, class: 'profile-groups-avatars', :title => group.name do
-    = image_tag group_icon(group.path)
+    - image_tag group_icon(group.path)


### PR DESCRIPTION
After: inter group avatar space slightly reduced by one rogue whitespace:

![screenshot from 2014-10-21 20 17 30 after](https://cloud.githubusercontent.com/assets/1429315/4724237/e3be6c5e-594e-11e4-8ae6-047a13e546cf.png)

Before: on hover, rogue whitespace gets underlined like a link to the right of second avatar:

![screenshot from 2014-10-21 20 17 08](https://cloud.githubusercontent.com/assets/1429315/4724238/e9493a0a-594e-11e4-87a2-7f69c739c2c9.png)
