### PR TITLE
Update gitlab-shell in docs to 2.4.1

### DIFF
--- a/doc/update/6.x-or-7.x-to-7.7.md
+++ b/doc/update/6.x-or-7.x-to-7.7.md
@@ -119,7 +119,7 @@ sudo apt-get install pkg-config cmake
 ```bash
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
-sudo -u git -H git checkout v2.4.0
+sudo -u git -H git checkout v2.4.1
 ```
 
 ## 7. Install libs, migrations, etc.

--- a/doc/update/7.6-to-7.7.md
+++ b/doc/update/7.6-to-7.7.md
@@ -37,7 +37,7 @@ sudo -u git -H git checkout 7-7-stable-ee
 ```bash
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
-sudo -u git -H git checkout v2.4.0
+sudo -u git -H git checkout v2.4.1
 ```
 
 ### 4. Install libs, migrations, etc.


### PR DESCRIPTION
#### What does this MR do?

Updates gitlab-shell in update guides to 2.4.1 as defined in [GITLAB_SHELL_VERSION](https://github.com/gitlabhq/gitlabhq/blob/7-7-stable/GITLAB_SHELL_VERSION)
#### What are the relevant issue numbers?

Fixes #8584 
