### PR TITLE
fix backup rake task

### DIFF
--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -14,7 +14,7 @@ You can only restore a backup to exactly the same version of GitLab that you cre
 sudo gitlab-rake gitlab:backup:create
 
 # if you've installed GitLab from source or using the cookbook
-bundle exec rake gitlab:backup:create RAILS_ENV=production
+sudo -u git -H bundle exec rake gitlab:backup:create RAILS_ENV=production
 ```
 
 Example output:


### PR DESCRIPTION
Documentation did not properly tell you to run as `git`.
