### PR TITLE
add very basic Go CD notity support

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -46,7 +46,7 @@ class Admin::ServicesController < Admin::ApplicationController
         :user_key, :device, :priority, :sound, :bamboo_url, :username, :password,
         :build_key, :server, :teamcity_url, :build_type,
         :description, :issues_url, :new_issue_url, :restrict_to_branch,
-        :send_from_committer_email, :disable_diffs
+        :send_from_committer_email, :disable_diffs, :gocd_url
     ])
   end
 end

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -53,7 +53,8 @@ class Projects::ServicesController < Projects::ApplicationController
       :description, :issues_url, :new_issue_url, :restrict_to_branch, :channel,
       :colorize_messages, :channels,
       :push_events, :issues_events, :merge_requests_events, :tag_push_events,
-      :note_events, :send_from_committer_email, :disable_diffs, :external_wiki_url
+      :note_events, :send_from_committer_email, :disable_diffs,
+      :external_wiki_url, :gocd_url
     )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,6 +90,7 @@ class Project < ActiveRecord::Base
   has_one :custom_issue_tracker_service, dependent: :destroy
   has_one :gitlab_issue_tracker_service, dependent: :destroy
   has_one :external_wiki_service, dependent: :destroy
+  has_one :gocd_service, dependent: :destroy
 
   has_one :forked_project_link, dependent: :destroy, foreign_key: "forked_to_project_id"
 

--- a/app/models/project_services/gocd_service.rb
+++ b/app/models/project_services/gocd_service.rb
@@ -1,0 +1,108 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id         :integer          not null, primary key
+#  type       :string(255)
+#  title      :string(255)
+#  project_id :integer
+#  created_at :datetime
+#  updated_at :datetime
+#  active     :boolean          default(FALSE), not null
+#  properties :text
+#  template   :boolean          default(FALSE)
+#
+class GocdService < Service
+  include HTTParty
+
+  prop_accessor :gocd_url, :username, :password, :restrict_to_branch
+
+  validates :gocd_url, presence: true, if: :activated?
+
+  def execute(push)
+    user = push[:user_name]
+    branch = push[:ref].gsub('refs/heads/', '')
+
+    branch_restriction = restrict_to_branch.to_s
+
+    # check the branch restriction is poplulated and branch is not included
+    if branch_restriction.length > 0 && branch_restriction.index(branch) == nil
+      return
+    end
+
+    notify()
+  end
+
+  def notify_url
+    "#{gocd_url}/api/material/notify/git"
+  end
+
+  def notify()
+    url = notify_url()
+    #body = "repository_url=#{Gitlab.config.gitlab.url}/#{project.path_with_namespace}"
+    body = "repository_url=#{Gitlab.config.gitlab.user}@#{Gitlab.config.gitlab.ssh_host}:#{project.path_with_namespace}.git"
+
+    if username.blank? && password.blank?
+      response = HTTParty.post(url, body: body, verify: false)
+    else
+      auth = {
+          username: username,
+          password: password,
+      }
+      response = HTTParty.post(url, body: body, verify: false, basic_auth: auth)
+    end
+
+    if response.code == 200 && response['status']
+      response['status']
+    else
+      :error
+    end
+  end
+
+  #def build_page(sha)
+  #  # No suitable page so we return the top level
+  #  return gocd_url
+  #end
+
+  #def commit_status(sha)
+  #  notify()
+  #end
+
+  def check_commit(message, push_msg)
+    echo 'Check commit called in gocd'
+  end
+
+  def title
+    'Go CD'
+  end
+
+  def description
+    'Continuous integration and deployments'
+  end
+
+  def to_param
+    'gocd'
+  end
+
+  def fields
+    [
+      { type: 'text',
+        name: 'username',
+        placeholder: 'Go CD login username' },
+
+      { type: 'password',
+        name: 'password',
+        placeholder: 'Go CD login password' },
+
+      { type: 'text',
+        name: 'gocd_url',
+        placeholder: 'http://gocd.example.com:8153/go'},
+      {
+        type: 'text',
+        name: 'restrict_to_branch',
+        placeholder: 'Comma-separated list of branches which will be
+automatically inspected. Leave blank to include all branches.'
+      }
+    ]
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -141,6 +141,7 @@ class Service < ActiveRecord::Base
       custom_issue_tracker
       irker
       external_wiki
+      gocd
     )
   end
 


### PR DESCRIPTION
This isn't in a great state I'm afraid, but better than nothing.  This notifies GoCD about git changes, code was mostly copied from buildbox and asana services as I found little documentation available.

Note that gocd works out which pipelines to kick as a result of source code chages for itself - providing a 'build status' link simply isn't possible.
