### PR TITLE
Issue merge req ui

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,7 +54,7 @@ v 7.8.0
   - 
   - 
   - 
-  - 
+  - Added link to milestone and keeping resource context on smaller viewports for issues and merge requests (Jason Blanchard)
   - 
   - 
   - API: Add support for editing an existing project (Mika Mäenpää and Hannes Rosenögger) 

--- a/app/views/projects/issues/_discussion.html.haml
+++ b/app/views/projects/issues/_discussion.html.haml
@@ -4,34 +4,10 @@
       = link_to 'Reopen Issue', project_issue_path(@project, @issue, issue: {state_event: :reopen }, status_only: true), method: :put, class: "btn btn-grouped btn-reopen js-note-target-reopen", title: 'Reopen Issue'
     - else
       = link_to 'Close Issue', project_issue_path(@project, @issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn btn-grouped btn-close js-note-target-close", title: "Close Issue"
-.row
-  .col-md-9
-    .participants
-      %cite.cgray
-        = pluralize(@issue.participants.count, 'participant')
-      - @issue.participants.each do |participant|
-        = link_to_member(@project, participant, name: false, size: 24)
+.participants
+  %cite.cgray
+    = pluralize(@issue.participants.count, 'participant')
+  - @issue.participants.each do |participant|
+    = link_to_member(@project, participant, name: false, size: 24)
 
-    .voting_notes#notes= render "projects/notes/notes_with_form"
-  .col-md-3.hidden-sm.hidden-xs
-    %div
-    .clearfix
-      %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}
-        = cross_project_reference(@project, @issue)
-    %hr
-    .context
-      %cite.cgray
-        = render partial: 'issue_context', locals: { issue: @issue }
-    %hr
-    .clearfix
-      .votes-holder
-        %h6 Votes
-        #votes= render 'votes/votes_block', votable: @issue
-
-    - if @issue.labels.any?
-      %hr
-      %h6 Labels
-      .issue-show-labels
-        - @issue.labels.each do |label|
-          = link_to project_issues_path(@project, label_name: label.name) do
-            %p= render_colored_label(label)
+.voting_notes#notes= render "projects/notes/notes_with_form"

--- a/app/views/projects/issues/_issue_context.html.haml
+++ b/app/views/projects/issues/_issue_context.html.haml
@@ -17,8 +17,11 @@
       = f.select(:milestone_id, milestone_options(@issue), { include_blank: "Select milestone" }, {class: 'select2 select2-compact js-select2 js-milestone'})
       = hidden_field_tag :issue_context
       = f.submit class: 'btn'
+      - if issue.milestone
+        .back-to-milestone
+          = icon 'arrow-left'
+          Back to #{link_to @issue.milestone.title, project_milestone_path(@project, @issue.milestone)}
     - elsif issue.milestone
-      = link_to project_milestone_path(@project, @issue.milestone) do
-        = @issue.milestone.title
+      = link_to @issue.milestone.title, project_milestone_path(@project, @issue.milestone)
     - else
       None

--- a/app/views/projects/issues/show.html.haml
+++ b/app/views/projects/issues/show.html.haml
@@ -24,14 +24,35 @@
         Edit
 
 %hr
-%h3.issue-title
-  = gfm escape_once(@issue.title)
-%div
-  - if @issue.description.present?
-    .description
-      .wiki
-        = preserve do
-          = markdown(@issue.description, parse_tasks: true)
+.row
+  .col-md-9
+    %h3.issue-title
+      = gfm escape_once(@issue.title)
+      %div
+        - if @issue.description.present?
+          .description
+            .wiki
+              = preserve do
+                = markdown(@issue.description, parse_tasks: true)
+    %hr
+    = render "projects/issues/discussion"
+  .col-md-3
+    %div
+    .clearfix
+      %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}
+        = cross_project_reference(@project, @issue)
+    .context
+      %cite.cgray
+        = render partial: 'issue_context', locals: { issue: @issue }
+    .clearfix
+      .votes-holder
+        %h6 Votes
+        #votes= render 'votes/votes_block', votable: @issue
 
