### PR TITLE
Set gitlab shell origin under tmp/tests on every test run [can be updated]

### DIFF
--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -22,6 +22,10 @@ namespace :gitlab do
 
       # Make sure we're on the right tag
       Dir.chdir(target_dir) do
+        # Allows to change the origin URL to the fork
+        # so that the CI can pass.
+        sh(*%W(git remote set-url origin #{args.repo}))
+
         # First try to checkout without fetching
         # to avoid stalling tests if the Internet is down.
         reset = "git reset --hard $(git describe #{args.tag} || git describe origin/#{args.tag})"


### PR DESCRIPTION
so that developers can temporarily change the origin to their fork
and still have the CI pass even if tmp/tests/gitlab-shell is cached
between builds.

Before this PR, there is no way to let the CI run your tests if you modify gitlab-shell, because:
- the CI caches tmp/gitlab-shell between builds
- you want to make it point to your own modified fork of gitlab shell to ensure that tests will pass with the new shell

But that was not possible since the origin was fixed to the existing cached one.

Now it is explicitly set.

Extracted from: https://github.com/gitlabhq/gitlabhq/pull/8086
