### PR TITLE
Merge request error display

### DIFF
--- a/app/services/merge_requests/build_service.rb
+++ b/app/services/merge_requests/build_service.rb
@@ -13,7 +13,7 @@ module MergeRequests
       merge_request.target_branch ||= merge_request.target_project.default_branch
 
       unless merge_request.target_branch && merge_request.source_branch
-        return build_failed(merge_request, "You must select source and target branches")
+        return build_failed(merge_request, nil)
       end
 
       # Generate suggested MR title based on source branch name
@@ -59,7 +59,7 @@ module MergeRequests
     end
 
     def build_failed(merge_request, message)
-      merge_request.errors.add(:base, message)
+      merge_request.errors.add(:base, message) unless message.nil?
       merge_request.compare_commits = []
       merge_request.can_be_created = false
       merge_request


### PR DESCRIPTION
Fixes #8432 

Currently, GitLab displays an error message whenever a new merge request is created. This is often confusing for users. There is another catch point that will show an error (see screenshot) if a user clicks "Compare branches" without specifying a source or target. If a source and target branch are not specified under other circumstances I think it's OK to quietly 'fail' without showing a message. I'm not sure if this is acceptable but I can't see any pitfalls so far. Please provide feedback.

Before:
![screen shot 2014-12-26 at 3 28 35 pm](https://cloud.githubusercontent.com/assets/2394772/5559464/e7084d6e-8d13-11e4-97f3-d0b811b716ad.png)

Existing and unchanged (if user clicks 'Compare branches' without specifying'):
![screen shot 2014-12-26 at 3 25 03 pm](https://cloud.githubusercontent.com/assets/2394772/5559461/c0e63a06-8d13-11e4-94b9-b93ced7fba8f.png)
