### PR TITLE
Add new style to "New group" button

### DIFF
--- a/app/assets/stylesheets/sections/dashboard.scss
+++ b/app/assets/stylesheets/sections/dashboard.scss
@@ -120,6 +120,15 @@
   }
 }
 
+.dash-new-group {
+  background: $bg_success;
+  border: 1px solid $border_success;
+
+  a {
+    color: #FFF;
+  }
+}
+
 .dash-list .str-truncated {
   max-width: 72%;
 }

--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -3,7 +3,7 @@
     .input-group
       = search_field_tag :filter_group, nil, placeholder: 'Filter by name', class: 'dash-filter form-control'
       - if current_user.can_create_group?
-        .input-group-addon
+        .input-group-addon.dash-new-group
           = link_to new_group_path, class: "" do
             %strong New group
   %ul.well-list.dash-list


### PR DESCRIPTION
In 7.8 The "New project" button background color on the dashboard changed to green ($bg_success) but the "New group" button did not. I changed the button style to have the same look as the "New
project" button.

Before:

![image](https://cloud.githubusercontent.com/assets/1237001/6236443/0ee5ab46-b6eb-11e4-9840-df55e814b41a.png)
![image](https://cloud.githubusercontent.com/assets/1237001/6236541/ade96d54-b6eb-11e4-84d7-e892c4c4344f.png)

After:

![image](https://cloud.githubusercontent.com/assets/1237001/6236443/0ee5ab46-b6eb-11e4-9840-df55e814b41a.png)
![image](https://cloud.githubusercontent.com/assets/1237001/6236485/3bc2efb6-b6eb-11e4-86d4-57cf2eeec1d1.png)

Is this patch ok for you or did I do it "the wrong way"? Is it breaking something else?
I was not able to find any problems...
