### PR TITLE
Minor spec output cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -254,7 +254,7 @@ end
 
 group :test do
   gem "simplecov", require: false
-  gem "shoulda-matchers", "~> 2.1.0"
+  gem "shoulda-matchers", "~> 2.7.0"
   gem 'email_spec'
   gem "webmock"
   gem 'test_after_commit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       multi_xml (>= 0.5.2)
     httpauth (0.2.1)
     httpclient (2.5.3.3)
-    i18n (0.6.11)
+    i18n (0.7.0)
     ice_nine (0.10.0)
     jasmine (2.0.2)
       jasmine-core (~> 2.0.0)
@@ -279,7 +279,7 @@ GEM
       turbolinks
     jquery-ui-rails (4.2.1)
       railties (>= 3.2.16)
-    json (1.8.1)
+    json (1.8.2)
     jwt (0.1.13)
       multi_json (>= 1.5)
     kaminari (0.15.1)
@@ -495,7 +495,7 @@ GEM
       sass (~> 3.2)
     settingslogic (2.0.9)
     sexp_processor (4.4.0)
-    shoulda-matchers (2.1.0)
+    shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     sidekiq (3.3.0)
       celluloid (>= 0.16.0)
@@ -719,7 +719,7 @@ DEPENDENCIES
   select2-rails
   semantic-ui-sass (~> 1.8.0)
   settingslogic
-  shoulda-matchers (~> 2.1.0)
+  shoulda-matchers (~> 2.7.0)
   sidekiq (~> 3.3)
   simplecov
   sinatra

--- a/spec/lib/votes_spec.rb
+++ b/spec/lib/votes_spec.rb
@@ -161,8 +161,8 @@ describe Issue, 'Votes' do
       add_note '+1 I still like this'
       add_note '+1 I really like this'
       add_note '+1 Give me this now!!!!'
-      p issue.downvotes.should == 0
-      p issue.upvotes.should == 1
+      issue.downvotes.should == 0
+      issue.upvotes.should == 1
     end
 
     it 'should count a users vote only once without caring about comments' do
@@ -171,8 +171,8 @@ describe Issue, 'Votes' do
       add_note 'Another comment'
       add_note '+1 vote'
       add_note 'final comment'
-      p issue.downvotes.should == 0
-      p issue.upvotes.should == 1
+      issue.downvotes.should == 0
+      issue.upvotes.should == 1
     end
 
   end

--- a/spec/models/members_spec.rb
+++ b/spec/models/members_spec.rb
@@ -10,7 +10,7 @@ describe Member do
 
     it { should validate_presence_of(:user) }
     it { should validate_presence_of(:source) }
-    it { should ensure_inclusion_of(:access_level).in_array(Gitlab::Access.values) }
+    it { should validate_inclusion_of(:access_level).in_array(Gitlab::Access.values) }
   end
 
   describe "Delegate methods" do


### PR DESCRIPTION
Two minor cleanups of stuff getting printed during tests that shouldn't:
- `shoulda-matchers` was outdated and causing those MiniTest warnings: `MiniTest::Unit::TestCase is now Minitest::Test. From /Users/tsigo/.rbenv/versions/2.1.5/lib/ruby/2.1.0/test/unit/testcase.rb:8:in <module:Unit>`
- Two `p` statements got left in one of the specs and were printing `true` during test runs.
