### PR TITLE
Add api version property on hipchat service

### DIFF
--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -1,5 +1,5 @@
 class Projects::ServicesController < Projects::ApplicationController
-  ALLOWED_PARAMS = [:title, :token, :type, :active, :api_key, :subdomain,
+  ALLOWED_PARAMS = [:title, :token, :type, :active, :api_key, :api_version, :subdomain,
                     :room, :recipients, :project_url, :webhook,
                     :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
                     :build_key, :server, :teamcity_url, :build_type,

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -20,7 +20,7 @@
 class HipchatService < Service
   MAX_COMMITS = 3
 
-  prop_accessor :token, :room, :server, :notify, :color
+  prop_accessor :token, :room, :server, :notify, :color, :api_version
   validates :token, presence: true, if: :activated?
 
   def title
@@ -41,6 +41,8 @@ class HipchatService < Service
       { type: 'text', name: 'room',      placeholder: 'Room name or ID' },
       { type: 'checkbox', name: 'notify' },
       { type: 'select', name: 'color', choices: ['yellow', 'red', 'green', 'purple', 'gray', 'random'] },
+      { type: 'text', name: 'api_version',
+        placeholder: 'Leave blank for default (v2)' },
       { type: 'text', name: 'server',
         placeholder: 'Leave blank for default. https://hipchat.example.com' }
     ]
@@ -60,7 +62,7 @@ class HipchatService < Service
   private
 
   def gate
-    options = { api_version: 'v2' }
+    options = { api_version: api_version || 'v2' }
     options[:server_url] = server unless server.blank?
     @gate ||= HipChat::Client.new(token, options)
   end


### PR DESCRIPTION
There are two types of Hipchat API token - group-level and account-level. Found that group-level api token is not working with v2 API.

So let's make it configurable.

See also #7373
