### PR TITLE
Move issue title to the top of the page [Awaiting developper feedback]

### DIFF
--- a/app/assets/stylesheets/generic/issue_box.scss
+++ b/app/assets/stylesheets/generic/issue_box.scss
@@ -93,7 +93,7 @@
   }
 
   .description {
-    padding: 0 15px 10px 15px;
+    padding: 10px 15px;
 
     code {
       white-space: pre-wrap;

--- a/app/assets/stylesheets/sections/issues.scss
+++ b/app/assets/stylesheets/sections/issues.scss
@@ -152,3 +152,11 @@ form.edit-issue {
     }
   }
 }
+
+body[data-page="projects:issues:show"] {
+  .page-title {
+    .id {
+      @extend .text-muted;
+    }
+  }
+}

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -1,5 +1,8 @@
 %h3.page-title
-  Issue ##{@issue.iid}
+  %span.title
+    = gfm escape_once(@issue.title)
+  %span.id
+    \##{@issue.iid}
 
   %span.pull-right.issue-btn-group
     - if can?(current_user, :write_issue, @project)
@@ -40,9 +43,6 @@
 
     .creator
       Created by #{link_to_member(@project, @issue.author)} #{issue_timestamp(@issue)}
-
-  %h4.title
-    = gfm escape_once(@issue.title)
 
   - if @issue.description.present?
     .description


### PR DESCRIPTION
Every time I look at a GitLab issue I feel my eyes wondering for 2 seconds to find the title.

Titles should be one of the first things we see on pages.

After: remove "Issue" since already on the tab, put the title there, de-emphasize the id with a gray color:

![screenshot from 2014-11-16 18 51 02 after](https://cloud.githubusercontent.com/assets/1429315/5062429/263d7a8e-6dc2-11e4-82d6-90581e2f5763.png)

Before:

![screenshot from 2014-11-16 18 53 24 before](https://cloud.githubusercontent.com/assets/1429315/5062431/2be126fc-6dc2-11e4-88a5-5fdf2662203c.png)

It gets even worse if there are headers in the description, since even an `h2` is larger than the title:

![screenshot from 2014-11-16 18 54 08 before with header](https://cloud.githubusercontent.com/assets/1429315/5062438/3b64554a-6dc2-11e4-9275-d69bb1b8a49c.png)

This is also closer to how GitHub looks.

If you like this, it should also be done for merge requests and milestones simultaneously.
