### PR TITLE
Format Project.path like github does

### DIFF
--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -12,12 +12,12 @@ module Projects
         @project.visibility_level = default_features.visibility_level
       end
 
-      # Parametrize path for project
+      # Format path for project
       #
       # Ex.
-      #  'GitLab HQ'.parameterize => "gitlab-hq"
+      #  'GitLab HQ'.gsub(/\s+/, '-') => "GitLab-HQ"
       #
-      @project.path = @project.name.dup.parameterize unless @project.path.present?
+      @project.path = @project.name.dup.gsub(/\s+/, '-') unless @project.path.present?
 
       # get namespace id
       namespace_id = params[:namespace_id]

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -4,6 +4,10 @@ module Projects
       @current_user, @params = user, params.dup
     end
 
+    def format(str)
+      str.to_s.gsub(/\s+/, '-')
+    end
+
     def execute
       @project = Project.new(params)
 
@@ -15,9 +19,9 @@ module Projects
       # Format path for project
       #
       # Ex.
-      #  'GitLab HQ'.gsub(/\s+/, '-') => "GitLab-HQ"
+      #  format('GitLab HQ') => "GitLab-HQ"
       #
-      @project.path = @project.name.dup.gsub(/\s+/, '-') unless @project.path.present?
+      @project.path = format(@project.name.dup) unless @project.path.present?
 
       # get namespace id
       namespace_id = params[:namespace_id]


### PR DESCRIPTION
I think it is better to format project.path like github does.

and then we can mirror Github or Bitbucket Projects easily
