### PR TITLE
Made diff colors a little less In Your Face

### DIFF
--- a/app/assets/stylesheets/sections/diff.scss
+++ b/app/assets/stylesheets/sections/diff.scss
@@ -40,12 +40,12 @@
     font-size: $code_font_size;
     .old {
       span.idiff {
-        background-color: #F99;
+        background-color: #f8cbcb;
       }
     }
     .new {
       span.idiff {
-        background-color: #8F8;
+        background-color: #a6f3a6;
       }
     }
     .unfold {
@@ -84,7 +84,7 @@
       padding: 0px;
       border: none;
       background: #F5F5F5;
-      color: #666;
+      color: rgba(0,0,0,0.3);
       padding: 0px 5px;
       border-right: 1px solid #ccc;
       text-align: right;
@@ -96,7 +96,7 @@
         float: left;
         width: 35px;
         font-weight: normal;
-        color: #666;
+        color: rgba(0,0,0,0.3);
         &:hover {
           text-decoration: underline;
         }
@@ -114,13 +114,13 @@
     .line_holder {
       &.old .old_line,
       &.old .new_line {
-        background: #FCC;
-        border-color: #E7BABA;
+        background: #ffdddd;
+        border-color: #f1c0c0;
       }
       &.new .old_line,
       &.new .new_line {
-        background: #CFC;
-        border-color: #B9ECB9;
+        background: #dbffdb;
+        border-color: #c1e9c1;
       }
     }
     .line_content {
@@ -129,10 +129,10 @@
       padding: 0px 0.5em;
       border: none;
       &.new {
-        background: #CFD;
+        background: #eaffea;
       }
       &.old {
-        background: #FDD;
+        background: #ffecec;
       }
       &.matched {
         color: #ccc;


### PR DESCRIPTION
**What does this MR do?**
It makes the diff colors a little less bright, easier to read

**Why was this MR needed?**
I think the old colors are to bright, makes it hard to do a lot of code reviewing. This makes the colors a bit less bright and easier on the eye.

**What are the relevant issue numbers / Feature requests?**
None that I know of

**Screenshots**
Before:
![screenshot 2015-02-03 10 50 52](https://cloud.githubusercontent.com/assets/1362793/6017879/9b59ba72-ab92-11e4-8d99-9ba1db11ed5b.png)

After:
![screenshot 2015-02-03 10 50 30](https://cloud.githubusercontent.com/assets/1362793/6017880/9fb6ed42-ab92-11e4-9fc2-23ceb12ed31f.png)
