### PR TITLE
Add Irker service

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,7 +46,7 @@ v 7.8.0
   - 
   - 
   - Add action property to merge request hook (Julien Bianchi)
-  - 
+  - Add a service to send updates to an Irker gateway (Romain Coltel)
   - 
   - 
   - 

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -47,7 +47,8 @@ class Projects::ServicesController < Projects::ApplicationController
       :room, :recipients, :project_url, :webhook,
       :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
       :build_key, :server, :teamcity_url, :build_type,
-      :description, :issues_url, :new_issue_url
+      :description, :issues_url, :new_issue_url,
+      :colorize_messages, :channels
     )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -64,6 +64,7 @@ class Project < ActiveRecord::Base
   has_one :gitlab_ci_service, dependent: :destroy
   has_one :campfire_service, dependent: :destroy
   has_one :emails_on_push_service, dependent: :destroy
+  has_one :irker_service, dependent: :destroy
   has_one :pivotaltracker_service, dependent: :destroy
   has_one :hipchat_service, dependent: :destroy
   has_one :flowdock_service, dependent: :destroy
@@ -360,7 +361,8 @@ class Project < ActiveRecord::Base
 
   def available_services_names
     %w(gitlab_ci campfire hipchat pivotaltracker flowdock assembla
-       emails_on_push gemnasium slack pushover buildbox bamboo teamcity jira redmine custom_issue_tracker)
+       emails_on_push gemnasium slack pushover buildbox bamboo teamcity jira
+       redmine custom_issue_tracker irker)
   end
 
   def gitlab_ci?

--- a/app/models/project_services/irker_service.rb
+++ b/app/models/project_services/irker_service.rb
@@ -1,0 +1,155 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id         :integer          not null, primary key
+#  type       :string(255)
+#  title      :string(255)
+#  project_id :integer          not null
+#  created_at :datetime
+#  updated_at :datetime
+#  active     :boolean          default(FALSE), not null
+#  properties :text
+#
+
+require 'uri'
+require 'socket'
+
+# See the note in the worker for extra configuration
+
+class IrkerService < Service
+  prop_accessor :colorize_messages, :recipients, :channels
+  validates :recipients, presence: true, if: :activated?
+  validate :check_recipients_count, if: :activated?
+  validate :check_irker
+
+  before_validation :get_channels
+
+  def title
+    'Irker (IRC gateway)'
+  end
+
+  def description
+    'Send IRC messages, on update, to a list of recipients through an Irker '\
+    'gateway.'
+  end
+
+  def help
+    msg = 'Recipients have to be specified with a full URI: '\
+    'irc[s]://irc.network.net[:port]/#channel. Special cases: if you want '\
+    'the channel to be a nickname instead, append ",isnick" to the channel '\
+    'name; if the channel is protected by a secret password, append '\
+    '"?key=secretpassword" to the URI. '
+    
+    begin 
+      default_irc = Gitlab.config.irker.default_irc_uri
+    rescue Settingslogic::MissingSetting
+      # Display nothing more
+    else
+      msg += 'Note that a default IRC URI is provided by this service\'s '\
+      "administrator: #{default_irc}. You can thus just give a channel name."
+    end
+    msg
+  end
+
+  def to_param
+    'irker'
+  end
+
+  def execute(push_data)
+    IrkerWorker.perform_async(project_id, channels,
+                              colorize_messages, push_data)
+  end
+
+  def fields
+    [
+      { type: 'textarea', name: 'recipients',
+          placeholder: 'Recipients/channels separated by whitespaces' },
+      { type: 'checkbox', name: 'colorize_messages' },
+    ]
+  end
+
+  def check_recipients_count
+    return false if recipients.nil? || recipients.empty?
+
+    begin
+      max_chans = Gitlab.config.irker.max_channels
+    rescue Settingslogic::MissingSetting
+      max_chans = 3
+    end
+
+    if recipients.split(/\s+/).count > max_chans
+      errors.add(:recipients, "are limited to #{max_chans}")
+    end
+  end
+
+  def check_irker
+    begin
+      host = Gitlab.config.irker.server_ip
+      port = Gitlab.config.irker.server_port
+    rescue Settingslogic::MissingSetting
+      host = 'localhost'
+      port = 6659
+    end
+    begin
+      TCPSocket.new(host, port).close
+    rescue Errno::ECONNREFUSED => e
+      logger.fatal "Can't connect to Irker daemon: #{e}"
+      msg  = '- Can\'t connect to the Irker daemon, '
+      msg += 'please contact the server administrator if the problem persists.'
+      errors.add(:active, msg)
+    end
+  end
+
+  def get_channels
+    return true unless :activated?
+
+    begin
+      default_irc = Gitlab.config.irker.default_irc_uri
+    rescue Settingslogic::MissingSetting
+      default_irc = nil
+    else
+      default_irc += '/' unless default_irc[-1] == '/'
+    end
+
+    self.channels = recipients.split(/\s+/).map do |recipient|
+      format_channel default_irc, recipient
+    end
+    self.channels.reject! { |c| c.nil? }
+
+    errors.add(:recipients, 'are all invalid') if channels.empty?
+    logger.debug "IrkerService: rcpts = #{recipients}; chans = #{channels}"
+    true
+  end
+
+  def format_channel(default_irc, recipient)
+    cnt = 0
+    url = nil
+
+    # Try to parse the chan as a full URI
+    begin
+      uri = URI.parse(recipient)
+      raise URI::InvalidURIError if uri.scheme.nil? && cnt == 0
+    rescue URI::InvalidURIError
+      unless default_irc.nil?
+        cnt += 1
+        recipient = "#{default_irc}#{recipient}"
+        retry if cnt == 1
+      end
+    else
+      # Authorize both irc://domain.com/#chan and irc://domain.com/chan
+      if uri.is_a?(URI) && uri.scheme[/^ircs?$/] && !uri.path.nil?
+        if uri.fragment.nil?
+          # Do not authorize irc://domain.com/
+          url = uri.to_s if uri.path.length > 1
+        else
+          # Authorize irc://domain.com/smthg#chan
+          # The irker daemon will deal with it by concatenating smthg and
+          # chan, thus sending messages on #smthgchan
+          url = uri.to_s
+        end
+      end
+    end
+    url
+  end
+end

