### PR TITLE
Only search gitlab:import:repos on repos on subdir [failure unrelated][can be updated]

### DIFF
--- a/doc/raketasks/import.md
+++ b/doc/raketasks/import.md
@@ -22,6 +22,8 @@ your repositories are located by looking at `config/gitlab.yml` under the `gitla
 $ cp -r /old/git/foo.git/ /home/git/repositories/new_group/
 ```
 
+The repository folder must end in `.git`.
+
 ### Run the command below depending on your type of installation:
 
 #### Omnibus Installation


### PR DESCRIPTION
of type `repos_path/group/repo.git`.

Before this, any other location like `repos_path/repo.git`
or `repos_path/group/XXX/repo.git` does generate new projects, but
these projects are empty since no copy is done.

Fix https://github.com/gitlabhq/gitlabhq/issues/4137

This behavior probably exists to support the old global repositories, but since it is broken already, I propose we remove support for that once and for all here. Let users put their repositories on the regular repository structure only which is less confusing and easier to maintain.

Implementation notes: 
- `group_name == '.'` is not possible since glob does not expand to `.`, so that logic was removed.
