### PR TITLE
fix git installation

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -76,6 +76,7 @@ Is the system packaged Git too old? Remove it and compile from source.
     cd /tmp
     curl -L --progress https://www.kernel.org/pub/software/scm/git/git-2.1.2.tar.gz | tar xz
     cd git-2.1.2/
+    ./configure
     make prefix=/usr/local all
 
     # Install into /usr/local/bin


### PR DESCRIPTION
To get `git` to compile from source I had to first run `./configure`.
