### PR TITLE
First entry in wiki history leads to newest revision.

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -237,4 +237,9 @@ module ProjectsHelper
     result.password = '*****' if result.password.present?
     result
   end
+
+  def project_wiki_path_with_version(proj, page, version, is_newest)
+    url_params = is_newest ? {} : { version_id: version }
+    project_wiki_path(proj, page, url_params)
+  end
 end

--- a/app/views/projects/wikis/history.html.haml
+++ b/app/views/projects/wikis/history.html.haml
@@ -12,11 +12,12 @@
       %th Last updated
       %th Format
   %tbody
-    - @page.versions.each do |version|
+    - @page.versions.each_with_index do |version, index|
       - commit = version
       %tr
         %td
-          = link_to project_wiki_path(@project, @page, version_id: commit.id) do
+          = link_to project_wiki_path_with_version(@project, @page,
+                                                   commit.id, index == 0) do
             = truncate_sha(commit.id)
         %td
           = commit.author.name


### PR DESCRIPTION
Getting to newest revision of a wiki page from its history lead to a page with a notice, that it's not newest. This PR fixes this unpleasantness.
