### PR TITLE
Fix import.rake failed import if project name is also an existing namespace.

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -15,8 +15,6 @@ namespace :gitlab do
       git_base_path = Gitlab.config.gitlab_shell.repos_path
       repos_to_import = Dir.glob(git_base_path + '/**/*.git')
 
-      namespaces = Namespace.pluck(:path)
-
       repos_to_import.each do |repo_path|
         # strip repo base path
         repo_path[0..git_base_path.length] = ''
@@ -25,12 +23,6 @@ namespace :gitlab do
         name = File.basename path
         group_name = File.dirname path
         group_name = nil if group_name == '.'
-
-        # Skip if group or user
-        if namespaces.include?(name)
-          puts "Skipping #{project.name} due to namespace conflict with group or user".yellow
-          next
-        end
 
         puts "Processing #{repo_path}".yellow
 
@@ -53,9 +45,9 @@ namespace :gitlab do
 
           # find group namespace
           if group_name
-            group = Group.find_by(path: group_name)
+            group = Namespace.find_by(path: group_name)
             # create group namespace
-            if !group
+            unless group
               group = Group.new(:name => group_name)
               group.path = group_name
               group.owner = user


### PR DESCRIPTION
also an existing namespace. E.g., when trying to import
group/root.git, that would fail if there is an user called root.

The error was twofold:
- it would execute project.name, where project is not defined
- it should not `continue` before creating the project!
