### PR TITLE
Improve Monokai highlight style to match original

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 7.5.0
   - Return valid json for deleting branch via API (sponsored by O'Reilly Media)
   - Expose username in project events API (sponsored by O'Reilly Media)
   - Adds comments to commits in the API
+  - Monokai highlighting style now more accurate to original (Mark Riedesel)
 
 v 7.4.3
   - Fix raw snippets view

--- a/app/assets/stylesheets/highlight/monokai.scss
+++ b/app/assets/stylesheets/highlight/monokai.scss
@@ -29,27 +29,29 @@
 
   .hljs-tag,
   .hljs-tag .hljs-title,
-  .hljs-keyword,
-  .hljs-literal,
   .hljs-strong,
   .hljs-change,
   .hljs-winutils,
   .hljs-flow,
   .lisp .hljs-title,
   .clojure .hljs-built_in,
+  .hljs-keyword,
   .nginx .hljs-title,
   .tex .hljs-special {
     color: #F92672;
   }
 
   .hljs {
-    color: #DDD;
+    color: #F8F8F2;
   }
 
-  .hljs .hljs-constant,
-  .asciidoc .hljs-code {
+  .asciidoc .hljs-code,
+  .markdown .hljs-code,
+  .hljs-literal,
+  .hljs-function .hljs-keyword {
     color: #66D9EF;
   }
+
 
   .hljs-code,
   .hljs-class .hljs-title,
@@ -62,18 +64,27 @@
   .hljs-symbol,
   .hljs-symbol .hljs-string,
   .hljs-value,
+  .hljs-constant,
+  .hljs-number,
   .hljs-regexp {
-    color: #BF79DB;
+    color: #AE81FF;
+  }
+
+  .hljs-string {
+    color: #E6DB74;
+  }
+
+  .hljs-params {
+    color: #fd971f;
   }
 
   .hljs-link_url,
   .hljs-tag .hljs-value,
-  .hljs-string,
   .hljs-bullet,
   .hljs-subst,
   .hljs-title,
   .hljs-emphasis,
-  .haskell .hljs-type,
+  .hljs-type,
   .hljs-preprocessor,
   .hljs-pragma,
   .ruby .hljs-class .hljs-parent,
@@ -99,12 +110,12 @@
   }
 
   .hljs-comment,
-  .java .hljs-annotation,
+  .hljs-annotation,
   .smartquote,
   .hljs-blockquote,
   .hljs-horizontal_rule,
-  .python .hljs-decorator,
   .hljs-template_comment,
+  .hljs-decorator,
   .hljs-pi,
   .hljs-doctype,
   .hljs-deletion,


### PR DESCRIPTION
The current monokai style in highlightjs is not very true to the
original and lacks colors for certain syntactic items as mentioned in ticket #6855. This change's
goal is to bring the highlightjs monokai style in line with the original
design from http://www.monokai.nl/blog/2006/07/15/textmate-color-theme/

Here's the current monokai highlighting style
![monokai-old](https://cloud.githubusercontent.com/assets/9374/5034946/b8b87486-6b38-11e4-9dea-73034fd92e29.png)

After this change:
![monokai](https://cloud.githubusercontent.com/assets/9374/5034949/bf9cbf78-6b38-11e4-8b6b-65d48fdc0517.png)

Thanks!
