### PR TITLE
adding "Update gitlab-shell" info in doc 7.3-to-7.4.md

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -35,7 +35,15 @@ For GitLab Enterprise Edition:
 sudo -u git -H git checkout 7-4-stable-ee
 ```
 
-### 3. Install libs, migrations, etc.
+## 3. Update gitlab-shell
+
+```bash
+cd /home/git/gitlab-shell
+sudo -u git -H git fetch
+sudo -u git -H git checkout v2.0.1
+```
+
+### 4. Install libs, migrations, etc.
 
 ```bash
 cd /home/git/gitlab
@@ -57,7 +65,7 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 ```
 
 
-### 4. Configure Redis to use sockets
+### 5. Configure Redis to use sockets
 
     # Configure redis to use sockets
     sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.orig
@@ -80,7 +88,7 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
     # Configure gitlab-shell to use Redis sockets
     sudo -u git -H sed -i 's|^  # socket.*|  socket: /var/run/redis/redis.sock|' /home/git/gitlab-shell/config.yml
 
-### 5. Update config files
+### 6. Update config files
 
 #### New configuration options for gitlab.yml
 
@@ -106,12 +114,12 @@ timeout 60
 * Add `collation: utf8_general_ci` to config/database.yml as seen in [config/database.yml.mysql](config/database.yml.mysql)
 
 
-### 6. Start application
+### 7. Start application
 
     sudo service gitlab start
     sudo service nginx restart
 
-### 7. Check application status
+### 8. Check application status
 
 Check if GitLab and its environment are configured correctly:
 
@@ -123,13 +131,13 @@ To make sure you didn't miss anything run a more thorough check with:
 
 If all items are green, then congratulations upgrade is complete!
 
-### 8. Update OmniAuth configuration
+### 9. Update OmniAuth configuration
 
 When using Google omniauth login, changes of the Google account required.
 Ensure that `Contacts API` and the `Google+ API` are enabled in the [Google Developers Console](https://console.developers.google.com/).
 More details can be found at the [integration documentation](../integration/google.md).
 
-### 9. Optional optimizations for GitLab setups with MySQL databases
+### 10. Optional optimizations for GitLab setups with MySQL databases
 
 Only applies if running MySQL database created with GitLab 6.7 or earlier. If you are not experiencing any issues you may not need the following instructions however following them will bring your database in line with the latest recommended installation configuration and help avoid future issues. Be sure to follow these directions exactly. These directions should be safe for any MySQL instance but to be sure make a current MySQL database backup beforehand.
 


### PR DESCRIPTION
I just saw that this section was missing from the doc, and got it from the `6.x-or-7.x-to-7.4.md`.
And I followed the order that it used to appear in others docs like `7.2-to-7.3.md`
