### PR TITLE
Remember the project default tab for 30 days

### DIFF
--- a/app/assets/javascripts/project_show.js.coffee
+++ b/app/assets/javascripts/project_show.js.coffee
@@ -6,7 +6,7 @@ class @ProjectShow
       new Flash('Star toggle failed. Try again later.', 'alert')
 
     $("a[data-toggle='tab']").on "shown.bs.tab", (e) ->
-        $.cookie "default_view", $(e.target).attr("href")
+        $.cookie "default_view", $(e.target).attr("href"), { expires: 30 }
 
       defaultView = $.cookie("default_view")
       if defaultView


### PR DESCRIPTION
### 1. What does this MR do?

Remember the project default tab (Activity or Readme) for 30 days.
### 2. Are there points in the code the reviewer needs to double check?

No there are.
### 3. Why was this MR needed?

It is incommodious that the project default tab is forgotten in every new sessions(new tabs and new windows).
### 4. What are the relevant issue numbers / Feature requests?

Nothing.
### 5. Screenshots (if relevant)

Nothing.
