### PR TITLE
Fix the email variable substituation in ssh help page

### DIFF
--- a/app/views/help/show.html.haml
+++ b/app/views/help/show.html.haml
@@ -1,2 +1,2 @@
 .documentation.wiki
-  = markdown File.read(Rails.root.join('doc', @category, @file + '.md'))
+  = markdown File.read(Rails.root.join('doc', @category, @file + '.md')).gsub("$your_email", current_user.email)

--- a/spec/features/help_pages_spec.rb
+++ b/spec/features/help_pages_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "Help Pages", feature: true do
-  describe "Show SSH page" do
+describe 'Help Pages', feature: true do
+  describe 'Show SSH page' do
     before do
       login_as :user
     end
-    it "replace the variable $your_email with the email of the user" do
-      visit help_page_path(category: "ssh", file: "ssh.md")
+    it 'replace the variable $your_email with the email of the user' do
+      visit help_page_path(category: 'ssh', file: 'ssh.md')
       page.should have_content("ssh-keygen -t rsa -C \"#{@user.email}\"")
     end
   end

--- a/spec/features/help_pages_spec.rb
+++ b/spec/features/help_pages_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe "Help Pages", feature: true do
+  describe "Show SSH page" do
+    before do
+      login_as :user
+    end
+    it "replace the variable $your_email with the email of the user" do
+      visit help_page_path(category: "ssh", file: "ssh.md")
+      page.should have_content("ssh-keygen -t rsa -C \"#{@user.email}\"")
+    end
+  end
+end


### PR DESCRIPTION
Fixing Issue #7623 to fix the email variable in help page.
