### PR TITLE
Do not require immediate password reset if specifying a password

### DIFF
--- a/db/fixtures/production/001_admin.rb
+++ b/db/fixtures/production/001_admin.rb
@@ -1,8 +1,12 @@
-password = if ENV['GITLAB_ROOT_PASSWORD'].blank?
-             "5iveL!fe"
-           else
-             ENV['GITLAB_ROOT_PASSWORD']
-           end
+password = nil
+expire_time = nil
+if ENV['GITLAB_ROOT_PASSWORD'].blank?
+  password = '5iveL!fe'
+  expire_time = Time.now
+else
+  password = ENV['GITLAB_ROOT_PASSWORD']
+  expire_time = nil
+end
 
 admin = User.create(
   email: "admin@example.com",
@@ -10,7 +14,7 @@ admin = User.create(
   username: 'root',
   password: password,
   password_confirmation: password,
-  password_expires_at: Time.now,
+  password_expires_at: expire_time,
   theme_id: Gitlab::Theme::MARS
 
 )

--- a/db/fixtures/production/001_admin.rb
+++ b/db/fixtures/production/001_admin.rb
@@ -1,5 +1,3 @@
-password = nil
-expire_time = nil
 if ENV['GITLAB_ROOT_PASSWORD'].blank?
   password = '5iveL!fe'
   expire_time = Time.now


### PR DESCRIPTION
The database seeding routine allows for a password to be set for the root user, but will require that password to be immediately reset on first login.

This diff sets the password expiry time to nil if a password is provided at seed time.
