### PR TITLE
"upload" and "replace" functionality added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,11 @@ v 7.5.2
 v 7.5.1
   - Add missing timestamps to 'members' table
 
+1. add "upload" functionality, which allows user upload file into current repository.
+2. add "replace" functionality, which allows user replace file in the current repository.
+
+
+
 v 7.5.0
   - API: Add support for Hipchat (Kevin Houdebert)
   - Add time zone configuration on gitlab.yml (Sullivan Senechal)

--- a/app/controllers/projects/new_tree_controller.rb
+++ b/app/controllers/projects/new_tree_controller.rb
@@ -6,15 +6,65 @@ class Projects::NewTreeController < Projects::BaseTreeController
   end
 
   def update
-    file_path = File.join(@path, File.basename(params[:file_name]))
-    result = Files::CreateService.new(@project, current_user, params, @ref, file_path).execute
-
+	flag=0
+	#replace & upload 
+	if params[:file_upload] != nil
+		#get the name of the upload file
+		file_na=params[:file_upload].original_filename
+		file_path=nil
+		
+	    if file_na != nil
+			file_list = tree.entries.select(&:file?)
+			dir_list = tree.entries.select(&:dir?)
+			
+			dir_list.each do |dir|		#check whether current path is sub-repository
+				if dir.name != nil
+					flag=1
+				end
+			end
+			
+			file_list.each do |file|	#check whether current path is sub-repository
+				if file.name != nil
+					flag=1
+				end
+			end
+			
+			if @path.match(/(.*\/)*(.+)\z/) != nil && flag==0	#replace existing file
+				flag=2
+				params[:content]=params[:file_upload].read
+				params[:file_name]=@path	
+				file_path=@path
+				result=Files::UpdateService.new(@project, current_user, params, @ref, @path).execute
+			end
+				
+			if flag==1 || flag==0	#upload new file	
+				flag=3
+				file_list.each do |file|				
+					if file.name == file_na
+						flash[:alert] = file.name + " already exists!"
+						redirect_to project_blob_path(@project, File.join(@ref, @path))
+						return 
+					end
+				end
+				params[:content]=params[:file_upload].read
+				params[:file_name]=file_na	
+				file_path = File.join(@path, File.basename(params[:file_name]))
+				result = Files::CreateService.new(@project, current_user, params, @ref, file_path).execute
+			end
+		end
+	end 
+	
+	if flag==0
+		file_path = File.join(@path, File.basename(params[:file_name]))
+		result = Files::CreateService.new(@project, current_user, params, @ref, file_path).execute
+	end
+	
     if result[:status] == :success
-      flash[:notice] = "Your changes have been successfully committed"
-      redirect_to project_blob_path(@project, File.join(@ref, file_path))
-    else
-      flash[:alert] = result[:message]
-      render :show
+		flash[:notice] = "Your changes have been successfully commited."		
+		redirect_to project_blob_path(@project, File.join(@ref, file_path))
+	else
+		flash[:alert] = result[:message]
+		render :show
     end
   end
 end

--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -23,6 +23,10 @@
         tree_join(@commit.sha, @path)), class: 'btn btn-small'
 
 - if allowed_tree_edit?
+  = button_tag class: 'btn btn-small btn-primary btn-xs',
+      'data-toggle' => 'modal', 'data-target' => '#modal-update-blob' do
+    Replace	 
+  = |
   = button_tag class: 'remove-blob btn btn-small btn-remove',
       'data-toggle' => 'modal', 'data-target' => '#modal-remove-blob' do
     Remove

--- a/app/views/projects/blob/_update.html.haml
+++ b/app/views/projects/blob/_update.html.haml
@@ -1,0 +1,35 @@
+#modal-update-blob.modal.hide
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %a.close{href: "#", "data-dismiss" => "modal"} ×
+        %h3.page-title Replace #{@blob.name}
+        %p.light
+          From branch
+          %strong= @ref
+      .modal-body
+        = form_tag project_new_tree_path(@project, @id), method: :put, class: 'form-horizontal', :multipart => true, :onChange => 'checkFile()' do
+          %br
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = file_field_tag :file_upload, :id => "file-upload", :class => "file_up"
+          %br
+          = render 'shared/commit_message_replace_container', params: params,
+                  placeholder: 'Replace this file because...'
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = button_tag 'Replace', class: 'btn btn-small btn-primary', id: 'replace_btn'
+              = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+:javascript 
+  function checkFile(){
+    str=document.getElementById('file_upload').value; 
+    if(str.length < 1){
+      alert('Please select file!');
+    }
+  }
+  disableButtonIfAnyEmptyField('#commit_message')
+
+
+

--- a/app/views/projects/blob/show.html.haml
+++ b/app/views/projects/blob/show.html.haml
@@ -6,3 +6,5 @@
 
 - if allowed_tree_edit?
   = render 'projects/blob/remove'
+- if allowed_tree_edit?
+  = render 'projects/blob/update'

