### PR TITLE
Fix (project_)name_regex to accept non-ASCII letters and dash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ v 7.11.0 (unreleased)
   - Prevent sending empty messages to HipChat (Chulki Lee)
   - Improve UI for mobile phones on dashboard and project pages
   - Add room notification and message color option for HipChat
+  - Allow to use non-ASCII letters and dashes in project and namespace name. (Jakub Jirutka)
 
 v 7.10.0
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -15,20 +15,20 @@ module Gitlab
 
 
     def namespace_name_regex
-      @namespace_name_regex ||= /\A[a-zA-Z0-9_\-\. ]*\z/.freeze
+      @namespace_name_regex ||= /\A[\p{Alnum}\p{Pd}_\. ]*\z/.freeze
     end
 
     def namespace_name_regex_message
-      "can contain only letters, digits, '_', '-', '.' and space."
+      "can contain only letters, digits, '_', '.', dash and space."
     end
 
 
     def project_name_regex
-      @project_name_regex ||= /\A[a-zA-Z0-9_.][a-zA-Z0-9_\-\. ]*\z/.freeze
+      @project_name_regex ||= /\A[\p{Alnum}_][\p{Alnum}\p{Pd}_\. ]*\z/.freeze
     end
 
     def project_name_regex_message
-      "can contain only letters, digits, '_', '-', '.' and space. " \
+      "can contain only letters, digits, '_', '.', dash and space. " \
       "It must start with letter, digit or '_'."
     end
 

--- a/spec/lib/gitlab/regex_spec.rb
+++ b/spec/lib/gitlab/regex_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Gitlab::Regex do
@@ -16,6 +17,8 @@ describe Gitlab::Regex do
     it { expect('GitLab CE').to match(Gitlab::Regex.project_name_regex) }
     it { expect('100 lines').to match(Gitlab::Regex.project_name_regex) }
     it { expect('gitlab.git').to match(Gitlab::Regex.project_name_regex) }
+    it { expect('Český název').to match(Gitlab::Regex.project_name_regex) }
+    it { expect('Dash – is this').to match(Gitlab::Regex.project_name_regex) }
     it { expect('?gitlab').not_to match(Gitlab::Regex.project_name_regex) }
   end
 end


### PR DESCRIPTION
This validates a project/group name, not directory path, so there’s no reason to forbid non-ASCII letters.
