### PR TITLE
update slack-notifier for new webhook_url format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,7 @@ gem "gitlab-flowdock-git-hook", "~> 0.4.2"
 gem "gemnasium-gitlab-service", "~> 0.2"
 
 # Slack integration
-gem "slack-notifier", "~> 0.3.2"
+gem "slack-notifier", "~> 1.0.0"
 
 # d3
 gem "d3_rails", "~> 3.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     six (0.2.0)
-    slack-notifier (0.3.2)
+    slack-notifier (1.0.0)
     slim (2.0.2)
       temple (~> 0.6.6)
       tilt (>= 1.3.3, < 2.1)
@@ -688,7 +688,7 @@ DEPENDENCIES
   simplecov
   sinatra
   six
-  slack-notifier (~> 0.3.2)
+  slack-notifier (~> 1.0.0)
   slim
   spinach-rails
   spring (= 1.1.3)

--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -30,24 +30,20 @@ class SlackService < Service
 
   def fields
     [
-      { type: 'text', name: 'webhook', placeholder: '' }
+      { type: 'text', name: 'webhook', placeholder: 'https://hooks.slack.com/services/...' }
     ]
   end
 
   def execute(push_data)
+    return unless webhook.present?
+
     message = SlackMessage.new(push_data.merge(
       project_url: project_url,
       project_name: project_name
     ))
 
-    credentials = webhook.match(/([\w-]*).slack.com.*services\/(.*)/)
-
-    if credentials.present?
-      subdomain =  credentials[1]
-      token = credentials[2].split("token=").last
-      notifier = Slack::Notifier.new(subdomain, token)
-      notifier.ping(message.pretext, attachments: message.attachments)
-    end
+    notifier = Slack::Notifier.new(webhook)
+    notifier.ping(message.pretext, attachments: message.attachments)
   end
 
   private

--- a/doc/integration/slack.md
+++ b/doc/integration/slack.md
@@ -4,15 +4,23 @@
 
 To enable Slack integration you must create an Incoming WebHooks integration on Slack;
 
