### PR TITLE
Allow users' to be created/updated as having confirmed email via the API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v 7.9.0 (unreleased)
   - Upgrade Rails gem to version 4.1.9.
   - Improve UI for commits, issues and merge request lists
   - Fix commit comments on first line of diff not rendering in Merge Request Discussion view.
+  - Improve API to support creating users with confirmed email and confirming email for existing users (Boyan Tabakov)
 
 v 7.8.0
   - Fix access control and protection against XSS for note attachments and other uploads.

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -57,6 +57,9 @@ GET /users
     "color_scheme_id": 2,
     "is_admin": false,
     "avatar_url": "http://localhost:3000/uploads/user/avatar/1/cd8.jpeg",
+    "confirmed_at": "2012-05-23T08:00:58Z",
+    "confirmation_token": null,
+    "confirmation_sent_at": null,
     "can_create_group": true
   },
   {
@@ -79,6 +82,9 @@ GET /users
     "avatar_url": "http://localhost:3000/uploads/user/avatar/1/cd8.jpeg",
     "can_create_group": true,
     "can_create_project": true,
+    "confirmed_at": null,
+    "confirmation_token": "b08f8d809eb9f9",
+    "confirmation_sent_at": "2012-05-23T08:01:01Z",
     "projects_limit": 100
   }
 ]
@@ -142,6 +148,9 @@ Parameters:
   "is_admin": false,
   "can_create_group": true,
   "can_create_project": true,
+  "confirmed_at": "2012-05-23T08:00:58Z",
+  "confirmation_token": null,
+  "confirmation_sent_at": null,
   "projects_limit": 100
 }
 ```
@@ -170,6 +179,9 @@ Parameters:
 - `bio` (optional)              - User's biography
 - `admin` (optional)            - User is admin - true or false (default)
 - `can_create_group` (optional) - User can create groups - true or false
+- `confirmed` (optional)        - Mark user's email as confirmed
+                                  and don't send confirmation email -
+                                  true of false (default)
 
 ## User modification
 
@@ -195,6 +207,8 @@ Parameters:
 - `bio`                         - User's biography
 - `admin` (optional)            - User is admin - true or false (default)
 - `can_create_group` (optional) - User can create groups - true or false
+- `confirmed` (optional)        - Mark user's email as confirmed if set to true,
+                                  ignored otherwise.
 
 Note, at the moment this method does only return a 404 error,
 even in cases where a 409 (Conflict) would be more appropriate,
@@ -243,6 +257,9 @@ GET /user
   "is_admin": false,
   "can_create_group": true,
   "can_create_project": true,
+  "confirmed_at": "2012-05-23T08:00:58Z",
+  "confirmation_token": null,
+  "confirmation_sent_at": null,
   "projects_limit": 100
 }
 ```

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -24,6 +24,7 @@ module API
       expose :identities, using: Entities::Identity
       expose :can_create_group?, as: :can_create_group
       expose :can_create_project?, as: :can_create_project
+      expose :confirmed_at, :confirmation_token, :confirmation_sent_at
     end
 
     class UserLogin < UserFull

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -35,6 +35,9 @@ describe API::API, api: true  do
         expect(json_response.first.keys).to include 'email'
         expect(json_response.first.keys).to include 'identities'
         expect(json_response.first.keys).to include 'can_create_project'
+        expect(json_response.first.keys).to include 'confirmed_at'
+        expect(json_response.first.keys).to include 'confirmation_token'
+        expect(json_response.first.keys).to include 'confirmation_sent_at'
       end
     end
   end
@@ -68,23 +71,31 @@ describe API::API, api: true  do
     end
 
     it "should create user with correct attributes" do
-      post api('/users', admin), attributes_for(:user, admin: true, can_create_group: true)
+      post api('/users', admin), attributes_for(
+        :user, admin: true, can_create_group: true, confirmed: true
+      )
       expect(response.status).to eq(201)
       user_id = json_response['id']
       new_user = User.find(user_id)
       expect(new_user).not_to eq(nil)
       expect(new_user.admin).to eq(true)
       expect(new_user.can_create_group).to eq(true)
+      expect(new_user.confirmed_at).not_to eq(nil)
+      expect(new_user.confirmation_token).to eq(nil)
     end
 
     it "should create non-admin user" do
-      post api('/users', admin), attributes_for(:user, admin: false, can_create_group: false)
+      post api('/users', admin), attributes_for(
+        :user, admin: false, can_create_group: false, confirmed: false
+      )
       expect(response.status).to eq(201)
       user_id = json_response['id']
       new_user = User.find(user_id)
       expect(new_user).not_to eq(nil)
       expect(new_user.admin).to eq(false)
       expect(new_user.can_create_group).to eq(false)
+      expect(new_user.confirmed_at).to eq(nil)
+      expect(new_user.confirmation_token).not_to eq(nil)
     end
 
     it "should create non-admin users by default" do
@@ -94,6 +105,8 @@ describe API::API, api: true  do
       new_user = User.find(user_id)
       expect(new_user).not_to eq(nil)
       expect(new_user.admin).to eq(false)
+      expect(new_user.confirmed_at).to eq(nil)
+      expect(new_user.confirmation_token).not_to eq(nil)
     end
 
     it "should return 201 Created on success" do
@@ -267,6 +280,26 @@ describe API::API, api: true  do
           to eq(['must be greater than or equal to 0'])
       expect(json_response['message']['username']).
           to eq([Gitlab::Regex.send(:default_regex_message)])
+    end
+
+    context 'email confirmation' do
+      let (:unconfirmed_user) { create(:user, confirmed_at: nil) }
+
+      it 'should update confirmed status' do
+        put api("/users/#{unconfirmed_user.id}", admin), confirmed: true
+        expect(response.status).to eq(200)
+        expect(json_response['confirmed_at']).not_to eq(nil)
+        expect(unconfirmed_user.reload.confirmed_at).not_to eq(nil)
+        expect(unconfirmed_user.reload.confirmation_token).to eq(nil)
+      end
+
+      it 'should not change confirmed status' do
+        put api("/users/#{unconfirmed_user.id}", admin), confirmed: false
+        expect(response.status).to eq(200)
+        expect(json_response['confirmed_at']).to eq(nil)
+        expect(unconfirmed_user.reload.confirmed_at).to eq(nil)
+        expect(unconfirmed_user.reload.confirmation_token).not_to eq(nil)
+      end
     end
 
     context "with existing user" do


### PR DESCRIPTION
Also exposes confirmation status, token and email timestamp via the API.

Fixes #6895.
