### PR TITLE
add necessary dir for uploads in update to 6.7

### DIFF
--- a/doc/update/6.6-to-6.7.md
+++ b/doc/update/6.6-to-6.7.md
@@ -70,6 +70,9 @@ sudo -u git -H gzip /home/git/gitlab-shell/gitlab-shell.log.1
 
 # Close access to gitlab-satellites for others
 sudo chmod u+rwx,g=rx,o-rwx /home/git/gitlab-satellites
+
+# Add directory for uploads
+sudo -u git -H mkdir -p /home/git/gitlab/public/uploads
 ```
 
 ## 5. Start application


### PR DESCRIPTION
rake task gitlab:backup:create crashes otherwise
