### PR TITLE
Reduce the size of Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:14.04
 
 # Install required packages
 RUN apt-get update -q \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
+      ca-certificates \
       openssh-server \
-      wget \
-    && apt-get clean
+      wget
 
 # Download & Install GitLab
 # If the Omnibus package version below is outdated please contribute a merge request to update it.


### PR DESCRIPTION
1) Add `--no-install-recommends` option to `apt-get install`, this
   avoids lots of (~30MB) unnecessary packages.
2) Add `ca-certificates` package for `wget` fetching stuffs from Amazon
   S3.
3) There is no need to run `apt-get clean` for an image derived from
   official Ubuntu since they already cleaned (see also:
   http://goo.gl/B2SQRB) all the garbages produced by `apt-get`.

Signed-off-by: kfei kfei@kfei.net
