### PR TITLE
Add 'url' to merge request webhook

### DIFF
--- a/app/services/merge_requests/base_service.rb
+++ b/app/services/merge_requests/base_service.rb
@@ -8,6 +8,8 @@ module MergeRequests
     def execute_hooks(merge_request)
       if merge_request.project
         hook_data = merge_request.to_hook_data(current_user)
+        url = Gitlab::UrlBuilder.new(:merge_request).build(merge_request.id)
+        hook_data[:object_attributes].merge!(url: url)
         merge_request.project.execute_hooks(hook_data, :merge_request_hooks)
       end
     end

--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -119,6 +119,7 @@ Triggered when a new merge request is created or an existing merge request was u
     "merge_status": "unchecked",
     "target_project_id": 14,
     "iid": 1,
+    "url": "http://example.com/awesome_space/awesome_project/merge_requests/1",
     "description": "",
     "source": {
       "name": "awesome_project",

--- a/lib/gitlab/url_builder.rb
+++ b/lib/gitlab/url_builder.rb
@@ -10,6 +10,8 @@ module Gitlab
       case @type
       when :issue
         issue_url(id)
+      when :merge_request
+        merge_request_url(id)
       end
     end
 
@@ -20,6 +22,13 @@ module Gitlab
       project_issue_url(id: issue.iid,
                         project_id: issue.project,
                         host: Gitlab.config.gitlab['url'])
+    end
+
+    def merge_request_url(id)
+      merge_request = MergeRequest.find(id)
+      project_merge_request_url(id: merge_request.iid,
+                                project_id: merge_request.project,
+                                host: Gitlab.config.gitlab['url'])
     end
   end
 end

--- a/spec/lib/gitlab/url_builder_spec.rb
+++ b/spec/lib/gitlab/url_builder_spec.rb
@@ -8,4 +8,13 @@ describe Gitlab::UrlBuilder do
       expect(url).to eq "#{Settings.gitlab['url']}/#{issue.project.to_param}/issues/#{issue.iid}"
     end
   end
+
+  describe 'When asking for a merge request' do
+    it 'returns the merge request url' do
+      merge_request = create(:merge_request)
+      url = Gitlab::UrlBuilder.new(:merge_request).build(merge_request.id)
+      expect(url).to eq Settings.gitlab['url'] +
+        "/#{merge_request.project.to_param}/merge_requests/#{merge_request.iid}"
+    end
+  end
 end


### PR DESCRIPTION
When a webhook for merge requests is triggered,
it should also return the resource URL.