--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -10,9 +10,11 @@
         = link_to title, '#'
   - if current_user && can_push_branch?(@project, @ref)
     %li
-      = link_to project_new_tree_path(@project, @id), title: 'New file', id: 'new-file-link' do
-        %small
-          %i.fa.fa-plus
+      = link_to project_new_tree_path(@project, @id), class: 'btn btn-small btn-xs', title: 'Create New file', id: 'new-file-link' do
+        Create        
+      = | 
+      = button_tag class: 'btn btn-small btn-xs', 'data-toggle' => 'modal', title: 'Upload New file', 'data-target' => '#modal-upload-tree' do
+        Upload	
 
 %div#tree-content-holder.tree-content-holder
   %table#tree-slider{class: "table_#{@hex_path} tree-table" }
@@ -44,7 +46,9 @@
   - if tree.readme
     = render "projects/tree/readme", readme: tree.readme
 
+
 %div.tree_progress
+
 
 :javascript
   // Load last commit log for each file in tree

--- a/app/views/projects/tree/_upload.html.haml
+++ b/app/views/projects/tree/_upload.html.haml
@@ -1,0 +1,35 @@
+#modal-upload-tree.modal.hide
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %a.close{href: "#", "data-dismiss" => "modal"} ×
+        %h3.page-title Upload 
+        %p.light
+          From branch
+          %strong= @ref
+      .modal-body
+        = form_tag project_new_tree_path(@project, @id), method: :put, class: 'form-horizontal', :multipart => true , :onChange => 'checkFile()' do
+          %br
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = file_field_tag :file_upload, :id => "file", :class => "file_up"
+          %br
+          = render 'shared/commit_message_container', params: params,
+                  placeholder: 'Upload this file because...'
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = button_tag 'Upload', class: 'btn btn-small btn-primary'
+              = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+:javascript 
+  function checkFile(){
+    str=document.getElementById('file').value; 
+    if(str.length < 1){
+      alert('Please select file!');
+    }
+  }
+  disableButtonIfAnyEmptyField( '#commit_message')
+
+
+

--- a/app/views/projects/tree/show.html.haml
+++ b/app/views/projects/tree/show.html.haml
@@ -5,5 +5,11 @@
   .tree-download-holder
     = render 'projects/repositories/download_archive', ref: @ref, btn_class: 'btn-group-small pull-right hidden-xs hidden-sm', split_button: true
 
+- if allowed_tree_edit?
+  = render 'projects/tree/upload'
+
 #tree-holder.tree-holder.clearfix
   = render "tree", tree: @tree
+
+
+

--- a/app/views/shared/_commit_message_replace_container.html.haml
+++ b/app/views/shared/_commit_message_replace_container.html.haml
@@ -1,0 +1,14 @@
+.form-group.commit_message-group
+  = label_tag 'commit_message_replace', class: 'control-label' do
+    Commit message
+  .col-sm-10
+    .commit-message-replace-container
+      .max-width-marker
+      = text_area_tag 'commit_message',
+          (params[:commit_message] || local_assigns[:text]),
+          class: 'form-control', placeholder: local_assigns[:placeholder],
+          required: true, rows: (local_assigns[:rows] || 3)
+    - if local_assigns[:hint]
+      %p.hint
+        Try to keep the first line under 52 characters
+        and the others under 72.

--- a/lib/gitlab/satellite/files/file_action.rb
+++ b/lib/gitlab/satellite/files/file_action.rb
@@ -14,10 +14,11 @@ module Gitlab
       end
 
       def write_file(abs_file_path, content, file_encoding = 'text')
-        if file_encoding == 'base64'
-          File.open(abs_file_path, 'wb') { |f| f.write(Base64.decode64(content)) }
-        else
-          File.open(abs_file_path, 'w') { |f| f.write(content) }
+		if file_encoding == 'base64'
+			 File.open(abs_file_path, 'wb') { |f| f.write(Base64.encode64(content))}
+		else
+			 enc_64=Base64.encode64(content)
+			 File.open(abs_file_path, 'wb') { |f| f.write(Base64.decode64(enc_64))} 
         end
       end
     end


### PR DESCRIPTION
This merge requst contains the "upload" and "replace" functionality.
They enable user upload file to the current repository and replace existing file in the current repository.
![replace_01](https://cloud.githubusercontent.com/assets/7370334/5959112/b1739956-a7cb-11e4-84ab-57e5c4b88d25.png)
![replace_02](https://cloud.githubusercontent.com/assets/7370334/5959113/b175bb64-a7cb-11e4-8d89-c6425cd008de.png)
![upload_01](https://cloud.githubusercontent.com/assets/7370334/5959114/b176469c-a7cb-11e4-9d63-cccd6db5a28d.png)
![upload_02](https://cloud.githubusercontent.com/assets/7370334/5959115/b1792510-a7cb-11e4-80f3-70881f3b0d2d.png)
