### PR TITLE
Fix raw image paste from clipboard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,7 +42,7 @@ v 7.8.0
   - Password reset token validity increased from 2 hours to 2 days since it is also send on account creation.
   - 
   - 
-  - 
+  - Enable raw image paste from clipboard, currently Chrome only (Marco Cyriacks)
   - 
   - 
   - Add action property to merge request hook (Julien Bianchi)

--- a/app/assets/javascripts/dropzone_input.js.coffee
+++ b/app/assets/javascripts/dropzone_input.js.coffee
@@ -13,6 +13,8 @@ class @DropzoneInput
 
     form_textarea = $(form).find("textarea.markdown-area")
     form_textarea.wrap "<div class=\"div-dropzone\"></div>"
+    form_textarea.bind 'paste', (event) =>
+      handlePaste(event)
 
     form_dropzone = $(form).find('.div-dropzone')
     form_dropzone.parent().addClass "div-dropzone-wrapper"
@@ -133,24 +135,17 @@ class @DropzoneInput
     formatLink = (str) ->
       "![" + str.alt + "](" + str.url + ")"
 
-    handlePaste = (e) ->
-      e.preventDefault()
-      my_event = e.originalEvent
+    handlePaste = (event) ->
+      pasteEvent = event.originalEvent
+      if pasteEvent.clipboardData and pasteEvent.clipboardData.items
+        image = isImage(pasteEvent)
+        if image
+          event.preventDefault()
 
-      if my_event.clipboardData and my_event.clipboardData.items
-        processItem(my_event)
-
-    processItem = (e) ->
-      image = isImage(e)
-      if image
-        filename = getFilename(e) or "image.png"
-        text = "{{" + filename + "}}"
-        pasteText(text)
-        uploadFile image.getAsFile(), filename
-
-      else
-        text = e.clipboardData.getData("text/plain")
-        pasteText(text)
+          filename = getFilename(pasteEvent) or "image.png"
+          text = "{{" + filename + "}}"
+          pasteText(text)
+          uploadFile image.getAsFile(), filename
 
     isImage = (data) ->
       i = 0


### PR DESCRIPTION
This is a patch that activates the functionality to paste raw images from the clipboard to markdown areas in GitLab. Unfortunately this currently only works in the chrome browser but I think it is a first step.

This is a possible solution for #7392 

Please review and consider for inclusion.

@jvanbaarsen This is the new pull request replacing pull request #7891

Best regards
Marco
