### PR TITLE
Adds link to milestone and keeping resource context on smaller viewports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,7 +54,7 @@ v 7.8.0
   - 
   - 
   - 
-  - 
+  - Added link to milestone and keeping resource context on smaller viewports for issues and merge requests (Jason Blanchard)
   - 
   - 
   - API: Add support for editing an existing project (Mika Mäenpää and Hannes Rosenögger) 

--- a/app/views/projects/issues/_discussion.html.haml
+++ b/app/views/projects/issues/_discussion.html.haml
@@ -13,7 +13,7 @@
         = link_to_member(@project, participant, name: false, size: 24)
 
     .voting_notes#notes= render "projects/notes/notes_with_form"
-  .col-md-3.hidden-sm.hidden-xs
+  .col-md-3
     %div
     .clearfix
       %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}

--- a/app/views/projects/issues/_issue_context.html.haml
+++ b/app/views/projects/issues/_issue_context.html.haml
@@ -2,23 +2,21 @@
   %div.prepend-top-20
     %p
       Assignee:
-
+      - if issue.assignee
+        = link_to_member(@project, @issue.assignee)
+      - else
+        none
     - if can?(current_user, :modify_issue, @issue)
       = project_users_select_tag('issue[assignee_id]', placeholder: 'Select assignee', class: 'custom-form-control js-select2 js-assignee', selected: @issue.assignee_id)
-    - elsif issue.assignee
-      = link_to_member(@project, @issue.assignee)
-    - else
-      None
 
   %div.prepend-top-20
     %p
       Milestone:
+      - if issue.milestone
+        #{link_to @issue.milestone.title, project_milestone_path(@project, @issue.milestone)}
+      - else
+        none
     - if can?(current_user, :modify_issue, @issue)
       = f.select(:milestone_id, milestone_options(@issue), { include_blank: "Select milestone" }, {class: 'select2 select2-compact js-select2 js-milestone'})
       = hidden_field_tag :issue_context
       = f.submit class: 'btn'
-    - elsif issue.milestone
-      = link_to project_milestone_path(@project, @issue.milestone) do
-        = @issue.milestone.title
-    - else
-      None

--- a/app/views/projects/issues/update.js.haml
+++ b/app/views/projects/issues/update.js.haml
@@ -3,8 +3,15 @@
     :plain
       $("##{dom_id(@issue)}").fadeOut();
 - elsif params[:issue_context]
+  $('.context').html("#{escape_javascript(render partial: 'issue_context', locals: { issue: @issue })}");
   $('.context').effect('highlight');
   - if @issue.milestone
     $('.milestone-nav-link').replaceWith("<span class='milestone-nav-link'>| <span class='light'>Milestone</span> #{escape_javascript(link_to @issue.milestone.title, project_milestone_path(@issue.project, @issue.milestone))}</span>")
   - else
     $('.milestone-nav-link').html('')
+
+
+$('select.select2').select2({width: 'resolve', dropdownAutoWidth: true})
+$('.edit-issue.inline-update input[type="submit"]').hide();
+new ProjectUsersSelect();
+new Issue();

--- a/app/views/projects/merge_requests/_discussion.html.haml
+++ b/app/views/projects/merge_requests/_discussion.html.haml
@@ -9,7 +9,7 @@
   .col-md-9
     = render "projects/merge_requests/show/participants"
     = render "projects/notes/notes_with_form"
-  .col-md-3.hidden-sm.hidden-xs
+  .col-md-3
     .clearfix
       %span.slead.has_tooltip{:"data-original-title" => 'Cross-project reference'}
         = cross_project_reference(@project, @merge_request)
@@ -18,7 +18,7 @@
       %cite.cgray
         = render partial: 'projects/merge_requests/show/context', locals: { merge_request: @merge_request }
     %hr
-    .votes-holder.hidden-sm.hidden-xs
+    .votes-holder
       %h6 Votes
       #votes= render 'votes/votes_block', votable: @merge_request
 

