### PR TITLE
requests/api/project_spec.rb speed up

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -325,9 +325,9 @@ ActiveRecord::Schema.define(version: 20150116234545) do
     t.string   "import_status"
     t.float    "repository_size",        default: 0.0
     t.integer  "star_count",             default: 0,        null: false
+    t.string   "avatar"
     t.string   "import_type"
     t.string   "import_source"
-    t.string   "avatar"
   end
 
   add_index "projects", ["creator_id"], name: "index_projects_on_creator_id", using: :btree


### PR DESCRIPTION
**What does this MR do?**
It improves the speed of the `request/api/project_spec.rb` tests by ~3 minutes. It also removes some test duplication, and moves some assertions into the same tests so another API call is not needed.

**Before:** `~3.51 min`
**After:** `~ 50 sec.`
