### PR TITLE
Fix GitLab shell setup spacing

### DIFF
--- a/lib/tasks/gitlab/shell.rake
+++ b/lib/tasks/gitlab/shell.rake
@@ -112,6 +112,7 @@ namespace :gitlab do
         print '.'
       end
     end
+    puts ""
 
     unless $?.success?
       puts "Failed to add keys...".red


### PR DESCRIPTION
Running the `gitlab:shell:setup` task can result in a misalignment.  As seen in the following screenshot:

![gitlab-shell-setup-task](https://cloud.githubusercontent.com/assets/650603/6757519/171113de-cf08-11e4-9a31-5ad44b439b2f.png)

After printing the "status dots," a new line should be added to ensure the command prompt is printed at the expected location.  This is a minor issue with a simple fix.
