### PR TITLE
Added a way to retrieve MR files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ v 7.8.0
   - Better UI for project services page
   - Cleaner UI for web editor
   - Add diff syntax highlighting in email-on-push service notifications (Hannes Rosenögger)
-  - 
+  - Add API endpoint to fetch all changes on a MergeRequest (Jeroen van Baarsen)
   - 
   - 
   - Allow more variations for commit messages closing issues (Julien Bianchi and Hannes Rosenögger)

--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -94,6 +94,76 @@ Parameters:
 }
 ```
 
+## Get single MR changes
+
+Shows information about the merge request including its files and changes
+
+```
+GET /projects/:id/merge_request/:merge_request_id/changes
+```
+
+Parameters:
+
+- `id` (required) - The ID of a project
+- `merge_request_id` (required) - The ID of MR
+
+```json
+{
+  "id": 21,
+  "iid": 1,
+  "project_id": 4,
+  "title": "Blanditiis beatae suscipit hic assumenda et molestias nisi asperiores repellat et.",
+  "description": "Qui voluptatibus placeat ipsa alias quasi. Deleniti rem ut sint. Optio velit qui distinctio.",
+  "state": "reopened",
+  "created_at": "2015-02-02T19:49:39.159Z",
+  "updated_at": "2015-02-02T20:08:49.959Z",
+  "target_branch": "secret_token",
+  "source_branch": "version-1-9",
+  "upvotes": 0,
+  "downvotes": 0,
+  "author": {
+    "name": "Chad Hamill",
+    "username": "jarrett",
+    "id": 5,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/b95567800f828948baf5f4160ebb2473?s=40&d=identicon"
+  },
+  "assignee": {
+    "name": "Administrator",
+    "username": "root",
+    "id": 1,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon"
+  },
+  "source_project_id": 4,
+  "target_project_id": 4,
+  "labels": [ ],
+  "milestone": {
+    "id": 5,
+    "iid": 1,
+    "project_id": 4,
+    "title": "v2.0",
+    "description": "Assumenda aut placeat expedita exercitationem labore sunt enim earum.",
+    "state": "closed",
+    "created_at": "2015-02-02T19:49:26.013Z",
+    "updated_at": "2015-02-02T19:49:26.013Z",
+    "due_date": null
+  },
+  "files": [
+    {
+    "old_path": "VERSION",
+    "new_path": "VERSION",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "diff": "--- a/VERSION\ +++ b/VERSION\ @@ -1 +1 @@\ -1.9.7\ +1.9.8",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+    }
+  ]
+}
+```
+
 ## Create MR
 
 Creates a new merge request.

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -147,6 +147,11 @@ module API
       expose :state, :created_at, :updated_at
     end
 
+    class RepoDiff < Grape::Entity
+      expose :old_path, :new_path, :a_mode, :b_mode, :diff
+      expose :new_file, :renamed_file, :deleted_file
+    end
+
     class Milestone < ProjectEntity
       expose :due_date
     end
@@ -164,6 +169,12 @@ module API
       expose :label_names, as: :labels
       expose :description
       expose :milestone, using: Entities::Milestone
+    end
+
+    class MergeRequestChanges < MergeRequest
+      expose :diffs, as: :changes, using: Entities::RepoDiff do |compare, _|
+        compare.diffs
+      end
     end
 
     class SSHKey < Grape::Entity
@@ -234,11 +245,6 @@ module API
 
     class Label < Grape::Entity
       expose :name, :color
-    end
-
-    class RepoDiff < Grape::Entity
-      expose :old_path, :new_path, :a_mode, :b_mode, :diff
-      expose :new_file, :renamed_file, :deleted_file
     end
 
     class Compare < Grape::Entity

--- a/lib/api/merge_requests.rb
+++ b/lib/api/merge_requests.rb
@@ -75,6 +75,22 @@ module API
         present merge_request, with: Entities::MergeRequest
       end
 
+      # Show MR changes
+      #
+      # Parameters:
+      #   id (required)               - The ID of a project
+      #   merge_request_id (required) - The ID of MR
+      #
+      # Example:
+      #   GET /projects/:id/merge_request/:merge_request_id/changes
+      #
+      get ':id/merge_request/:merge_request_id/changes' do
+        merge_request = user_project.merge_requests.
+          find(params[:merge_request_id])
+        authorize! :read_merge_request, merge_request
+        present merge_request, with: Entities::MergeRequestChanges
+      end
+
       # Create MR
       #
       # Parameters:

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -114,6 +114,19 @@ describe API::API, api: true  do
     end
   end
 
+  describe 'GET /projects/:id/merge_request/:merge_request_id/changes' do
+    it 'should return the change information of the merge_request' do
+      get api("/projects/#{project.id}/merge_request/#{merge_request.id}/changes", user)
+      expect(response.status).to eq 200
+      expect(json_response['changes'].size).to eq(merge_request.diffs.size)
+    end
+
+    it 'returns a 404 when merge_request_id not found' do
+      get api("/projects/#{project.id}/merge_request/999/changes", user)
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe "POST /projects/:id/merge_requests" do
     context 'between branches projects' do
       it "should return merge_request" do


### PR DESCRIPTION
**What does this MR do?**
It adds an endpoint to the API to retrieve all files that have changed in a MR, including its diff

**Why was this MR needed?**
Currently there is no such way, this prevents systems like HoundCI to be able to communicate with GitLab

**What are the relevant issue numbers / Feature requests?**
None that I know of
