### PR TITLE
Add description attribute to group API (GET and POST)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ v 7.8.0
   - Replace highlight.js with rouge-fork rugments (Stefan Tatschner)
   - 
   - 
-  - 
+  - Expose description in groups API
   - 
   - 
   - 

--- a/doc/api/groups.md
+++ b/doc/api/groups.md
@@ -14,7 +14,8 @@ GET /groups
     "id": 1,
     "name": "Foobar Group",
     "path": "foo-bar",
-    "owner_id": 18
+    "owner_id": 18,
+    "description": "An interesting group"
   }
 ]
 ```
@@ -45,6 +46,7 @@ Parameters:
 
 - `name` (required) - The name of the group
 - `path` (required) - The path of the group
+- `description` (optional) - The group's description
 
 ## Transfer project to group
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -65,7 +65,7 @@ module API
     end
 
     class Group < Grape::Entity
-      expose :id, :name, :path, :owner_id
+      expose :id, :name, :path, :owner_id, :description
     end
 
     class GroupDetail < Group

--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -47,7 +47,7 @@ module API
         authenticated_as_admin!
         required_attributes! [:name, :path]
 
-        attrs = attributes_for_keys [:name, :path]
+        attrs = attributes_for_keys [:name, :path, :description]
         @group = Group.new(attrs)
         @group.owner = current_user
 


### PR DESCRIPTION
The group entity has a `description` attribute that wasn't available to the group API. This PR adds this attribute to the API.
