### PR TITLE
Also show colors in the sidebar of comment

### DIFF
--- a/app/views/projects/notes/discussions/_diff.html.haml
+++ b/app/views/projects/notes/discussions/_diff.html.haml
@@ -19,8 +19,10 @@
               %td.new_line= "..."
               %td.line_content.matched= line.text
             - else
-              %td.old_line= raw(line.type == "new" ? "&nbsp;" : line.old_pos)
-              %td.new_line= raw(line.type == "old" ? "&nbsp;" : line.new_pos)
+              %td.old_line{class: line.type == "new" ? "new" : "old"}
+                = raw(line.type == "new" ? "&nbsp;" : line.old_pos)
+              %td.new_line{class: line.type == "new" ? "new" : "old"}
+                = raw(line.type == "old" ? "&nbsp;" : line.new_pos)
               %td.line_content{class: "noteable_line #{line.type} #{line_code}", "line_code" => line_code}= raw diff_line_content(line.text)
 
               - if line_code == note.line_code


### PR DESCRIPTION
**What does this MR do?**
It adds colors to the sidebar of a code comment

**Why was this MR needed?**
To be consistend when you're viewing the Changes tab

**Screenshots (if relevant)**
Before:
![screenshot 2015-02-03 18 47 49](https://cloud.githubusercontent.com/assets/1362793/6025741/2d52092e-abd5-11e4-9dc0-9ca6652272c9.png)

After:
![screenshot 2015-02-03 18 47 18](https://cloud.githubusercontent.com/assets/1362793/6025745/34274f7a-abd5-11e4-9ce7-ab22dd33e45b.png)
