### PR TITLE
use gitlab branch of mysql-postgresql-converter

### DIFF
--- a/doc/update/mysql_to_postgresql.md
+++ b/doc/update/mysql_to_postgresql.md
@@ -11,7 +11,7 @@ sudo service gitlab stop
 
 # Update /home/git/gitlab/config/database.yml
 
-git clone https://github.com/gitlabhq/mysql-postgresql-converter.git
+git clone https://github.com/gitlabhq/mysql-postgresql-converter.git -b gitlab
 cd mysql-postgresql-converter
 mysqldump --compatible=postgresql --default-character-set=utf8 -r databasename.mysql -u root gitlabhq_production -p
 python db_converter.py databasename.mysql databasename.psql
@@ -38,7 +38,7 @@ On non-omnibus installations (distributed using Git) we retrieve the index decla
 ```
 # Clone the database converter on your Postgres-backed GitLab server
 cd /tmp
-git clone https://github.com/gitlabhq/mysql-postgresql-converter.git
+git clone https://github.com/gitlabhq/mysql-postgresql-converter.git -b gitlab
 
 cd /home/git/gitlab
 
@@ -59,7 +59,7 @@ On omnibus-gitlab we need to get the index declarations from a file called `sche
 ```
 # Clone the database converter on your Postgres-backed GitLab server
 cd /tmp
-/opt/gitlab/embedded/bin/git clone https://github.com/gitlabhq/mysql-postgresql-converter.git
+/opt/gitlab/embedded/bin/git clone https://github.com/gitlabhq/mysql-postgresql-converter.git -b gitlab
 cd /tmp/mysql-postgresql-converter
 
 # Download schema.rb.bundled if necessary
@@ -97,7 +97,7 @@ cd tmp/backups/postgresql
 sudo -u git -H mysqldump --compatible=postgresql --default-character-set=utf8 -r gitlabhq_production.mysql -u root gitlabhq_production -p
 
 # Clone the database converter
-sudo -u git -H git clone https://github.com/gitlabhq/mysql-postgresql-converter.git
+sudo -u git -H git clone https://github.com/gitlabhq/mysql-postgresql-converter.git -b gitlab
 
 # Convert gitlabhq_production.mysql
 sudo -u git -H mkdir db


### PR DESCRIPTION
When converting from MySQL to PostgreSQL make sure to use `gitlab` branch.
