### PR TITLE
Update charlock_holmes to 0.7.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       json (>= 1.7)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    charlock_holmes (0.6.9.4)
+    charlock_holmes (0.7.3)
     cliver (0.3.2)
     coderay (1.1.0)
     coercible (1.0.0)


### PR DESCRIPTION
Version 0.6.9.4 fails to install on Gentoo Linux. This version is almost 2 years old. I’ve updated it to 0.7.3, the latest stable version from June 2014.
