### PR TITLE
Key comment extraction for generic comments

### DIFF
--- a/app/views/profiles/keys/new.html.haml
+++ b/app/views/profiles/keys/new.html.haml
@@ -8,9 +8,9 @@
   $('#key_key').on('focusout', function(){
     var title = $('#key_title'),
         val      = $('#key_key').val(),
-        key_mail = val.match(/([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+|\.[a-zA-Z0-9._-]+)/gi);
+        comment = val.match(/^\S+ \S+ (.+)$/);
 
-    if( key_mail && key_mail.length > 0 && title.val() == '' ){
-      $('#key_title').val( key_mail );
+    if( comment && comment.length > 1 && title.val() == '' ){
+      $('#key_title').val( comment[1] );
     }
   });


### PR DESCRIPTION
When adding public keys to my account, I love that I don't need to title them as it extracts part of my comment that I've attached to the text. However, I regularly add extra spaces to my comments for extra data (like creation date) and that extra data does not get passed on to the key's title.

Looking into it, it looks like the little helper js code just searches for any text that looks like an email address and adds that to the title. This seems wrong and too restrictive, IMHO.
