### PR TITLE
Use send only where necessary

### DIFF
--- a/app/finders/issuable_finder.rb
+++ b/app/finders/issuable_finder.rb
@@ -45,7 +45,7 @@ class IssuableFinder
 
     if project
       if project.public? || (current_user && current_user.can?(:read_project, project))
-        project.send(table_name)
+        project.public_send(table_name)
       else
         []
       end

--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -87,8 +87,8 @@ module CommitsHelper
   #  avatar: true will prepend the avatar image
   #  size:   size of the avatar image in px
   def commit_person_link(commit, options = {})
-    source_name = clean(commit.send "#{options[:source]}_name".to_sym)
-    source_email = clean(commit.send "#{options[:source]}_email".to_sym)
+    source_name = clean(commit.public_send "#{options[:source]}_name".to_sym)
+    source_email = clean(commit.public_send "#{options[:source]}_email".to_sym)
 
     user = User.find_for_commit(source_email, source_name)
     person_name = user.nil? ? source_name : user.name

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -144,7 +144,7 @@ module ProjectsHelper
     end
 
     [:issues, :wiki, :snippets].each do |feature|
-      nav_tabs << feature if project.send :"#{feature}_enabled"
+      nav_tabs << feature if project.public_send :"#{feature}_enabled"
     end
 
     nav_tabs.flatten

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -126,7 +126,7 @@ class Commit
   end
 
   def method_missing(m, *args, &block)
-    @raw.send(m, *args, &block)
+    @raw.public_send(m, *args, &block)
   end
 
   def respond_to?(method)

--- a/app/models/concerns/internal_id.rb
+++ b/app/models/concerns/internal_id.rb
@@ -7,7 +7,7 @@ module InternalId
   end
 
   def set_iid
-    max_iid = project.send(self.class.name.tableize).maximum(:iid)
+    max_iid = project.public_send(self.class.name.tableize).maximum(:iid)
     self.iid = max_iid.to_i + 1
   end
 

--- a/app/models/network/commit.rb
+++ b/app/models/network/commit.rb
@@ -12,7 +12,7 @@ module Network
     end
 
     def method_missing(m, *args, &block)
-      @commit.send(m, *args, &block)
+      @commit.public_send(m, *args, &block)
     end
 
     def space

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -309,7 +309,7 @@ class Project < ActiveRecord::Base
 
       # If service is available but missing in db
       # we should create an instance. Ex `create_gitlab_ci_service`
-      service = self.send :"create_#{service_name}_service" if service.nil?
+      send :"create_#{service_name}_service" if service.nil?
     end
   end
 
@@ -384,7 +384,7 @@ class Project < ActiveRecord::Base
   end
 
   def execute_hooks(data, hooks_scope = :push_hooks)
-    hooks.send(hooks_scope).each do |hook|
+    hooks.public_send(hooks_scope).each do |hook|
       hook.async_execute(data)
     end
   end

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -40,7 +40,7 @@ class HipchatService < Service
   end
 
   def execute(push_data)
-    gate[room].send('GitLab', create_message(push_data))
+    gate[room].public_send('GitLab', create_message(push_data))
   end
 
   private

--- a/app/models/project_team.rb
+++ b/app/models/project_team.rb
@@ -155,8 +155,8 @@ class ProjectTeam
     group_members = group ? group.group_members : []
 
     if level
-      project_members = project_members.send(level)
-      group_members = group_members.send(level) if group
+      project_members = project_members.public_send(level)
+      group_members = group_members.public_send(level) if group
     end
 
     user_ids = project_members.pluck(:user_id)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -159,7 +159,7 @@ class Repository
   end
 
   def method_missing(m, *args, &block)
-    raw_repository.send(m, *args, &block)
+    raw_repository.public_send(m, *args, &block)
   end
 
   def respond_to?(method)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -424,8 +424,8 @@ class User < ActiveRecord::Base
 
   def sanitize_attrs
     %w(name username skype linkedin twitter bio).each do |attr|
-      value = self.send(attr)
-      self.send("#{attr}=", Sanitize.clean(value)) if value.present?
+      value = send(attr)
+      send("#{attr}=", Sanitize.clean(value)) if value.present?
     end
   end
 
@@ -447,7 +447,7 @@ class User < ActiveRecord::Base
 
   def with_defaults
     User.defaults.each do |k, v|
-      self.send("#{k}=", v)
+      send("#{k}=", v)
     end
 
     self

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -176,7 +176,7 @@ class WikiPage
 
   def save(method, *args)
     project_wiki = wiki
-    if valid? && project_wiki.send(method, *args)
+    if valid? && project_wiki.public_send(method, *args)
 
       page_details = if method == :update_page
                        @page.path

--- a/app/services/issues/bulk_update_service.rb
+++ b/app/services/issues/bulk_update_service.rb
@@ -27,7 +27,7 @@ module Issues
 
       issues.each do |issue|
         issue.update_attributes(opts)
