### PR TITLE
Make web hooks retry on non-200 status code.

### DIFF
--- a/app/models/hooks/web_hook.rb
+++ b/app/models/hooks/web_hook.rb
@@ -32,18 +32,25 @@ class WebHook < ActiveRecord::Base
   def execute(data)
     parsed_url = URI.parse(url)
     if parsed_url.userinfo.blank?
-      WebHook.post(url, body: data.to_json, headers: { "Content-Type" => "application/json" }, verify: false)
+      response = WebHook.post(url,
+                   body: data.to_json,
+                   headers: { 'Content-Type' => 'application/json' },
+                   verify: false)
     else
       post_url = url.gsub("#{parsed_url.userinfo}@", "")
       auth = {
         username: URI.decode(parsed_url.user),
         password: URI.decode(parsed_url.password),
       }
-      WebHook.post(post_url,
+      response = WebHook.post(post_url,
                    body: data.to_json,
-                   headers: {"Content-Type" => "application/json"},
+                   headers: {'Content-Type' => 'application/json'},
                    verify: false,
                    basic_auth: auth)
+    end
+
+    unless response.code.to_s =~ /^2\d\d$/
+      raise Exception.new("Server returned status code #{response.code}#{response.message}.")
     end
   end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -70,5 +70,13 @@ describe ProjectHook do
         @project_hook.execute(@data)
       }.should raise_error
     end
+
+    it 'raises exception on non-2xx server response' do
+      WebMock.stub_request(:post, @project_hook.url).to_return(:status => 404, :body => nil, :headers => {})
+
+      lambda {
+        @project_hook.execute(@data)
+      }.should raise_error
+    end
   end
 end


### PR DESCRIPTION
Web hooks are currently handled in a fire-and-forget manner. If the remote server returns a non-2XX status code, the hook is never retried.

With this change, an exception is raised on non-2XX status code and this the hook is scheduled for retry.
