### PR TITLE
Adds persistent collapse button for left side bar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@ v 7.8.0
   - 
   - 
   - Added support for firing system hooks on group create/destroy and adding/removing users to group (Boyan Tabakov)
+  - Added persistent collapse button for left side nav bar (Jason Blanchard)
 
 v 7.7.2
   - Update GitLab Shell to version 2.4.2 that fixes a bug when developers can push to protected branch

--- a/app/assets/javascripts/sidebar.js.coffee
+++ b/app/assets/javascripts/sidebar.js.coffee
@@ -24,3 +24,13 @@ $ ->
 $(window).resize ->
   responsive_resize()
   return
+
+$(document).on("click", '.toggle-nav-collapse', (e) ->
+  e.preventDefault()
+  if $('.page-with-sidebar').hasClass('collapsed')
+    $('.page-with-sidebar').removeClass('collapsed')
+    $.cookie("collapsed_nav", "false", { path: '/' })
+  else
+    $('.page-with-sidebar').addClass('collapsed')
+    $.cookie("collapsed_nav", "true", { path: '/' })
+)

--- a/app/assets/stylesheets/sections/nav_sidebar.scss
+++ b/app/assets/stylesheets/sections/nav_sidebar.scss
@@ -110,7 +110,7 @@
 
     .nav-sidebar {
       margin-top: 20px;
-      position: fixed;
+      position: relative;
       top: 45px;
       width: $sidebar_width;
     }
@@ -150,10 +150,47 @@
   }
 }
 
+.collapse-nav {
+  position: relative;
+  top: 50px;
+  width: 230px;
+  text-align: right;
+  padding-right: 21px;
+}
+
+.page-with-sidebar.collapsed {
+
+  .collapse-nav {
+    width: 53px;
+  }
+
+  padding-left: 50px;
+
+  .sidebar-wrapper {
+    width: 52px;
+    overflow-x: hidden;
+
+    .nav-sidebar {
+      width: 52px;
+    }
+    
+    .nav-sidebar li a > span {
+      display: none;
+    }
+  }
+}
+
+
 @media (max-width: $screen-md-max) {
   @include folded-sidebar;
 }
 
 @media(min-width: $screen-md-max) {
   @include expanded-sidebar;
+}
+
+@media (max-width: $screen-md-max) {
+  .collapse-nav {
+    display: none;
+  }
 }

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -1,0 +1,5 @@
+module NavHelper
+  def nav_menu_collapsed?
+    cookies[:collapsed_nav] == 'true'
+  end
+end

--- a/app/views/layouts/_collapse_button.html.haml
+++ b/app/views/layouts/_collapse_button.html.haml
@@ -1,0 +1,4 @@
+- if nav_menu_collapsed?
+  = link_to icon('plus-square'), '#', class: 'toggle-nav-collapse'
+- else
+  = link_to icon('minus-square'), '#', class: 'toggle-nav-collapse'

--- a/app/views/layouts/_page.html.haml
+++ b/app/views/layouts/_page.html.haml
@@ -1,8 +1,10 @@
 - if defined?(sidebar)
-  .page-with-sidebar
+  .page-with-sidebar{:class => ("collapsed" if nav_menu_collapsed?)}
     = render "layouts/broadcast"
     .sidebar-wrapper
       = render(sidebar)
+      .collapse-nav
+        = render :partial => 'layouts/collapse_button'
     .content-wrapper
       .container-fluid
         .content

--- a/spec/helpers/nav_helper_spec.rb
+++ b/spec/helpers/nav_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+# Specs in this file have access to a helper object that includes
+# the NavHelper. For example:
+#
+# describe NavHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+describe NavHelper do
+  describe '#nav_menu_collapsed?' do
+    it 'returns true when the nav is collapsed in the cookie' do
+      helper.request.cookies[:collapsed_nav] = 'true'
+      expect(helper.nav_menu_collapsed?).to eq true
+    end
+
+    it 'returns false when the nav is not collapsed in the cookie' do
+      helper.request.cookies[:collapsed_nav] = 'false'
+      expect(helper.nav_menu_collapsed?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Fixes #8684 by adding a "collapse" and "expand" button on the left sidebar nav. State is stored in the `session` hash as suggested by @randx.

The purpose of this change is to allow for more screen real estate for larger viewports.

Here's what it looks like expanded

![expanded](https://cloud.githubusercontent.com/assets/1238532/5982597/939d7786-a892-11e4-82ce-305f7ecb4295.png)

Here is is collapsed (ahhh, so refreshing :)

![collapsed](https://cloud.githubusercontent.com/assets/1238532/5982600/993eda2c-a892-11e4-8df4-4451fcc01895.png)

The option is hidden on small viewports:

![small](https://cloud.githubusercontent.com/assets/1238532/5982604/a0ece87c-a892-11e4-94c7-143275c776f1.png)

I'm not super in love with the button placement, so let me know if folks have other suggestions.

Note that I hit this bug https://github.com/activeadmin/activeadmin/issues/512 when testing the helper with the `session` hash. I used the fix suggested in that issue which required that I changed a few other tests. Everything appears to be working locally, but let me know if it causes other problems.
