### PR TITLE
Specify shell while run me as git user

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -35,13 +35,14 @@ pid_path="$app_root/tmp/pids"
 socket_path="$app_root/tmp/sockets"
 web_server_pid_path="$pid_path/unicorn.pid"
 sidekiq_pid_path="$pid_path/sidekiq.pid"
+shell_path="/bin/bash"
 
 # Read configuration variable file if it is present
 test -f /etc/default/gitlab && . /etc/default/gitlab
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then
-  eval su - "$app_user" -c $(echo \")$0 "$@"$(echo \"); exit;
+  eval su - "$app_user" -s $shell_path -c $(echo \")$0 "$@"$(echo \"); exit;
 fi
 
 # Switch to the gitlab path, exit on failure.

--- a/lib/support/init.d/gitlab.default.example
+++ b/lib/support/init.d/gitlab.default.example
@@ -29,3 +29,9 @@ web_server_pid_path="$pid_path/unicorn.pid"
 # sidekiq_pid_path defines the path in which to create the pid file for sidekiq
 # The default is "$pid_path/sidekiq.pid"
 sidekiq_pid_path="$pid_path/sidekiq.pid"
+
+# shell_path defines the path of shell for "$app_user" in case you disabled
+# shell of "$app_user" by commands like `usermod -s /sbin/nologin $app_user"
+# for security decision.
+# The default is "/bin/bash"
+shell_path="/bin/bash"

--- a/lib/support/init.d/gitlab.default.example
+++ b/lib/support/init.d/gitlab.default.example
@@ -30,8 +30,7 @@ web_server_pid_path="$pid_path/unicorn.pid"
 # The default is "$pid_path/sidekiq.pid"
 sidekiq_pid_path="$pid_path/sidekiq.pid"
 
-# shell_path defines the path of shell for "$app_user" in case you disabled
-# shell of "$app_user" by commands like `usermod -s /sbin/nologin $app_user"
-# for security decision.
+# shell_path defines the path of shell for "$app_user" in case you are using
+# shell other than "bash"
 # The default is "/bin/bash"
 shell_path="/bin/bash"


### PR DESCRIPTION
Some users disabled "git" user's shell after finished installation, this
will lead to "This account is currently not available" and could not
run /etc/init.d/gitlab, this dirty trick fix it.

Signed-off-by: Drunkard Zhang gongfan193@gmail.com
