### PR TITLE
[bugfix] Merge request diff view behaviour fix

### DIFF
--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -123,7 +123,7 @@ class @MergeRequest
   loadDiff: (event) ->
     $.ajax
       type: 'GET'
-      url: this.$('.merge-request-tabs .diffs-tab a').attr('href') + ".json";
+      url: this.$('.merge-request-tabs .diffs-tab a').attr('href') + ".json"
       beforeSend: =>
         this.$('.mr-loading-status .loading').show()
       complete: =>

--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -123,7 +123,7 @@ class @MergeRequest
   loadDiff: (event) ->
     $.ajax
       type: 'GET'
-      url: this.$('.merge-request-tabs .diffs-tab a').attr('href')
+      url: this.$('.merge-request-tabs .diffs-tab a').attr('href') + ".json";
       beforeSend: =>
         this.$('.mr-loading-status .loading').show()
       complete: =>


### PR DESCRIPTION
Fixed 'back button' bug in merge request view.

Steps to reproduce:
1) Open merge request view page at a URL like this: http://localhost:3000/gitlab-org/gitlab-test/merge_requests/3/diffs on "Discussion" tab
2) Click on 'Changes' tab
3) Click 'View file @ rev-number' button
4) Click 'BACK' browser button

Expected result:
User moves back to the diff page

Actual result:
User is moved to the diff page which is shown as a plain json diff document, because browser has cached the last AJAX-call of `loadDiff` coffee-script method.
