### PR TITLE
Use pry-rails gem instead of pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -221,7 +221,7 @@ group :development, :test do
   gem 'spinach-rails'
   gem "rspec-rails"
   gem "capybara", '~> 2.2.1'
-  gem "pry"
+  gem "pry-rails"
   gem "awesome_print"
   gem "database_cleaner"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,8 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-rails (0.3.2)
+      pry (>= 0.9.10)
     pyu-ruby-sasl (0.0.3.3)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
@@ -694,7 +696,7 @@ DEPENDENCIES
   org-ruby (= 0.9.12)
   pg
   poltergeist (~> 1.5.1)
-  pry
+  pry-rails
   quiet_assets (~> 1.0.1)
   rack-attack
   rack-cors


### PR DESCRIPTION
pry-rails has pry as a dependency and this lets us have all that pry goodness when we run `rails console` :heart:
