### PR TITLE
teamcity basic support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -257,3 +257,4 @@ group :production do
 end
 
 gem "newrelic_rpm"
+gem 'teamcity-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
       activesupport (>= 4.0.1)
       haml (>= 3.1, < 5.0)
       railties (>= 4.0.1)
-    hashie (2.1.2)
+    hashie (2.0.5)
     hike (1.2.3)
     hipchat (1.4.0)
       httparty
@@ -516,6 +516,10 @@ GEM
     stamp (0.5.0)
     state_machine (1.2.0)
     stringex (2.5.1)
+    teamcity-ruby-client (1.2.0)
+      faraday (~> 0.8.5)
+      faraday_middleware (~> 0.9.0)
+      hashie (~> 2.0.0)
     temple (0.6.7)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
@@ -696,6 +700,7 @@ DEPENDENCIES
   spring-commands-spinach (= 1.0.0)
   stamp
   state_machine
+  teamcity-ruby-client
   test_after_commit
   therubyracer
   thin

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -42,7 +42,8 @@ class Projects::ServicesController < Projects::ApplicationController
       :title, :token, :type, :active, :api_key, :subdomain,
       :room, :recipients, :project_url, :webhook,
       :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
-      :build_key, :server
+      :build_key, :server,
+      :teamcity_server_url, :teamcity_build_configuration_id
     )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,7 @@ class Project < ActiveRecord::Base
   # Project services
   has_many :services
   has_one :gitlab_ci_service, dependent: :destroy
+  has_one :teamcity_ci_service, dependent: :destroy
   has_one :campfire_service, dependent: :destroy
   has_one :emails_on_push_service, dependent: :destroy
   has_one :pivotaltracker_service, dependent: :destroy
@@ -314,7 +315,10 @@ class Project < ActiveRecord::Base
   end
 
   def available_services_names
-    %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla emails_on_push gemnasium slack pushover buildbox bamboo)
+    %w(
+      gitlab_ci campfire hipchat pivotaltracker flowdock assembla emails_on_push
+      gemnasium slack pushover buildbox bamboo teamcity_ci
+    )
   end
 
   def gitlab_ci?

--- a/app/models/project_services/teamcity_ci_service.rb
+++ b/app/models/project_services/teamcity_ci_service.rb
@@ -1,0 +1,142 @@
+# Base class for CI services
+# List methods you need to implement to get your CI service
+# working with GitLab Merge Requests
+
+require 'teamcity'
+
+class TeamcityCiService < CiService
+  prop_accessor :teamcity_server_url
+  prop_accessor :teamcity_build_configuration_id
+  prop_accessor :username
+  prop_accessor :password
+
+  validates :teamcity_server_url, presence: true, if: :activated?
+  validates :teamcity_build_configuration_id, presence: true, if: :activated?
+  validates :username, presence: true, if: :activated?
+  validates :password, presence: true, if: :activated?
+
+  def build_page(sha)
+    build = find_build_id_by_sha sha
+
+    return 'http://error' unless build
+
+    build.webUrl
+  rescue => e
+    Gitlab::AppLogger.info(
+      "Exception: #{e}"
+    )
+
+    'http://error'
+  end
+
+  def commit_status(sha)
+    convert_state_teamcity_to_gitlab(find_build_id_by_sha(sha))
+  rescue => e
+    Gitlab::AppLogger.info(
+      "Exception: #{e}"
+    )
+
+    :failed
+  end
+
+  def title
+    'Teamcity CI'
+  end
+
+  def description
+    'Continuous integration server from Teamcity'
+  end
+
+  def to_param
+    'teamcity_ci'
+  end
+
+  def fields
+    [
+      { type: 'text', name: 'teamcity_server_url',
+        placeholder: 'https://teamcity.example.com' },
+      { type: 'text', name: 'teamcity_build_configuration_id',
+        placeholder: 'Build Configuration Id' },
+      { type: 'text', name: 'username',
+        placeholder: '' },
+      { type: 'text', name: 'password',
+        placeholder: '' },
+    ]
+  end
+
+  def execute(_push_data)
+  end
+
+  def can_test?
+    false
+  end
+
+  private
+
+  def find_merge_request_source_branch_by_last_commit(sha)
+    project.merge_requests.each do |mr|
+      if mr.last_commit.sha == sha
+        return mr.source_branch
+      end
+    end
+  end
+
+  def find_build_id_by_sha(sha)
+    branch = ERB::Util.url_encode(find_merge_request_source_branch_by_last_commit(sha))
+    if branch
+      my_find_build_id_by_sha(sha, "refs/heads/#{branch}") ||
+        my_find_build_id_by_sha(sha, "#{branch}")
+    else
+      my_find_build_id_by_sha sha, '(branched:any)'
+    end
+  end
+
+  def my_find_build_id_by_sha(sha, branch)
+    tc = TeamCity.client(
+      endpoint: "#{teamcity_server_url}/httpAuth/app/rest",
+      http_user: username,
+      http_password: password
+    )
+    builds = tc.builds(
+      buildType: teamcity_build_configuration_id,
+      branch: branch,
+      running: 'any',
+      canceled: 'any'
+    )
+
+    return nil unless builds
+
+    builds.each do |b|
+      info = tc.build(id: b.id)
+      info.revisions.revision.each do |r|
+        if r.version == sha
+          return info
+        end
+      end
+    end
+
+    nil
+  end
+
+  STATUS = { 'success' => 'success',
+             'failure' => 'failed' }
+
+  def convert_state_teamcity_to_gitlab(build_info)
+    return :pending unless build_info
+    return :running if build_info.state == 'running'
+
+    if build_info.state.downcase == 'finished'
+      if STATUS.has_key?(build_info.status.downcase)
+        return STATUS[build_info.status.downcase]
+      end
+    end
+
+    Gitlab::AppLogger.info(
+      "teamcity build_info.state = #{build_info.state}" \
+      " with  build_info.status = #{build_info.status} are not supported," \
+      ' suppose it failed'
+    )
+
+    :failed
+  end
+end

--- a/doc/project_services/project_services.md
+++ b/doc/project_services/project_services.md
@@ -16,3 +16,4 @@ __Project integrations with external services for continuous integration and mor
 - PivotalTracker
 - Pushover
 - Slack
+- [Teamcity CI](teamcity.md) A Jetbrains product for continous integration and deploy.

--- a/doc/project_services/teamcity.md
+++ b/doc/project_services/teamcity.md
@@ -1,0 +1,35 @@
+# Jetbrains Teamcity CI Service
+
+GitLab provides integration with Jetbrains Teamcity for continuous integration.
+When configured Merge requests will display CI status showing whether the build
+is pending, failed, or completed successfully. It also provides a link to the 
+Teamcity build page for more information.
+
+There are a few things that need to be configured in a Teamcity build 
+configuration before GitLab can integrate.
+
+## Setup
+
+### Complete these steps in Teamcity:
+
+1. Create new build configuration.
+1. Add a VCS corresponding to your gitlab project
+1. Select the 'Triggers' tab.
+1. Add VCS Trigger for Teamcity to periodically poll for new commits and build them.
+1. Configure your build steps.
+
+Teamcity is now ready to trigger builds when new changes are pushed to GitLab.
+Next, set up the Teamcity service in GitLab.
+
+### Complete these steps in GitLab:
+
+1. Navigate to the project you want to configure to trigger builds.
+1. Select 'Settings' in the top navigation.
+1. Select 'Services' in the left navigation.
+1. Click 'Teamcity CI'
+1. Select the 'Active' checkbox.
+1. Enter the base URL of your Teamcity server. 'https://teamcity.example.com'
+1. Enter the Build Configuration Id from your Teamcity build configuration.
+1. Enter username and password for a Teamcity user with Project viewer role
+assigned.
+1. Save.

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -66,3 +66,9 @@ Feature: Project Services
     And I click Atlassian Bamboo CI service link
     And I fill Atlassian Bamboo CI settings
     Then I should see Atlassian Bamboo CI service settings saved
+
+  Scenario: Activate Teamcity CI service
+    When I visit project "Shop" services page
+    And I click Teamcity CI service link
+    And I fill Teamcity CI settings
+    Then I should see Teamcity CI service settings saved

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -15,6 +15,7 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
     page.should have_content 'Assembla'
     page.should have_content 'Pushover'
     page.should have_content 'Atlassian Bamboo'
+    page.should have_content 'Teamcity CI'
   end
 
   step 'I click gitlab-ci service link' do
@@ -167,5 +168,31 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
     find_field('Bamboo url').value.should == 'http://bamboo.example.com'
     find_field('Build key').value.should == 'KEY'
     find_field('Username').value.should == 'user'
+  end
+
+  step 'I click Teamcity CI service link' do
+    click_link 'Teamcity CI'
+  end
+
+  step 'I fill Teamcity CI settings' do
+    check 'Active'
+    fill_in 'Teamcity server url', with: 'http://teamcity.mydomain.com'
+    fill_in(
+      'Teamcity build configuration',
+      with: 'TestProjects_GitlabTest_TestIntegration'
+    )
+    fill_in 'Username', with: 'my_username'
+    fill_in 'Password', with: 'my_password'
+    click_button 'Save'
+  end
+
+  step 'I should see Teamcity CI service settings saved' do
+    find_field('Teamcity server url').
+      value.should == 'http://teamcity.mydomain.com'
+    find_field('Teamcity build configuration').
+      value.should == 'TestProjects_GitlabTest_TestIntegration'
+
+    find_field('Username').value.should == 'my_username'
+    find_field('Password').value.should == 'my_password'
   end
 end


### PR DESCRIPTION
FR http://feedback.gitlab.com/forums/176466-general/suggestions/4139027-teamcity-integration

[This is a clone of https://github.com/gitlabhq/gitlabhq/pull/7570, because of a pull request bug.]

Simple Teamcity integration for MergeRequest build status and link on a build.

Algorithm: get status of the last build in Teamcity for concrete Teamcity.BuildConfiguration_ID and MergeRequest.SourceBranch and MergeRequest.Commits.Last
Have to create a build configuration Teamcity.BuildConfiguration_ID to trigger build on each push.
Have to create a survice user and give him viewer-access rights on Teamcity.BuildConfiguration_ID.

Algorithm is very simple but it is working for us since 2014/07/15 and everybody happy :-)
