### PR TITLE
Add support for colored header on Android Lollipop with Chrome

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -19,6 +19,7 @@
   = csrf_meta_tags
   = include_gon
   %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
+  %meta{name: 'theme-color', content: '#474D57'}
 
   = render 'layouts/google_analytics' if extra_config.has_key?('google_analytics_id')
   = render 'layouts/piwik' if extra_config.has_key?('piwik_url') && extra_config.has_key?('piwik_site_id')


### PR DESCRIPTION
Chrome on Android Lollipop supports a colored header. See http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
