### PR TITLE
Add icon helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -247,15 +247,6 @@ module ApplicationHelper
     Gitlab::MarkdownHelper.gitlab_markdown?(filename)
   end
 
-  def spinner(text = nil, visible = false)
-    css_class = 'loading'
-    css_class << ' hide' unless visible
-
-    content_tag :div, class: css_class do
-      content_tag(:i, nil, class: 'fa fa-spinner fa-spin') + text
-    end
-  end
-
   def link_to(name = nil, options = nil, html_options = nil, &block)
     begin
       uri = URI(options)

--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -65,8 +65,7 @@ module CommitsHelper
     branches.sort.map do |branch|
       link_to(project_tree_path(project, branch)) do
         content_tag :span, class: 'label label-gray' do
-          content_tag(:i, nil, class: 'fa fa-code-fork') + ' ' +
-            branch
+          icon('code-fork') + ' ' + branch
         end
       end
     end.join(" ").html_safe
@@ -78,8 +77,7 @@ module CommitsHelper
     sorted.map do |tag|
       link_to(project_commits_path(project, project.repository.find_tag(tag).name)) do
         content_tag :span, class: 'label label-gray' do
-          content_tag(:i, nil, class: 'fa fa-tag') + ' ' +
-            tag
+          icon('tag') + ' ' + tag
         end
       end
     end.join(" ").html_safe

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -27,18 +27,17 @@ module EventsHelper
 
     content_tag :li, class: "filter_icon #{active}" do
       link_to request.path, class: 'has_tooltip event_filter_link', id: "#{key}_event_filter", 'data-original-title' => tooltip do
-        content_tag(:i, nil, class: icon_for_event[key]) +
-          content_tag(:span, ' ' + tooltip)
+        icon(icon_for_event[key]) + content_tag(:span, ' ' + tooltip)
       end
     end
   end
 
   def icon_for_event
     {
-      EventFilter.push     => 'fa fa-upload',
-      EventFilter.merged   => 'fa fa-check-square-o',
-      EventFilter.comments => 'fa fa-comments',
-      EventFilter.team     => 'fa fa-user',
+      EventFilter.push     => 'upload',
+      EventFilter.merged   => 'check-square-o',
+      EventFilter.comments => 'comments',
+      EventFilter.team     => 'user',
     }
   end
 

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -1,21 +1,30 @@
 module IconsHelper
+  # Creates an icon tag given icon name(s) and possible icon modifiers.
+  #
+  # Right now this method simply delegates directly to `fa_icon` from the
+  # font-awesome-rails gem, but should we ever use a different icon pack in the
+  # future we won't have to change hundreds of method calls.
+  def icon(names, options = {})
+    fa_icon(names, options)
+  end
+
   def boolean_to_icon(value)
     if value.to_s == "true"
-      content_tag :i, nil, class: 'fa fa-circle cgreen'
+      icon('circle', class: 'cgreen')
     else
-      content_tag :i, nil, class: 'fa fa-power-off clgray'
+      icon('power-off', class: 'clgray')
     end
   end
 
   def public_icon
-    content_tag :i, nil, class: 'fa fa-globe'
+    icon('globe')
   end
 
   def internal_icon
-    content_tag :i, nil, class: 'fa fa-shield'
+    icon('shield')
   end
 
   def private_icon
-    content_tag :i, nil, class: 'fa fa-lock'
+    icon('lock')
   end
 end

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -8,6 +8,15 @@ module IconsHelper
     fa_icon(names, options)
   end
 
+  def spinner(text = nil, visible = false)
+    css_class = 'loading'
+    css_class << ' hide' unless visible
+
+    content_tag :div, class: css_class do
+      icon('spinner spin') + text
+    end
+  end
+
   def boolean_to_icon(value)
     if value.to_s == "true"
       icon('circle', class: 'cgreen')

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -62,7 +62,7 @@ module IssuesHelper
       ts << capture_haml do
         haml_tag :span do
           haml_concat '&middot;'
-          haml_concat '<i class="fa fa-edit" title="edited"></i> '
+          haml_concat icon('edit', title: 'edited')
           haml_concat time_ago_with_tooltip(issue.updated_at, 'bottom', 'issue_edited_ago')
         end
       end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -22,7 +22,7 @@ module NotesHelper
       ts << capture_haml do
         haml_tag :span do
           haml_concat '&middot;'
-          haml_concat '<i class="fa fa-edit" title="edited"></i> '
+          haml_concat icon('edit', title: 'edited')
           haml_concat time_ago_with_tooltip(note.updated_at, 'bottom', 'note_edited_ago')
         end
       end
@@ -57,7 +57,7 @@ module NotesHelper
     button_tag(class: 'btn add-diff-note js-add-diff-note-button',
                data: data,
                title: 'Add a comment to this line') do
-      content_tag :i, nil, class: 'fa fa-comment-o'
+      icon('comment-o')
     end
   end
 
@@ -74,7 +74,7 @@ module NotesHelper
 
     button_tag class: 'btn reply-btn js-discussion-reply-button',
                data: data, title: 'Add a reply' do
-      link_text = content_tag(:i, nil, class: 'fa fa-comment')
+      link_text = icon('comment')
       link_text << ' Reply'
     end
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,13 +1,13 @@
 module NotificationsHelper
   def notification_icon(notification)
     if notification.disabled?
-      content_tag :i, nil, class: 'fa fa-volume-off ns-mute'
+      icon('volume-off', class: 'ns-mute')
     elsif notification.participating?
-      content_tag :i, nil, class: 'fa fa-volume-down ns-part'
+      icon('volume-down', class: 'ns-part')
     elsif notification.watch?
-      content_tag :i, nil, class: 'fa fa-volume-up ns-watch'
+      icon('volume-up', class: 'ns-watch')
     else
-      content_tag :i, nil, class: 'fa fa-circle-o ns-default'
+      icon('circle-o', class: 'ns-default')
     end
   end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -83,7 +83,7 @@ module ProjectsHelper
                       ' Star'
                     end
 
-      content_tag('i', ' ', class: 'fa fa-star') + toggle_text
+      icon('star') + toggle_text
     end
 
     count_html = content_tag('span', class: 'count') do
@@ -107,7 +107,7 @@ module ProjectsHelper
   end
 
   def link_to_toggle_fork
-    out = content_tag(:i, '', class: 'fa fa-code-fork')
+    out = icon('code-fork')
     out << ' Fork'
     out << content_tag(:span, class: 'count') do
       @project.forks_count.to_s

--- a/app/helpers/tree_helper.rb
+++ b/app/helpers/tree_helper.rb
@@ -38,13 +38,8 @@ module TreeHelper
   #
   # type - String type of the tree item; either 'folder' or 'file'
   def tree_icon(type)
-    icon_class = if type == 'folder'
-                   'fa fa-folder'
-                 else
-                   'fa fa-file-o'
-                 end
-
-    content_tag :i, nil, class: icon_class
+    icon_class = type == 'folder' ? 'folder' : 'file-o'
+    icon(icon_class)
   end
 
   def tree_hex_class(content)


### PR DESCRIPTION
This adds an `icon` helper method to the `IconsHelper` module (and also moves the `spinner` helper method there to make `ApplicationHelper` less of a junk drawer). Right now this method simply delegates to `fa_icon` built into the `font-awesome-rails` gem. It handles creating the `i` element and adds the necessary classes.

This cleans up some minor pieces of code. If this PR gets accepted I've got another one that updates all of the HAML views to use this as well (e.g., `%i.fa.fa-code-fork` becomes `= icon('code-fork')`), but I didn't include it in this one because its touches dozens of files and I want to minimize the merge conflicts.
