### PR TITLE
+ support upload file

### DIFF
--- a/lib/api/files.rb
+++ b/lib/api/files.rb
@@ -74,8 +74,8 @@ module API
         required_attributes! [:file_path, :branch_name, :content, :commit_message]
         attrs = attributes_for_keys [:file_path, :branch_name, :content, :commit_message, :encoding]
         if params[:content].try(:include?, 'tempfile')
-            attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
-            attrs['encoding'] = 'base64'
+          attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
+          attrs['encoding'] = 'base64'
         end
         branch_name = attrs.delete(:branch_name)
         file_path = attrs.delete(:file_path)
@@ -110,8 +110,8 @@ module API
         required_attributes! [:file_path, :branch_name, :content, :commit_message]
         attrs = attributes_for_keys [:file_path, :branch_name, :content, :commit_message, :encoding]
         if params[:content].try(:include?, 'tempfile')
-            attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
-            attrs['encoding'] = 'base64'
+          attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
+          attrs['encoding'] = 'base64'
         end
         branch_name = attrs.delete(:branch_name)
         file_path = attrs.delete(:file_path)

--- a/lib/api/files.rb
+++ b/lib/api/files.rb
@@ -73,6 +73,10 @@ module API
 
         required_attributes! [:file_path, :branch_name, :content, :commit_message]
         attrs = attributes_for_keys [:file_path, :branch_name, :content, :commit_message, :encoding]
+        if params[:content].try(:include?, 'tempfile')
+            attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
+            attrs['encoding'] = 'base64'
+        end
         branch_name = attrs.delete(:branch_name)
         file_path = attrs.delete(:file_path)
         result = ::Files::CreateService.new(user_project, current_user, attrs, branch_name, file_path).execute
@@ -105,6 +109,10 @@ module API
 
         required_attributes! [:file_path, :branch_name, :content, :commit_message]
         attrs = attributes_for_keys [:file_path, :branch_name, :content, :commit_message, :encoding]
+        if params[:content].try(:include?, 'tempfile')
+            attrs['content'] = Base64.encode64(params[:content][:tempfile].read)
+            attrs['encoding'] = 'base64'
+        end
         branch_name = attrs.delete(:branch_name)
         file_path = attrs.delete(:file_path)
         result = ::Files::UpdateService.new(user_project, current_user, attrs, branch_name, file_path).execute


### PR DESCRIPTION
why ?
when use javascript client post/put file, js can't load the file content and transcode into base64
how ?
use multipart/form-data upload file in Form or Ajax is very simple and normal.
just check if `content` contain Tempfile object,  then encode in base64.

```
<form enctype="multipart/form-data" method="post" action="/api/v3/projects/1/repository/files?private_token=">
<input name="file_path" value="image.png">
<input name="branch_name" value="master">
<input name="encoding" value="text">
<input name="commit_message" value="message">
<input type="file" name="content">
<!--input name="content"-->
<input name="_method" value="post">
<input type="submit">
</from>
```