--- a/app/views/projects/merge_requests/show/_context.html.haml
+++ b/app/views/projects/merge_requests/show/_context.html.haml
@@ -2,22 +2,22 @@
   %div.prepend-top-20
     %p
       Assignee:
-
+      - if @merge_request.assignee
+        = link_to_member(@project, @merge_request.assignee)
+      - else
+        none
     - if can?(current_user, :modify_merge_request, @merge_request)
       = project_users_select_tag('merge_request[assignee_id]', placeholder: 'Select assignee', class: 'custom-form-control js-select2 js-assignee', selected: @merge_request.assignee_id)
-    - elsif merge_request.assignee
-      = link_to_member(@project, @merge_request.assignee)
-    - else
-      None
 
   %div.prepend-top-20
     %p
       Milestone:
+      - if @merge_request.milestone
+        %span.back-to-milestone
+          #{link_to @merge_request.milestone.title, project_milestone_path(@project, @merge_request.milestone)}
+      - else
+        none
     - if can?(current_user, :modify_merge_request, @merge_request)
       = f.select(:milestone_id, milestone_options(@merge_request), { include_blank: "Select milestone" }, {class: 'select2 select2-compact js-select2 js-milestone'})
       = hidden_field_tag :merge_request_context
       = f.submit class: 'btn'
-    - elsif merge_request.milestone
-      = link_to merge_request.milestone.title, project_milestone_path
-    - else
-      None

--- a/app/views/projects/merge_requests/update.js.haml
+++ b/app/views/projects/merge_requests/update.js.haml
@@ -1,2 +1,8 @@
 - if params[:merge_request_context]
+  $('.context').html("#{escape_javascript(render partial: 'projects/merge_requests/show/context', locals: { issue: @issue })}");
   $('.context').effect('highlight');
+
+  new ProjectUsersSelect();
+
+  $('select.select2').select2({width: 'resolve', dropdownAutoWidth: true});
+  merge_request = new MergeRequest();

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -65,7 +65,7 @@ describe "Issues", feature: true do
 
       click_button "Save changes"
 
-      page.should have_content "Assignee: Select assignee"
+      page.should have_content 'Assignee: none'
       issue.reload.assignee.should be_nil
     end
   end
@@ -249,6 +249,7 @@ describe "Issues", feature: true do
         click_button 'Update Issue'
 
         page.should have_content "Milestone changed to #{milestone.title}"
+        page.should have_content "Milestone: #{milestone.title}"
         has_select?('issue_assignee_id', :selected => milestone.title)
       end
     end
@@ -287,7 +288,7 @@ describe "Issues", feature: true do
         sleep 2 # wait for ajax stuff to complete
         first('.user-result').click
 
-        page.should have_content "Assignee: Unassigned"
+        page.should have_content 'Assignee: none'
         sleep 2 # wait for ajax stuff to complete
         issue.reload.assignee.should be_nil
       end


### PR DESCRIPTION
Fixes #8675 by adding links to the milestone for issues and merge requests using @randx design (https://github.com/gitlabhq/gitlabhq/issues/8675#issuecomment-72549130)

Issue:
![screen shot 2015-02-02 at 6 35 16 pm](https://cloud.githubusercontent.com/assets/1238532/6011490/60eba6bc-ab0a-11e4-83a7-d6ce652695a8.png)

Merge request:
![screen shot 2015-02-02 at 6 35 04 pm](https://cloud.githubusercontent.com/assets/1238532/6011499/6f132d8c-ab0a-11e4-94cc-6b875d7820a0.png)

Also removes the `hidden-sm` and `hidden-xs` so that the `context` div is accessible on smaller viewports:

![screen shot 2015-02-02 at 6 37 35 pm](https://cloud.githubusercontent.com/assets/1238532/6011518/97d27fca-ab0a-11e4-969d-d2649d739924.png)