-%hr
-= render "projects/issues/discussion"
+    - if @issue.labels.any?
+      %h6 Labels
+      .issue-show-labels
+        - @issue.labels.each do |label|
+          = link_to project_issues_path(@project, label_name: label.name) do
+            %p= render_colored_label(label)
+

--- a/app/views/projects/issues/update.js.haml
+++ b/app/views/projects/issues/update.js.haml
@@ -3,8 +3,15 @@
     :plain
       $("##{dom_id(@issue)}").fadeOut();
 - elsif params[:issue_context]
+  $('.context').html("#{escape_javascript(render partial: 'issue_context', locals: { issue: @issue })}");
   $('.context').effect('highlight');
   - if @issue.milestone
     $('.milestone-nav-link').replaceWith("<span class='milestone-nav-link'>| <span class='light'>Milestone</span> #{escape_javascript(link_to @issue.milestone.title, project_milestone_path(@issue.project, @issue.milestone))}</span>")
   - else
     $('.milestone-nav-link').html('')
+
+
+$('select.select2').select2({width: 'resolve', dropdownAutoWidth: true})
+$('.edit-issue.inline-update input[type="submit"]').hide();
+new ProjectUsersSelect();
+new Issue();

--- a/app/views/projects/merge_requests/_discussion.html.haml
+++ b/app/views/projects/merge_requests/_discussion.html.haml
@@ -9,23 +9,3 @@
   .col-md-9
     = render "projects/merge_requests/show/participants"
     = render "projects/notes/notes_with_form"
-  .col-md-3.hidden-sm.hidden-xs
-    .clearfix
-      %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}
-        = cross_project_reference(@project, @merge_request)
-    %hr
-    .context
-      %cite.cgray
-        = render partial: 'projects/merge_requests/show/context', locals: { merge_request: @merge_request }
-    %hr
-    .votes-holder.hidden-sm.hidden-xs
-      %h6 Votes
-      #votes= render 'votes/votes_block', votable: @merge_request
-
-    - if @merge_request.labels.any?
-      %hr
-      %h6 Labels
-      .merge-request-show-labels
-        - @merge_request.labels.each do |label|
-          = link_to project_merge_requests_path(@project, label_name: label.name) do
-            %p= render_colored_label(label)

--- a/app/views/projects/merge_requests/_show.html.haml
+++ b/app/views/projects/merge_requests/_show.html.haml
@@ -1,76 +1,100 @@
 .merge-request{'data-url' => project_merge_request_path(@project, @merge_request)}
-  = render "projects/merge_requests/show/mr_title"
-  %hr
-  = render "projects/merge_requests/show/mr_box"
-  %hr
-  .append-bottom-20
-    .slead
-      %span From
-      - if @merge_request.for_fork?
-        %strong.label-branch<
-          - if @merge_request.source_project
-            = link_to @merge_request.source_project_namespace, project_path(@merge_request.source_project)
+  .row
+    .col-md-12
+      = render "projects/merge_requests/show/mr_title"
+      %hr
+    .col-md-9
+      = render "projects/merge_requests/show/mr_box"
+      %hr
+      .append-bottom-20
+        .slead
+          %span From
+          - if @merge_request.for_fork?
+            %strong.label-branch<
+              - if @merge_request.source_project
+                = link_to @merge_request.source_project_namespace, project_path(@merge_request.source_project)
+              - else
+                \ #{@merge_request.source_project_namespace}
+              \:#{@merge_request.source_branch}
+            %span into
+            %strong.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
           - else
