### PR TITLE
Add confirmation when accept merge request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@ v 7.10.0 (unreleased)
   - Archive repositories in background worker.
   - Import GitHub, Bitbucket or GitLab.com projects owned by authenticated user into current namespace.
   - Fix and improve help rendering (Sullivan Sénéchal)
+  - Add confirmation dialog when click in "Accept Merge Request".
 
 
 v 7.9.2
@@ -70,9 +71,6 @@ v 7.9.1
   - Fix missing events and in admin Slack service template settings form (Stan Hu)
   - Don't show commit comment button when user is not signed in.
   - Downgrade gemnasium-gitlab-service gem
-
-v 7.9.0
-  - Add confirmation dialog when click in "Accept Merge Request".
 
 v 7.9.0 (unreleased)
   - Add HipChat integration documentation (Stan Hu)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,9 @@ v 7.9.1
   - Downgrade gemnasium-gitlab-service gem
 
 v 7.9.0
+  - Add confirmation dialog when click in "Accept Merge Request".
+
+v 7.9.0 (unreleased)
   - Add HipChat integration documentation (Stan Hu)
   - Update documentation for object_kind field in Webhook push and tag push Webhooks (Stan Hu)
   - Fix broken email images (Hannes Rosenögger)

--- a/app/assets/javascripts/confirm_danger_modal.js.coffee
+++ b/app/assets/javascripts/confirm_danger_modal.js.coffee
@@ -1,5 +1,5 @@
 class @ConfirmDangerModal
-  constructor: (form, text) ->
+  constructor: (form, text, actionCallback) ->
     @form = form
     $('.js-confirm-text').text(text || '')
     $('.js-confirm-danger-input').val('')
@@ -16,3 +16,4 @@ class @ConfirmDangerModal
 
     $('.js-confirm-danger-submit').on 'click', =>
       @form.submit()
+      actionCallback() if actionCallback

--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -66,6 +66,12 @@ class @MergeRequest
       this.activateTab($(event.currentTarget).data('action'))
 
     this.$('.accept_merge_request').on 'click', ->
+      source_branch = $('#source_branch').text()
+      target_branch = $('#target_branch').text()
+      message = 'This will merge ' + source_branch + ' into ' +
+                target_branch + '. Are you sure?'
+      if !confirm(message)
+        return false
       $('.automerge_widget.can_be_merged').hide()
       $('.merge-in-progress').show()
 

--- a/app/assets/javascripts/merge_request.js.coffee
+++ b/app/assets/javascripts/merge_request.js.coffee
@@ -27,6 +27,8 @@ class @MergeRequest
         bottom: ->
           @bottom = $('.footer').outerHeight(true)
 
+
+
   # Local jQuery finder
   $: (selector) ->
     this.$el.find(selector)
@@ -65,15 +67,17 @@ class @MergeRequest
     this.$('.merge-request-tabs').on 'click', 'li', (event) =>
       this.activateTab($(event.currentTarget).data('action'))
 
-    this.$('.accept_merge_request').on 'click', ->
-      source_branch = $('#source_branch').text()
-      target_branch = $('#target_branch').text()
-      message = 'This will merge ' + source_branch + ' into ' +
-                target_branch + '. Are you sure?'
-      if !confirm(message)
-        return false
-      $('.automerge_widget.can_be_merged').hide()
-      $('.merge-in-progress').show()
+    this.$('.js-confirm-merge-danger').on 'click', (e) ->
+      e.preventDefault()
+      btn = $(e.target)
+      text = btn.data("confirm-danger-message")
+      form = btn.closest("form")
+      mergeCallback = ->
+        $('.automerge_widget.can_be_merged').hide()
+        $('.merge-in-progress').show()
+        $('#modal-confirm-danger').modal('hide')
+
+      new ConfirmDangerModal(form, text, mergeCallback)
 
     this.$('.remove_source_branch').on 'click', ->
       $('.remove_source_branch_widget').hide()

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -49,4 +49,8 @@ module MergeRequestsHelper
   def issues_sentence(issues)
     issues.map { |i| "##{i.iid}" }.to_sentence
   end
+
+  def merge_request_message(merge_request)
+    "This will merge #{merge_request.source_branch} into #{merge_request.target_branch}.\nAre you ABSOLUTELY sure?"
+  end
 end

--- a/app/views/projects/merge_requests/_show.html.haml
+++ b/app/views/projects/merge_requests/_show.html.haml
@@ -8,18 +8,18 @@
       .slead
         %span From
         - if @merge_request.for_fork?
-          %strong#source_branch.label-branch<
+          %strong.label-branch<
             - if @merge_request.source_project
               = link_to @merge_request.source_project_namespace, namespace_project_path(@merge_request.source_project.namespace, @merge_request.source_project)
             - else
               \ #{@merge_request.source_project_namespace}
             \:#{@merge_request.source_branch}
           %span into
-          %strong#target_branch.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
+          %strong.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
         - else
-          %strong#source_branch.label-branch #{@merge_request.source_branch}
+          %strong.label-branch #{@merge_request.source_branch}
           %span into
-          %strong#target_branch.label-branch #{@merge_request.target_branch}
+          %strong.label-branch #{@merge_request.target_branch}
         - if @merge_request.open?
           %span.pull-right
             .btn-group
@@ -40,7 +40,7 @@
         = link_to merge_request_path(@merge_request) do
           %i.fa.fa-comments
           Discussion
