### PR TITLE
Don't output to stdout from lib non-interactive methods [failure unrelated]

### DIFF
--- a/lib/gitlab/backend/shell.rb
+++ b/lib/gitlab/backend/shell.rb
@@ -16,7 +16,8 @@ module Gitlab
     #   add_repository("gitlab/gitlab-ci")
     #
     def add_repository(name)
-      system gitlab_shell_projects_path, 'add-project', "#{name}.git"
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path,
+                                   'add-project', "#{name}.git"])
     end
 
     # Import repository
@@ -27,7 +28,8 @@ module Gitlab
     #   import_repository("gitlab/gitlab-ci", "https://github.com/randx/six.git")
     #
     def import_repository(name, url)
-      system gitlab_shell_projects_path, 'import-project', "#{name}.git", url, '240'
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'import-project',
+                                   "#{name}.git", url, '240'])
     end
 
     # Move repository
@@ -39,7 +41,8 @@ module Gitlab
     #   mv_repository("gitlab/gitlab-ci", "randx/gitlab-ci-new.git")
     #
     def mv_repository(path, new_path)
-      system gitlab_shell_projects_path, 'mv-project', "#{path}.git", "#{new_path}.git"
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'mv-project',
+                                   "#{path}.git", "#{new_path}.git"])
     end
 
     # Update HEAD for repository
@@ -51,7 +54,8 @@ module Gitlab
     #  update_repository_head("gitlab/gitlab-ci", "3-1-stable")
     #
     def update_repository_head(path, branch)
-      system gitlab_shell_projects_path, 'update-head', "#{path}.git", branch
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'update-head',
+                                   "#{path}.git", branch])
     end
 
     # Fork repository to new namespace
@@ -63,7 +67,8 @@ module Gitlab
     #  fork_repository("gitlab/gitlab-ci", "randx")
     #
     def fork_repository(path, fork_namespace)
-      system gitlab_shell_projects_path, 'fork-project', "#{path}.git", fork_namespace
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'fork-project',
+                                   "#{path}.git", fork_namespace])
     end
 
     # Remove repository from file system
@@ -74,7 +79,8 @@ module Gitlab
     #   remove_repository("gitlab/gitlab-ci")
     #
     def remove_repository(name)
-      system gitlab_shell_projects_path, 'rm-project', "#{name}.git"
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path,
+                                   'rm-project', "#{name}.git"])
     end
 
     # Add repository branch from passed ref
@@ -87,7 +93,8 @@ module Gitlab
     #   add_branch("gitlab/gitlab-ci", "4-0-stable", "master")
     #
     def add_branch(path, branch_name, ref)
-      system gitlab_shell_projects_path, 'create-branch', "#{path}.git", branch_name, ref
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'create-branch',
+                                   "#{path}.git", branch_name, ref])
     end
 
     # Remove repository branch
@@ -99,7 +106,8 @@ module Gitlab
     #   rm_branch("gitlab/gitlab-ci", "4-0-stable")
     #
     def rm_branch(path, branch_name)
-      system gitlab_shell_projects_path, 'rm-branch', "#{path}.git", branch_name
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'rm-branch',
+                                   "#{path}.git", branch_name])
     end
 
     # Add repository tag from passed ref
@@ -117,7 +125,7 @@ module Gitlab
       cmd = %W(#{gitlab_shell_path}/bin/gitlab-projects create-tag #{path}.git
                #{tag_name} #{ref})
       cmd << message unless message.nil? || message.empty?
-      system *cmd
+      Gitlab::Utils.system_silent(cmd)
     end
 
     # Remove repository tag
@@ -129,7 +137,8 @@ module Gitlab
     #   rm_tag("gitlab/gitlab-ci", "v4.0")
     #
     def rm_tag(path, tag_name)
-      system gitlab_shell_projects_path, 'rm-tag', "#{path}.git", tag_name
+      Gitlab::Utils.system_silent([gitlab_shell_projects_path, 'rm-tag',
+                                   "#{path}.git", tag_name])
     end
 
     # Add new key to gitlab-shell
@@ -138,7 +147,8 @@ module Gitlab
     #   add_key("key-42", "sha-rsa ...")
     #
     def add_key(key_id, key_content)
-      system gitlab_shell_keys_path, 'add-key', key_id, key_content
+      Gitlab::Utils.system_silent([gitlab_shell_keys_path,
+                                   'add-key', key_id, key_content])
     end
 
     # Batch-add keys to authorized_keys
@@ -157,7 +167,8 @@ module Gitlab
     #   remove_key("key-342", "sha-rsa ...")
     #
     def remove_key(key_id, key_content)
-      system gitlab_shell_keys_path, 'rm-key', key_id, key_content
+      Gitlab::Utils.system_silent([gitlab_shell_keys_path,
+                                   'rm-key', key_id, key_content])
     end
 
     # Remove all ssh keys from gitlab shell
@@ -166,7 +177,7 @@ module Gitlab
     #   remove_all_keys
     #
     def remove_all_keys
-      system gitlab_shell_keys_path, 'clear'
+      Gitlab::Utils.system_silent([gitlab_shell_keys_path, 'clear'])
     end
 
     # Add empty directory for storing repositories

--- a/lib/gitlab/git_ref_validator.rb
+++ b/lib/gitlab/git_ref_validator.rb
@@ -5,7 +5,8 @@ module Gitlab
     #
     # Returns true for a valid reference name, false otherwise
     def validate(ref_name)
-      system *%W(git check-ref-format refs/#{ref_name})
+      Gitlab::Utils.system_silent(
+        %W(git check-ref-format refs/#{ref_name})) == 0
     end
   end
 end

--- a/lib/gitlab/utils.rb
+++ b/lib/gitlab/utils.rb
@@ -1,0 +1,14 @@
+module Gitlab
+  module Utils
+    extend self
+
+    # Run system command without outputting to stdout.
+    #
+    # @param  cmd [Array<String>]
+    # @return [Integer] exit status
+    def system_silent(cmd)
+      IO.popen(cmd).close
+      $?.exitstatus
+    end
+  end
+end


### PR DESCRIPTION
It pollutes the test output too much.

This only affects methods which are called primarily from GitLab's normal operation: lib commands that are triggered by command like actions like Rake tasks were not changed.

Just check for example https://semaphoreapp.com/gitlabhq/gitlabhq/branches/pull-request-8233/builds/1: there are parts of the RSpec where you see nothing but messages like:

```
Initialized empty Git repository in /home/runner/gitlabhq/tmp/tests/repositories/group336/gitlab.git/
```

If anyone misses the messages, please patch to log them instead. This can be done with `popen` as well.
