### PR TITLE
Doc rake import repo must end in .git [ci skip]

### DIFF
--- a/doc/raketasks/import.md
+++ b/doc/raketasks/import.md
@@ -12,6 +12,7 @@ Notes:
 How to use:
 
 1. copy your bare repos under git repos_path (see `config/gitlab.yml` gitlab_shell -> repos_path)
+    The directory name of the repositories must end in `.git`.
 2. run the command below
 
 ```


### PR DESCRIPTION
Because of: https://github.com/gitlabhq/gitlabhq/blob/ce01916a68655aa0e7be27e6f6f9654db40d0219/lib/tasks/gitlab/import.rake#L16
