### PR TITLE
Update 6.x-or-7.x-to-7.6.md

### DIFF
--- a/doc/update/6.x-or-7.x-to-7.6.md
+++ b/doc/update/6.x-or-7.x-to-7.6.md
@@ -125,6 +125,8 @@ sudo -u git -H git checkout v2.4.0
 ## 7. Install libs, migrations, etc.
 
 ```bash
+sudo apt-get install libkrb5-dev
+
 cd /home/git/gitlab
 
 # MySQL installations (note: the line below states '--without ... postgres')


### PR DESCRIPTION
Added missing libkrb5-dev as mentioned here https://github.com/gitlabhq/gitlabhq/blob/master/doc/update/7.5-to-7.6.md
