### PR TITLE
Replace the existing file 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+
+Yakun's Change
+
+1. I add the function to replace one file in current repository throught the file edit mainboard.
+
+2. Changes are made to the original file "new_tree_controller.rb", "_actions.html.haml" , "show.html.haml".
+
+3. New file "update.html.haml" is added.
+
+
 v 7.6.0
   - Fork repository to groups
   - New rugged version

--- a/app/controllers/projects/new_tree_controller.rb
+++ b/app/controllers/projects/new_tree_controller.rb
@@ -6,6 +6,14 @@ class Projects::NewTreeController < Projects::BaseTreeController
   end
 
   def update
+
+    if @path.match(/(.*\/)*(.+)\z/)!=nil
+      file_na=@path.match(/(.*\/)*(.+)\z/)[2]
+      @path=@path.gsub(file_na,'')
+      params[:content]=params[:file_upload].read
+      params[:file_name]=file_na
+    end
+    
     file_path = File.join(@path, File.basename(params[:file_name]))
     result = Files::CreateService.new(@project, current_user, params, @ref, file_path).execute
 

--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -23,6 +23,13 @@
         tree_join(@commit.sha, @path)), class: 'btn btn-small'
 
 - if allowed_tree_edit?
+
+  = button_tag class: 'btn btn-small btn-primary btn-xs',
+      'data-toggle' => 'modal', 'data-target' => '#modal-update-blob' do
+    Replace	
+  
+  = |
+  
   = button_tag class: 'remove-blob btn btn-small btn-remove',
       'data-toggle' => 'modal', 'data-target' => '#modal-remove-blob' do
     Remove

--- a/app/views/projects/blob/_update.html.haml
+++ b/app/views/projects/blob/_update.html.haml
@@ -1,0 +1,32 @@
+#modal-update-blob.modal.hide
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %a.close{href: "#", "data-dismiss" => "modal"} ×
+        %h3.page-title Replace #{@blob.name}
+        %p.light
+          From branch
+          %strong= @ref
+
+      .modal-body
+        = form_tag project_new_tree_path(@project, @id), method: :put, class: 'form-horizontal', :multipart => true do
+          %br
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = file_field_tag :file_upload
+          
+              
+          %br
+          = render 'shared/commit_message_container', params: params,
+                  placeholder: 'Replace this file because...'
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = button_tag 'Replace', class: 'btn btn-small btn-primary'
+              = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+             
+             
+                    
+:javascript
+  disableButtonIfEmptyField('#commit_message', '.btn-remove-file')

--- a/app/views/projects/blob/show.html.haml
+++ b/app/views/projects/blob/show.html.haml
@@ -6,3 +6,4 @@
 
 - if allowed_tree_edit?
   = render 'projects/blob/remove'
+  = render 'projects/blob/update'


### PR DESCRIPTION
When you need to edit some file of your project, then you need to edit it. One function to replace the existing file is added, which enable user to choose a new file to replace the existing one, and the name of the new file will be the same as previous one. The UI is changed also, please check the attachment.

Existing file "new_tree_controller.rb", "_actions.html.haml" and "show.html.haml" are changed. New file "_update.html.haml" is created. 
