### PR TITLE
Handle errors on API when a project does not have a repository

### DIFF
--- a/lib/api/repositories.rb
+++ b/lib/api/repositories.rb
@@ -58,11 +58,13 @@ module API
       #   ref_name (optional) - The name of a repository branch or tag, if not given the default branch is used
       # Example Request:
       #   GET /projects/:id/repository/tree
-      get ":id/repository/tree" do
+      get ':id/repository/tree' do
         ref = params[:ref_name] || user_project.try(:default_branch) || 'master'
         path = params[:path] || nil
 
         commit = user_project.repository.commit(ref)
+        not_found!('Tree') unless commit
+
         tree = user_project.repository.tree(commit.id, path)
 
         present tree.sorted_entries, with: Entities::RepoTreeObject
@@ -100,14 +102,18 @@ module API
       #   sha (required) - The blob's sha
       # Example Request:
       #   GET /projects/:id/repository/raw_blobs/:sha
-      get ":id/repository/raw_blobs/:sha" do
+      get ':id/repository/raw_blobs/:sha' do
         ref = params[:sha]
 
         repo = user_project.repository
 
-        blob = Gitlab::Git::Blob.raw(repo, ref)
+        begin
+          blob = Gitlab::Git::Blob.raw(repo, ref)
+        rescue
+          not_found! 'Blob'
+        end
 
-        not_found! "Blob" unless blob
+        not_found! 'Blob' unless blob
 
         env['api.format'] = :txt
 
@@ -122,13 +128,23 @@ module API
       #   sha (optional) - the commit sha to download defaults to the tip of the default branch
       # Example Request:
       #   GET /projects/:id/repository/archive
-      get ":id/repository/archive", requirements: { format: Gitlab::Regex.archive_formats_regex } do
+      get ':id/repository/archive',
+          requirements: { format: Gitlab::Regex.archive_formats_regex } do
         authorize! :download_code, user_project
-        file_path = ArchiveRepositoryService.new.execute(user_project, params[:sha], params[:format])
+
+        begin
+          file_path = ArchiveRepositoryService.new.execute(
+              user_project,
+              params[:sha],
+              params[:format])
+        rescue
+          not_found!('File')
+        end
 
         if file_path && File.exists?(file_path)
           data = File.open(file_path, 'rb').read
-          header["Content-Disposition"] = "attachment; filename=\"#{File.basename(file_path)}\""
+          basename = File.basename(file_path)
+          header['Content-Disposition'] = "attachment; filename=\"#{basename}\""
           content_type MIME::Types.type_for(file_path).first.content_type
           env['api.format'] = :binary
           present data
@@ -161,7 +177,12 @@ module API
       get ':id/repository/contributors' do
         authorize! :download_code, user_project
 
-        present user_project.repository.contributors, with: Entities::Contributor
+        begin
+          present user_project.repository.contributors,
+                  with: Entities::Contributor
+        rescue
+          not_found!
+        end
       end
     end
   end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -101,6 +101,14 @@ describe API::API, api: true  do
         json_response.first['type'].should == 'tree'
         json_response.first['mode'].should == '040000'
       end
+
+      it 'should return a 404 for unknown ref' do
+        get api("/projects/#{project.id}/repository/tree?ref_name=foo", user)
+        response.status.should == 404
+
+        json_response.should be_an Object
+        json_response['message'] == '404 Tree Not Found'
+      end
     end
 
     context "unauthorized user" do
@@ -144,6 +152,14 @@ describe API::API, api: true  do
     it "should get the raw file contents" do
       get api("/projects/#{project.id}/repository/raw_blobs/#{sample_blob.oid}", user)
       response.status.should == 200
+    end
+
+    it 'should return a 404 for unknown blob' do
+      get api("/projects/#{project.id}/repository/raw_blobs/123456", user)
+      response.status.should == 404
+
+      json_response.should be_an Object
+      json_response['message'] == '404 Blob Not Found'
     end
   end
 


### PR DESCRIPTION
This is basically a fix for #6289: when a project does not have a repository (i.e no refs have been pushed) API was giving badly formatted errors.

It will now return 404 errors when appropriate
