### PR TITLE
Faulty LDAP DN name escaping removed

### DIFF
--- a/lib/gitlab/ldap/person.rb
+++ b/lib/gitlab/ldap/person.rb
@@ -14,7 +14,6 @@ module Gitlab
       end
 
       def self.find_by_dn(dn, adapter)
-        dn = Net::LDAP::Filter.escape(dn)
         adapter.user('dn', dn)
       end
 


### PR DESCRIPTION
The Net::LDAP::Filter.escape function can not be used to escape the DN name because the backslash is required to escape special chars in the DN name. This leads to the error message "Access denied for your LDAP account." and prevents the user from logging in to gitlab.

Example DN: 
CN=Test\, User,OU=Organization,DC=Company
CN=Test User,OU=Organization,DC=Company

http://www.ietf.org/rfc/rfc4514.txt
