### PR TITLE
Update version sorter to 2.0.0, fixes #8572

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,7 @@ GEM
       raindrops (~> 0.7)
     unicorn-worker-killer (0.4.2)
       unicorn (~> 4)
-    version_sorter (1.1.0)
+    version_sorter (2.0.0)
     virtus (1.0.1)
       axiom-types (~> 0.0.5)
       coercible (~> 1.0)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -192,10 +192,12 @@ describe ApplicationHelper do
     it 'sorts tags in a natural order' do
       # Stub repository.tag_names to make sure we get some valid testing data
       expect(@project.repository).to receive(:tag_names).
-        and_return(['v1.0.9', 'v1.0.10', 'v2.0', 'v3.1.4.2', 'v1.0.9a'])
+        and_return(['v1.0.9', 'v1.0.10', 'v2.0', 'v3.1.4.2', 'v1.0.9a',
+                    'v2.0-rc1', 'v2.0rc2'])
 
       expect(options[1][1]).
-        to eq(['v3.1.4.2', 'v2.0', 'v1.0.10', 'v1.0.9a', 'v1.0.9'])
+        to eq(['v3.1.4.2', 'v2.0', 'v2.0rc2', 'v2.0-rc1', 'v1.0.10', 'v1.0.9',
+               'v1.0.9a'])
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -192,12 +192,12 @@ describe ApplicationHelper do
     it 'sorts tags in a natural order' do
       # Stub repository.tag_names to make sure we get some valid testing data
       expect(@project.repository).to receive(:tag_names).
-        and_return(['v1.0.9', 'v1.0.10', 'v2.0', 'v3.1.4.2', 'v1.0.9a',
-                    'v2.0-rc1', 'v2.0rc2'])
+        and_return(['v1.0.9', 'v1.0.10', 'v2.0', 'v3.1.4.2', 'v2.0rc1¿',
+                    'v1.0.9a', 'v2.0-rc1', 'v2.0rc2'])
 
       expect(options[1][1]).
-        to eq(['v3.1.4.2', 'v2.0', 'v2.0rc2', 'v2.0-rc1', 'v1.0.10', 'v1.0.9',
-               'v1.0.9a'])
+        to eq(['v3.1.4.2', 'v2.0', 'v2.0rc2', 'v2.0rc1¿', 'v2.0-rc1', 'v1.0.10',
+               'v1.0.9', 'v1.0.9a'])
     end
   end
 


### PR DESCRIPTION
This updates the `version_sorter` gem to 2.0.0. The API is the same, but the implementation improved.
This also includes a fix for encoding. The the current used version, tags get reencoded to ASCII rather than preserving its encoding.

/cc @tsigo 
