### PR TITLE
Remove some unneeded html_safe calls [can be updated]

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -51,7 +51,7 @@ module CommitsHelper
       end
     end
 
-    crumbs.html_safe
+    crumbs
   end
 
   # Return Project default branch, if it present in array

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -33,9 +33,11 @@ module ProjectsHelper
     author_html = author_html.html_safe
 
     if opts[:name]
-      link_to(author_html, user_path(author), class: "author_link").html_safe
+      link_to(author_html, user_path(author), class: 'author_link')
     else
-      link_to(author_html, user_path(author), class: "author_link has_tooltip", data: { :'original-title' => sanitize(author.name) } ).html_safe
+      link_to(author_html, user_path(author),
+              class: 'author_link has_tooltip',
+              data: { :'original-title' => sanitize(author.name) })
     end
   end
 


### PR DESCRIPTION
Those calls are not necessary because:
- `content_tag` calls it on it's output already: what could make a difference would be to call `html_safe` on the input of that function
- the concatenation `+` of `SafeBuffer` (returned by `html_safe`) is another `SafeBuffer`.
- `link_to` uses `content_tag`
