### PR TITLE
Add X-GitLab-Event header for web hooks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v 7.11.0 (unreleased)
   - Add "Reply quoting selected text" shortcut key (`r`)
   - Fix bug causing `@whatever` inside an issue's first code block to be picked up as a user mention.
   - Fix bug causing `@whatever` inside an inline code snippet (backtick-style) to be picked up as a user mention.
+  - Added GitLab Event header for project hooks
   -
   - Show Atom feed buttons everywhere where applicable.
   - Add project activity atom feed.

--- a/app/controllers/admin/hooks_controller.rb
+++ b/app/controllers/admin/hooks_controller.rb
@@ -33,7 +33,7 @@ class Admin::HooksController < Admin::ApplicationController
       owner_name: "Someone",
       owner_email: "example@gitlabhq.com"
     }
-    @hook.execute(data)
+    @hook.execute(data, 'system_hooks')
 
     redirect_to :back
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -483,7 +483,7 @@ class Project < ActiveRecord::Base
 
   def execute_hooks(data, hooks_scope = :push_hooks)
     hooks.send(hooks_scope).each do |hook|
-      hook.async_execute(data)
+      hook.async_execute(data, hooks_scope.to_s)
     end
   end
 

--- a/app/services/system_hooks_service.rb
+++ b/app/services/system_hooks_service.rb
@@ -7,12 +7,12 @@ class SystemHooksService
 
   def execute_hooks(data)
     SystemHook.all.each do |sh|
-      async_execute_hook sh, data
+      async_execute_hook(sh, data, 'system_hooks')
     end
   end
 
-  def async_execute_hook(hook, data)
-    Sidekiq::Client.enqueue(SystemHookWorker, hook.id, data)
+  def async_execute_hook(hook, data, hook_name)
+    Sidekiq::Client.enqueue(SystemHookWorker, hook.id, data, hook_name)
   end
 
   def build_event_data(model, event)

--- a/app/services/test_hook_service.rb
+++ b/app/services/test_hook_service.rb
@@ -1,6 +1,6 @@
 class TestHookService
   def execute(hook, current_user)
     data = Gitlab::PushDataBuilder.build_sample(hook.project, current_user)
-    hook.execute(data)
+    hook.execute(data, 'push_hooks')
   end
 end

--- a/app/workers/project_web_hook_worker.rb
+++ b/app/workers/project_web_hook_worker.rb
@@ -3,8 +3,8 @@ class ProjectWebHookWorker
 
   sidekiq_options queue: :project_web_hook
 
-  def perform(hook_id, data)
+  def perform(hook_id, data, hook_name)
     data = data.with_indifferent_access
-    WebHook.find(hook_id).execute(data)
+    WebHook.find(hook_id).execute(data, hook_name)
   end
 end

--- a/app/workers/system_hook_worker.rb
+++ b/app/workers/system_hook_worker.rb
@@ -3,7 +3,7 @@ class SystemHookWorker
 
   sidekiq_options queue: :system_hook
 
-  def perform(hook_id, data)
-    SystemHook.find(hook_id).execute data
+  def perform(hook_id, data, hook_name)
+    SystemHook.find(hook_id).execute(data, hook_name)
   end
 end

--- a/lib/api/system_hooks.rb
+++ b/lib/api/system_hooks.rb
@@ -47,7 +47,7 @@ module API
           owner_name: "Someone",
           owner_email: "example@gitlabhq.com"
         }
-        @hook.execute(data)
+        @hook.execute(data, 'system_hooks')
         data
       end
 

--- a/spec/models/hooks/web_hook_spec.rb
+++ b/spec/models/hooks/web_hook_spec.rb
@@ -52,22 +52,26 @@ describe ProjectHook do
     end
 
     it "POSTs to the web hook URL" do
-      @project_hook.execute(@data)
-      expect(WebMock).to have_requested(:post, @project_hook.url).once
+      @project_hook.execute(@data, 'push_hooks')
+      expect(WebMock).to have_requested(:post, @project_hook.url).
+        with(headers: {'Content-Type'=>'application/json', 'X-Gitlab-Event'=>'Push Hook'}).
+        once
     end
 
     it "POSTs the data as JSON" do
       json = @data.to_json
 
-      @project_hook.execute(@data)
-      expect(WebMock).to have_requested(:post, @project_hook.url).with(body: json).once
+      @project_hook.execute(@data, 'push_hooks')
+      expect(WebMock).to have_requested(:post, @project_hook.url).
+        with(headers: {'Content-Type'=>'application/json', 'X-Gitlab-Event'=>'Push Hook'}).
+        once
     end
 
     it "catches exceptions" do
       expect(WebHook).to receive(:post).and_raise("Some HTTP Post error")
 
       expect {
-        @project_hook.execute(@data)
+        @project_hook.execute(@data, 'push_hooks')
       }.to raise_error
     end
   end


### PR DESCRIPTION
**What does this MR do?**
This MR adds to all webhooks.
**Are there points in the code the reviewer needs to double check?**
- https://github.com/Bugagazavr/gitlabhq/blob/1957bbb661f423d0454d3a05ac913ea7af99dabe/app/models/hooks/web_hook.rb#L32

**Why was this MR needed?**
This allow filter incoming hooks without parsing payload, similar feature on github https://developer.github.com/v3/activity/events/types/

**What are the relevant issue numbers / Feature requests?**
nil
**Screenshots (if relevant)**
nil
