### PR TITLE
remove extra cd command

### DIFF
--- a/doc/update/7.3-to-7.4.md
+++ b/doc/update/7.3-to-7.4.md
@@ -35,8 +35,6 @@ sudo -u git -H git checkout 7-4-stable-ee
 ### 3. Install libs, migrations, etc.
 
 ```bash
-cd /home/git/gitlab
-
 # MySQL installations (note: the line below states '--without ... postgres')
 sudo -u git -H bundle install --without development test postgres --deployment
 


### PR DESCRIPTION
No need for extra `cd` in upgrade guide.
