### PR TITLE
Fix auto-selection of URL field with X11 selection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
 v 7.11.0 (unreleased)
-  -
+  - Fix clone URL field and X11 Primary selection (Dmitry Medvinsky)
   -
   -
   -

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -115,8 +115,8 @@ if location.hash
 window.addEventListener "hashchange", shiftWindow
 
 $ ->
-  # Click a .one_click_select field, select the contents
-  $(".one_click_select").on 'click', -> $(@).select()
+  # Click a .js-select-on-focus field, select the contents
+  $(".js-select-on-focus").on "focusin", -> $(this).select()
 
   $('.remove-row').bind 'ajax:success', ->
     $(this).closest('li').fadeOut()

--- a/app/views/shared/_clone_panel.html.haml
+++ b/app/views/shared/_clone_panel.html.haml
@@ -15,7 +15,7 @@
       :"data-html" => "true",
       :"data-container" => "body"}
       = gitlab_config.protocol.upcase
-  = text_field_tag :project_clone, default_url_to_repo(project), class: "one_click_select form-control", readonly: true
+  = text_field_tag :project_clone, default_url_to_repo(project), class: "js-select-on-focus form-control", readonly: true
   - if project.kind_of?(Project)
     .input-group-addon
       .visibility-level-label.has_tooltip{'data-title' => "#{visibility_level_label(project.visibility_level)} project" }


### PR DESCRIPTION
We use `focusin` event instead of `click` because when using the latter,
when the selection is created it isn't put into X11 PRIMARY selection.
And as a Linux user I'm very used to such behaviour that when something
gets selected, it's ready for pasting, which is the primary purpose of
the clone URL field.

When `focusin` is used, the selection is copied to X11 buffer
automatically, so it works as expected (tested in Firefox and Chrome).
