### PR TITLE
Fix invalid GitHub `authorize_url`.

### DIFF
--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -341,6 +341,12 @@ test:
         group_base: 'ou=groups,dc=example,dc=com'
         admin_group: ''
         sync_ssh_keys: false
+  omniauth:
+    enabled: false
+    providers:
+      - { name: 'github', app_id: 'YOUR_APP_ID',
+          app_secret: 'YOUR_APP_SECRET',
+          args: { scope: 'user:email' } }
 
 staging:
   <<: *base

--- a/lib/gitlab/github_import/client.rb
+++ b/lib/gitlab/github_import/client.rb
@@ -46,7 +46,8 @@ module Gitlab
       end
 
       def github_options
-        OmniAuth::Strategies::GitHub.default_options[:client_options]
+        default_options = OmniAuth::Strategies::GitHub.default_options
+        default_options[:client_options].symbolize_keys
       end
     end
   end

--- a/spec/lib/gitlab/github_import/client_spec.rb
+++ b/spec/lib/gitlab/github_import/client_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Gitlab::GithubImport::Client do
+  it '#authorize_url' do
+    client = Gitlab::GithubImport::Client.new(nil)
+    authorize_url = 'https://github.com/login/oauth/authorize?' +
+                    'response_type=code&' +
+                    'client_id=YOUR_APP_ID&' +
+                    'redirect_uri=https%3A%2F%2Fapp.com&' +
+                    'scope=repo%2C+user%2C+user%3Aemail'
+
+    expect(client.authorize_url('https://app.com')).to eq(authorize_url)
+  end
+end


### PR DESCRIPTION
``` shell
$ ./bin/rspec ./spec/lib/gitlab/github_import/client_spec.rb
F

Failures:

  1) Gitlab::GithubImport::Client #authorize_url
     Failure/Error: expect(client.authorize_url("https://app.com")).to eq(authorize_url)

       expected: "https://github.com/login/oauth/authorize?response_type=code&client_id=YOUR_APP_ID&redirect_uri=https%3A%2F%2Fapp.com&scope=repo%2C+user%2C+user%3Aemail"
            got: "https://api.github.com/oauth/authorize?response_type=code&client_id=YOUR_APP_ID&redirect_uri=https%3A%2F%2Fapp.com&scope=repo%2C+user%2C+user%3Aemail"

       (compared using ==)
     # ./spec/lib/gitlab/github_import/client_spec.rb:12:in `block (2 levels) in <top (required)>'
     # -e:1:in `<main>'

Finished in 5.87 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/lib/gitlab/github_import/client_spec.rb:4 # Gitlab::GithubImport::Client test
```
