### PR TITLE
use git log --follow on history and blame

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v 7.6.0
   - Fork repository to groups
+  - Show complete file history even when file renamed
   - New rugged version
   -
   -

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -34,13 +34,14 @@ class Repository
     nil
   end
 
-  def commits(ref, path = nil, limit = nil, offset = nil, skip_merges = false)
+  def commits(ref, path = nil, limit = nil, offset = nil, skip_merges = false, follow = true)
     commits = Gitlab::Git::Commit.where(
       repo: raw_repository,
       ref: ref,
       path: path,
       limit: limit,
       offset: offset,
+      follow: follow,
     )
     commits = Commit.decorate(commits) if commits.present?
     commits


### PR DESCRIPTION
Show complete file history even when file has been renamed.

Replaces https://github.com/gitlabhq/gitlabhq/pull/8188
Related to https://github.com/gitlabhq/gitlabhq/pull/7417, https://github.com/gitlabhq/gitlabhq/pull/3502, https://github.com/gitlabhq/gitlabhq/issues/6966, https://github.com/gitlabhq/gitlabhq/issues/1954
Fixes https://github.com/gitlabhq/gitlabhq/issues/7832
Closes https://github.com/gitlabhq/gitlab_git/pull/35
