### PR TITLE
changelog: IPv6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ v 7.5.0
   - Performance improvements
   - Fix post-receive issue for projects with deleted forks
   - New gitlab-shell version with custom hooks support
+  - Nginx config changes to support IPv6 connections
   - Improve code 
   - GitLab CI 5.2+ support (does not support older versions)
   - Fixed bug when you can not push commits starting with 000000 to protected branches


### PR DESCRIPTION
Changelog entry for https://github.com/gitlabhq/gitlabhq/commit/e3098b69e7a4bc8b08bd85093204305991d8370d

Replaces https://github.com/gitlabhq/gitlabhq/pull/8278.
