### PR TITLE
Add krb5 dependency for packaging

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -4,6 +4,7 @@ before_precompile: ./bin/pkgr_before_precompile.sh
 targets:
   debian-7: &wheezy
     build_dependencies:
+      - libkrb5-dev
       - libicu-dev
       - cmake
       - pkg-config
@@ -14,6 +15,7 @@ targets:
   ubuntu-12.04: *wheezy
   ubuntu-14.04:
     build_dependencies:
+      - libkrb5-dev
       - libicu-dev
       - cmake
       - pkg-config
@@ -23,6 +25,7 @@ targets:
       - git
   centos-6:
     build_dependencies:
+      - krb5-devel
       - libicu-devel
       - cmake
       - pkgconfig

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,5 +1,7 @@
 user: git
 group: git
+services:
+  - postgres
 before_precompile: ./bin/pkgr_before_precompile.sh
 targets:
   debian-7: &wheezy

--- a/bin/pkgr_before_precompile.sh
+++ b/bin/pkgr_before_precompile.sh
@@ -18,6 +18,3 @@ rm config/resque.yml
 
 # Set default unicorn.rb file
 echo "" > config/unicorn.rb
-
-# Required for assets precompilation
-sudo service postgresql start


### PR DESCRIPTION
Update packager.io recipe to install `libkrb5-dev` before the `bundle install` step, otherwise the package fails to build on ubuntu 14.04.

Before: https://packager.io/gh/gitlabhq/gitlabhq/build_runs/142#10313
After: https://packager.io/gh/pkgr/gitlabhq/build_runs/42#10327