-            \ #{@merge_request.source_project_namespace}
-          \:#{@merge_request.source_branch}
-        %span into
-        %strong.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
-      - else
-        %strong.label-branch #{@merge_request.source_branch}
-        %span into
-        %strong.label-branch #{@merge_request.target_branch}
-      - if @merge_request.open?
-        %span.pull-right
-          .btn-group
-            %a.btn.dropdown-toggle{ data: {toggle: :dropdown} }
-              %i.fa.fa-download
-              Download as
-              %span.caret
-            %ul.dropdown-menu
-              %li= link_to "Email Patches", project_merge_request_path(@project, @merge_request, format: :patch)
-              %li= link_to "Plain Diff",    project_merge_request_path(@project, @merge_request, format: :diff)
+            %strong.label-branch #{@merge_request.source_branch}
+            %span into
+            %strong.label-branch #{@merge_request.target_branch}
+          - if @merge_request.open?
+            %span.pull-right
+              .btn-group
+                %a.btn.dropdown-toggle{ data: {toggle: :dropdown} }
+                  %i.fa.fa-download
+                  Download as
+                  %span.caret
+                %ul.dropdown-menu
+                  %li= link_to "Email Patches", project_merge_request_path(@project, @merge_request, format: :patch)
+                  %li= link_to "Plain Diff",    project_merge_request_path(@project, @merge_request, format: :diff)
 
-  = render "projects/merge_requests/show/how_to_merge"
-  = render "projects/merge_requests/show/state_widget"
+      = render "projects/merge_requests/show/how_to_merge"
+      = render "projects/merge_requests/show/state_widget"
 
-  - if @commits.present?
-    %ul.nav.nav-tabs.merge-request-tabs
-      %li.notes-tab{data: {action: 'notes'}}
-        = link_to project_merge_request_path(@project, @merge_request) do
-          %i.fa.fa-comments
-          Discussion
-          %span.badge= @merge_request.mr_and_commit_notes.count
-      %li.commits-tab{data: {action: 'commits'}}
-        = link_to project_merge_request_path(@project, @merge_request), title: 'Commits' do
-          %i.fa.fa-history
-          Commits
-          %span.badge= @commits.size
-      %li.diffs-tab{data: {action: 'diffs'}}
-        = link_to diffs_project_merge_request_path(@project, @merge_request) do
-          %i.fa.fa-list-alt
-          Changes
-          %span.badge= @merge_request.diffs.size
+      - if @commits.present?
+        %ul.nav.nav-tabs.merge-request-tabs
+          %li.notes-tab{data: {action: 'notes'}}
+            = link_to project_merge_request_path(@project, @merge_request) do
+              %i.fa.fa-comments
+              Discussion
+              %span.badge= @merge_request.mr_and_commit_notes.count
+          %li.commits-tab{data: {action: 'commits'}}
+            = link_to project_merge_request_path(@project, @merge_request), title: 'Commits' do
+              %i.fa.fa-history
+              Commits
+              %span.badge= @commits.size
+          %li.diffs-tab{data: {action: 'diffs'}}
+            = link_to diffs_project_merge_request_path(@project, @merge_request) do
+              %i.fa.fa-list-alt
+              Changes
+              %span.badge= @merge_request.diffs.size
 
-  .notes.tab-content.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
-    = render "projects/merge_requests/discussion"
-  .commits.tab-content
-    = render "projects/merge_requests/show/commits"
-  .diffs.tab-content
-    - if current_page?(action: 'diffs')
-      = render "projects/merge_requests/show/diffs"
+      .notes.tab-content.voting_notes#notes{ class: (controller.action_name == 'show') ? "" : "hide" }
+        = render "projects/merge_requests/discussion"
+      .commits.tab-content
+        = render "projects/merge_requests/show/commits"
+      .diffs.tab-content
+        - if current_page?(action: 'diffs')
+          = render "projects/merge_requests/show/diffs"
 
-  .mr-loading-status
-    = spinner
+      .mr-loading-status
+        = spinner
 
 
-:javascript
-  var merge_request;
+    .col-md-3
+      .clearfix
+        %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}
+          = cross_project_reference(@project, @merge_request)
+      %hr
+      .context
+        %cite.cgray
+          = render partial: 'projects/merge_requests/show/context', locals: { merge_request: @merge_request }
+      %hr
+      .votes-holder.hidden-sm.hidden-xs
+        %h6 Votes
+        #votes= render 'votes/votes_block', votable: @merge_request
 
