### PR TITLE
Only count the user's last vote

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ v 7.8.0
   - 
   - 
   - 
-  - 
+  - Only count a user's vote once on a merge request or issue (Michael Clarke)
   - 
   - 
   - 

--- a/app/assets/stylesheets/generic/typography.scss
+++ b/app/assets/stylesheets/generic/typography.scss
@@ -128,3 +128,7 @@ a:focus {
 textarea.js-gfm-input {
   font-family: $monospace_font;
 }
+
+.strikethrough {
+  text-decoration: line-through;
+}

--- a/app/models/concerns/issuable.rb
+++ b/app/models/concerns/issuable.rb
@@ -88,7 +88,7 @@ module Issuable
 
   # Return the number of -1 comments (downvotes)
   def downvotes
-    notes.select(&:downvote?).size
+    filter_superceded_votes(notes.select(&:downvote?), notes).size
   end
 
   def downvotes_in_percent
@@ -101,7 +101,7 @@ module Issuable
 
   # Return the number of +1 comments (upvotes)
   def upvotes
-    notes.select(&:upvote?).size
+    filter_superceded_votes(notes.select(&:upvote?), notes).size
   end
 
   def upvotes_in_percent
@@ -153,5 +153,17 @@ module Issuable
         color: Label::DEFAULT_COLOR).find_or_create_by(title: label_name.strip)
       self.labels << label
     end
+  end
+
+  private
+
+  def filter_superceded_votes(votes, notes)
+    filteredvotes = [] + votes
+    votes.each do |vote|
+      if vote.superceded?(notes)
+        filteredvotes.delete(vote)
+      end
+    end
+    filteredvotes
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -459,6 +459,23 @@ class Note < ActiveRecord::Base
                 )
   end
 
+  def superceded?(notes)
+    return false unless vote?
+    notes.each do |note|
+      next if note == self
+      if note.vote? &&
+          self[:author_id] == note[:author_id] &&
+          self[:created_at] <= note[:created_at]
+        return true
+      end
+    end
+    false
+  end
+
+  def vote?
+    upvote? || downvote?
+  end
+
   def votable?
     for_issue? || (for_merge_request? && !for_diff_line?)
   end

--- a/app/views/projects/notes/_note.html.haml
+++ b/app/views/projects/notes/_note.html.haml
@@ -28,14 +28,24 @@
         %span.note-last-update
           = note_timestamp(note)
 
-        - if note.upvote?
-          %span.vote.upvote.label.label-success
-            %i.fa.fa-thumbs-up
-            \+1
-        - if note.downvote?
-          %span.vote.downvote.label.label-danger
-            %i.fa.fa-thumbs-down
-            \-1
+        - if note.superceded?(@notes)
+          - if note.upvote?
+            %span.vote.upvote.label.label-gray.strikethrough
+              %i.fa.fa-thumbs-up
+              \+1
+          - if note.downvote?
+            %span.vote.downvote.label.label-gray.strikethrough
+              %i.fa.fa-thumbs-down
+              \-1
+        - else
+          - if note.upvote?
+            %span.vote.upvote.label.label-success
+              %i.fa.fa-thumbs-up
+              \+1
+          - if note.downvote?
+            %span.vote.downvote.label.label-danger
+              %i.fa.fa-thumbs-down
+              \-1
 
 
       .note-body


### PR DESCRIPTION
Where a user votes multiple times on an item, each of their votes is currently included in the total vote count. This allows users to artificially inflate (or decrease) the importance of an item by voting multiple times on it, and means a user casting a new vote to change their opinion from -1 to +1 just blanks out their previous vote, rather than reversing their input as expected.

This change limits the vote count to only include the last vote a user places, and 'greys out' the superceded  vote markers to make it clear which votes are excluded from the count.

Original:
![gitlab-vote-original](https://cloud.githubusercontent.com/assets/1250331/4926569/8a1add58-6534-11e4-8c02-1c7547749c1a.png)

Updated:
![gitlab-vote-changes](https://cloud.githubusercontent.com/assets/1250331/4926571/8ea21b98-6534-11e4-9c73-cc3709a31440.png)
