### PR TITLE
Fix generating SSH key fingerprints with OpenSSH 6.8.

### DIFF
--- a/app/models/key.rb
+++ b/app/models/key.rb
@@ -95,7 +95,7 @@ class Key < ActiveRecord::Base
         out, _ = version_output.scan /.*?(\d)\.(\d).*?,/
         major, minor = out[0], out[1]
         if major.to_i > 6 or (major.to_i == 6 and minor.to_i >= 8)
-            explicit_fingerprint_algorithm = true
+          explicit_fingerprint_algorithm = true
         end
       end
 


### PR DESCRIPTION
OpenSSH 6.8 [introduces](http://www.openssh.com/txt/release-6.8) a new feature that changes the default fingerprint format and algorithm used by `ssh-keygen`. This breaks adding new SSH keys, because GitLab expects the colon-delimited format. 

The message the user sees on the Add an SSH Key screen is "Fingerprint cannot be generated", similar to #7413, but the underlying cause is different. 

This change checks the OpenSSH version and explicitly specifies the previous format if needed. 