-        issue.send new_state if new_state
+        issue.public_send new_state if new_state
       end
 
       {

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -154,7 +154,7 @@ class NotificationService
     notify_method = "note_#{note.noteable_type.underscore}_email".to_sym
 
     recipients.each do |recipient|
-      mailer.send(notify_method, recipient.id, note.id)
+      mailer.public_send(notify_method, recipient.id, note.id)
     end
   end
 
@@ -296,7 +296,7 @@ class NotificationService
     recipients.delete(target.author)
 
     recipients.each do |recipient|
-      mailer.send(method, recipient.id, target.id)
+      mailer.public_send(method, recipient.id, target.id)
     end
   end
 
@@ -306,7 +306,7 @@ class NotificationService
     recipients.delete(current_user)
 
     recipients.each do |recipient|
-      mailer.send(method, recipient.id, target.id, current_user.id)
+      mailer.public_send(method, recipient.id, target.id, current_user.id)
     end
   end
 
@@ -325,7 +325,8 @@ class NotificationService
     recipients.delete(current_user)
 
     recipients.each do |recipient|
-      mailer.send(method, recipient.id, target.id, assignee_id_was, current_user.id)
+      mailer.public_send(method, recipient.id, target.id,
+                         assignee_id_was, current_user.id)
     end
   end
 
@@ -335,7 +336,8 @@ class NotificationService
     recipients.delete(current_user)
 
     recipients.each do |recipient|
-      mailer.send(method, recipient.id, target.id, status, current_user.id)
+      mailer.public_send(method, recipient.id, target.id,
+                         status, current_user.id)
     end
   end
 

--- a/app/workers/gitlab_shell_worker.rb
+++ b/app/workers/gitlab_shell_worker.rb
@@ -5,6 +5,6 @@ class GitlabShellWorker
   sidekiq_options queue: :gitlab_shell
 
   def perform(action, *arg)
-    gitlab_shell.send(action, *arg)
+    gitlab_shell.public_send(action, *arg)
   end
 end

--- a/app/workers/repository_import_worker.rb
+++ b/app/workers/repository_import_worker.rb
@@ -6,9 +6,8 @@ class RepositoryImportWorker
 
   def perform(project_id)
     project = Project.find(project_id)
-    result = gitlab_shell.send(:import_repository,
-                               project.path_with_namespace,
-                               project.import_url)
+    result = gitlab_shell.import_repository(project.path_with_namespace,
+                                            project.import_url)
 
     if result
       project.import_finish

--- a/lib/api/notes.rb
+++ b/lib/api/notes.rb
@@ -19,7 +19,8 @@ module API
         #   GET /projects/:id/issues/:noteable_id/notes
         #   GET /projects/:id/snippets/:noteable_id/notes
         get ":id/#{noteables_str}/:#{noteable_id_str}/notes" do
-          @noteable = user_project.send(:"#{noteables_str}").find(params[:"#{noteable_id_str}"])
+          @noteable = user_project.public_send(:"#{noteables_str}").
+            find(params[:"#{noteable_id_str}"])
           present paginate(@noteable.notes), with: Entities::Note
         end
 
@@ -33,7 +34,8 @@ module API
         #   GET /projects/:id/issues/:noteable_id/notes/:note_id
         #   GET /projects/:id/snippets/:noteable_id/notes/:note_id
         get ":id/#{noteables_str}/:#{noteable_id_str}/notes/:note_id" do
-          @noteable = user_project.send(:"#{noteables_str}").find(params[:"#{noteable_id_str}"])
+          @noteable = user_project.public_send(:"#{noteables_str}").
+            find(params[:"#{noteable_id_str}"])
           @note = @noteable.notes.find(params[:note_id])
           present @note, with: Entities::Note
         end

--- a/lib/file_size_validator.rb
+++ b/lib/file_size_validator.rb
@@ -42,7 +42,7 @@ class FileSizeValidator < ActiveModel::EachValidator
       value ||= [] if key == :maximum
 
       value_size = value.size
-      next if value_size.send(validity_check, check_value)
+      next if value_size.public_send(validity_check, check_value)
 
       errors_options = options.except(*RESERVED_OPTIONS)
       errors_options[:file_size] = help.number_to_human_size check_value

--- a/lib/gitlab/ldap/person.rb
+++ b/lib/gitlab/ldap/person.rb
@@ -31,7 +31,7 @@ module Gitlab
       end
 
       def uid
-        entry.send(config.uid).first
+        entry.public_send(config.uid).first
       end
 
       def username

--- a/spec/controllers/commit_controller_spec.rb
+++ b/spec/controllers/commit_controller_spec.rb
@@ -27,7 +27,7 @@ describe Projects::CommitController do
       it "should render it" do
         get :show, project_id: project.to_param, id: commit.id, format: format
 
-        expect(response.body).to eq(commit.send(:"to_#{format}"))
+        expect(response.body).to eq(commit.public_send(:"to_#{format}"))
       end
 
       it "should not escape Html" do

--- a/spec/controllers/merge_requests_controller_spec.rb
+++ b/spec/controllers/merge_requests_controller_spec.rb
@@ -27,7 +27,7 @@ describe Projects::MergeRequestsController do
       it "should render it" do
         get :show, project_id: project.to_param, id: merge_request.iid, format: format
 
-        expect(response.body).to eq((merge_request.send(:"to_#{format}",user)).to_s)
+        expect(response.body).to eq((merge_request.public_send(:"to_#{format}",user)).to_s)
       end
 
       it "should not escape Html" do

--- a/spec/lib/gitlab/popen_spec.rb
+++ b/spec/lib/gitlab/popen_spec.rb
@@ -5,7 +5,7 @@ describe 'Gitlab::Popen', no_db: true do
 
   before do
     @klass = Class.new(Object)
-    @klass.send(:include, Gitlab::Popen)
+    @klass.include(Gitlab::Popen)
   end
 
   context 'zero status' do


### PR DESCRIPTION
Prefer public_send if methods are public,
and method calls if the method is a constant symbol.

`public_send` mentioned in bbatsov: https://github.com/bbatsov/ruby-style-guide#prefer-public-send

Under `app` and `lib`:

```
find . -iname "*.rb" | xargs perl -lapi -e 's/\.send\b/.public_send/'
```

but some manual refactor was also done in addition.

Exceptions:
- `self.send` and just `send`. I moved `self.send` to just `send` for uniformity and to avoid hound barks. In those cases, the call can access private methods, so it does not matter.
- at `lib/redcarpet/render/gitlab_html` there is an `h.send` which causes problems is replaced... seems like we are using something we shouldn't. 
