### PR TITLE
Link to blob edit from tree view with row on hover visible links [Awaiting developper feedback]

### DIFF
--- a/app/assets/stylesheets/sections/tree.scss
+++ b/app/assets/stylesheets/sections/tree.scss
@@ -1,4 +1,8 @@
 .tree-holder {
+
+  $line_height: 20px;
+  $padding_vertical: 8px;
+
   .tree-content-holder {
     float: left;
     width: 100%;
@@ -18,8 +22,8 @@
 
     tr {
       td, th {
-        padding: 8px 10px;
-        line-height: 20px;
+        padding: $padding_vertical 10px;
+        line-height: $line_height;
       }
       th {
         font-weight: normal;
@@ -37,12 +41,31 @@
           border-bottom: 1px solid #ADF;
         }
         cursor: pointer;
+        &.tree-item td.actions a {
+          visibility: visible;
+        }
       }
       &.selected {
         td {
           background: #f5f5f5;
           border-top: 1px solid #EEE;
           border-bottom: 1px solid #EEE;
+        }
+      }
+      &.tree-item {
+        td.actions {
+          $large_icon_font_size: 1.5em;
+          line-height: $line_height + 2 * $padding_vertical;
+          padding: 0;
+          text-align: center;
+          min-width: $large_icon_font_size;
+          a {
+            display: block;
+            visibility: hidden;
+            &:hover {
+              font-size: $large_icon_font_size;
+            }
+          }
         }
       }
     }

--- a/app/views/projects/tree/_blob_item.html.haml
+++ b/app/views/projects/tree/_blob_item.html.haml
@@ -6,3 +6,7 @@
   %td.tree_time_ago.cgray
     = render 'spinner'
   %td.hidden-xs.tree_commit
+  %td.hidden-xs.actions
+    - if allowed_tree_edit?
+      = link_to project_edit_tree_path(@project, tree_join(@id, blob_item.name)) do
+        %i.fa.fa-pencil

--- a/app/views/projects/tree/_submodule_item.html.haml
+++ b/app/views/projects/tree/_submodule_item.html.haml
@@ -12,3 +12,4 @@
         = link_to "#{truncate_sha(submodule_item.id)}", commit
   %td
   %td.hidden-xs
+  %td.hidden-xs.actions

--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -31,6 +31,7 @@
               &ndash;
               = truncate(@commit.title, length: 50)
           = link_to 'History', project_commits_path(@project, @id), class: 'pull-right'
+        %th.hidden-xs
 
     - if @path.present?
       %tr.tree-item

--- a/app/views/projects/tree/_tree_item.html.haml
+++ b/app/views/projects/tree/_tree_item.html.haml
@@ -6,3 +6,4 @@
   %td.tree_time_ago.cgray
     = render 'spinner'
   %td.hidden-xs.tree_commit
+  %td.hidden-xs.actions


### PR DESCRIPTION
So as to not clutter the UI, the link only appears when you hover the row for the given file:

![screenshot from 2014-11-17 17 19 25 row hover](https://cloud.githubusercontent.com/assets/1429315/5072916/5c6b7a9a-6e7e-11e4-8691-a187bf9b5fb9.png)

When you hover the edit icon, it becomes larger:

![screenshot from 2014-11-17 17 19 37 icon hover](https://cloud.githubusercontent.com/assets/1429315/5072920/652e03b4-6e7e-11e4-8eeb-d56bc8f5604a.png)

The links take up little space, and disappear completely on `xs` screens.

The only part missing is to determine if the blob is text or not to determine if the button should or not be shown: this should be done on the same AJAX request that gets the commit data so as to not halt page loading.
