### PR TITLE
Expose Link header in CORS Api calls

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -70,7 +70,10 @@ module Gitlab
     config.middleware.use Rack::Cors do
       allow do
         origins '*'
-        resource '/api/*', headers: :any, methods: [:get, :post, :options, :put, :delete], expose: ["Link"]
+        resource '/api/*', 
+          :headers => :any,
+          :methods => [:get, :post, :options, :put, :delete],
+          :expose => ['Link']
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,7 +70,7 @@ module Gitlab
     config.middleware.use Rack::Cors do
       allow do
         origins '*'
-        resource '/api/*', headers: :any, methods: [:get, :post, :options, :put, :delete]
+        resource '/api/*', headers: :any, methods: [:get, :post, :options, :put, :delete], expose: ["Link"]
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,10 +70,10 @@ module Gitlab
     config.middleware.use Rack::Cors do
       allow do
         origins '*'
-        resource '/api/*', 
-          :headers => :any,
-          :methods => [:get, :post, :options, :put, :delete],
-          :expose => ['Link']
+        resource '/api/*',
+          headers: :any,
+          methods: [:get, :post, :options, :put, :delete],
+          expose: ['Link']
       end
     end
 


### PR DESCRIPTION
Adds "Link" to a list of exposed headers created by Rack Cors on API requests.
This enables pagination link headers to be used cross domain.
