### PR TITLE
Fix serialize migration

### DIFF
--- a/db/migrate/20140907220153_serialize_service_properties.rb
+++ b/db/migrate/20140907220153_serialize_service_properties.rb
@@ -23,7 +23,7 @@ class SerializeServiceProperties < ActiveRecord::Migration
       associations[service.type.to_sym].each do |attribute|
         service.send("#{attribute}=", service.attributes[attribute.to_s])
       end
-      service.save!
+      service.save(validate: false)
     end
 
     remove_column :services, :project_url, :string


### PR DESCRIPTION
Skip validation on the serialize migration. This might sound scary, but we only have the data we have when the migration happens. Presumably if a validation would fail it's because there is a new property that a future migration will fix. 

Fixes #8157 
Fixes #8141
Fixes #8184 
