### PR TITLE
Remove unneeded || @commit.id [can be updated]

### DIFF
--- a/app/views/projects/tree/_blob_item.html.haml
+++ b/app/views/projects/tree/_blob_item.html.haml
@@ -2,7 +2,7 @@
   %td.tree-item-file-name
     = tree_icon(type)
     %span.str-truncated
-      = link_to blob_item.name, project_blob_path(@project, tree_join(@id || @commit.id, blob_item.name))
+      = link_to blob_item.name, project_blob_path(@project, tree_join(@id, blob_item.name))
   %td.tree_time_ago.cgray
     = render 'spinner'
   %td.hidden-xs.tree_commit

--- a/app/views/projects/tree/_tree_item.html.haml
+++ b/app/views/projects/tree/_tree_item.html.haml
@@ -2,7 +2,7 @@
   %td.tree-item-file-name
     = tree_icon(type)
     %span.str-truncated
-      = link_to tree_item.name, project_tree_path(@project, tree_join(@id || @commit.id, tree_item.name))
+      = link_to tree_item.name, project_tree_path(@project, tree_join(@id, tree_item.name))
   %td.tree_time_ago.cgray
     = render 'spinner'
   %td.hidden-xs.tree_commit


### PR DESCRIPTION
I think this is not necessary because the commit is always taken from the id: https://github.com/gitlabhq/gitlabhq/blob/e37461979a5eb890975125134e7717c470c76a5f/lib/extracts_path.rb#L105

unless `@options[:extended_sha1]` is present, which only happens for the network, and never for trees.
