### PR TITLE
Improvement to identity builder in LDAP::User

### DIFF
--- a/lib/gitlab/ldap/user.rb
+++ b/lib/gitlab/ldap/user.rb
@@ -42,9 +42,11 @@ module Gitlab
         gl_user.email = auth_hash.email
 
         # Build new identity only if we dont have have same one
-        gl_user.identities.find_or_initialize_by(provider: auth_hash.provider,
-                                                 extern_uid: auth_hash.uid)
-
+        if gl_user.persisted?
+          gl_user.identities.find_or_initialize_by(provider: auth_hash.provider,
+                                                   extern_uid: auth_hash.uid)
+        end
+  
         gl_user
       end
 


### PR DESCRIPTION
Currently, the find_or_initialize_by statement in the LDAP::User model will cause duplicate identities to be created when a new user logs in. This is because find_or_initialize_by can't check in-memory records, and a new identity is created by build_new_user in the OAuth::User model. By adding a persisted? check, find_or_initialize_by is ignored on the first run, and so duplicate identities aren't created.

This has only been a problem on our local installation of Gitlab because we block new LDAP accounts from logging in if they don't already exist (needs_blocking? is true if it's a new user). The duplicate identities wouldn't cause the user.save! statement to fail, but the user.block statement following it would fail.
