### PR TITLE
Fix Node.js Error in Documentation

### DIFF
--- a/doc/update/7.8-to-7.9.md
+++ b/doc/update/7.8-to-7.9.md
@@ -42,6 +42,8 @@ sudo -u git -H git checkout v2.6.0
 
 ### 4. Install libs, migrations, etc.
 
+Please refer to the [Node.js setup documentation](https://github.com/joyent/node/wiki/installing-node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions) if you aren't running default GitLab server setup.
+
 ```bash
 sudo apt-get install nodejs
 


### PR DESCRIPTION
Installing `nodejs` didn't work for me, instead I've installed it but just writing `node`.
