### PR TITLE
Fix authorized_projects pagination

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,7 +299,7 @@ class User < ActiveRecord::Base
                                project_ids = personal_projects.pluck(:id)
                                project_ids += groups_projects.pluck(:id)
                                project_ids += projects.pluck(:id).uniq
-                               Project.where(id: project_ids).joins(:namespace).order('namespaces.name ASC')
+                               Project.where(id: project_ids).joins(:namespace).order('namespaces.name, projects.id ASC')
                              end
   end
 


### PR DESCRIPTION
The Gitlab API uses pagination when you try to get the project list for
a user using the `@current_user.authorized_projects` method as a scope.

This method does not reliably order projects (it's non-deterministic).
This leads to missing or duplicate projects in the pagination.

Example:

``` sql
gitlabhq_production=# SELECT  "projects".id, projects.name,
namespaces.name
FROM "projects" INNER JOIN "namespaces" ON
"namespaces"."id" = "projects"."namespace_id" WHERE "projects"."id" IN
(33, 5, 18, 20, 30, 17, 32, 22, 6, 31, 95, 19, 91, 90, 33, 11, 13)
ORDER BY namespaces.name ASC
limit 4 offset 0;

 id |    name     |   name
----+-------------+----------
 31 | Test        | AnnaTest
 90 | Hadoop Test | AnnaTest
 20 | Eva Test    | AnnaTest
  6 | Adam        | AnnaTest
(4 rows)

gitlabhq_production=# SELECT  "projects".id, projects.name,
namespaces.name
FROM "projects" INNER JOIN "namespaces" ON
"namespaces"."id" = "projects"."namespace_id" WHERE "projects"."id" IN
(33, 5, 18, 20, 30, 17, 32, 22, 6, 31, 95, 19, 91, 90, 33, 11, 13)
ORDER BY namespaces.name ASC
limit 2 offset 0;

 id |    name     |   name
----+-------------+----------
  6 | Adam | AnnaTest
 31 | Test | AnnaTest
(2 rows)

gitlabhq_production=# SELECT  "projects".id, projects.name,
namespaces.name
FROM "projects" INNER JOIN "namespaces" ON
"namespaces"."id" = "projects"."namespace_id" WHERE "projects"."id" IN
(33, 5, 18, 20, 30, 17, 32, 22, 6, 31, 95, 19, 91, 90, 33, 11, 13)
ORDER BY namespaces.name ASC
limit 2 offset 2;

 id |    name     |   name
----+-------------+----------
 20 | Eva Test | AnnaTest
  6 | Adam     | AnnaTest
(2 rows)
```
