### PR TITLE
Disabled expansion of top/bottom blobs for new file diffs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ v 7.8.0
   - Upgrade Sidekiq gem to version 3.3.0
   - Stop git zombie creation during force push check
   - Show success/error messages for test setting button in services
+  - Disabled expansion of top/bottom blobs for new file diffs
   - Added Rubocop for code style checks
   - Fix commits pagination
   - 

--- a/app/helpers/diff_helper.rb
+++ b/app/helpers/diff_helper.rb
@@ -92,6 +92,10 @@ module DiffHelper
     (bottom) ? 'js-unfold-bottom' : ''
   end
 
+  def unfold_class(unfold)
+    (unfold) ? 'unfold js-unfold' : ''
+  end
+
   def diff_line_content(line)
     if line.blank?
       " &nbsp;"

--- a/app/views/projects/blob/diff.html.haml
+++ b/app/views/projects/blob/diff.html.haml
@@ -2,7 +2,7 @@
   - if @form.unfold? && @form.since != 1 && !@form.bottom?
     %tr.line_holder{ id: @form.since }
       = render "projects/diffs/match_line", {line: @match_line,
-        line_old: @form.since, line_new: @form.since, bottom: false}
+        line_old: @form.since, line_new: @form.since, bottom: false, new_file: false}
 
   - @lines.each_with_index do |line, index|
     - line_new = index + @form.since
@@ -16,4 +16,4 @@
   - if @form.unfold? && @form.bottom? && @form.to < @blob.loc
     %tr.line_holder{ id: @form.to }
       = render "projects/diffs/match_line", {line: @match_line,
-        line_old: @form.to, line_new: @form.to, bottom: true}
+        line_old: @form.to, line_new: @form.to, bottom: true, new_file: false}

--- a/app/views/projects/diffs/_match_line.html.haml
+++ b/app/views/projects/diffs/_match_line.html.haml
@@ -1,7 +1,7 @@
-%td.old_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_old},
- class: unfold_bottom_class(bottom)}
+%td.old_line.diff-line-num{data: {linenumber: line_old},
+ class: [unfold_bottom_class(bottom), unfold_class(!new_file)]}
   \...
-%td.new_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_new},
- class: unfold_bottom_class(bottom)}
+%td.new_line.diff-line-num{data: {linenumber: line_new},
+ class: [unfold_bottom_class(bottom), unfold_class(!new_file)]}
   \...
 %td.line_content.matched= line

--- a/app/views/projects/diffs/_text_file.html.haml
+++ b/app/views/projects/diffs/_text_file.html.haml
@@ -12,7 +12,7 @@
     %tr.line_holder{ id: line_code, class: "#{type}" }
       - if type == "match"
         = render "projects/diffs/match_line", {line: line.text,
-          line_old: line_old, line_new: line.new_pos, bottom: false}
+          line_old: line_old, line_new: line.new_pos, bottom: false, new_file: diff_file.new_file}
       - else
         %td.old_line
           = link_to raw(type == "new" ? "&nbsp;" : line_old), "##{line_code}", id: line_code
@@ -29,7 +29,7 @@
 
   - if last_line > 0
     = render "projects/diffs/match_line", {line: "",
-      line_old: last_line, line_new: last_line, bottom: true}
+      line_old: last_line, line_new: last_line, bottom: true, new_file: diff_file.new_file}
 
 - if diff_file.diff.blank? && diff_file.mode_changed?
   .file-mode-changed

--- a/spec/helpers/diff_helper_spec.rb
+++ b/spec/helpers/diff_helper_spec.rb
@@ -52,6 +52,16 @@ describe DiffHelper do
     end
   end
 
+  describe 'unfold_class' do
+    it 'returns empty on false' do
+      expect(unfold_class(false)).to eq('')
+    end
+
+    it 'returns a class on true' do
+      expect(unfold_class(true)).to eq('unfold js-unfold')
+    end
+  end
+
   describe 'diff_line_content' do
 
     it 'should return non breaking space when line is empty' do


### PR DESCRIPTION
This fixes issue #8679.

Before:

![screen shot 2015-02-08 at 5 21 42 pm](https://cloud.githubusercontent.com/assets/475263/6099160/06b34054-afb7-11e4-8380-1d3ca690b178.png)

After:

![screen shot 2015-02-08 at 5 21 10 pm](https://cloud.githubusercontent.com/assets/475263/6099165/12bc87a2-afb7-11e4-85c1-ef9ed33585b5.png)
