### PR TITLE
Added max-width to login stylesheet

### DIFF
--- a/app/assets/stylesheets/sections/login.scss
+++ b/app/assets/stylesheets/sections/login.scss
@@ -15,6 +15,10 @@
 
     .login-footer {
       margin-top: 10px;
+
+      img {
+        max-width: 100%;
+      }
     }
 
     .btn {


### PR DESCRIPTION
This patch makes sure that images aren't shown bigger than possible. It's now limited to the width of the parent container.
