### PR TITLE
Change update recommendation

### DIFF
--- a/doc/update/6.x-or-7.x-to-7.3.md
+++ b/doc/update/6.x-or-7.x-to-7.3.md
@@ -1,6 +1,6 @@
-# From 6.x or 7.x to 7.4
+# From 6.x or 7.x to 7.3
 
-This allows you to upgrade any version of GitLab from 6.0 and up (including 7.0 and up) to 7.4.
+This allows you to upgrade any version of GitLab from 6.0 and up (including 7.0 and up) to 7.3.
 
 ## Global issue numbers
 
@@ -70,7 +70,7 @@ sudo -u git -H git checkout -- db/schema.rb # local changes will be restored aut
 For GitLab Community Edition:
 
 ```bash
-sudo -u git -H git checkout 7-4-stable
+sudo -u git -H git checkout 7-3-stable
 ```
 
 OR
@@ -78,7 +78,7 @@ OR
 For GitLab Enterprise Edition:
 
 ```bash
-sudo -u git -H git checkout 7-4-stable-ee
+sudo -u git -H git checkout 7-3-stable-ee
 ```
 
 ## 4. Install additional packages
@@ -154,14 +154,14 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 TIP: to see what changed in `gitlab.yml.example` in this release use next command:
 
 ```
-git diff 6-0-stable:config/gitlab.yml.example 7-4-stable:config/gitlab.yml.example
+git diff 6-0-stable:config/gitlab.yml.example 7-3-stable:config/gitlab.yml.example
 ```
 
-* Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/config/gitlab.yml.example but with your settings.
-* Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/config/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/config/gitlab.yml.example but with your settings.
+* Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/config/unicorn.rb.example but with your settings.
 * Make `/home/git/gitlab-shell/config.yml` the same as https://gitlab.com/gitlab-org/gitlab-shell/blob/v2.0.1/config.yml.example but with your settings.
-* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab but with your settings.
-* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab-ssl but with your settings.
+* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab but with your settings.
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab-ssl but with your settings.
 * Copy rack attack middleware config
 
 ```bash


### PR DESCRIPTION
Due to the potentially conflicting migrations between 7.3 and 7.4 regarding services, I recommend we change this guide. Until we can backport a 'fix' for the migrations that eliminates the potential problem it is unwise to tell users it's safe to upgrade across 7.3 and 7.4 in one go.

This PR is against master and should also be backported to 7-4-stable.
