### PR TITLE
WIP: Fix redis details

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -159,9 +159,9 @@ We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](da
     sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
 
     # Create the directory which contains the socket
-    mkdir -p /var/run/redis
-    chown redis:redis /var/run/redis
-    chmod 755 /var/run/redis
+    sudo mkdir -p /var/run/redis
+    sudo chown redis:redis /var/run/redis
+    sudo chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable
     if [ -d /etc/tmpfiles.d ]; then
       echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -155,11 +155,11 @@ We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](da
 
     # Enable Redis socket for default Debian / Ubuntu path
     echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis/redis.conf
-    # Grant permission to the socket to all members of the redis group
-    echo 'unixsocketperm 770' | sudo tee -a /etc/redis/redis.conf
+    # Be sure redis group can write to the socket, enable only if supported (>= redis 2.4.0).
+    sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
 
     # Create the directory which contains the socket
-    mkdir /var/run/redis
+    mkdir -p /var/run/redis
     chown redis:redis /var/run/redis
     chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable

--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -110,8 +110,8 @@ sudo apt-get install pkg-config cmake
     
     # Create the directory which contains the socket
     mkdir -p /var/run/redis
-    chown redis:redis /var/run/redis
-    chmod 755 /var/run/redis
+    sudo chown redis:redis /var/run/redis
+    sudo chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable
     if [ -d /etc/tmpfiles.d ]; then
       echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf

--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -95,14 +95,31 @@ sudo apt-get install pkg-config cmake
 
     # Configure redis to use sockets
     sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.orig
+    
     # Disable Redis listening on TCP by setting 'port' to 0
     sed 's/^port .*/port 0/' /etc/redis/redis.conf.orig | sudo tee /etc/redis/redis.conf
+    
     # Enable Redis socket for default Debian / Ubuntu path
     echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis/redis.conf
+    
     # Be sure redis group can write to the socket, enable only if supported (>= redis 2.4.0).
-    sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0775/' /etc/redis/redis.conf
+    sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
+
+    # Secure existing Redis socket
+    sudo sed -i '/unixsocketperm/ s/^unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
+    
+    # Create the directory which contains the socket
+    mkdir -p /var/run/redis
+    chown redis:redis /var/run/redis
+    chmod 755 /var/run/redis
+    # Persist the directory which contains the socket, if applicable
+    if [ -d /etc/tmpfiles.d ]; then
+      echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf
+    fi
+    
     # Activate the changes to redis.conf
     sudo service redis-server restart
+    
     # Add git to the redis group
     sudo usermod -aG redis git
 

--- a/doc/update/6.x-or-7.x-to-7.4.md
+++ b/doc/update/6.x-or-7.x-to-7.4.md
@@ -109,7 +109,7 @@ sudo apt-get install pkg-config cmake
     sudo sed -i '/unixsocketperm/ s/^unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
     
     # Create the directory which contains the socket
-    mkdir -p /var/run/redis
+    sudo mkdir -p /var/run/redis
     sudo chown redis:redis /var/run/redis
     sudo chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable

--- a/doc/update/7.2-to-7.3.md
+++ b/doc/update/7.2-to-7.3.md
@@ -69,14 +69,28 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
 
     # Configure redis to use sockets
     sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.orig
+    
     # Disable Redis listening on TCP by setting 'port' to 0
     sed 's/^port .*/port 0/' /etc/redis/redis.conf.orig | sudo tee /etc/redis/redis.conf
+    
     # Enable Redis socket for default Debian / Ubuntu path
     echo 'unixsocket /var/run/redis/redis.sock' | sudo tee -a /etc/redis/redis.conf
+    
     # Be sure redis group can write to the socket, enable only if supported (>= redis 2.4.0).
     sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0775/' /etc/redis/redis.conf
+    
+    # Create the directory which contains the socket
+    mkdir -p /var/run/redis
+    chown redis:redis /var/run/redis
+    chmod 755 /var/run/redis
+    # Persist the directory which contains the socket, if applicable
+    if [ -d /etc/tmpfiles.d ]; then
+      echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf
+    fi
+    
     # Activate the changes to redis.conf
     sudo service redis-server restart
+    
     # Add git to the redis group
     sudo usermod -aG redis git
 

--- a/doc/update/7.2-to-7.3.md
+++ b/doc/update/7.2-to-7.3.md
@@ -80,9 +80,9 @@ sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
     sudo sed -i '/# unixsocketperm/ s/^# unixsocketperm.*/unixsocketperm 0775/' /etc/redis/redis.conf
     
     # Create the directory which contains the socket
-    mkdir -p /var/run/redis
-    chown redis:redis /var/run/redis
-    chmod 755 /var/run/redis
+    sudo mkdir -p /var/run/redis
+    sudo chown redis:redis /var/run/redis
+    sudo chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable
     if [ -d /etc/tmpfiles.d ]; then
       echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf

--- a/doc/update/7.4-to-7.5.md
+++ b/doc/update/7.4-to-7.5.md
@@ -4,9 +4,9 @@
     sudo sed -i '/unixsocketperm/ s/^unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
 
     # Make sure redis is setup correctly
-    mkdir -p /var/run/redis
-    chown redis:redis /var/run/redis
-    chmod 755 /var/run/redis
+    sudo mkdir -p /var/run/redis
+    sudo chown redis:redis /var/run/redis
+    sudo chmod 755 /var/run/redis
     # Persist the directory which contains the socket, if applicable
     if [ -d /etc/tmpfiles.d ]; then
       echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf

--- a/doc/update/7.4-to-7.5.md
+++ b/doc/update/7.4-to-7.5.md
@@ -1,0 +1,16 @@
+## 5. Redis
+
+    # Secure existing Redis socket
+    sudo sed -i '/unixsocketperm/ s/^unixsocketperm.*/unixsocketperm 0770/' /etc/redis/redis.conf
+
+    # Make sure redis is setup correctly
+    mkdir -p /var/run/redis
+    chown redis:redis /var/run/redis
+    chmod 755 /var/run/redis
+    # Persist the directory which contains the socket, if applicable
+    if [ -d /etc/tmpfiles.d ]; then
+      echo 'd  /var/run/redis  0755  redis  redis  10d  -' | sudo tee -a /etc/tmpfiles.d/redis.conf
+    fi
+    
+    # Activate the changes to redis.conf
+    sudo service redis-server restart


### PR DESCRIPTION
As discussed at https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/224 and add5d43b6ea0f4fbe85af4c07afe9e549b700205 the redis setup details aren't quite correct.

Currently the upgrade and installation guides differ in how you should set socket permissions. This PR aims to unify the settings both for a few old upgrade guides and, for users with already broken installations, in a new upgrade guide.

I will squash and make this mergeable if other users agree.

/cc @axilleas @hobarrera
