### PR TITLE
Complete transition to using color_field for selecting colors

### DIFF
--- a/app/views/admin/broadcast_messages/index.html.haml
+++ b/app/views/admin/broadcast_messages/index.html.haml
@@ -21,13 +21,11 @@
   .form-group.js-toggle-colors-container.hide
     = f.label :color, "Background Color", class: 'control-label'
     .col-sm-10
-      = f.color_field :color, placeholder: "#AA33EE", class: "form-control"
-      .light 6 character hex values starting with a # sign.
+      = f.color_field :color, value: "#AA33EE", class: "form-control"
   .form-group.js-toggle-colors-container.hide
     = f.label :font, "Font Color", class: 'control-label'
     .col-sm-10
-      = f.color_field :font, placeholder: "#224466", class: "form-control"
-      .light 6 character hex values starting with a # sign.
+      = f.color_field :font, value: "#224466", class: "form-control"
   .form-group
     = f.label :starts_at, class: 'control-label'
     .col-sm-10.datetime-controls

--- a/app/views/admin/broadcast_messages/index.html.haml
+++ b/app/views/admin/broadcast_messages/index.html.haml
@@ -21,12 +21,12 @@
   .form-group.js-toggle-colors-container.hide
     = f.label :color, "Background Color", class: 'control-label'
     .col-sm-10
-      = f.text_field :color, placeholder: "#AA33EE", class: "form-control"
+      = f.color_field :color, placeholder: "#AA33EE", class: "form-control"
       .light 6 character hex values starting with a # sign.
   .form-group.js-toggle-colors-container.hide
     = f.label :font, "Font Color", class: 'control-label'
     .col-sm-10
-      = f.text_field :font, placeholder: "#224466", class: "form-control"
+      = f.color_field :font, placeholder: "#224466", class: "form-control"
       .light 6 character hex values starting with a # sign.
   .form-group
     = f.label :starts_at, class: 'control-label'

--- a/app/views/projects/labels/_form.html.haml
+++ b/app/views/projects/labels/_form.html.haml
@@ -16,9 +16,9 @@
     .col-sm-10
       .input-group
         .input-group-addon.label-color-preview &nbsp;
-        = f.color_field :color, placeholder: "#AA33EE", class: "form-control"
+        = f.color_field :color, value: "#AA33EE", class: "form-control"
       .help-block
-        6 character hex values starting with a # sign.
+        Choose any color.
         %br
         Or you can choose one of suggested colors below
 


### PR DESCRIPTION
The labels color field was updated to use the `color_field` form helper in commit 7606b93.  This PR updates the broadcast messages form to do the same.
