### PR TITLE
Refactor Repository to use new RepositoryCache class

### DIFF
--- a/lib/repository_cache.rb
+++ b/lib/repository_cache.rb
@@ -1,0 +1,25 @@
+# Interface to the Redis-backed cache store used by the Repository model
+class RepositoryCache
+  attr_reader :namespace
+
+  def initialize(namespace, backend = Rails.cache)
+    @namespace = namespace
+    @backend = backend
+  end
+
+  def cache_key(type)
+    "#{type}:#{namespace}"
+  end
+
+  def expire(key)
+    backend.delete(cache_key(key))
+  end
+
+  def fetch(key, &block)
+    backend.fetch(cache_key(key), &block)
+  end
+
+  private
+
+  attr_reader :backend
+end

--- a/spec/lib/repository_cache_spec.rb
+++ b/spec/lib/repository_cache_spec.rb
@@ -1,0 +1,34 @@
+require 'rspec'
+require_relative '../../lib/repository_cache'
+
+describe RepositoryCache do
+  let(:backend) { double('backend').as_null_object }
+  let(:cache) { RepositoryCache.new('example', backend) }
+
+  describe '#cache_key' do
+    it 'includes the namespace' do
+      expect(cache.cache_key(:foo)).to eq 'foo:example'
+    end
+  end
+
+  describe '#expire' do
+    it 'expires the given key from the cache' do
+      cache.expire(:foo)
+      expect(backend).to have_received(:delete).with('foo:example')
+    end
+  end
+
+  describe '#fetch' do
+    it 'fetches the given key from the cache' do
+      cache.fetch(:bar)
+      expect(backend).to have_received(:fetch).with('bar:example')
+    end
+
+    it 'accepts a block' do
+      p = -> {}
+
+      cache.fetch(:baz, &p)
+      expect(backend).to have_received(:fetch).with('baz:example', &p)
+    end
+  end
+end


### PR DESCRIPTION
Abstracts away the lower-level implementation details from the Repository model.
