### PR TITLE
Fix broken paths

### DIFF
--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -17,7 +17,7 @@
           = issue.notes.count
 
   .issue-info
-    = link_to "##{issue.iid}", issue_path(issue), class: "light"
+    = link_to "##{issue.iid}", namespace_project_issue_path(issue.project.namespace, issue.project, issue), class: "light"
     - if issue.assignee
       assigned to #{link_to_member(@project, issue.assignee)}
     - if issue.votes_count > 0

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -22,7 +22,7 @@
           %i.fa.fa-comments
           = merge_request.mr_and_commit_notes.count
   .merge-request-info
-    = link_to "##{merge_request.iid}", merge_request_path(merge_request), class: "light"
+    = link_to "##{merge_request.iid}", namespace_project_merge_request_path(merge_request.project.namespace, merge_request.target_project, merge_request), class: "light"
     - if merge_request.assignee
       assigned to #{link_to_member(merge_request.source_project, merge_request.assignee)}
     - else


### PR DESCRIPTION
When I rebased the PR #8974, some tests broken with a invalid path.

This PR fix the paths to use the namespace. 
