### PR TITLE
Fixed duplicate username error message

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -270,7 +270,7 @@ class User < ActiveRecord::Base
   def namespace_uniq
     namespace_name = self.username
     if Namespace.find_by(path: namespace_name)
-      self.errors.add :username, "already exists"
+      self.errors.add(:username, "already exists") unless errors.get(:username)
     end
   end
 


### PR DESCRIPTION
It will show an error only when a username is correct and there is a namespace conflict. It removes duplicate "already exists" errors for usernames.
Issue #8323
