### PR TITLE
Link to create blob from blob show [Awaiting developper feedback][Can be updated]

### DIFF
--- a/app/views/projects/blob/_blob.html.haml
+++ b/app/views/projects/blob/_blob.html.haml
@@ -14,6 +14,11 @@
           = link_to truncate(title, length: 40), project_tree_path(@project, path)
       - else
         = link_to title, '#'
+    &nbsp;
+    &nbsp;
+    = link_to 'test', title: 'New file', id: 'new-file-link' do
+      %small
+        %i.fa.fa-plus
 
 %ul.blob-commit-info.bs-callout.bs-callout-info.hidden-xs
   - blob_commit = @repository.last_commit_for_path(@commit.id, @blob.path)


### PR DESCRIPTION
After: add a `+` sign link to create a new blob. Clicking on it will create a new file in current directory.

![screenshot from 2014-11-02 19 15 43 after](https://cloud.githubusercontent.com/assets/1429315/4876245/72bc8118-62bc-11e4-82fb-a02cef6b641d.png)

Before:

![screenshot from 2014-11-02 19 15 36 before](https://cloud.githubusercontent.com/assets/1429315/4876246/77f1fbf4-62bc-11e4-9310-8b7dd2e89083.png)

This would make it analogous to many other show pages which also have a create new button, like tree show:

![screenshot from 2014-11-02 19 15 52 tree](https://cloud.githubusercontent.com/assets/1429315/4876251/8713dcd8-62bc-11e4-9531-c72ba06e3756.png)

and wiki pages:

![screenshot from 2014-11-02 19 16 14 wiki](https://cloud.githubusercontent.com/assets/1429315/4876252/8bd7b5aa-62bc-11e4-8039-fe0e4e8d9708.png)

If concept OK I'll implement.
