### PR TITLE
Expose projects_limit through users API if UserFull.

### DIFF
--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -78,7 +78,8 @@ GET /users
     "is_admin": false,
     "avatar_url": "http://localhost:3000/uploads/user/avatar/1/cd8.jpeg",
     "can_create_group": true,
-    "can_create_project": true
+    "can_create_project": true,
+    "projects_limit": 100
   }
 ]
 ```
@@ -140,7 +141,8 @@ Parameters:
   "color_scheme_id": 2,
   "is_admin": false,
   "can_create_group": true,
-  "can_create_project": true
+  "can_create_project": true,
+  "projects_limit": 100
 }
 ```
 
@@ -240,7 +242,8 @@ GET /user
   "color_scheme_id": 2,
   "is_admin": false,
   "can_create_group": true,
-  "can_create_project": true
+  "can_create_project": true,
+  "projects_limit": 100
 }
 ```
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -16,7 +16,8 @@ module API
 
     class UserFull < User
       expose :email
-      expose :theme_id, :color_scheme_id, :extern_uid, :provider
+      expose :theme_id, :color_scheme_id, :extern_uid, :provider, \
+             :projects_limit
       expose :can_create_group?, as: :can_create_group
       expose :can_create_project?, as: :can_create_project
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -433,6 +433,7 @@ describe API::API, api: true  do
       json_response['is_admin'].should == user.is_admin?
       json_response['can_create_project'].should == user.can_create_project?
       json_response['can_create_group'].should == user.can_create_group?
+      json_response['projects_limit'].should == user.projects_limit
     end
 
     it "should return 401 error if user is unauthenticated" do


### PR DESCRIPTION
If the authenticated user of the API is an admin, they will be using the Entities::UserFull set of exposed params. This patch exposes User.projects_limit and updates the relevant documentation and tests.

As background justification for this proposed change, I had a use case to want to see how many projects a user is limited to for our site's GitLab installation. We do space auditing as a multiplier of the projects limit.
