### PR TITLE
Remove truncation from issue titles on milestone page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,6 +76,7 @@ v 7.10.0 (unreleased)
   - Bust group page project list cache when namespace name or path changes.
   - Explicitly set image alt-attribute to prevent graphical glitches if gravatars could not be loaded
   - Allow user to choose a public email to show on public profile
+  - Remove truncation from issue titles on milestone page (Jason Blanchard)
 
 v 7.9.3
   - Contains no changes

--- a/app/views/projects/milestones/_issue.html.haml
+++ b/app/views/projects/milestones/_issue.html.haml
@@ -1,9 +1,9 @@
 %li{ id: dom_id(issue, 'sortable'), class: 'issue-row', 'data-iid' => issue.iid, 'data-url' => issue_path(issue) }
-  %span.str-truncated
-    = link_to [@project.namespace.becomes(Namespace), @project, issue] do
-      %span.cgray ##{issue.iid}
-    = link_to_gfm issue.title, [@project.namespace.becomes(Namespace), @project, issue], title: issue.title
   .pull-right.assignee-icon
     - if issue.assignee
       = image_tag avatar_icon(issue.assignee.email, 16), class: "avatar s16", alt: ''
+  %span
+    = link_to [@project.namespace.becomes(Namespace), @project, issue] do
+      %span.cgray ##{issue.iid}
+    = link_to_gfm issue.title, [@project.namespace.becomes(Namespace), @project, issue], title: issue.title
 


### PR DESCRIPTION
Currently, issues titles on the milestone page are truncated down to one line:
![screen shot 2015-03-02 at 6 49 41 pm](https://cloud.githubusercontent.com/assets/1238532/6453557/37abb4fe-c10d-11e4-9c06-942e15b57ad8.png)
![screen shot 2015-03-02 at 6 50 01 pm](https://cloud.githubusercontent.com/assets/1238532/6453559/40031048-c10d-11e4-94f5-598cd84b1f09.png)

This makes it really hard to use this page to get a "birds-eye-view" of the status of a milestone. We've found that it's especially difficult during team stand-ups when we have the milestone page up on a projector and we are trying to use this page to plan feature development. As the titles and number of issues grow, I don't think the length of the columns is as much of an issue now that we can determine a priority order by dragging-and-dropping issues to sort at the top of the list.

This merge request proposes removing the truncation class entirely and letting the issue titles naturally wrap to multiple lines, which I think is substantially more readable on both small and large viewports:

![screen shot 2015-03-02 at 6 46 00 pm](https://cloud.githubusercontent.com/assets/1238532/6453625/eda7835a-c10d-11e4-93a5-9d02239b64ab.png)
![screen shot 2015-03-02 at 6 46 34 pm](https://cloud.githubusercontent.com/assets/1238532/6453627/f19a4768-c10d-11e4-8fb5-c4c168b4d7f8.png)
