### PR TITLE
Fixed a lot of already defined notices

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -10,12 +10,12 @@ class Commit
   # Used to prevent 500 error on huge commits by suppressing diff
   #
   # User can force display of diff above this size
-  DIFF_SAFE_FILES  = 100
-  DIFF_SAFE_LINES  = 5000
+  DIFF_SAFE_FILES  = 100 unless defined?(DIFF_SAFE_FILES)
+  DIFF_SAFE_LINES  = 5000 unless defined?(DIFF_SAFE_LINES)
 
   # Commits above this size will not be rendered in HTML
-  DIFF_HARD_LIMIT_FILES = 1000
-  DIFF_HARD_LIMIT_LINES = 50000
+  DIFF_HARD_LIMIT_FILES = 1000 unless defined?(DIFF_HARD_LIMIT_FILES)
+  DIFF_HARD_LIMIT_LINES = 50000 unless defined?(DIFF_HARD_LIMIT_LINES)
 
   class << self
     def decorate(commits)

--- a/app/models/project_wiki.rb
+++ b/app/models/project_wiki.rb
@@ -5,7 +5,7 @@ class ProjectWiki
     'Markdown' => :markdown,
     'RDoc'     => :rdoc,
     'AsciiDoc' => :asciidoc
-  }
+  } unless defined?(MARKUPS)
 
   class CouldNotCreateWikiError < StandardError; end
 


### PR DESCRIPTION
**What does this MR do?**
When you start GitLab you get a lot of notices about already defined constants. This MR fixes it.
