### PR TITLE
fixes the `block_removed_ldap_users` rake task

### DIFF
--- a/lib/tasks/gitlab/cleanup.rake
+++ b/lib/tasks/gitlab/cleanup.rake
@@ -92,11 +92,11 @@ namespace :gitlab do
 
       User.ldap.each do |ldap_user|
         print "#{ldap_user.name} (#{ldap_user.extern_uid}) ..."
-        if Gitlab::LDAP::Access.open { |access| access.allowed?(ldap_user) }
+        if Gitlab::LDAP::Access.allowed?(ldap_user)
           puts " [OK]".green
         else
           if block_flag
-            ldap_user.block!
+            ldap_user.block! unless ldap_user.blocked?
             puts " [BLOCKED]".red
           else
             puts " [NOT IN LDAP]".yellow


### PR DESCRIPTION
In e23a26a (and later 1bc9936) the API for Gitlab::LDAP::Adapter was
changed. I assume this rake task was an oversight in the refactoring of
the changed class.

While being on it, I noticed that already blocked users cannot be
blocked again.
