### PR TITLE
add environment variable force to the documentation

### DIFF
--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -155,6 +155,7 @@ Options:
 
 ```
 BACKUP=timestamp_of_backup (required if more than one backup exists)
+force=yes (do not ask if the authorized_keys file should get regenerated)
 ```
 
 Example output:


### PR DESCRIPTION
This is necessary if you like to suppress the question for rebuilding the authorized_keys file. This is necessary for example if you would like to run the command unattended in a script.
[ci skip]
