### PR TITLE
Remove useless `assets.compress` option, Rails 4 uses only `assets.js_co...

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,8 +11,9 @@ Gitlab::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_assets = false
 
-  # Compress JavaScripts and CSS
-  config.assets.compress = true
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = true
@@ -74,7 +75,6 @@ Gitlab::Application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   config.eager_load = true
-  config.assets.js_compressor = :uglifier
 
   config.allow_concurrency = false
 end


### PR DESCRIPTION
...mpressor`

> The config.assets.compress option should be changed to config.assets.js_compressor like so for instance