--- a/app/workers/irker_worker.rb
+++ b/app/workers/irker_worker.rb
@@ -1,0 +1,145 @@
+require 'json'
+require 'socket'
+
+# Note: extra configuration possible, in config/gitlab.yml :
+# production:
+#   irker:
+#     server_ip: localhost
+#     server_port: 6659
+#     max_channels: 3
+#     # Next one has no default, this is just an example
+#     default_irc_uri: irc://chat.freenode.net/
+# You can place the 'irker' section just below the already-there 'extra' section
+
+class IrkerWorker
+  include Sidekiq::Worker
+
+  def perform(project_id, chans, colors, push_data)
+    project             = Project.find(project_id)
+
+    # Get config parameters
+    begin
+      irker_server = Gitlab.config.irker.server_ip
+      irker_port   = Gitlab.config.irker.server_port
+    rescue Settingslogic::MissingSetting
+      irker_server = 'localhost'
+      irker_port   = 6659
+    end
+
+    logger.info "IrkerWorker: messages destination = #{chans}"
+    return false unless setup_members chans, irker_server, irker_port
+
+    repo_name = push_data['repository']['name']
+    committer = push_data['user_name']
+    branch    = push_data['ref'].gsub(%r'refs/[^/]*/', '')
+
+    if colors
+      repo_name = "\x0304#{repo_name}\x0f"
+      branch    = "\x0305#{branch}\x0f"
+    end
+
+    # Firsts messages are for branch creation/deletion
+    if push_data["before"] =~ /^000000/
+      send_new_branch project.path_with_namespace, repo_name, committer, branch
+    elsif push_data["after"] =~ /^000000/
+      send_del_branch repo_name, committer, branch
+    end
+
+    # Next message is for number of commit pushed, if any
+    if push_data['total_commits_count'] == 0
+      return true
+    end
+
+    if push_data["before"] =~ /^000000/
+      # Tweak on push_data["before"] in order to have a nice compare URL
+      commit_id = push_data['commits'][0]['id']
+      commit = Gitlab::Git::Commit.find(project.repository, commit_id)
+      commit = Commit.new(commit)
+      parents = commit.parents
+      push_data['before'] = parents[0].id unless parents.empty?
+    end
+
+    send_commits_count(push_data, project, repo_name, committer,
+                       branch, colors)
+
+    # Finally, one message per commit, limited by 3 messages (same limit as the
+    # github irc hook)
+    commits = push_data['commits'].first(3)
+    commits.each do |hook_attrs|
+      send_commit project, hook_attrs, repo_name, branch, colors
+    end
+
+    @socket.close
+    true
+  ensure
+    GC.start
+  end
+
+  def sendtoirker(privmsg)
+    to_send = { to: @channels, privmsg: privmsg }
+    @socket.puts JSON.dump(to_send)
+  end
+
+  def setup_members(channels, irker_server, irker_port)
+    @channels = channels
+    begin
+      @socket = TCPSocket.new irker_server, irker_port
+    rescue Errno::ECONNREFUSED => e
+      logger.fatal "Can't connect to Irker daemon: #{e}"
+      return false
+    end
+    true
+  end
+
+  def send_new_branch(repo_path, repo_name, committer, branch)
+    newbranch = "#{Gitlab.config.gitlab.url}/#{repo_path}/branches"
+    if colors
+      newbranch = "\x0302\x1f#{newbranch}\x0f"
+    end
+
+    privmsg  = "[#{repo_name}] #{committer} has created a new branch "
+    privmsg += "#{branch}: #{newbranch}"
+    sendtoirker privmsg
+  end
+
+  def send_del_branch(repo_name, committer, branch)
+    privmsg = "[#{repo_name}] #{committer} has deleted the branch #{branch}"
+    sendtoirker privmsg
+  end
+
+  def send_commits_count(data, project, repo_name, committer, branch, colors)
+    repo_path     = project.path_with_namespace
+    sha1          = Commit::truncate_sha(data['before'])
+    sha2          = Commit::truncate_sha(data['after'])
+    compare_url   = "#{Gitlab.config.gitlab.url}/#{repo_path}/compare"
+    compare_url  += "/#{sha1}...#{sha2}"
+    compare_url   = "\x0302\x1f#{compare_url}\x0f" if colors
+    commits_count = data['total_commits_count']
+    commits_count = "\x02#{commits_count}\x0f" if colors
+
+    new_commits   = 'new commit'
+    new_commits  += 's' if data['total_commits_count'] > 1
+
+    privmsg       = "[#{repo_name}] #{committer} pushed #{commits_count} "
+    privmsg      += "#{new_commits} to #{branch}: #{compare_url}"
+    sendtoirker privmsg
+  end
+
+  def send_commit(project, hook_attrs, repo_name, branch, colors)
+    commit = Gitlab::Git::Commit.find(project.repository, hook_attrs['id'])
+    commit = Commit.new(commit)
+    sha    = Commit::truncate_sha(hook_attrs['id'])
+    author = hook_attrs['author']['name']
+    files  = "#{commit.diffs.count} file"
+    files += 's' if commit.diffs.count > 1
+    title  = commit.title
+
+    if colors
+      sha = "\x0314#{sha}\x0f"
+      files = "\x0312#{files}\x0f"
+    end
+
+    privmsg = "#{repo_name}/#{branch} #{sha} #{author} (#{files}): #{title}"
+    sendtoirker privmsg
+  end
+end


### PR DESCRIPTION
The idea is to get messages for updates in the git repository of a Project on an IRC server. Irker[1] is an IRC gateway and is the ideal as it's easy to setup on a personnal server and doesn't require an Internet connection (for private networks).
In order to interface GitLab with this IRC gateway, a new service has been created. This service is derived from the email_on_push service and has its own worker.

[1] http://www.catb.org/esr/irker/
