### PR TITLE
Fixes #8478. Update timfel-krb5-auth to 0.8.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,7 @@ GEM
     tilt (1.4.1)
     timers (4.0.1)
       hitimes
-    timfel-krb5-auth (0.8)
+    timfel-krb5-auth (0.8.3)
     tinder (1.9.3)
       eventmachine (~> 1.0)
       faraday (~> 0.8)


### PR DESCRIPTION
Fix for build on Gentoo (and other recent systems).
