### PR TITLE
Make MR and issue numbers clickable links in MR and issue lists.

### DIFF
--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -11,7 +11,7 @@
         CLOSED
 
   .issue-info
-    %span.light= "##{issue.iid}"
+    = link_to "##{issue.iid}", project_issue_path(issue.project, issue), class: "light"
     - if issue.assignee
       assigned to #{link_to_member(@project, issue.assignee)}
     - if issue.votes_count > 0

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -14,7 +14,7 @@
         %i.fa.fa-angle-right.light
         = merge_request.target_branch
   .merge-request-info
-    %span.light= "##{merge_request.iid}"
+    = link_to "##{merge_request.iid}", project_merge_request_path(merge_request.target_project, merge_request), class: "light"
     - if merge_request.assignee
       assigned to #{link_to_member(merge_request.source_project, merge_request.assignee)}
     - else


### PR DESCRIPTION
This is a small improvement, that fixes a bug in the following use-case:
if a title of MR consists only of issue number (e.g. `#1234`), then there's no possibility to open this MR from the MR list, as its title will lead to an issue.
