### PR TITLE
Don't cache classes in tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Gitlab::Application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true


### PR DESCRIPTION
**What does this PR do?**
It stops caching of classes in test environment

**Wht is this PR needed?**
It fixes a problem with spring explained here: #8781 
