### PR TITLE
Remove GFM from titles

### DIFF
--- a/app/views/projects/commits/_commit.html.haml
+++ b/app/views/projects/commits/_commit.html.haml
@@ -3,7 +3,7 @@
     = link_to commit.short_id, project_commit_path(project, commit), class: "commit_short_id"
     &nbsp;
     %span.str-truncated
-      = link_to_gfm commit.title, project_commit_path(project, commit.id), class: "commit-row-message"
+      = link_to commit.title, project_commit_path(project, commit.id), class: "commit-row-message"
       - if commit.description?
         %a.text-expander.js-toggle-button ...
 

--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -5,7 +5,7 @@
 
   .issue-title
     %span.str-truncated
-      = link_to_gfm issue.title, project_issue_path(issue.project, issue), class: "row_title"
+      = link_to issue.title, project_issue_path(issue.project, issue), class: "row_title"
     - if issue.closed?
       %small.pull-right
         CLOSED

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -1,6 +1,6 @@
 %li{ class: mr_css_classes(merge_request) }
   .merge-request-title
-    = link_to_gfm truncate(merge_request.title, length: 80), project_merge_request_path(merge_request.target_project, merge_request), class: "row_title"
+    = link_to truncate(merge_request.title, length: 80), project_merge_request_path(merge_request.target_project, merge_request), class: "row_title"
     - if merge_request.merged?
       %small.pull-right
         %i.fa.fa-check


### PR DESCRIPTION
Remove markdown rendering from titles in a list. It doesn't make sense to render markdown with links to issues, etc in a list because it disjoints the link. For example 'This merge request fixes #1' will result in 'This merge request fixes' being a link to the merge request and '#1' is a link to issue #1. 

This change makes sense for merge request, issue and commit lists. For merge requests and issues markdown will continue to be rendered when the merge request/issue is viewed.
