### PR TITLE
Fixed markdown error in 7.3-to-7.4 update guide

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -9,6 +9,7 @@
 ```bash
 cd /home/git/gitlab
 sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
+```
 
 ### 2. Get latest code
 


### PR DESCRIPTION
Just fixed a minor bug in the markdown notation :smile: 
