### PR TITLE
Socket [::]:123 on Linux listens on IPv4 and IPv6

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -39,7 +39,7 @@ upstream gitlab {
 ## Redirects all HTTP traffic to the HTTPS host
 server {
   listen 0.0.0.0:80;
-  listen [::]:80 default_server;
+  listen [::]:80 ipv6only=on default_server;
   server_name YOUR_SERVER_FQDN; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
   return 301 https://$server_name$request_uri;
@@ -51,7 +51,7 @@ server {
 ## HTTPS host
 server {
   listen 0.0.0.0:443 ssl;
-  listen [::]:443 ssl default_server;
+  listen [::]:443 ipv6only=on ssl default_server;
   server_name YOUR_SERVER_FQDN; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
   root /home/git/gitlab/public;


### PR DESCRIPTION
This will ensure nginx starts up without the following errors messages:
nginx: [emerg] bind() to [::]:443 failed (98: Address already in use)
nginx: [emerg] bind() to [::]:443 failed (98: Address already in use)
nginx: [emerg] bind() to [::]:443 failed (98: Address already in use)
nginx: [emerg] bind() to [::]:443 failed (98: Address already in use)
nginx: [emerg] bind() to [::]:443 failed (98: Address already in use)
nginx: [emerg] still could not bind()

Googling for them leads you to this site:
https://chrisjean.com/2014/02/10/fix-nginx-emerg-bind-to-80-failed-98-address-already-in-use/
