### PR TITLE
Remove commit indicator from path on Commits tab [UI]

### DIFF
--- a/app/views/projects/commits/show.html.haml
+++ b/app/views/projects/commits/show.html.haml
@@ -11,8 +11,6 @@
 
 %ul.breadcrumb.repo-breadcrumb
   = commits_breadcrumbs
-  %li.active
-    commits
 
 %div{id: dom_id(@project)}
   #commits-list= render "commits"


### PR DESCRIPTION
After: removed the "commit" after the breadcrumb path:

![screenshot from 2014-11-16 17 20 51 after](https://cloud.githubusercontent.com/assets/1429315/5062151/f202eb58-6db4-11e4-988f-398390d3a245.png)

Before:

![](https://cloud.githubusercontent.com/assets/1429315/5043398/20f24d54-6be5-11e4-908c-9377218b8580.png)

I think that "commits" looks weird just a after the breadcrumb as it looks like part of the path, and we are already on the Commits tab, so it is redundant.
