### PR TITLE
Make web hooks retry on non-200 status codes from remote server.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@ v 7.8.0
   - 
   - 
   - Added support for firing system hooks on group create/destroy and adding/removing users to group (Boyan Tabakov)
+  - Make web hooks raise exception on non-200 status codes so that sidekiq retries failed requests (Boyan Tabakov)
 
 v 7.7.2
   - Update GitLab Shell to version 2.4.2 that fixes a bug when developers can push to protected branch

--- a/app/models/hooks/web_hook.rb
+++ b/app/models/hooks/web_hook.rb
@@ -32,22 +32,34 @@ class WebHook < ActiveRecord::Base
   def execute(data)
     parsed_url = URI.parse(url)
     if parsed_url.userinfo.blank?
-      WebHook.post(url,
-                   body: data.to_json,
-                   headers: { "Content-Type" => "application/json" },
-                   verify: false)
+      res = WebHook.post(
+        url,
+        body: data.to_json,
+        headers: { 'Content-Type' => 'application/json' },
+        verify: false
+      )
     else
       post_url = url.gsub("#{parsed_url.userinfo}@", "")
       auth = {
         username: URI.decode(parsed_url.user),
         password: URI.decode(parsed_url.password),
       }
-      WebHook.post(post_url,
-                   body: data.to_json,
-                   headers: {"Content-Type" => "application/json"},
-                   verify: false,
-                   basic_auth: auth)
+      res = WebHook.post(
+        post_url,
+        body: data.to_json,
+        headers: { 'Content-Type' => 'application/json' },
+        verify: false,
+        basic_auth: auth
+      )
     end
+
+    unless res.code.to_s =~ /^2\d\d$/
+      raise Exception.new(
+        "Server returned status code #{res.code}#{res.message}."
+      )
+    end
+
+    res
   rescue SocketError, Errno::ECONNREFUSED, Net::OpenTimeout => e
     logger.error("WebHook Error => #{e}")
     false

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -70,5 +70,12 @@ describe ProjectHook do
         @project_hook.execute(@data)
       }.should raise_error
     end
+
+    it 'raises exception on non-2xx server response' do
+      WebMock.stub_request(:post, @project_hook.url).
+        to_return(status: 404, body: nil, headers: {})
+
+      lambda { @project_hook.execute(@data) }.should raise_error
+    end
   end
 end


### PR DESCRIPTION
Web hooks are previously handled in a fire-and-forget manner. If the remote server returns a non-2XX status code, the hook is never retried.

With this change, an exception is raised on non-2XX status code and this the hook is scheduled for retry.

Fixes #5768.
