### PR TITLE
use constant-time string compare for internal api authentication

### DIFF
--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -83,7 +83,10 @@ module API
     end
 
     def authenticate_by_gitlab_shell_token!
-      unauthorized! unless secret_token == params['secret_token'].try(:chomp)
+      input = params['secret_token'].try(:chomp)
+      unless Devise.secure_compare(secret_token, input)
+        unauthorized!
+      end
     end
 
     def authenticated_as_admin!


### PR DESCRIPTION
Ruby str_equal uses memcmp internally to compare String.
Memcmp is vunerable to timing attacs because it returns early
on mismatch (on most x32 platforms memcmp uses a bytewise comparision).
Devise.secure_compare implements a constant time comparision instead.
