### PR TITLE
Add error message when have error on profile screen

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 7.10.0 (unreleased)
   - Fix alignment of navbar toggle button (Cody Mize)
   - Identical look of selectboxes in UI
   - Move "Import existing repository by URL" option to button.
+  - Improve error message when save profile has error.
 
 v 7.9.0 (unreleased)
   - Add HipChat integration documentation (Stan Hu)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -25,7 +25,8 @@ class ProfilesController < ApplicationController
     if @user.update_attributes(user_params)
       flash[:notice] = "Profile was successfully updated"
     else
-      flash[:alert] = "Failed to update profile"
+      messages = @user.errors.full_messages.uniq.join('. ')
+      flash[:alert] = "Failed to update profile. #{messages}"
     end
 
     respond_to do |format|


### PR DESCRIPTION
Like described in issue #8972, when trying to update the profile with an email already in use, the error message only provides the error: `Failed to update profile`. With this change, the message will describe the exactly error occurred in the process.

Before:
![update_profile_befor](https://cloud.githubusercontent.com/assets/771411/6723396/1a40d8ca-cdc6-11e4-9e07-b1dc8d484c7a.png)
After:
![update_profile_after](http://img.prntscr.com/img?url=http://i.imgur.com/thzcDil.png)
