### PR TITLE
Add owner name to mailing subject

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ v 7.8.0
   - 
   - 
   - Fix commits pagination
-  - 
+  - Add project owner name to mailing subject
   - 
   - 
   - 

--- a/app/mailers/notify.rb
+++ b/app/mailers/notify.rb
@@ -81,7 +81,8 @@ class Notify < ActionMailer::Base
   #   >> subject('Lorem ipsum')
   #   => "Lorem ipsum"
   #
-  #   # Automatically inserts Project name when @project is set
+  #   # Automatically inserts Project name and Project owner name when
+  #   # @project is set
   #   >> @project = Project.last
   #   => #<Project id: 1, name: "Ruby on Rails", path: "ruby_on_rails", ...>
   #   >> subject('Lorem ipsum')
@@ -92,7 +93,7 @@ class Notify < ActionMailer::Base
   #   => "Lorem ipsum | Dolor sit amet"
   def subject(*extra)
     subject = ""
-    subject << "#{@project.name} | " if @project
+    subject << "[#{@project.owner.name}] #{@project.name} | " if @project
     subject << extra.join(' | ') if extra.present?
     subject
   end


### PR DESCRIPTION
An email subject containing the name of the project's owner is useful for filtering received emails by namespaces or groups in email clients.
The name of the project's owner is given in the email subject in squared brackets ([...]).
