### PR TITLE
Better js -> URL projects map to reduce unneeded execution

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -58,11 +58,6 @@ class Dispatcher
       when 'groups:show', 'projects:show'
         new Activities()
         shortcut_handler = new ShortcutsNavigation()
-      when 'projects:new'
-        new Project()
-      when 'projects:edit'
-        new Project()
-        shortcut_handler = new ShortcutsNavigation()
       when 'projects:teams:members:index'
         new TeamMembers()
       when 'groups:members'
@@ -85,7 +80,15 @@ class Dispatcher
       when 'dashboard'
         shortcut_handler = new ShortcutsDashboardNavigation()
       when 'projects'
+        new Project()
         switch path[1]
+          when 'edit'
+            shortcut_handler = new ShortcutsNavigation()
+            new ProjectNew()
+          when 'new'
+            new ProjectNew()
+          when 'show'
+            new ProjectShow()
           when 'wikis'
             new Wikis()
             shortcut_handler = new ShortcutsNavigation()

--- a/app/assets/javascripts/project.js.coffee
+++ b/app/assets/javascripts/project.js.coffee
@@ -1,59 +1,20 @@
 class @Project
   constructor: ->
-    $('.project-edit-container').on 'ajax:before', =>
-      $('.project-edit-container').hide()
-      $('.save-project-loader').show()
+    # Git clone panel switcher
+    scope = $ '.git-clone-holder'
+    if scope.length > 0
+      $('a, button', scope).click ->
+        $('a, button', scope).removeClass 'active'
+        $(@).addClass 'active'
+        $('#project_clone', scope).val $(@).data 'clone'
+        $(".clone").text("").append $(@).data 'clone'
 
-    @initEvents()
+    # Ref switcher
+    $('.project-refs-select').on 'change', ->
+      $(@).parents('form').submit()
 
-
-  initEvents: ->
-    disableButtonIfEmptyField '#project_name', '.project-submit'
-
-    $('#project_issues_enabled').change ->
-      if ($(this).is(':checked') == true)
-        $('#project_issues_tracker').removeAttr('disabled')
-      else
-        $('#project_issues_tracker').attr('disabled', 'disabled')
-
-      $('#project_issues_tracker').change()
-
-    $('#project_issues_tracker').change ->
-      if ($(this).val() == gon.default_issues_tracker || $(this).is(':disabled'))
-        $('#project_issues_tracker_id').attr('disabled', 'disabled')
-      else
-        $('#project_issues_tracker_id').removeAttr('disabled')
-
-$ ->
-  # Git clone panel switcher
-  scope = $ '.git-clone-holder'
-  if scope.length > 0
-    $('a, button', scope).click ->
-      $('a, button', scope).removeClass 'active'
-      $(@).addClass 'active'
-      $('#project_clone', scope).val $(@).data 'clone'
-      $(".clone").text("").append $(@).data 'clone'
-
-  # Ref switcher
-  $('.project-refs-select').on 'change', ->
-    $(@).parents('form').submit()
-
-  $('.hide-no-ssh-message').on 'click', (e) ->
-    path = '/'
-    $.cookie('hide_no_ssh_message', 'false', { path: path })
-    $(@).parents('.no-ssh-key-message').hide()
-    e.preventDefault()
-
-  $('.project-home-panel .star').on 'ajax:success', (e, data, status, xhr) ->
-    $(@).toggleClass('on').find('.count').html(data.star_count)
-  .on 'ajax:error', (e, xhr, status, error) ->
-    new Flash('Star toggle failed. Try again later.', 'alert')
-
-  $("a[data-toggle='tab']").on "shown.bs.tab", (e) ->
-      $.cookie "default_view", $(e.target).attr("href")
-
-    defaultView = $.cookie("default_view")
-    if defaultView
-      $("a[href=" + defaultView + "]").tab "show"
-    else
-      $("a[data-toggle='tab']:first").tab "show"
+    $('.hide-no-ssh-message').on 'click', (e) ->
+      path = '/'
+      $.cookie('hide_no_ssh_message', 'false', { path: path })
+      $(@).parents('.no-ssh-key-message').hide()
+      e.preventDefault()

--- a/app/assets/javascripts/project_new.js.coffee
+++ b/app/assets/javascripts/project_new.js.coffee
@@ -1,0 +1,25 @@
+class @ProjectNew
+  constructor: ->
+    $('.project-edit-container').on 'ajax:before', =>
+      $('.project-edit-container').hide()
+      $('.save-project-loader').show()
+
+    @initEvents()
+
+
+  initEvents: ->
+    disableButtonIfEmptyField '#project_name', '.project-submit'
+
+    $('#project_issues_enabled').change ->
+      if ($(this).is(':checked') == true)
+        $('#project_issues_tracker').removeAttr('disabled')
+      else
+        $('#project_issues_tracker').attr('disabled', 'disabled')
+
+      $('#project_issues_tracker').change()
+
+    $('#project_issues_tracker').change ->
+      if ($(this).val() == gon.default_issues_tracker || $(this).is(':disabled'))
+        $('#project_issues_tracker_id').attr('disabled', 'disabled')
+      else
+        $('#project_issues_tracker_id').removeAttr('disabled')

--- a/app/assets/javascripts/project_show.js.coffee
+++ b/app/assets/javascripts/project_show.js.coffee
@@ -1,0 +1,15 @@
+class @ProjectShow
+  constructor: ->
+    $('.project-home-panel .star').on 'ajax:success', (e, data, status, xhr) ->
+      $(@).toggleClass('on').find('.count').html(data.star_count)
+    .on 'ajax:error', (e, xhr, status, error) ->
+      new Flash('Star toggle failed. Try again later.', 'alert')
+
+    $("a[data-toggle='tab']").on "shown.bs.tab", (e) ->
+        $.cookie "default_view", $(e.target).attr("href")
+
+      defaultView = $.cookie("default_view")
+      if defaultView
+        $("a[href=" + defaultView + "]").tab "show"
+      else
+        $("a[data-toggle='tab']:first").tab "show"


### PR DESCRIPTION
This PR splits up the `$ ->` which run on every page. Now project functions are run on much less pages, making things faster and less error prone.

Projects have been split into 3 Js classes:
- Project: runs on all project namespace
- ProjectShow
- ProjectNew: new and edit
