### PR TITLE
Added aditional options to the HipChat project service (color & notify options)

### DIFF
--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -53,7 +53,8 @@ class Projects::ServicesController < Projects::ApplicationController
       :description, :issues_url, :new_issue_url, :restrict_to_branch, :channel,
       :colorize_messages, :channels,
       :push_events, :issues_events, :merge_requests_events, :tag_push_events,
-      :note_events, :send_from_committer_email, :disable_diffs
+      :note_events, :send_from_committer_email, :disable_diffs,
+      :notification, :color,
     )
   end
 end

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -43,12 +43,12 @@ class HipchatService < Service
       { type: 'checkbox', name: 'notification' },
       { type: 'select', name: 'color', choices:
         [
-          [ '- Random Color -', 'random'],
-          [ 'Gray', 'gray' ],
-          [ 'Green', 'green' ],
-          [ 'Purple', 'purple' ],
-          [ 'Red', 'red' ],
-          [ 'Yellow', 'yellow' ]
+          ['- Random Color -', 'random'],
+          ['Gray', 'gray'],
+          ['Green', 'green'],
+          ['Purple', 'purple'],
+          ['Red', 'red'],
+          ['Yellow', 'yellow']
         ],
         default_choice: 'yellow'
       },
@@ -64,7 +64,9 @@ class HipchatService < Service
   def execute(data)
     return unless supported_events.include?(data[:object_kind])
 
-    gate[room].send('GitLab', create_message(data), { color: color, notify: notification? })
+    options = { color: color, notify: notification? }
+
+    gate[room].send('GitLab', create_message(data), options)
   end
 
   private
@@ -234,7 +236,7 @@ class HipchatService < Service
   end
 
   def notification?
-    self.notification == "1"
+    notification == '1'
   end
 
   def project_name

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -20,8 +20,9 @@
 class HipchatService < Service
   MAX_COMMITS = 3
 
-  prop_accessor :token, :room, :server
+  prop_accessor :token, :room, :server, :color, :notification
   validates :token, presence: true, if: :activated?
+  validates :room, presence: true, if: :activated?
 
   def title
     'HipChat'
@@ -39,6 +40,18 @@ class HipchatService < Service
     [
       { type: 'text', name: 'token',     placeholder: 'Room token' },
       { type: 'text', name: 'room',      placeholder: 'Room name or ID' },
+      { type: 'checkbox', name: 'notification' },
+      { type: 'select', name: 'color', choices:
+        [
+          [ '- Random Color -', 'random'],
+          [ 'Gray', 'gray' ],
+          [ 'Green', 'green' ],
+          [ 'Purple', 'purple' ],
+          [ 'Red', 'red' ],
+          [ 'Yellow', 'yellow' ]
+        ],
+        default_choice: 'yellow'
+      },
       { type: 'text', name: 'server',
         placeholder: 'Leave blank for default. https://hipchat.example.com' }
     ]
@@ -51,7 +64,7 @@ class HipchatService < Service
   def execute(data)
     return unless supported_events.include?(data[:object_kind])
 
-    gate[room].send('GitLab', create_message(data))
+    gate[room].send('GitLab', create_message(data), { color: color, notify: notification? })
   end
 
   private
@@ -218,6 +231,10 @@ class HipchatService < Service
     end
 
     message
+  end
+
+  def notification?
+    self.notification == "1"
   end
 
   def project_name

--- a/spec/models/project_services/hipchat_service_spec.rb
+++ b/spec/models/project_services/hipchat_service_spec.rb
@@ -36,6 +36,8 @@ describe HipchatService do
         project_id: project.id,
         project: project,
         room: 123456,
+        color: 'yellow',
+	notification: '0',
         server: 'https://hipchat.example.com',
         token: 'verySecret'
       )

--- a/spec/models/project_services/hipchat_service_spec.rb
+++ b/spec/models/project_services/hipchat_service_spec.rb
@@ -37,7 +37,7 @@ describe HipchatService do
         project: project,
         room: 123456,
         color: 'yellow',
-	notification: '0',
+        notification: '0',
         server: 'https://hipchat.example.com',
         token: 'verySecret'
       )


### PR DESCRIPTION
HipChat has support for coloring messages and notify it's room members.
Those options where missing in the HipChat service options (I personally hate the bright yellow messages gitlab creates by default).

Passes all tests on my machine.
