### PR TITLE
fix media xml namespace for atom builders

### DIFF
--- a/app/views/dashboard/issues.atom.builder
+++ b/app/views/dashboard/issues.atom.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlnsmedia" => "http://search.yahoo.com/mrss/" do
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://search.yahoo.com/mrss/" do
   xml.title   "#{current_user.name} issues"
   xml.link    href: issues_dashboard_url(:atom, private_token: current_user.private_token), rel: "self", type: "application/atom+xml"
   xml.link    href: issues_dashboard_url(private_token: current_user.private_token), rel: "alternate", type: "text/html"

--- a/app/views/dashboard/show.atom.builder
+++ b/app/views/dashboard/show.atom.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlnsmedia" => "http://search.yahoo.com/mrss/" do
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://search.yahoo.com/mrss/" do
   xml.title   "Dashboard feed#{" - #{current_user.name}" if current_user.name.present?}"
   xml.link    href: dashboard_url(:atom), rel: "self", type: "application/atom+xml"
   xml.link    href: dashboard_url, rel: "alternate", type: "text/html"

--- a/app/views/groups/show.atom.builder
+++ b/app/views/groups/show.atom.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlnsmedia" => "http://search.yahoo.com/mrss/" do
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://search.yahoo.com/mrss/" do
   xml.title   "Group feed - #{@group.name}"
   xml.link    href: group_path(@group, :atom), rel: "self", type: "application/atom+xml"
   xml.link    href: group_path(@group), rel: "alternate", type: "text/html"

--- a/app/views/users/show.atom.builder
+++ b/app/views/users/show.atom.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlnsmedia" => "http://search.yahoo.com/mrss/" do
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xmlns:media" => "http://search.yahoo.com/mrss/" do
   xml.title   "Activity feed for #{@user.name}"
   xml.link    href: user_url(@user, :atom), rel: "self", type: "application/atom+xml"
   xml.link    href: user_url(@user), rel: "alternate", type: "text/html"


### PR DESCRIPTION
This PR fixes the media xml namespace in the atom builders. These are broken since 7.6.0 as of commit https://github.com/gitlabhq/gitlabhq/commit/d31d711a70779132ea43387f93eb4ccc1e472761. The W3C definition can be found here: http://www.w3.org/TR/2006/REC-xml-names-20060816/#ns-decl

Best regards
Segaja