-1.  Sign in to [Slack](https://slack.com) (https://YOURSUBDOMAIN.slack.com/services)
-1.  Click on the Integrations menu at the top of the page.
-1.  Add a new Integration.
-1.  Pick Incoming WebHooks
-1.  Choose the channel name you want to send notifications to, in the Settings section
-1.  Add Integrations.
-    - Optional step; You can change bot's name and avatar by clicking "change the name of your bot", and "change the icon" after that you have to click "Save settings".
+1.  [Sign in to Slack](https://slack.com/signin)
 
-Now, Slack is ready to get external hooks. Before you leave this page don't forget to get the Token that you'll need on GitLab. You can find it by clicking Expand button, located in the "Instructions for creating Incoming WebHooks" section. It's a random alpha-numeric text 24 characters long.
+1.  Select **Configure Integrations** from the dropdown next to your team name.
+
+1.  Select the **All Services** tab
+
+1.  Click **Add** next to Incoming Webhooks
+
+1.  Pick Incoming WebHooks
+
+1.  Choose the channel name you want to send notifications to
+
+1.  Click **Add Incoming WebHooks Integration**Add Integrations.
+    - Optional step; You can change bot's name and avatar by clicking modifying the bot name or avatar under **Integration Settings**.
+
+1. Copy the **Webhook URL**, we'll need this later for GitLab.
+
 
 ## On GitLab
 
@@ -26,10 +34,8 @@ After Slack is ready we need to setup GitLab. Here are the steps to achieve this
 
 1.  Fill in your Slack details
 
-    - Mark as active it
-    - Type your subdomain's prefix (If your subdomain is https://somedomain.slack.com you only have to type the somedomain)
-    - Type in the token you got from Slack
-    - Type in the channel name you want to use (eg. #announcements)
+    - Mark it as active
+    - Paste in the webhook url you got from Slack
 
 Have fun :)
 

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -108,12 +108,12 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
 
   step 'I fill Slack settings' do
     check 'Active'
-    fill_in 'Webhook', with: 'https://gitlabhq.slack.com/services/hooks?token=cdIj4r4LfXUOySDUjp0tk3OI'
+    fill_in 'Webhook', with: 'https://hooks.slack.com/services/SVRWFV0VVAR97N/B02R25XN3/ZBqu7xMupaEEICInN685'
     click_button 'Save'
   end
 
   step 'I should see Slack service settings saved' do
-    find_field('Webhook').value.should == 'https://gitlabhq.slack.com/services/hooks?token=cdIj4r4LfXUOySDUjp0tk3OI'
+    find_field('Webhook').value.should == 'https://hooks.slack.com/services/SVRWFV0VVAR97N/B02R25XN3/ZBqu7xMupaEEICInN685'
   end
 
   step 'I click Pushover service link' do

--- a/spec/models/slack_service_spec.rb
+++ b/spec/models/slack_service_spec.rb
@@ -31,71 +31,27 @@ describe SlackService do
   end
 
   describe "Execute" do
-    let(:slack) { SlackService.new }
-    let(:slack_service) { SlackService.new }
-    let(:user) { create(:user) }
+    let(:slack)   { SlackService.new }
+    let(:user)    { create(:user) }
     let(:project) { create(:project) }
     let(:sample_data) { GitPushService.new.sample_data(project, user) }
-    let(:webhook) { 'https://gitlabhq.slack.com/services/hooks?token=cdIj4r4LfXUOySDUjp0tk3OI' }
-    let(:new_webhook) { 'https://hooks.gitlabhq.slack.com/services/cdIj4r4LfXUOySDUjp0tk3OI' }
-    let(:api_url) {
-      'https://gitlabhq.slack.com/services/hooks/incoming-webhook?token=cdIj4r4LfXUOySDUjp0tk3OI'
-    }
+    let(:webhook_url) { 'https://hooks.slack.com/services/SVRWFV0VVAR97N/B02R25XN3/ZBqu7xMupaEEICInN685' }
 
     before do
       slack.stub(
         project: project,
         project_id: project.id,
         service_hook: true,
-        webhook: webhook
+        webhook: webhook_url
       )
 
-      WebMock.stub_request(:post, api_url)
+      WebMock.stub_request(:post, webhook_url)
     end
 
     it "should call Slack API" do
       slack.execute(sample_data)
 
-      WebMock.should have_requested(:post, api_url).once
-    end
-
-    context 'with new webhook syntax' do
-      before do
-        slack_service.stub(
-          project: project,
-          project_id: project.id,
-          service_hook: true,
-          webhook: new_webhook
-        )
-
-        WebMock.stub_request(:post, api_url)
-      end
-
-      it "should call Slack API" do
-        slack_service.execute(sample_data)
-
-        WebMock.should have_requested(:post, api_url).once
-      end
-    end
-
-    context 'with new webhook syntax with slack allowed team name' do
-      before do
-        @allowed_webhook = 'https://gitlab-hq-123.slack.com/services/hooks/incoming-webhook?token=cdIj4r4LfXUOySDUjp0tk3OI'
-        slack_service.stub(
-          project: project,
-          project_id: project.id,
-          service_hook: true,
-          webhook: @allowed_webhook
-        )
-
-        WebMock.stub_request(:post, @allowed_webhook)
-      end
-
-      it "should call Slack API" do
-        slack_service.execute(sample_data)
-
-        WebMock.should have_requested(:post, @allowed_webhook).once
-      end
+      WebMock.should have_requested(:post, webhook_url).once
     end
   end
 end


### PR DESCRIPTION
Just got a report about this for the gem and knew y'all were using it so took a crack at getting things updated. Took me a minute to get things running to work on this, so please let me know if I missed anything.

I saw y'all have been running into issues with the way parsing out the token & teams have been working ([#gitlab-701](https://gitlab.com/gitlab-org/gitlab-ce/issues/701)), as well as needing to make changes as slack does (https://github.com/gitlabhq/gitlabhq/commit/e5998adc26f66b2b84cbcc28e98f3fc8f89b4696). Talking to their integrations team the preferrence is for integrations to use the raw webhook_url. This gives them more flexibility in the future. (one issue this addressed for them was team names could change w/o breaking webhooks). And _should_ be less headache for integrations if/when they change things.
