### PR TITLE
Update gemnasium-gitlab-service to version 0.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.4)
-    gemnasium-gitlab-service (0.2.2)
+    gemnasium-gitlab-service (0.2.3)
       rugged (~> 0.19)
     gherkin-ruby (0.3.1)
       racc


### PR DESCRIPTION
Latest version of gemnasium-gitlab-service relies on the new Gemnasium API (the previous API is now deprecated). It supports Bower dependency files and searches for dependency files in sub-directories.
