### PR TITLE
Expose avatar_url in projects API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v 7.9.0 (unreleased)
   - Save web edit in new branch
   - Fix ordering of imported but unchanged projects (Marco Wessel)
   - Mobile UI improvements: make aside content expandable
+  - Expose avatar_url in projects API
   - Generalize image upload in drag and drop in markdown to all files (Hannes Rosenögger)
 
 v 7.8.1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,10 +58,8 @@ module ApplicationHelper
         Project.find_with_namespace(project_id)
       end
 
-    if project.avatar.present?
-      image_tag project.avatar.url, options
-    elsif project.avatar_in_git
-      image_tag namespace_project_avatar_path(project.namespace, project), options
+    if project.avatar_url
+      image_tag project.avatar_url, options
     else # generated icon
       project_identicon(project, options)
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -37,6 +37,8 @@ class Project < ActiveRecord::Base
   include Gitlab::ShellAdapter
   include Gitlab::VisibilityLevel
   include Gitlab::ConfigHelper
+  include Rails.application.routes.url_helpers
+
   extend Gitlab::ConfigHelper
   extend Enumerize
 
@@ -406,6 +408,14 @@ class Project < ActiveRecord::Base
     @avatar_file ||= 'logo.jpg' if repository.blob_at_branch('master', 'logo.jpg')
     @avatar_file ||= 'logo.gif' if repository.blob_at_branch('master', 'logo.gif')
     @avatar_file
+  end
+
+  def avatar_url
+    if avatar.present?
+      [gitlab_config.url, avatar.url].join
+    elsif avatar_in_git
+      [gitlab_config.url, namespace_project_avatar_path(namespace, self)].join
+    end
   end
 
   # For compatibility with old code

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -68,7 +68,8 @@ Parameters:
       "path": "diaspora",
       "updated_at": "2013-09-30T13: 46: 02Z"
     },
-    "archived": false
+    "archived": false,
+    "avatar_url": "http://example.com/uploads/project/avatar/4/uploads/avatar.png"
   },
   {
     "id": 6,
@@ -103,7 +104,8 @@ Parameters:
       "path": "brightbox",
       "updated_at": "2013-09-30T13:46:02Z"
     },
-    "archived": false
+    "archived": false,
+    "avatar_url": null
   }
 ]
 ```
@@ -195,7 +197,8 @@ Parameters:
       "notification_level": 3
     }
   },
-  "archived": false
+  "archived": false,
+  "avatar_url": "http://example.com/uploads/project/avatar/3/uploads/avatar.png"
 }
 ```
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -56,6 +56,7 @@ module API
       expose :issues_enabled, :merge_requests_enabled, :wiki_enabled, :snippets_enabled, :created_at, :last_activity_at
       expose :namespace
       expose :forked_from_project, using: Entities::ForkedFromProject, if: lambda{ | project, options | project.forked? }
+      expose :avatar_url
     end
 
     class ProjectMember < UserBasic

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,8 +64,9 @@ describe ApplicationHelper do
       project = create(:project)
       project.avatar = File.open(avatar_file_path)
       project.save!
+      avatar_url = "http://localhost/uploads/project/avatar/#{ project.id }/gitlab_logo.png"
       expect(project_icon("#{project.namespace.to_param}/#{project.to_param}").to_s).to eq(
-        "<img alt=\"Gitlab logo\" src=\"/uploads/project/avatar/#{ project.id }/gitlab_logo.png\" />"
+        "<img alt=\"Gitlab logo\" src=\"#{avatar_url}\" />"
       )
     end
 
@@ -75,8 +76,9 @@ describe ApplicationHelper do
 
       allow_any_instance_of(Project).to receive(:avatar_in_git).and_return(true)
 
+      avatar_url = 'http://localhost' + namespace_project_avatar_path(project.namespace, project)
       expect(project_icon("#{project.namespace.to_param}/#{project.to_param}").to_s).to match(
-        image_tag(namespace_project_avatar_path(project.namespace, project)))
+        image_tag(avatar_url))
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -326,4 +326,35 @@ describe Project do
       expect(project.avatar_type).to eq(['only images allowed'])
     end
   end
+
+  describe :avatar_url do
+    subject { project.avatar_url }
+
+    let(:project) { create(:project) }
+
+    context 'When avatar file is uploaded' do
+      before do
+        project.update_columns(avatar: 'uploads/avatar.png')
+        allow(project.avatar).to receive(:present?) { true }
+      end
+
+      let(:avatar_path) do
+        "/uploads/project/avatar/#{project.id}/uploads/avatar.png"
+      end
+
+      it { should eq "http://localhost#{avatar_path}" }
+    end
+
+    context 'When avatar file in git' do
+      before do
+        allow(project).to receive(:avatar_in_git) { true }
+      end
+
+      let(:avatar_path) do
+        "/#{project.namespace.name}/#{project.path}/avatar"
+      end
+
+      it { should eq "http://localhost#{avatar_path}" }
+    end
+  end
 end


### PR DESCRIPTION
Add `avatar_url` to  response of project API

For using avatar url from third party tools (ex. [chrome-gitlab-notifier](https://github.com/sue445/chrome-gitlab-notifier) :sweat_smile:)
# example

``` sh
curl -s http://localhost:3000/api/v3/projects/h5bp%2Fhtml5-boilerplate?private_token=xxxxxxxxxxxx | jq .
{
  "id": 8,
  "description": "Dolorem eum deserunt qui dolorum quia sapiente.",
  "default_branch": "master",
  "public": false,
  "archived": false,
  "visibility_level": 10,
  "ssh_url_to_repo": "sue445@localhost:h5bp/html5-boilerplate.git",
  "http_url_to_repo": "http://localhost:3000/h5bp/html5-boilerplate.git",
  "web_url": "http://localhost:3000/h5bp/html5-boilerplate",
  "name": "Html5 Boilerplate",
  "name_with_namespace": "H5bp / Html5 Boilerplate",
  "path": "html5-boilerplate",
  "path_with_namespace": "h5bp/html5-boilerplate",
  "issues_enabled": true,
  "merge_requests_enabled": true,
  "wiki_enabled": true,
  "snippets_enabled": false,
  "created_at": "2015-02-26T23:29:50.000Z",
  "last_activity_at": "2015-02-26T23:36:45.000Z",
  "namespace": {
    "id": 5,
    "name": "H5bp",
    "path": "h5bp",
    "owner_id": null,
    "created_at": "2015-02-26T23:29:50.000Z",
    "updated_at": "2015-02-26T23:29:50.000Z",
    "description": "Voluptatem cumque cupiditate suscipit.",
    "avatar": {
      "url": null
    }
  },
  "avatar_url": "http://localhost:3000/uploads/project/avatar/8/avatar.png",
  "permissions": {
    "project_access": null,
    "group_access": {
      "access_level": 50,
      "notification_level": 3
    }
  }
}
```
