### PR TITLE
fix nginx config location & improve setting paths

### DIFF
--- a/doc/update/5.1-to-6.0.md
+++ b/doc/update/5.1-to-6.0.md
@@ -164,8 +164,8 @@ sudo -u git -H git config --global core.autocrlf input
 
 Note: We switched from Puma in GitLab 5.x to unicorn in GitLab 6.0.
 
-- Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/6-0-stable/config/gitlab.yml.example but with your settings.
-- Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/6-0-stable/config/unicorn.rb.example but with your settings.
+- Make `/home/git/gitlab/config/gitlab.yml` the same as [`lib/support/nginx/gitlab`](/lib/support/nginx/gitlab) but with your settings.
+- Make `/home/git/gitlab/config/unicorn.rb` the same as [`config/unicorn.rb.example`](/config/unicorn.rb.example) but with your settings.
 
 ## 7. Update Init script
 

--- a/doc/update/5.4-to-6.0.md
+++ b/doc/update/5.4-to-6.0.md
@@ -94,8 +94,8 @@ sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 
 Note: We switched from Puma in GitLab 5.4 to unicorn in GitLab 6.0.
 
-- Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example but with your settings.
-- Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/unicorn.rb.example but with your settings.
+- Make `/home/git/gitlab/config/gitlab.yml` the same as [`lib/support/nginx/gitlab`](/lib/support/nginx/gitlab) but with your settings.
+- Make `/home/git/gitlab/config/unicorn.rb` the same as [`config/unicorn.rb.example`](/config/unicorn.rb.example) but with your settings.
 
 ## 7. Update Init script
 

--- a/doc/update/6.9-to-7.0.md
+++ b/doc/update/6.9-to-7.0.md
@@ -105,8 +105,8 @@ There are new configuration options available for gitlab.yml. View them with the
 git diff origin/6-9-stable:config/gitlab.yml.example origin/7-0-stable:config/gitlab.yml.example
 ```
 
-* HTTP setups: Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-0-stable/lib/support/nginx/gitlab but with your settings.
-* HTTPS setups: Make `/etc/nginx/sites-available/nginx-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-0-stable/lib/support/nginx/gitlab-ssl but with your setting
+* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as [`lib/support/nginx/gitlab`](/lib/support/nginx/gitlab) but with your settings.
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
 
 ### 7. Start application
 

--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -157,11 +157,11 @@ TIP: to see what changed in `gitlab.yml.example` in this release use next comman
 git diff 6-0-stable:config/gitlab.yml.example 7-4-stable:config/gitlab.yml.example
 ```
 
-* Make `/home/git/gitlab/config/gitlab.yml` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/config/gitlab.yml.example but with your settings.
-* Make `/home/git/gitlab/config/unicorn.rb` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/config/unicorn.rb.example but with your settings.
+* Make `/home/git/gitlab/config/gitlab.yml` the same as [`config/gitlab.yml.example`](/config/gitlab.yml.example) but with your settings.
+* Make `/home/git/gitlab/config/unicorn.rb` the same as [`config/unicorn.rb.example`](/config/unicorn.rb.example) but with your settings.
 * Make `/home/git/gitlab-shell/config.yml` the same as https://gitlab.com/gitlab-org/gitlab-shell/blob/v2.0.1/config.yml.example but with your settings.
-* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab but with your settings.
-* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab-ssl but with your settings.
+* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as [`lib/support/nginx/gitlab`](/lib/support/nginx/gitlab) but with your settings.
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
 * Copy rack attack middleware config
 
 ```bash

--- a/doc/update/7.1-to-7.2.md
+++ b/doc/update/7.1-to-7.2.md
@@ -89,8 +89,8 @@ There are new configuration options available for `gitlab.yml`. View them with t
 git diff 7-1-stable:config/gitlab.yml.example 7-2-stable:config/gitlab.yml.example
 ```
 
-* HTTP setups: Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-0-stable/lib/support/nginx/gitlab but with your settings.
-* HTTPS setups: Make `/etc/nginx/sites-available/nginx-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-0-stable/lib/support/nginx/gitlab-ssl but with your setting
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
 
 Update rack attack middleware config
 

--- a/doc/update/7.2-to-7.3.md
+++ b/doc/update/7.2-to-7.3.md
@@ -103,8 +103,8 @@ git diff origin/7-2-stable:config/gitlab.yml.example origin/7-3-stable:config/gi
 sudo -u git -H sed -i 's/:backlog => 64/:backlog => 1024/' config/unicorn.rb
 ```
 
-* HTTP setups: Make `/etc/nginx/sites-available/nginx` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab but with your settings.
-* HTTPS setups: Make `/etc/nginx/sites-available/nginx-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-3-stable/lib/support/nginx/gitlab-ssl but with your setting
+* HTTP setups: Make `/etc/nginx/sites-available/gitlab` the same as [`lib/support/nginx/gitlab`](/lib/support/nginx/gitlab) but with your settings.
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
 
 ### 7. Start application
 

--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -70,9 +70,9 @@ git diff origin/7-3-stable:config/gitlab.yml.example origin/7-4-stable:config/gi
 sudo -u git -H editor config/unicorn.rb
 ```
 
-#### Change nginx https settings
+#### Change nginx HTTPS settings
 
-* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as https://gitlab.com/gitlab-org/gitlab-ce/blob/7-4-stable/lib/support/nginx/gitlab-ssl but with your setting
+* HTTPS setups: Make `/etc/nginx/sites-available/gitlab-ssl` the same as [`lib/support/nginx/gitlab-ssl`](/lib/support/nginx/gitlab-ssl) but with your settings.
 
 #### MySQL Databases: Update database.yml config file
 


### PR DESCRIPTION
Replaces https://github.com/gitlabhq/gitlabhq/pull/8043 and https://github.com/gitlabhq/gitlabhq/pull/8069.

Make paths relative for ease of use, fix incorrect paths, & fix minor punctuation issues.
