### PR TITLE
add details on backing up your SSH host keys

### DIFF
--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -137,7 +137,7 @@ with the name of your bucket:
 Please be informed that a backup does not store your configuration files.
 If you use an Omnibus package please see the [instructions in the readme to backup your configuration](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#backup-and-restore-omnibus-gitlab-configuration).
 If you have a cookbook installation there should be a copy of your configuration in Chef.
-If you have a manual installation please consider backing up your gitlab.yml file and any SSL keys and certificates.
+If you have a manual installation please consider backing up your `gitlab.yml` file, any SSL keys and certificates, and your [SSH host keys](https://superuser.com/questions/532040/copy-ssh-keys-from-one-server-to-another-server/532079#532079).
 
 ## Restore a previously created backup
 


### PR DESCRIPTION
Users need to backup SSH keys if they want to do a complete restore to the same domain and not have users get the `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` message.
