### PR TITLE
Allow a user to specify a channel and username for the slack-webhook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,7 @@ v 7.8.0
   - Improve database performance for GitLab
   - Add Asana service (Jeremy Benoist)
   - Improve project web hooks with extra data
+  - Slack username and channel options
 
 v 7.7.2
   - Update GitLab Shell to version 2.4.2 that fixes a bug when developers can push to protected branch

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -50,7 +50,7 @@ class Projects::ServicesController < Projects::ApplicationController
       :room, :recipients, :project_url, :webhook,
       :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
       :build_key, :server, :teamcity_url, :build_type,
-      :description, :issues_url, :new_issue_url, :restrict_to_branch
+      :description, :issues_url, :new_issue_url, :restrict_to_branch, :channel
     )
   end
 end

--- a/app/models/project_services/slack_service.rb
+++ b/app/models/project_services/slack_service.rb
@@ -14,7 +14,7 @@
 #
 
 class SlackService < Service
-  prop_accessor :webhook
+  prop_accessor :webhook, :username, :channel
   validates :webhook, presence: true, if: :activated?
 
   def title
@@ -31,7 +31,10 @@ class SlackService < Service
 
   def fields
     [
-      { type: 'text', name: 'webhook', placeholder: 'https://hooks.slack.com/services/...' }
+      { type: 'text', name: 'webhook',
+        placeholder: 'https://hooks.slack.com/services/...' },
+      { type: 'text', name: 'username', placeholder: 'username' },
+      { type: 'text', name: 'channel', placeholder: '#channel' }
     ]
   end
 
@@ -43,7 +46,11 @@ class SlackService < Service
       project_name: project_name
     ))
 
-    notifier = Slack::Notifier.new(webhook)
+    opt = {}
+    opt[:channel] = channel if channel
+    opt[:username] = username if username
+
+    notifier = Slack::Notifier.new(webhook, opt)
     notifier.ping(message.pretext, attachments: message.attachments)
   end
 

--- a/spec/models/project_services/slack_service_spec.rb
+++ b/spec/models/project_services/slack_service_spec.rb
@@ -36,6 +36,8 @@ describe SlackService do
     let(:project) { create(:project) }
     let(:sample_data) { Gitlab::PushDataBuilder.build_sample(project, user) }
     let(:webhook_url) { 'https://hooks.slack.com/services/SVRWFV0VVAR97N/B02R25XN3/ZBqu7xMupaEEICInN685' }
+    let(:username) { 'slack_username' }
+    let(:channel) { 'slack_channel' }
 
     before do
       slack.stub(
@@ -52,6 +54,26 @@ describe SlackService do
       slack.execute(sample_data)
 
       expect(WebMock).to have_requested(:post, webhook_url).once
+    end
+
+    it 'should use the username as an option for slack when configured' do
+      slack.stub(username: username)
+      expect(Slack::Notifier).to receive(:new).
+        with(webhook_url, username: username).
+        and_return(
+          double(:slack_service).as_null_object
+                                   )
+      slack.execute(sample_data)
+    end
+
+    it 'should use the channel as an option when it is configured' do
+      slack.stub(channel: channel)
+      expect(Slack::Notifier).to receive(:new).
+        with(webhook_url, channel: channel).
+        and_return(
+          double(:slack_service).as_null_object
+        )
+      slack.execute(sample_data)
     end
   end
 end


### PR DESCRIPTION
In slack you can specify the username and/or channel to post to instead of the webhook-default. By using this options you allow a slack-user to use a single webhook for in multiple projects and still let each of them post to a separate channel.
