### PR TITLE
added own snippets restricted visibility levels

### DIFF
--- a/app/helpers/visibility_level_helper.rb
+++ b/app/helpers/visibility_level_helper.rb
@@ -63,4 +63,12 @@ module VisibilityLevelHelper
   def restricted_visibility_levels
     current_user.is_admin? ? [] : gitlab_config.restricted_visibility_levels
   end
+
+  def restricted_visibility_levels_snippets
+    if current_user.is_admin?
+      []
+    else
+      gitlab_config.restricted_visibility_levels_snippets
+    end
+  end
 end

--- a/app/views/shared/snippets/_visibility_level.html.haml
+++ b/app/views/shared/snippets/_visibility_level.html.haml
@@ -6,7 +6,7 @@
     - if can_change_visibility_level
       - Gitlab::VisibilityLevel.values.each do |level|
         .radio
-          - restricted = restricted_visibility_levels.include?(level)
+          - restricted = restricted_visibility_levels_snippets.include?(level)
           = f.radio_button :visibility_level, level, disabled: restricted
           = label "#{dom_class(@snippet)}_visibility_level", level do
             = visibility_level_icon(level)
@@ -14,7 +14,7 @@
               = visibility_level_label(level)
             .option-descr
               = snippet_visibility_level_description(level)
-      - unless restricted_visibility_levels.empty?
+      - unless restricted_visibility_levels_snippets.empty?
         .col-sm-10
           %span.info
             Some visibility level settings have been restricted by the administrator.

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -60,6 +60,10 @@ production: &base
     # The default is to allow all levels.
     # restricted_visibility_levels: [ "public" ]
 
+    # Restrict snippets setting visibility levels for non-admin users.
+    # The default is to allow all levels.
+    # restricted_visibility_levels_snippets: [ "public" ]
+
     ## Automatic issue closing
     # If a commit message matches this regular expression, all issues referenced from the matched text will be closed.
     # This happens when the commit is pushed or merged into the default branch of a project.

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -114,6 +114,11 @@ Settings.gitlab['signup_enabled'] ||= true if Settings.gitlab['signup_enabled'].
 Settings.gitlab['signin_enabled'] ||= true if Settings.gitlab['signin_enabled'].nil?
 Settings.gitlab['twitter_sharing_enabled'] ||= true if Settings.gitlab['twitter_sharing_enabled'].nil?
 Settings.gitlab['restricted_visibility_levels'] = Settings.send(:verify_constant_array, Gitlab::VisibilityLevel, Settings.gitlab['restricted_visibility_levels'], [])
+Settings.gitlab['restricted_visibility_levels_snippets'] =
+  Settings.send(:verify_constant_array,
+                Gitlab::VisibilityLevel,
+                Settings.gitlab['restricted_visibility_levels_snippets'],
+                [])
 Settings.gitlab['username_changing_enabled'] = true if Settings.gitlab['username_changing_enabled'].nil?
 Settings.gitlab['issue_closing_pattern'] = '((?:[Cc]los(?:e[sd]?|ing)|[Ff]ix(?:e[sd]|ing)?|[Rr]esolv(?:e[sd]?|ing)) +(?:(?:issues? +)?#\d+(?:(?:, *| +and +)?))+)' if Settings.gitlab['issue_closing_pattern'].nil?
 Settings.gitlab['default_projects_features'] ||= {}


### PR DESCRIPTION
Added own gitlab.yml parameter for snippets restricted visibility levels.
Goal. Allow only private projects, but allow public snippets.
