### PR TITLE
"Mentioned in" list in dashboard sidebar

### DIFF
--- a/app/views/dashboard/_mention.html.haml
+++ b/app/views/dashboard/_mention.html.haml
@@ -1,0 +1,18 @@
+= link_to project_merge_request_path(mention.target_project, mention), class: dom_class(mention) do
+  .dash-project-access-icon
+    = visibility_level_icon(mention.project.visibility_level)
+  %span.str-truncated
+    %span.namespace-name
+      - if mention.project.namespace
+        = mention.project.namespace.human_name
+        \/
+    %span.project-name.filter-title
+      = mention.project.name
+      \/
+    %span.merge_request-id
+      \ #
+      = mention.id
+  %span.arrow
+    - if not mention.responded
+      %i.fa.fa-comment
+    %i.fa.fa-angle-right

--- a/app/views/dashboard/_mentions.html.haml
+++ b/app/views/dashboard/_mentions.html.haml
@@ -1,0 +1,18 @@
+.panel.panel-default
+
+  %ul.well-list.dash-list
+    - @mentioned_in.each do |mention|
+      %li.project-row
+        = render "mention", mention: mention
+
+    - if @mentioned_in.blank?
+      %li
+        .nothing-here-block You are not mentioned in merge requests.
+    - if @mentions_count > @mentions_limit
+      %li.bottom
+        %span.light
+          #{@mentions_limit} of #{pluralize(@mentions_count, 'mention')} displayed.
+        .pull-right
+          = link_to mentions_dashboard_path do
+            Show all
+            %i.fa.fa-angle-right

--- a/app/views/dashboard/_sidebar.html.haml
+++ b/app/views/dashboard/_sidebar.html.haml
@@ -7,12 +7,18 @@
     = link_to '#groups', 'data-toggle' => 'tab', id: 'sidebar-groups-tab' do
       Groups
       %span.badge= @groups.count
+  %li
+    = link_to '#mentions', 'data-toggle' => 'tab', id: 'sidebar-mentions-tab' do
+      Mentioned In
+      %span.badge= @mentions_count
 
 .tab-content
   .tab-pane.active#projects
     = render "projects", projects: @projects
   .tab-pane#groups
     = render "groups", groups: @groups
+  .tab-pane#mentions
+    = render "mentions", mentions: @mentions
 
 .prepend-top-20
   = render 'shared/promo'


### PR DESCRIPTION
The [suggestion](http://feedback.gitlab.com/forums/176466-general/suggestions/4678160-ability-to-assign-merge-request-to-multiple-users) from [feedback.gitlab.com](feedback.gitlab.com) implementation.

The implementation uses short guidelines written by `Gitlab team (Admin, Gitlab)` user.

GitLab team (Admin, Gitlab) commented  ·  September 30, 2014 12:47
Proposal with three parts, can implement only 1, 1+2 or 1+2+3.
1. Users see a 'mentioned in' list of merge requests they were mentioned in. 
2. Users also see a 'to respond' list of merge requests they were mentioned in but didn't comment in after being mentioned. If they respond but are mentioned again the merge request gets added to the list again. 
3. We already show the participants in each merge request. With this feature you would also indicate in that list if they responded after their latest mention or not.

Here's also a small screenshot of how it looks like on fixtures-based data.
![mentioned_in_tab](https://cloud.githubusercontent.com/assets/372353/5852553/7ebac138-a221-11e4-9641-8c87edd3ad5e.png)
