### PR TITLE
Only run profile js on pages that need it

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -79,11 +79,15 @@ class Dispatcher
         # Ensure we don't create a particular shortcut handler here. This is
         # already created, where the network graph is created.
         shortcut_handler = true
+      when 'users:show'
+        new User()
 
     switch path.first()
       when 'admin' then new Admin()
       when 'dashboard'
         shortcut_handler = new ShortcutsDashboardNavigation()
+      when 'profiles'
+        new Profile()
       when 'projects'
         switch path[1]
           when 'wikis'

--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -1,30 +1,29 @@
-$ ->
-  $('.edit_user .application-theme input, .edit_user .code-preview-theme input').click ->
-    # Submit the form
-    $('.edit_user').submit()
+class @Profile
+  constructor: ->
+    $('.edit_user .application-theme input, .edit_user .code-preview-theme input').click ->
+      # Submit the form
+      $('.edit_user').submit()
 
-    new Flash("Appearance settings saved", "notice")
+      new Flash("Appearance settings saved", "notice")
 
-  $('.update-username form').on 'ajax:before', ->
-    $('.loading-gif').show()
-    $(this).find('.update-success').hide()
-    $(this).find('.update-failed').hide()
+    $('.update-username form').on 'ajax:before', ->
+      $('.loading-gif').show()
+      $(this).find('.update-success').hide()
+      $(this).find('.update-failed').hide()
 
-  $('.update-username form').on 'ajax:complete', ->
-    $(this).find('.btn-save').enableButton()
-    $(this).find('.loading-gif').hide()
+    $('.update-username form').on 'ajax:complete', ->
+      $(this).find('.btn-save').enableButton()
+      $(this).find('.loading-gif').hide()
 
-  $('.update-notifications').on 'ajax:complete', ->
-    $(this).find('.btn-save').enableButton()
+    $('.update-notifications').on 'ajax:complete', ->
+      $(this).find('.btn-save').enableButton()
 
 
-  $('.js-choose-user-avatar-button').bind "click", ->
-    form = $(this).closest("form")
-    form.find(".js-user-avatar-input").click()
+    $('.js-choose-user-avatar-button').bind "click", ->
+      form = $(this).closest("form")
+      form.find(".js-user-avatar-input").click()
 
-  $('.js-user-avatar-input').bind "change", ->
-    form = $(this).closest("form")
-    filename = $(this).val().replace(/^.*[\\\/]/, '')
-    form.find(".js-avatar-filename").text(filename)
-
-  $('.profile-groups-avatars').tooltip("placement": "top")
+    $('.js-user-avatar-input').bind "change", ->
+      form = $(this).closest("form")
+      filename = $(this).val().replace(/^.*[\\\/]/, '')
+      form.find(".js-avatar-filename").text(filename)

--- a/app/assets/javascripts/user.js.coffee
+++ b/app/assets/javascripts/user.js.coffee
@@ -1,0 +1,3 @@
+class @User
+  constructor: ->
+    $('.profile-groups-avatars').tooltip("placement": "top")


### PR DESCRIPTION
Needed to split up the `.profile-groups-avatars` line into `User` since it does not affect profile, only user. It's misnamed.

Once again `$ ->` is evil.
