### PR TITLE
Run user select Js only where needed

### DIFF
--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -62,6 +62,7 @@ class Dispatcher
         new TeamMembers()
       when 'groups:members'
         new GroupMembers()
+        new UsersSelect()
       when 'groups:new', 'groups:edit', 'admin:groups:edit'
         new GroupAvatar()
       when 'projects:tree:show'
@@ -81,6 +82,8 @@ class Dispatcher
       when 'admin'
         new Admin()
         switch path[1]
+          when 'groups'
+            new UsersSelect()
           when 'projects'
             new NamespaceSelect()
       when 'dashboard'
@@ -95,6 +98,8 @@ class Dispatcher
             new ProjectNew()
           when 'show'
             new ProjectShow()
+          when 'issues', 'merge_requests'
+            new ProjectUsersSelect()
           when 'wikis'
             new Wikis()
             shortcut_handler = new ShortcutsNavigation()
@@ -103,6 +108,7 @@ class Dispatcher
             shortcut_handler = new ShortcutsNavigation()
           when 'team_members', 'deploy_keys', 'hooks', 'services', 'protected_branches'
             shortcut_handler = new ShortcutsNavigation()
+            new UsersSelect()
 
 
     # If we haven't installed a custom shortcut handler, install the default one

--- a/app/assets/javascripts/project_users_select.js.coffee
+++ b/app/assets/javascripts/project_users_select.js.coffee
@@ -1,6 +1,6 @@
-@projectUsersSelect =
-  init: ->
-    $('.ajax-project-users-select').each (i, select) ->
+class @ProjectUsersSelect
+  constructor: ->
+    $('.ajax-project-users-select').each (i, select) =>
       project_id = $(select).data('project-id') || $('body').data('project-id')
 
       $(select).select2
@@ -28,14 +28,16 @@
             Api.user(id, callback)
 
 
-        formatResult: projectUsersSelect.projectUserFormatResult
-        formatSelection: projectUsersSelect.projectUserFormatSelection
+        formatResult: (args...) =>
+          @formatResult(args...)
+        formatSelection: (args...) =>
+          @formatSelection(args...)
         dropdownCssClass: "ajax-project-users-dropdown"
         dropdownAutoWidth: true
         escapeMarkup: (m) -> # we do not want to escape markup since we are displaying html in results
           m
 
-  projectUserFormatResult: (user) ->
+  formatResult: (user) ->
     if user.avatar_url
       avatar = user.avatar_url
     else
@@ -52,8 +54,5 @@
        <div class='user-username'>#{user.username}</div>
      </div>"
 
-  projectUserFormatSelection: (user) ->
+  formatSelection: (user) ->
     user.name
-
-$ ->
-  projectUsersSelect.init()

--- a/app/assets/javascripts/users_select.js.coffee
+++ b/app/assets/javascripts/users_select.js.coffee
@@ -1,5 +1,30 @@
-$ ->
-  userFormatResult = (user) ->
+class @UsersSelect
+  constructor: ->
+    $('.ajax-users-select').each (i, select) =>
+      $(select).select2
+        placeholder: "Search for a user"
+        multiple: $(select).hasClass('multiselect')
+        minimumInputLength: 0
+        query: (query) ->
+          Api.users query.term, (users) ->
+            data = { results: users }
+            query.callback(data)
+
+        initSelection: (element, callback) ->
+          id = $(element).val()
+          if id isnt ""
+            Api.user(id, callback)
+
+
+        formatResult: (args...) =>
+          @formatResult(args...)
+        formatSelection: (args...) =>
+          @formatSelection(args...)
+        dropdownCssClass: "ajax-users-dropdown"
+        escapeMarkup: (m) -> # we do not want to escape markup since we are displaying html in results
+          m
+
+  formatResult: (user) ->
     if user.avatar_url
       avatar = user.avatar_url
     else
@@ -11,27 +36,5 @@ $ ->
        <div class='user-username'>#{user.username}</div>
      </div>"
 
-  userFormatSelection = (user) ->
+  formatSelection: (user) ->
     user.name
-
-  $('.ajax-users-select').each (i, select) ->
-    $(select).select2
-      placeholder: "Search for a user"
-      multiple: $(select).hasClass('multiselect')
-      minimumInputLength: 0
-      query: (query) ->
-        Api.users query.term, (users) ->
-          data = { results: users }
-          query.callback(data)
-
-      initSelection: (element, callback) ->
-        id = $(element).val()
-        if id isnt ""
-          Api.user(id, callback)
-
-
-      formatResult: userFormatResult
-      formatSelection: userFormatSelection
-      dropdownCssClass: "ajax-users-dropdown"
-      escapeMarkup: (m) -> # we do not want to escape markup since we are displaying html in results
-        m


### PR DESCRIPTION
Transform current implementation into regular Coffescript classes
so that the same call method can be reused on the dispatcher
as for other classes.

Same rationale as: https://github.com/gitlabhq/gitlabhq/pull/8123

I have built the map by grepping for the touched classes + testing it out.

**Double check**

That I didn't make any mistakes when converting the existing coffee into classes.

The only changes are:
- `formatResult` and `formatSelection` became instance methods. For this to work, callbacks that use them need to bind with `=>` instead of `->` ( to avoid repeating class names by using the binded `this`)
- removed the prefix from instance methods, e.g. `userFormatSelection` became just `formatSelection` since it is already inside the `UserSelect` class
