### PR TITLE
Fix mentioning when username starts with number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,6 +84,7 @@ v 7.9.0 (unreleased)
   - Ability to unsubscribe/subscribe to issue or merge request
   - Delete deploy key when last connection to a project is destroyed.
   - Fix invalid Atom feeds when using emoji, horizontal rules, or images (Christian Walther)
+  - Fix when mentioning an user that the username start with number.
 
 v 7.8.4
   - Fix issue_tracker_id substitution in custom issue trackers

--- a/app/models/concerns/mentionable.rb
+++ b/app/models/concerns/mentionable.rb
@@ -46,7 +46,7 @@ module Mentionable
     users = []
     return users if mentionable_text.blank?
     has_project = self.respond_to? :project
-    matches = mentionable_text.scan(/@[a-zA-Z][a-zA-Z0-9_\-\.]*/)
+    matches = mentionable_text.scan Regexp.new(Gitlab::Markdown::NAME_STR)
     matches.each do |match|
       identifier = match.delete "@"
       if identifier == "all"

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -136,7 +136,7 @@ module Gitlab
       text
     end
 
-    NAME_STR = '[a-zA-Z0-9_][a-zA-Z0-9_\-\.]*'
+    NAME_STR = '[a-zA-Z0-9_\-\.]+'
     PROJ_STR = "(?<project>#{NAME_STR}/#{NAME_STR})"
 
     REFERENCE_PATTERN = %r{

--- a/spec/models/concerns/mentionable_spec.rb
+++ b/spec/models/concerns/mentionable_spec.rb
@@ -2,13 +2,25 @@ require 'spec_helper'
 
 describe Issue, "Mentionable" do
   describe :mentioned_users do
-    let!(:user) { create(:user, username: 'stranger') }
-    let!(:user2) { create(:user, username: 'john') }
-    let!(:issue) { create(:issue, description: '@stranger mentioned') }
+    let!(:user) { create(:user, username: 'john') }
+    context 'mentioning an user with the username starting with a letter' do
+      let!(:user_mentioned) { create(:user, username: 'stranger') }
+      let!(:issue) { create(:issue, description: '@stranger mentioned') }
 
-    subject { issue.mentioned_users }
+      subject { issue.mentioned_users }
 
-    it { is_expected.to include(user) }
-    it { is_expected.not_to include(user2) }
+      it { is_expected.to include(user_mentioned) }
+      it { is_expected.not_to include(user) }
+    end
+
+    context 'mentioning an user with the username starting with a number' do
+      let!(:user_mentioned) { create(:user, username: '123stranger') }
+      let!(:issue) { create(:issue, description: '@123stranger mentioned') }
+
+      subject { issue.mentioned_users }
+
+      it { is_expected.to include(user_mentioned) }
+      it { is_expected.not_to include(user) }
+    end
   end
 end


### PR DESCRIPTION
Fix #8791 
This problem occurs when the user try to mention a user that the username starts with number in issue comments.
