### PR TITLE
services: add private hipchat server support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,7 @@ gem "redis-rails"
 gem 'tinder', '~> 1.9.2'
 
 # HipChat integration
-gem "hipchat", "~> 0.14.0"
+gem "hipchat", "~> 1.3.0"
 
 # Flowdock integration
 gem "gitlab-flowdock-git-hook", "~> 0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,7 @@ GEM
       railties (>= 4.0.1)
     hashie (2.1.2)
     hike (1.2.3)
-    hipchat (0.14.0)
-      httparty
+    hipchat (1.3.0)
       httparty
     html-pipeline (1.11.0)
       activesupport (>= 2)
@@ -636,7 +635,7 @@ DEPENDENCIES
   guard-rspec
   guard-spinach
   haml-rails
-  hipchat (~> 0.14.0)
+  hipchat (~> 1.3.0)
   html-pipeline-gitlab (~> 0.1.0)
   httparty
   jasmine (= 2.0.2)

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -42,7 +42,7 @@ class Projects::ServicesController < Projects::ApplicationController
       :title, :token, :type, :active, :api_key, :subdomain,
       :room, :recipients, :project_url, :webhook,
       :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
-      :build_key
+      :build_key, :server
     )
   end
 end

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -15,8 +15,10 @@
 class HipchatService < Service
   MAX_COMMITS = 3
 
-  prop_accessor :token, :room
+  prop_accessor :token, :room, :server
+
   validates :token, presence: true, if: :activated?
+  validates :room, presence: true, if: :activated?
 
   def title
     'Hipchat'
@@ -32,8 +34,9 @@ class HipchatService < Service
 
   def fields
     [
-      { type: 'text', name: 'token',     placeholder: '' },
-      { type: 'text', name: 'room',      placeholder: '' }
+      { type: 'text', name: 'token',  placeholder: '' },
+      { type: 'text', name: 'room',   placeholder: '' },
+      { type: 'text', name: 'server', placeholder: 'Leave blank to use https://hipchat.com' }
     ]
   end
 
@@ -44,7 +47,9 @@ class HipchatService < Service
   private
 
   def gate
-    @gate ||= HipChat::Client.new(token)
+    options = { api_version: 'v2' }
+    options[:server_url] = server unless server.nil?
+    @gate ||= HipChat::Client.new(token, options)
   end
 
   def create_message(push)

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -38,9 +38,14 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
 
   step 'I fill hipchat settings' do
     check 'Active'
+    fill_in 'Server', with: 'http://hipchat.my.org'
     fill_in 'Room', with: 'gitlab'
     fill_in 'Token', with: 'verySecret'
     click_button 'Save'
+  end
+
+  step 'I should see hipchat setting settings saved' do
+    find_field('Server').value.should == 'http://hipchat.my.org'
   end
 
   step 'I should see hipchat service settings saved' do


### PR DESCRIPTION
- bump hipchat gem to:
  - support private server url
  - add $no_proxy support
- add server url to services table
- add server url to hipchat service object
- add server url to spinach tests
