### PR TITLE
Fix for TeamCity buildQueue REST API build/@branchName.

### DIFF
--- a/app/models/project_services/teamcity_service.rb
+++ b/app/models/project_services/teamcity_service.rb
@@ -115,13 +115,13 @@ class TeamcityService < CiService
     end
   end
 
-  def execute(data)
+  def execute(push)
     auth = {
       username: username,
       password: password,
     }
 
-    branch = data[:ref]
+    branch = push[:ref].gsub('refs/heads/', '')
 
     self.class.post("#{teamcity_url}/httpAuth/app/rest/buildQueue",
                     body: "<build branchName=\"#{branch}\">"\


### PR DESCRIPTION
Strips the refs/*/ if any to get just the branchName out of a :ref
e.g.: `refs/heads/feature/newProfile` -> `feature/newProfile`

The TeamCity buildQueue POST data require the branchName attribute
to contain just the branch name (just xyzbranch and not the full
ref in the refs/heads/xyzbranch). With the refs/heads/xyzbranch the
build is triggered and looks like it is working however it always
ompiles the default branch (or master).
