### PR TITLE
Update gemnasium-gitlab-service gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       dotenv (>= 0.7)
       thor (>= 0.13.6)
     formatador (0.2.4)
-    gemnasium-gitlab-service (0.2.4)
+    gemnasium-gitlab-service (0.2.5)
       rugged (~> 0.21)
     gherkin-ruby (0.3.1)
       racc


### PR DESCRIPTION
Update gemnasium-gitlab-service to version 0.2.5. Latest version of the Gemnasium service pushes the git branch name to Gemnasium's API. The dependency files will be synced only if the branch name matches the branch Gemnasium knows about.
