### PR TITLE
Show nothing instead of unassigned on issues

### DIFF
--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -14,8 +14,6 @@
   .issue-info
     - if issue.assignee
       assigned to #{link_to_member(@project, issue.assignee)}
-    - else
-      unassigned
     - if issue.votes_count > 0
       = render 'votes/votes_inline', votable: issue
     - if issue.notes.any?


### PR DESCRIPTION
Subjective like all UI features, but here goes:

After:

![screenshot from 2014-10-23 16 19 19 after](https://cloud.githubusercontent.com/assets/1429315/4754801/a53c9546-5ac0-11e4-81a9-f870336e6f6f.png)

Before (shows `unassigned`):

![screenshot from 2014-10-23 16 27 23 before](https://cloud.githubusercontent.com/assets/1429315/4754810/bfd85444-5ac0-11e4-8d83-940584eba856.png)

I think it's natural to understand that if there is no "Assigned to" then there it is unassigned.

Otherwise it produces too much interface clutter, e.g. from GitLab CE:

![screenshot from 2014-10-23 16 24 34 many unassigneds](https://cloud.githubusercontent.com/assets/1429315/4754827/f6dc9428-5ac0-11e4-85f4-b74b75fcb840.png)

When we have a single object to show, saying `not there` is OK. But on lists / tables where information is already overflowing, I'd rather not show anything.
