### PR TITLE
check email feature

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -205,7 +205,7 @@ class ProjectsController < ApplicationController
     params.require(:project).permit(
       :name, :path, :description, :issues_tracker, :tag_list,
       :issues_enabled, :merge_requests_enabled, :snippets_enabled, :issues_tracker_id, :default_branch,
-      :wiki_enabled, :visibility_level, :import_url, :last_activity_at, :namespace_id
+      :wiki_enabled, :visibility_level, :import_url, :last_activity_at, :namespace_id, :check_email
     )
   end
 end

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -80,6 +80,13 @@
                   = f.check_box :snippets_enabled
                   %span.descr Share code pastes with others out of git repository
 
+            .form-group
+              = f.label :check_email, "Check emails", class: 'control-label'
+              .col-sm-10
+                .checkbox
+                  = f.check_box :check_email
+                  %span.descr If enabled all commits emails should belongs to registered users
+
 
           .form-actions
             = f.submit 'Save changes', class: "btn btn-save"

--- a/db/migrate/20141104093219_add_check_email_flag_to_project.rb
+++ b/db/migrate/20141104093219_add_check_email_flag_to_project.rb
@@ -1,0 +1,5 @@
+class AddCheckEmailFlagToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :check_email, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007100818) do
+ActiveRecord::Schema.define(version: 20141104093219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 20141007100818) do
     t.string   "import_status"
     t.float    "repository_size",        default: 0.0
     t.integer  "star_count",             default: 0,        null: false
+    t.boolean  "check_email",            default: true,     null: false
   end
 
   add_index "projects", ["creator_id"], name: "index_projects_on_creator_id", using: :btree

--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -43,12 +43,13 @@ module API
 
         return false unless actor
 
-        access.allowed?(
+        result = access.allowed?(
           actor,
           params[:action],
           project,
           params[:changes]
         )
+        access.errors.present? ? access.errors.join("\n") : result
       end
 
       #

--- a/lib/gitlab/git_access.rb
+++ b/lib/gitlab/git_access.rb
@@ -67,7 +67,7 @@ module Gitlab
       if oldrev && newrev
         emails = IO.popen(%W(git --git-dir=#{project.repository.path_to_repo} log --format=%ae #{oldrev}...#{newrev})).read.split(/\s/).uniq
         if emails.present?
-            found_emails = User.where(email: emails).map{|u| u.emails}
+            found_emails = User.where(email: emails).map{|u| u.email}
             missing = emails - found_emails
             @errors << "User is not allowed to PUSH due to invalid e-mail address (#{missing.join(' ')}), please, use your registered e-mail address" if missing.present?
             return missing


### PR DESCRIPTION
When user is trying to do the "PUSH" operation, the Gitlab server perform the check of user's e-mail address within the existing Gitlab user database.
If user's e-mail does not exist, then Gitlab does not allow to "PUSH" and display the corresponding message "User is not allowed to PUSH due to invalid e-mail address, please, use your registered e-mail address".
To make error message displayed corresponding pull request to the repository gitlab-shell has been created
