### PR TITLE
Add action property to merge request hook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,7 +42,7 @@ v 7.8.0
   - 
   - 
   - 
-  - 
+  - Add action property to merge request hook (Julien Bianchi)
   - 
   - 
   - 

--- a/app/services/merge_requests/base_service.rb
+++ b/app/services/merge_requests/base_service.rb
@@ -5,9 +5,12 @@ module MergeRequests
       Note.create_status_change_note(merge_request, merge_request.target_project, current_user, merge_request.state, nil)
     end
 
-    def execute_hooks(merge_request)
+    def execute_hooks(merge_request, action = 'open')
       if merge_request.project
         hook_data = merge_request.to_hook_data(current_user)
+        merge_request_url = Gitlab::UrlBuilder.new(:merge_request).build(merge_request.id)
+        hook_data[:object_attributes][:url] = merge_request_url
+        hook_data[:object_attributes][:action] = action
         merge_request.project.execute_hooks(hook_data, :merge_request_hooks)
       end
     end

--- a/app/services/merge_requests/close_service.rb
+++ b/app/services/merge_requests/close_service.rb
@@ -9,7 +9,7 @@ module MergeRequests
         event_service.close_mr(merge_request, current_user)
         notification_service.close_mr(merge_request, current_user)
         create_note(merge_request)
-        execute_hooks(merge_request)
+        execute_hooks(merge_request, 'close')
       end
 
       merge_request

--- a/app/services/merge_requests/merge_service.rb
+++ b/app/services/merge_requests/merge_service.rb
@@ -12,7 +12,7 @@ module MergeRequests
       notification_service.merge_mr(merge_request, current_user)
       create_merge_event(merge_request, current_user)
       create_note(merge_request)
-      execute_hooks(merge_request)
+      execute_hooks(merge_request, 'merge')
 
       true
     rescue

--- a/app/services/merge_requests/reopen_service.rb
+++ b/app/services/merge_requests/reopen_service.rb
@@ -5,7 +5,7 @@ module MergeRequests
         event_service.reopen_mr(merge_request, current_user)
         notification_service.reopen_mr(merge_request, current_user)
         create_note(merge_request)
-        execute_hooks(merge_request)
+        execute_hooks(merge_request, 'reopen')
         merge_request.reload_code
         merge_request.mark_as_unchecked
       end

--- a/app/services/merge_requests/update_service.rb
+++ b/app/services/merge_requests/update_service.rb
@@ -38,7 +38,7 @@ module MergeRequests
         end
 
         merge_request.notice_added_references(merge_request.project, current_user)
-        execute_hooks(merge_request)
+        execute_hooks(merge_request, 'update')
       end
 
       merge_request

--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -166,7 +166,9 @@ Triggered when a new merge request is created or an existing merge request was u
         "name": "GitLab dev user",
         "email": "gitlabdev@dv6700.(none)"
       }
