### PR TITLE
Remove untracked asset files

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -16,6 +16,7 @@ sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```bash
 sudo -u git -H git fetch --all
 sudo -u git -H git checkout -- db/schema.rb # local changes will be restored automatically
+sudo -u git -H git clean -f # if you have untracked files in app/assets. This will remove all untracked files!
 ```
 
 For GitLab Community Edition:


### PR DESCRIPTION
We had some leftovers in our app/assets directory that caused the asset:precompile task to fail. I just ran `git clean -f`.
