### PR TITLE
Add Commits tab title like Branches, Tags, Compare [UI]

### DIFF
--- a/app/views/projects/commits/show.html.haml
+++ b/app/views/projects/commits/show.html.haml
@@ -1,5 +1,8 @@
 = render "head"
 
+%h3.page-title
+  Commits
+
 .tree-ref-holder
   = render 'shared/ref_switcher', destination: 'commits'
 
@@ -11,8 +14,6 @@
 
 %ul.breadcrumb.repo-breadcrumb
   = commits_breadcrumbs
-  %li.active
-    commits
 
 %div{id: dom_id(@project)}
   #commits-list= render "commits"


### PR DESCRIPTION
to make them more uniform.

After: removed `compare` from breadcrubs, added Compare h3 header:

![screenshot from 2014-11-14 09 58 48 after](https://cloud.githubusercontent.com/assets/1429315/5043395/19a4a2ae-6be5-11e4-9b85-154f43d210cb.png)

Before:

![screenshot from 2014-11-14 09 58 57 before](https://cloud.githubusercontent.com/assets/1429315/5043398/20f24d54-6be5-11e4-908c-9377218b8580.png)

The goal is to make it more uniform with the other tabs like Branches:

![screenshot from 2014-11-14 09 59 08 uniform](https://cloud.githubusercontent.com/assets/1429315/5043419/53e2f01a-6be5-11e4-8f87-fedf78860c3c.png)
