### PR TITLE
Raise group avatar filesize limit to 200kb, fixes #8527

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -21,7 +21,7 @@ class Group < Namespace
   has_many :users, through: :group_members
 
   validate :avatar_type, if: ->(user) { user.avatar_changed? }
-  validates :avatar, file_size: { maximum: 100.kilobytes.to_i }
+  validates :avatar, file_size: { maximum: 200.kilobytes.to_i }
 
   mount_uploader :avatar, AttachmentUploader
 


### PR DESCRIPTION
With GitLab 7.6, the file size limit for user avatars was raised from 100kb to 200kb. 

Since group avatars use the same view as user avatars there is now a conflict because UI says a limit of 200kb although the model validates against 100kb. This PR raises the file size limit for group avatars from 100kb to 200kb.
