### PR TITLE
HipChat custom server support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,7 @@ gem "redis-rails"
 gem 'tinder', '~> 1.9.2'
 
 # HipChat integration
-gem "hipchat", "~> 0.14.0"
+gem "hipchat", "~> 1.4.0"
 
 # Flowdock integration
 gem "gitlab-flowdock-git-hook", "~> 0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,7 @@ GEM
       railties (>= 4.0.1)
     hashie (2.1.2)
     hike (1.2.3)
-    hipchat (0.14.0)
-      httparty
+    hipchat (1.4.0)
       httparty
     html-pipeline (1.11.0)
       activesupport (>= 2)
@@ -636,7 +635,7 @@ DEPENDENCIES
   guard-rspec
   guard-spinach
   haml-rails
-  hipchat (~> 0.14.0)
+  hipchat (~> 1.4.0)
   html-pipeline-gitlab (~> 0.1.0)
   httparty
   jasmine (= 2.0.2)

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -42,7 +42,7 @@ class Projects::ServicesController < Projects::ApplicationController
       :title, :token, :type, :active, :api_key, :subdomain,
       :room, :recipients, :project_url, :webhook,
       :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
-      :build_key
+      :build_key, :server
     )
   end
 end

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -15,7 +15,7 @@
 class HipchatService < Service
   MAX_COMMITS = 3
 
-  prop_accessor :token, :room
+  prop_accessor :token, :room, :server
   validates :token, presence: true, if: :activated?
 
   def title
@@ -33,7 +33,9 @@ class HipchatService < Service
   def fields
     [
       { type: 'text', name: 'token',     placeholder: '' },
-      { type: 'text', name: 'room',      placeholder: '' }
+      { type: 'text', name: 'room',      placeholder: '' },
+      { type: 'text', name: 'server',
+        placeholder: 'Leave blank for default. https://chat.hipchat.com' }
     ]
   end
 
@@ -45,6 +47,7 @@ class HipchatService < Service
 
   def gate
     options = { api_version: 'v2' }
+    options[:server_url] = server unless server.nil?
     @gate ||= HipChat::Client.new(token, options)
   end
 

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -19,7 +19,7 @@ class HipchatService < Service
   validates :token, presence: true, if: :activated?
 
   def title
-    'Hipchat'
+    'HipChat'
   end
 
   def description
@@ -44,7 +44,8 @@ class HipchatService < Service
   private
 
   def gate
-    @gate ||= HipChat::Client.new(token)
+    options = { api_version: 'v2' }
+    @gate ||= HipChat::Client.new(token, options)
   end
 
   def create_message(push)

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -19,6 +19,12 @@ Feature: Project Services
     And I fill hipchat settings
     Then I should see hipchat service settings saved
 
+  Scenario: Activate hipchat service with custom server
+    When I visit project "Shop" services page
+    And I click hipchat service link
+    And I fill hipchat settings with custom server
+    Then I should see hipchat service settings with custom server saved
+
   Scenario: Activate pivotaltracker service
     When I visit project "Shop" services page
     And I click pivotaltracker service link

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -47,6 +47,17 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
     find_field('Room').value.should == 'gitlab'
   end
 
+  step 'I fill hipchat settings with custom server' do
+    check 'Active'
+    fill_in 'Room', with: 'gitlab_custom'
+    fill_in 'Token', with: 'secretCustom'
+    fill_in 'Server', with: 'https://chat.example.com'
+    click_button 'Save'
+  end
+
+  step 'I should see hipchat service settings with custom server saved' do
+    find_field('Server').value.should == 'https://chat.example.com'
+  end
 
   step 'I click pivotaltracker service link' do
     click_link 'PivotalTracker'

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -10,7 +10,7 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
   step 'I should see list of available services' do
     page.should have_content 'Project services'
     page.should have_content 'Campfire'
-    page.should have_content 'Hipchat'
+    page.should have_content 'HipChat'
     page.should have_content 'GitLab CI'
     page.should have_content 'Assembla'
     page.should have_content 'Pushover'
@@ -33,7 +33,7 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
   end
 
   step 'I click hipchat service link' do
-    click_link 'Hipchat'
+    click_link 'HipChat'
   end
 
   step 'I fill hipchat settings' do


### PR DESCRIPTION
HipChat allows users to host their own custom instance. This I believe adds support for that based on the HipChat Ruby bindings API.

Caveat: I don't know Ruby at all. Did this with a few minutes of Googling and looking at hipchat-rb docs. Not sure if it even works. I don't have an environment to test GitLab.
