### PR TITLE
Stop blacklisting project path

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -98,7 +98,6 @@ class Project < ActiveRecord::Base
             format: { with: Gitlab::Regex.project_name_regex,
                       message: Gitlab::Regex.project_regex_message }
   validates :path, presence: true, length: { within: 0..255 },
-            exclusion: { in: Gitlab::Blacklist.path },
             format: { with: Gitlab::Regex.path_regex,
                       message: Gitlab::Regex.path_regex_message }
   validates :issues_enabled, :merge_requests_enabled,

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -74,6 +74,12 @@ describe Project do
       project2.should_not be_valid
       project2.errors[:limit_reached].first.should match(/Your project limit is 0/)
     end
+
+    it 'should not blacklist project paths'\
+       'that are blacklisted for namespaces' do
+      (expect { create(:project, name: Gitlab::Blacklist.path.first) }).
+        not_to raise_error
+    end
   end
 
   describe "Respond to" do

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -86,6 +86,11 @@ describe ProjectsController, "routing" do
     get("/gitlab/gitlabhq").should route_to('projects#show', id: 'gitlab/gitlabhq')
   end
 
+  it 'to #show blacklisted project path' do
+    get("/gitlab/#{Gitlab::Blacklist.path.first}").should(
+      route_to('projects#show', id: "gitlab/#{Gitlab::Blacklist.path.first}"))
+  end
+
   it "to #update" do
     put("/gitlab/gitlabhq").should route_to('projects#update', id: 'gitlab/gitlabhq')
   end


### PR DESCRIPTION
Before this PR, all project paths at: https://github.com/gitlabhq/gitlabhq/blob/199029b842de7c9d52b5c95bdc1cc897da8e5560/lib/gitlab/blacklist.rb were forbidden.

This PR removes that restriction, keeping it only for namespaces where it is required.

The restriction is not necessary and just creates more exception cases that can annoy users.

The blacklist was used here because of the fear of conflicting an URLs like `/groupname/issues` for two possible uses:
1. all issues of the group
2. a project called `issues`

however case 1 is impossible since:
- all group URLs are prefixed by `/group` (e.g. `/group/groupname/issues`), except the base `/groupname` which redirects to `/group/groupname`
- currently URLs like `/groupname/issues` don't redirect to `/group/groupname/issues` and give 404 instead.
  
  This is sane and should not be undone in the future, or else we would have problems whenever we want to add a new path to the blacklist.

This is also the URL strategy used by GitHub.
