### PR TITLE
Add []s around user@ipv6addr (e.g., "[git@::1]/repo.git")

### DIFF
--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -13,7 +13,11 @@ class Settings < Settingslogic
       if gitlab_shell.ssh_port != 22
         "ssh://#{gitlab_shell.ssh_user}@#{gitlab_shell.ssh_host}:#{gitlab_shell.ssh_port}/"
       else
-        "#{gitlab_shell.ssh_user}@#{gitlab_shell.ssh_host}:"
+        if gitlab_shell.ssh_host.include? ':'
+          "[#{gitlab_shell.ssh_user}@#{gitlab_shell.ssh_host}]:"
+        else
+          "#{gitlab_shell.ssh_user}@#{gitlab_shell.ssh_host}:"
+        end
       end
     end
 


### PR DESCRIPTION
The following command does not work "git clone git@::1/repo.git", git requires surrounding user@addr with brackets instead.
