### PR TITLE
Update header so that the entire GitLab logo is clickable

### DIFF
--- a/app/assets/stylesheets/sections/header.scss
+++ b/app/assets/stylesheets/sections/header.scss
@@ -93,12 +93,10 @@ header {
    */
   .app_logo {
     float: left;
-    margin-right: 9px;
 
     a {
       float: left;
-      padding: 0px;
-      margin: 0 6px;
+      padding: 0 6px;
 
       h1 {
         margin: 0;
@@ -125,7 +123,7 @@ header {
     position: relative;
     float: left;
     margin: 0;
-    margin-left: 5px;
+    margin-left: 14px;
     @include header-font;
     @include str-truncated(37%);
   }
@@ -233,19 +231,12 @@ header {
     }
   }
 
-  .app_logo {
-    .separator {
-      margin-left: 0;
-      margin-right: 0;
-    }
-  }
-
   .separator {
     float: left;
     height: 46px;
     width: 2px;
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/app/views/layouts/_public_head_panel.html.haml
+++ b/app/views/layouts/_public_head_panel.html.haml
@@ -1,11 +1,11 @@
 %header.navbar.navbar-static-top.navbar-gitlab
   .navbar-inner
     .container
-      %div.app_logo
-        %span.separator
-        = link_to explore_root_path, class: "home" do
-          %h1 GITLAB
-        %span.separator
+      %span.separator
+        %div.app_logo
+          = link_to explore_root_path, class: "home" do
+            %h1 GITLAB
+      %span.separator
       %h1.title= title
 
       %button.navbar-toggle{"data-target" => ".navbar-collapse", "data-toggle" => "collapse", type: "button"}


### PR DESCRIPTION
At the moment, there is a 6px gap either side of the GitLab logo that changes background colour on the hover, but is not a link.

This is an annoying bit of design.

This pull request should resolve that.

**Note**: These are fairly simple changes, but I have not tested them. Feel free to redo them properly, and use this as a bug report instead.
