### PR TITLE
Fix gitlab shell test preparation reset method

### DIFF
--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -24,8 +24,10 @@ namespace :gitlab do
       Dir.chdir(target_dir) do
         # First try to checkout without fetching
         # to avoid stalling tests if the Internet is down.
-        reset = "git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"
-        sh "#{reset} || git fetch origin && #{reset}"
+        reset = "(rev=\"$(git describe #{args.tag} ||"\
+                "git describe \"origin/#{args.tag}\")\" &&"\
+                "git reset --hard \"$rev\")"
+        sh "#{reset} || (git fetch origin && #{reset})"
 
         config = {
           user: user,


### PR DESCRIPTION
Bug introduced by self at: https://github.com/gitlabhq/gitlabhq/pull/7823

Before this PR, the test gitlab shell under `tmp/tests/gitlab-shell` will not correctly fetch new commits if necessary when it exists already (the cache was introduced on the PR that causes this problem: before it would always get removed and cloned).

This happens because the `shell.rake` `sh reset` line I wrote was completely wrong because:
1. bad understanding of `git reset --hard`: if there is no reference, `reset --hard $()` will do just `git reset --hard`, which is valid, and does not activate the `||`
2. bad understanding of precedence: `true || echo a && echo b` translates to `(true || echo a) && echo b`, so the `fetch` part was never done!

Now it works, but is a monster expression. We could split this up into multiple system calls, but that would break the current convention of using `sh`.

This was extracted from: https://github.com/gitlabhq/gitlabhq/pull/8086