-  merge_request = new MergeRequest({
-    url_to_automerge_check: "#{automerge_check_project_merge_request_path(@project, @merge_request)}",
-    check_enable: #{@merge_request.unchecked? ? "true" : "false"},
-    url_to_ci_check: "#{ci_status_project_merge_request_path(@project, @merge_request)}",
-    ci_enable: #{@project.ci_service ? "true" : "false"},
-    current_status: "#{@merge_request.merge_status_name}",
-    action: "#{controller.action_name}"
-  });
+      - if @merge_request.labels.any?
+        %hr
+        %h6 Labels
+        .merge-request-show-labels
+          - @merge_request.labels.each do |label|
+            = link_to project_merge_requests_path(@project, label_name: label.name) do
+              %p= render_colored_label(label)
+
+    :javascript
+      var merge_request;
+
+      merge_request = new MergeRequest({
+        url_to_automerge_check: "#{automerge_check_project_merge_request_path(@project, @merge_request)}",
+        check_enable: #{@merge_request.unchecked? ? "true" : "false"},
+        url_to_ci_check: "#{ci_status_project_merge_request_path(@project, @merge_request)}",
+        ci_enable: #{@project.ci_service ? "true" : "false"},
+        current_status: "#{@merge_request.merge_status_name}",
+        action: "#{controller.action_name}"
+      });

--- a/app/views/projects/merge_requests/show/_context.html.haml
+++ b/app/views/projects/merge_requests/show/_context.html.haml
@@ -17,6 +17,10 @@
       = f.select(:milestone_id, milestone_options(@merge_request), { include_blank: "Select milestone" }, {class: 'select2 select2-compact js-select2 js-milestone'})
       = hidden_field_tag :merge_request_context
       = f.submit class: 'btn'
+      - if @merge_request.milestone
+        .back-to-milestone
+          = icon 'arrow-left'
+          Back to #{link_to @merge_request.milestone.title, project_milestone_path(@project, @merge_request.milestone)}
     - elsif merge_request.milestone
       = link_to merge_request.milestone.title, project_milestone_path
     - else

--- a/app/views/projects/merge_requests/update.js.haml
+++ b/app/views/projects/merge_requests/update.js.haml
@@ -1,2 +1,8 @@
 - if params[:merge_request_context]
+  $('.context').html("#{escape_javascript(render partial: 'projects/merge_requests/show/context', locals: { issue: @issue })}");
   $('.context').effect('highlight');
+
+  new ProjectUsersSelect();
+
+  $('select.select2').select2({width: 'resolve', dropdownAutoWidth: true});
+  merge_request = new MergeRequest();

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -249,6 +249,7 @@ describe "Issues", feature: true do
         click_button 'Update Issue'
 
         page.should have_content "Milestone changed to #{milestone.title}"
+        page.should have_content "Back to #{milestone.title}"
         has_select?('issue_assignee_id', :selected => milestone.title)
       end
     end


### PR DESCRIPTION
Fixes #8675 by adding in a link to the milestone when a milestone is selected. Also keeps the issue context on smaller viewports by moving it below issue discussion.

No milestone selected:
![screen shot 2015-01-30 at 11 27 38 pm](https://cloud.githubusercontent.com/assets/1238532/5986797/54d4f8a8-a8d8-11e4-88af-caaeba755867.png)

With milestone selected:
![screen shot 2015-01-30 at 11 27 42 pm](https://cloud.githubusercontent.com/assets/1238532/5986798/6333797e-a8d8-11e4-8f20-ef11df1acd4a.png)

Smaller viewport:
![screen shot 2015-01-30 at 11 28 35 pm](https://cloud.githubusercontent.com/assets/1238532/5986799/6a02320e-a8d8-11e4-87ea-640f29d573f9.png)

Same on merge request screen:

![screen shot 2015-02-02 at 1 32 55 pm](https://cloud.githubusercontent.com/assets/1238532/6006770/1670f1fe-aae3-11e4-955e-1daf5edcc656.png)
