### PR TITLE
 Fix push not allowed to protected branch if  commit starts with 7 zeros.

### DIFF
--- a/lib/gitlab/git.rb
+++ b/lib/gitlab/git.rb
@@ -1,0 +1,5 @@
+module Gitlab
+  module Git
+    BLANK_SHA = '0' * 40
+  end
+end

--- a/lib/gitlab/git_access.rb
+++ b/lib/gitlab/git_access.rb
@@ -67,7 +67,7 @@ module Gitlab
                  if forced_push?(project, oldrev, newrev)
                    :force_push_code_to_protected_branches
                    # and we dont allow remove of protected branch
-                 elsif newrev =~ /0000000/
+                 elsif newrev == Gitlab::Git::BLANK_SHA
                    :remove_protected_branches
                  else
                    :push_code_to_protected_branches
@@ -85,7 +85,7 @@ module Gitlab
     def forced_push?(project, oldrev, newrev)
       return false if project.empty_repo?
 
-      if oldrev !~ /00000000/ && newrev !~ /00000000/
+      if oldrev != Gitlab::Git::BLANK_SHA && newrev != Gitlab::Git::BLANK_SHA
         missed_refs = IO.popen(%W(git --git-dir=#{project.repository.path_to_repo} rev-list #{oldrev} ^#{newrev})).read
         missed_refs.split("\n").size > 0
       else

--- a/spec/lib/gitlab/git_access_spec.rb
+++ b/spec/lib/gitlab/git_access_spec.rb
@@ -55,12 +55,13 @@ describe Gitlab::GitAccess do
 
     def changes
       {
-        push_new_branch: '000000000 570e7b2ab refs/heads/wow',
+        push_new_branch: "#{Gitlab::Git::BLANK_SHA} 570e7b2ab refs/heads/wow",
         push_master: '6f6d7e7ed 570e7b2ab refs/heads/master',
         push_protected_branch: '6f6d7e7ed 570e7b2ab refs/heads/feature',
-        push_remove_protected_branch: '570e7b2ab 000000000 refs/heads/feature',
+        push_remove_protected_branch: "570e7b2ab #{Gitlab::Git::BLANK_SHA} "\
+                                      'refs/heads/feature',
         push_tag: '6f6d7e7ed 570e7b2ab refs/tags/v1.0.0',
-        push_new_tag: '000000000 570e7b2ab refs/tags/v7.8.9',
+        push_new_tag: "#{Gitlab::Git::BLANK_SHA} 570e7b2ab refs/tags/v7.8.9",
         push_all: ['6f6d7e7ed 570e7b2ab refs/heads/master', '6f6d7e7ed 570e7b2ab refs/heads/feature']
       }
     end


### PR DESCRIPTION
Fix https://github.com/gitlabhq/gitlabhq/issues/8232

This fix works because the function is only called by the `internal` API, which gets refs from git pre-receive-hook from gitlab shell, which always sends full SHA-1s to the stdin.

There are many other such similar problems on the APP where short `0` strings are tested for: there is even a `'0' * 5`, which exists in the gitlab repo: only 40 zeroes should be used everywhere: this SHA1 has not been inversed so far and would break Git: http://stackoverflow.com/questions/1902340/can-a-sha-1-hash-be-all-zeroes
