### PR TITLE
Don't render old data project / group names tags [can be updated]

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,11 +147,6 @@ module ApplicationHelper
     image_tag(image_path("authbuttons/#{file_name}"), alt: "Sign in with #{provider.to_s.titleize}")
   end
 
-  def simple_sanitize(str)
-    sanitize(str, tags: %w(a span))
-  end
-
-
   def body_data_page
     path = controller.controller_path.split('/')
     namespace = path.first if path.second

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -42,12 +42,14 @@ module ProjectsHelper
   def project_title(project)
     if project.group
       content_tag :span do
-        link_to(simple_sanitize(project.group.name), group_path(project.group)) + ' / ' + link_to(simple_sanitize(project.name), project_path(project))
+        link_to(project.group.name, group_path(project.group)) + ' / ' +
+          link_to(project.name, project_path(project))
       end
     else
       owner = project.namespace.owner
       content_tag :span do
-        link_to(simple_sanitize(owner.name), user_path(owner)) + ' / ' + link_to(simple_sanitize(project.name), project_path(project))
+        link_to(owner.name, user_path(owner)) + ' / ' +
+          link_to(project.name, project_path(project))
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -177,24 +177,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "simple_sanitize" do
-    let(:a_tag) { '<a href="#">Foo</a>' }
-
-    it "allows the a tag" do
-      simple_sanitize(a_tag).should == a_tag
-    end
-
-    it "allows the span tag" do
-      input = '<span class="foo">Bar</span>'
-      simple_sanitize(input).should == input
-    end
-
-    it "disallows other tags" do
-      input = "<strike><b>#{a_tag}</b></strike>"
-      simple_sanitize(input).should == a_tag
-    end
-  end
-
   describe "link_to" do
 
     it "should not include rel=nofollow for internal links" do

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
 
 describe SearchHelper do
-  # Override simple_sanitize for our testing purposes
-  def simple_sanitize(str)
-    str
-  end
-
   describe 'search_autocomplete_source' do
     context "with no current user" do
       before do


### PR DESCRIPTION
which could be added to the database before the current column
validation was in place.

Before this PR, sanitize would allow good tags to be rendered
and remove bad tags like script.

After this, any tags will be HTML escaped instead of sanitized,
so both bad and good tags will appear escaped.

Rationale: people who entered data earlier should not be able to
do things that newer users can't. When we forbid something from being done,
we should warn users who did it to prepare to migrate.

This continues the discussions at: https://github.com/gitlabhq/gitlabhq/pull/8107#issuecomment-61004035