-          %span.badge= @merge_request.mr_and_commit_notes.user.count
+          %span.badge= @merge_request.mr_and_commit_notes.count
       %li.commits-tab{data: {action: 'commits'}}
         = link_to merge_request_path(@merge_request), title: 'Commits' do
           %i.fa.fa-history
@@ -63,6 +63,7 @@
   .mr-loading-status
     = spinner
 
+  = render 'shared/confirm_modal', phrase: @merge_request.source_branch
 
 :javascript
   var merge_request;

--- a/app/views/projects/merge_requests/_show.html.haml
+++ b/app/views/projects/merge_requests/_show.html.haml
@@ -8,18 +8,18 @@
       .slead
         %span From
         - if @merge_request.for_fork?
-          %strong.label-branch<
+          %strong#source_branch.label-branch<
             - if @merge_request.source_project
               = link_to @merge_request.source_project_namespace, namespace_project_path(@merge_request.source_project.namespace, @merge_request.source_project)
             - else
               \ #{@merge_request.source_project_namespace}
             \:#{@merge_request.source_branch}
           %span into
-          %strong.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
+          %strong#target_branch.label-branch #{@merge_request.target_project_namespace}:#{@merge_request.target_branch}
         - else
-          %strong.label-branch #{@merge_request.source_branch}
+          %strong#source_branch.label-branch #{@merge_request.source_branch}
           %span into
-          %strong.label-branch #{@merge_request.target_branch}
+          %strong#target_branch.label-branch #{@merge_request.target_branch}
         - if @merge_request.open?
           %span.pull-right
             .btn-group

--- a/app/views/projects/merge_requests/show/_mr_accept.html.haml
+++ b/app/views/projects/merge_requests/show/_mr_accept.html.haml
@@ -15,7 +15,7 @@
       = form_for [:automerge, @project.namespace.becomes(Namespace), @project, @merge_request], remote: true, method: :post do |f|
         .accept-merge-holder.clearfix.js-toggle-container
           .accept-action
-            = f.submit "Accept Merge Request", class: "btn btn-create accept_merge_request"
+            = link_to 'Accept Merge Request', '#', class: "btn btn-create js-confirm-merge-danger", data: { "confirm-danger-message" => merge_request_message(@merge_request) }
           - if can_remove_branch?(@merge_request.source_project, @merge_request.source_branch) && !@merge_request.for_fork?
             .accept-control.checkbox
               = label_tag :should_remove_source_branch, class: "remove_source_checkbox" do

--- a/features/project/merge_requests.feature
+++ b/features/project/merge_requests.feature
@@ -75,14 +75,26 @@ Feature: Project Merge Requests
     Then I should see a discussion has started on commit
 
   @javascript
-  Scenario: I accept merge request with custom commit message
+  Scenario: I accept merge request with custom commit message and confirm the dialog
     Given project "Shop" have "Bug NS-05" open merge request with diffs inside
     And merge request "Bug NS-05" is mergeable
     And I visit merge request page "Bug NS-05"
     And merge request is mergeable
     Then I modify merge commit message
     And I accept this merge request
+    And I accept the confirmation dialog
     Then I should see merged request
+
+  @javascript
+  Scenario: I accept merge request with custom commit message and close the confirmation dialog
+    Given project "Shop" have "Bug NS-05" open merge request with diffs inside
+    And merge request "Bug NS-05" is mergeable
+    And I visit merge request page "Bug NS-05"
+    And merge request is mergeable
+    Then I modify merge commit message
+    And I accept this merge request
+    And I close the confirmation dialog
+    Then I should see the merge request is open yet
 
   # Markdown
 

--- a/features/steps/project/merge_requests.rb
+++ b/features/steps/project/merge_requests.rb
@@ -201,13 +201,28 @@ class Spinach::Features::ProjectMergeRequests < Spinach::FeatureSteps
     )
 
     within '.can_be_merged' do
-      click_button "Accept Merge Request"
+      click_link "Accept Merge Request"
     end
+  end
+
+  step 'I accept the confirmation dialog' do
+    fill_in 'confirm_name_input', with: merge_request.source_branch
+    first(:css, '.js-confirm-danger-submit').click
+  end
+
+  step 'I close the confirmation dialog' do
+    first(:css, '#modal-confirm-danger a.close').click
   end
 
   step 'I should see merged request' do
     within '.issue-box' do
       page.should have_content "Merged"
+    end
+  end
+
+  step 'I should see the merge request is open yet' do
+    within '.issue-box' do
+      page.should have_content "Open"
     end
   end
 

--- a/spec/helpers/merge_requests_helper.rb
+++ b/spec/helpers/merge_requests_helper.rb
@@ -9,4 +9,16 @@ describe MergeRequestsHelper do
 
     it { is_expected.to eq('#1, #2, and #3') }
   end
+
+  describe '#merge_request_message' do
+    subject { merge_request_message(merge_request) }
+    let(:expected_message) do
+      'This will merge bruce into wayne. Are you ABSOLUTELY sure?'
+    end
+    let(:merge_request) do
+      create(:merge_request, source_branch: 'bruce', target_branch: 'wayne' )
+    end
+
+    it { is_expected.to eq(expected_message) }
+  end
 end


### PR DESCRIPTION
Like proposed on issue #8286, this PR implements a simple confirmation dialog to avoid accidentally clicks on `Accept Merge Request` button.

![print](http://i.imgur.com/gKcXHIY.png)
