### PR TITLE
Fix HipChat Server

### DIFF
--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -35,7 +35,7 @@ class HipchatService < Service
       { type: 'text', name: 'token',     placeholder: '' },
       { type: 'text', name: 'room',      placeholder: '' },
       { type: 'text', name: 'server',
-        placeholder: 'Leave blank for default. https://chat.hipchat.com' }
+        placeholder: 'Leave blank for default. https://hipchat.example.com' }
     ]
   end
 
@@ -47,7 +47,7 @@ class HipchatService < Service
 
   def gate
     options = { api_version: 'v2' }
-    options[:server_url] = server unless server.nil?
+    options[:server_url] = server unless server.blank?
     @gate ||= HipChat::Client.new(token, options)
   end
 


### PR DESCRIPTION
Fixes a regression in the HipChat service.

This regression occurs when the HipChat server url is not specified (which should default to HipChat cloud service). The property is sometimes not registering as `nil` so added a `blank?` check.

Also, changed the placeholder on server url because it could potentially be confusing. 

Fixes https://gitlab.com/gitlab-org/gitlab-ce/issues/932
