### PR TITLE
Api: allow recursive tree request

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -200,12 +200,12 @@ class Repository
     commit(self.root_ref)
   end
 
-  def tree(sha = :head, path = nil)
+  def tree(sha = :head, path = nil, recursive = 0)
     if sha == :head
       sha = head_commit.sha
     end
 
-    Tree.new(self, sha, path)
+    Tree.new(self, sha, path, recursive)
   end
 
   def blob_at_branch(branch_name, path)

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -3,10 +3,15 @@ class Tree
 
   attr_accessor :entries, :readme, :contribution_guide
 
-  def initialize(repository, sha, path = '/')
+  def initialize(repository, sha, path = '/', recursive)
     path = '/' if path.blank?
     git_repo = repository.raw_repository
-    @entries = Gitlab::Git::Tree.where(git_repo, sha, path)
+
+    if recursive == '1'
+      @entries = get_recursive_entries(git_repo, sha, path)
+    else
+      @entries = Gitlab::Git::Tree.where(git_repo, sha, path)
+    end
 
     available_readmes = @entries.select(&:readme?)
 
@@ -33,6 +38,15 @@ class Tree
       contribution_path = path == '/' ? contribution_tree.name : File.join(path, contribution_tree.name)
       @contribution_guide = Gitlab::Git::Blob.find(git_repo, sha, contribution_path)
     end
+  end
+
+  def get_recursive_entries(git_repo, sha, path)
+    entries =  Gitlab::Git::Tree.where(git_repo, sha, path)
+
+    entries.select(&:dir?).each do |t|
+      entries += get_recursive_entries(git_repo,sha,t.path)
+    end
+		entries
   end
 
   def trees

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -44,9 +44,9 @@ class Tree
     entries =  Gitlab::Git::Tree.where(git_repo, sha, path)
 
     entries.select(&:dir?).each do |t|
-      entries += get_recursive_entries(git_repo,sha,t.path)
+      entries += get_recursive_entries(git_repo, sha,t.path)
     end
-		entries
+    entries
   end
 
   def trees

--- a/doc/api/repositories.md
+++ b/doc/api/repositories.md
@@ -90,41 +90,48 @@ Parameters:
 - `id` (required) - The ID of a project
 - `path` (optional) - The path inside repository. Used to get contend of subdirectories
 - `ref_name` (optional) - The name of a repository branch or tag or if not given the default branch
+- `recursive=1` (optional) - Used to get a recursive tree
 
 ```json
 [
   {
     "name": "assets",
+    "path": "assets",
     "type": "tree",
     "mode": "040000",
     "id": "6229c43a7e16fcc7e95f923f8ddadb8281d9c6c6"
   },
   {
     "name": "contexts",
+    "path": "contexts",
     "type": "tree",
     "mode": "040000",
     "id": "faf1cdf33feadc7973118ca42d35f1e62977e91f"
   },
   {
     "name": "controllers",
+    "path": "controllers",
     "type": "tree",
     "mode": "040000",
     "id": "95633e8d258bf3dfba3a5268fb8440d263218d74"
   },
   {
     "name": "Rakefile",
+    "path": "Rakefile",
     "type": "blob",
     "mode": "100644",
     "id": "35b2f05cbb4566b71b34554cf184a9d0bd9d46d6"
   },
   {
     "name": "VERSION",
+    "path": "VERSION",
     "type": "blob",
     "mode": "100644",
     "id": "803e4a4f3727286c3093c63870c2b6524d30ec4f"
   },
   {
     "name": "config.ru",
+    "path": "config.ru",
     "type": "blob",
     "mode": "100644",
     "id": "dfd2d862237323aa599be31b473d70a8a817943b"

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -116,7 +116,7 @@ module API
     end
 
     class RepoTreeObject < Grape::Entity
-      expose :id, :name, :type
+      expose :id, :name, :type, :path
 
       expose :mode do |obj, options|
         filemode = obj.mode.to_s(8)

--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -56,14 +56,16 @@ module API
       # Parameters:
       #   id (required) - The ID of a project
       #   ref_name (optional) - The name of a repository branch or tag, if not given the default branch is used
+      #   recursive=1 (optional) - Used to get a recursive tree
       # Example Request:
       #   GET /projects/:id/repository/tree
       get ":id/repository/tree" do
         ref = params[:ref_name] || user_project.try(:default_branch) || 'master'
         path = params[:path] || nil
+        recursive = params[:recursive] || '0'
 
         commit = user_project.repository.commit(ref)
-        tree = user_project.repository.tree(commit.id, path)
+        tree = user_project.repository.tree(commit.id, path, recursive)
 
         present tree.sorted_entries, with: Entities::RepoTreeObject
       end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -98,6 +98,7 @@ describe API::API, api: true  do
 
         json_response.should be_an Array
         json_response.first['name'].should == 'encoding'
+        json_response.first['path'].should == 'encoding'
         json_response.first['type'].should == 'tree'
         json_response.first['mode'].should == '040000'
       end
@@ -107,6 +108,23 @@ describe API::API, api: true  do
       it "should not return project commits" do
         get api("/projects/#{project.id}/repository/tree")
         response.status.should == 401
+      end
+    end
+  end
+
+  describe "GET /projects/:id/repository/tree?recursive=1" do
+    context "authorized user" do
+      before { project.team << [user2, :reporter] }
+
+      it "should return project commits" do
+        get api("/projects/#{project.id}/repository/tree?recursive=1", user)
+        response.status.should == 200
+
+        json_response.should be_an Array
+        json_response[2]['name'].should == 'html'
+        json_response[2]['path'].should == 'files/html'
+        json_response[2]['type'].should == 'tree'
+        json_response[2]['mode'].should == '040000'
       end
     end
   end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -88,12 +88,12 @@ describe API::API, api: true  do
     end
   end
 
-  describe "GET /projects/:id/repository/tree" do
-    context "authorized user" do
+  describe 'GET /projects/:id/repository/tree' do
+    context 'authorized user' do
       before { project.team << [user2, :reporter] }
 
-      it "should return project commits" do
-        get api("/projects/#{project.id}/repository/tree", user)
+      it 'should return project commits' do
+        get api('/projects/#{project.id}/repository/tree', user)
         response.status.should == 200
 
         json_response.should be_an Array
@@ -104,20 +104,20 @@ describe API::API, api: true  do
       end
     end
 
-    context "unauthorized user" do
-      it "should not return project commits" do
-        get api("/projects/#{project.id}/repository/tree")
+    context 'unauthorized user' do
+      it 'should not return project commits' do
+        get api('/projects/#{project.id}/repository/tree')
         response.status.should == 401
       end
     end
   end
 
-  describe "GET /projects/:id/repository/tree?recursive=1" do
-    context "authorized user" do
+  describe 'GET /projects/:id/repository/tree?recursive=1' do
+    context 'authorized user' do
       before { project.team << [user2, :reporter] }
 
-      it "should return project commits" do
-        get api("/projects/#{project.id}/repository/tree?recursive=1", user)
+      it 'should return project commits' do
+        get api('/projects/#{project.id}/repository/tree?recursive=1', user)
         response.status.should == 200
 
         json_response.should be_an Array


### PR DESCRIPTION
As i've suggested in http://feedback.gitlab.com/forums/176466-general/suggestions/6661459-api-allow-recursive-repository-tree: added a parameter in tree request to get a recursive tree and path attribute in response.
