### PR TITLE
add HTTPS warning about time you'll need cert for

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -396,6 +396,13 @@ Visit YOUR_SERVER in your web browser for your first GitLab login. The setup has
 
 ### Using HTTPS
 
+### Warning
+
+The GitLab application will tell browsers and clients to only communicate with your 
+GitLab instance over a secure connection for the next 24 months. By enabling 
+HTTPS you'll need to provide a secure connection to your instance for at least 
+the next 24 months.
+
 To use GitLab with HTTPS:
 
 1. In `gitlab.yml`:


### PR DESCRIPTION
Add warning that user will need to maintain HTTPS cert. As can be seen at https://github.com/gitlabhq/gitlabhq/blob/master/app/controllers/application_controller.rb#L163-L167 `Strict-Transport-Security` is set to require a cert for the next 24 months of seeing the header from the GitLab application.
