### PR TITLE
Use require spec_helper instead of relative path

### DIFF
--- a/spec/models/slack_message_spec.rb
+++ b/spec/models/slack_message_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../app/models/project_services/slack_message'
+require 'spec_helper'
 
 describe SlackMessage do
   subject { SlackMessage.new(args) }


### PR DESCRIPTION
More portable if either test or class gets moved,
more uniform with the rest of the tests.
