### PR TITLE
Fix small grammar issue on projects show page

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -59,7 +59,7 @@
             %span.light Created on
             #{@project.created_at.stamp('Aug 22, 2013')}
           %p
-            %span.light Owned by
+            %span.light Owned by #{@project.group ? "the" : nil}
             - if @project.group
               #{link_to @project.group.name, @project.group} group
             - else


### PR DESCRIPTION
When viewing a project owned by a group it currently looks like this:

![image](https://cloud.githubusercontent.com/assets/3237256/6131062/6cb98e6a-b117-11e4-8ea9-c6a194312616.png)

This commit will change it so it is now the following:

![image](https://cloud.githubusercontent.com/assets/3237256/6131093/97a3a534-b117-11e4-805f-1da6d34398e2.png)

Projects owned by individual users will stay the same:

![image](https://cloud.githubusercontent.com/assets/3237256/6131104/b7016b1e-b117-11e4-85e4-e2a31dfd3d47.png)
