### PR TITLE
Merge requests from forked projects to original project even #8287

### DIFF
--- a/app/services/merge_requests/build_service.rb
+++ b/app/services/merge_requests/build_service.rb
@@ -9,7 +9,12 @@ module MergeRequests
       merge_request.compare_commits = []
       merge_request.compare_diffs = []
       merge_request.source_project = project unless merge_request.source_project
-      merge_request.target_project ||= (project.forked_from_project || project)
+      merge_request.target_project ||=
+          if !project.forked_from_project.nil? && project.forked_from_project.merge_requests_enabled
+            project.forked_from_project
+          else
+            project
+          end
       merge_request.target_branch ||= merge_request.target_project.default_branch
 
       unless merge_request.target_branch && merge_request.source_branch

--- a/app/views/projects/merge_requests/_new_compare.html.haml
+++ b/app/views/projects/merge_requests/_new_compare.html.haml
@@ -20,7 +20,7 @@
         .panel-heading
           %strong Target branch
         .panel-body
-          - projects =  @project.forked_from_project.nil? ? [@project] : [@project, @project.forked_from_project]
+          - projects =  (@project.forked_from_project.nil? or not @project.forked_from_project.merge_requests_enabled) ? [@project] : [@project, @project.forked_from_project]
           = f.select(:target_project_id, options_from_collection_for_select(projects, 'id', 'path_with_namespace', f.object.target_project_id), {}, { class: 'target_project select2 span3', disabled: @merge_request.persisted? })
           &nbsp;
           = f.select(:target_branch, @merge_request.target_branches, { include_blank: "Select branch" }, {class: 'target_branch select2 span2'})


### PR DESCRIPTION
solution for task #8287
Now user can create merge request from forked project to original project only if in original project merge requests is enabled
