### PR TITLE
Fix invalid config examples in OmniAuth docs

### DIFF
--- a/doc/integration/github.md
+++ b/doc/integration/github.md
@@ -53,7 +53,7 @@ GitHub will generate an application ID and secret key for you to use.
           "app_id" => "YOUR_APP_ID",
           "app_secret" => "YOUR_APP_SECRET",
           "url" => "https://github.com/",
-          "args" => { "scope" => "user:email" } }
+          "args" => { "scope" => "user:email" }
         }
       ]
     ```

--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -58,7 +58,7 @@ GitLab.com will generate an application ID and secret key for you to use.
           "name" => "gitlab",
           "app_id" => "YOUR_APP_ID",
           "app_secret" => "YOUR_APP_SECRET",
-          "args" => { "scope" => "api" } }
+          "args" => { "scope" => "api" }
         }
       ]
     ```

--- a/doc/integration/google.md
+++ b/doc/integration/google.md
@@ -55,7 +55,7 @@ To enable the Google OAuth2 OmniAuth provider you must register your application
           "name" => "google_oauth2",
           "app_id" => "YOUR_APP_ID",
           "app_secret" => "YOUR_APP_SECRET",
-          "args" => { "access_type" => "offline", "approval_prompt" => '' } }
+          "args" => { "access_type" => "offline", "approval_prompt" => '' }
         }
       ]
     ```


### PR DESCRIPTION
Remove duplicate right braces ('}') in configuration examples of GitHub, GitLab, and Google.
