### PR TITLE
Update 7.6-to-7.7.md

### DIFF
--- a/doc/update/7.6-to-7.7.md
+++ b/doc/update/7.6-to-7.7.md
@@ -37,7 +37,7 @@ sudo -u git -H git checkout 7-7-stable-ee
 ```bash
 cd /home/git/gitlab-shell
 sudo -u git -H git fetch
-sudo -u git -H git checkout v2.4.0
+sudo -u git -H git checkout v2.4.1
 ```
 
 ### 4. Install libs, migrations, etc.


### PR DESCRIPTION
Fixed gitlab-shell version in guide (because of GitLab Shell version >= 2.4.1 ? ... FAIL. Please update gitlab-shell to 2.4.1 from 2.4.0)