-    }
+    },
+    "url": "http://example.com/diaspora/merge_requests/1",
+    "action": "open"
   }
 }
 ```

--- a/spec/services/merge_requests/create_service_spec.rb
+++ b/spec/services/merge_requests/create_service_spec.rb
@@ -5,21 +5,30 @@ describe MergeRequests::CreateService do
   let(:user) { create(:user) }
 
   describe :execute do
-    context "valid params" do
-      before do
-        project.team << [user, :master]
-        opts = {
+    context 'valid params' do
+      let(:opts) do
+        {
           title: 'Awesome merge_request',
           description: 'please fix',
           source_branch: 'stable',
           target_branch: 'master'
         }
+      end
+      let(:service) { MergeRequests::CreateService.new(project, user, opts) }
 
-        @merge_request = MergeRequests::CreateService.new(project, user, opts).execute
+      before do
+        project.team << [user, :master]
+        service.stub(:execute_hooks)
+
+        @merge_request = service.execute
       end
 
       it { @merge_request.should be_valid }
       it { @merge_request.title.should == 'Awesome merge_request' }
+
+      it 'should execute hooks with default action' do
+        expect(service).to have_received(:execute_hooks).with(@merge_request)
+      end
     end
   end
 end

--- a/spec/services/merge_requests/merge_service_spec.rb
+++ b/spec/services/merge_requests/merge_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MergeRequests::CloseService do
+describe MergeRequests::MergeService do
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:merge_request) { create(:merge_request, assignee: user2) }
@@ -13,31 +13,31 @@ describe MergeRequests::CloseService do
 
   describe :execute do
     context 'valid params' do
-      let(:service) { MergeRequests::CloseService.new(project, user, {}) }
+      let(:service) { MergeRequests::MergeService.new(project, user, {}) }
 
       before do
         service.stub(:execute_hooks)
 
-        @merge_request = service.execute(merge_request)
+        service.execute(merge_request, 'Awesome message')
       end
 
-      it { @merge_request.should be_valid }
-      it { @merge_request.should be_closed }
+      it { merge_request.should be_valid }
+      it { merge_request.should be_merged }
 
-      it 'should execute hooks with close action' do
+      it 'should execute hooks with merge action' do
         expect(service).to have_received(:execute_hooks).
-                               with(@merge_request, 'close')
+                               with(merge_request, 'merge')
       end
 
-      it 'should send email to user2 about assign of new merge_request' do
+      it 'should send email to user2 about merge of new merge_request' do
         email = ActionMailer::Base.deliveries.last
         email.to.first.should == user2.email
         email.subject.should include(merge_request.title)
       end
 
-      it 'should create system note about merge_request reassign' do
-        note = @merge_request.notes.last
-        note.note.should include 'Status changed to closed'
+      it 'should create system note about merge_request merge' do
+        note = merge_request.notes.last
+        note.note.should include 'Status changed to merged'
       end
     end
   end

--- a/spec/services/merge_requests/reopen_service_spec.rb
+++ b/spec/services/merge_requests/reopen_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe MergeRequests::CloseService do
+describe MergeRequests::ReopenService do
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:merge_request) { create(:merge_request, assignee: user2) }
@@ -13,31 +13,32 @@ describe MergeRequests::CloseService do
 
   describe :execute do
     context 'valid params' do
-      let(:service) { MergeRequests::CloseService.new(project, user, {}) }
+      let(:service) { MergeRequests::ReopenService.new(project, user, {}) }
 
       before do
         service.stub(:execute_hooks)
 
-        @merge_request = service.execute(merge_request)
+        merge_request.state = :closed
+        service.execute(merge_request)
       end
 
-      it { @merge_request.should be_valid }
-      it { @merge_request.should be_closed }
+      it { merge_request.should be_valid }
+      it { merge_request.should be_reopened }
 
-      it 'should execute hooks with close action' do
+      it 'should execute hooks with reopen action' do
         expect(service).to have_received(:execute_hooks).
-                               with(@merge_request, 'close')
+                               with(merge_request, 'reopen')
       end
 
-      it 'should send email to user2 about assign of new merge_request' do
+      it 'should send email to user2 about reopen of merge_request' do
         email = ActionMailer::Base.deliveries.last
         email.to.first.should == user2.email
         email.subject.should include(merge_request.title)
       end
 
-      it 'should create system note about merge_request reassign' do
-        note = @merge_request.notes.last
-        note.note.should include 'Status changed to closed'
+      it 'should create system note about merge_request reopen' do
+        note = merge_request.notes.last
+        note.note.should include 'Status changed to reopened'
       end
     end
   end


### PR DESCRIPTION
Issue hook provide a usefull information: in its JSON payload, there is the `action` property  which gives information on what exactly happened on the issue.

With this patch, the merge request hook will provide the same information. The `action` property will have the following values:
- `open` when the merge request is created
- `close` when the merge request is closed
- `merge` when the merge request is merged
- `reopen` when the merge request is reopened
- `update` when the merge request is updated

This will let hook consumers behave differently depending on what's happening on the merge request. 

For example, I'm working on a hubot scripts which will notify events on channels. Actually, I'm not able to filter notification without complex logic.
