### PR TITLE
Unescape branch param to delete

### DIFF
--- a/lib/api/branches.rb
+++ b/lib/api/branches.rb
@@ -1,4 +1,5 @@
 require 'mime/types'
+require 'uri'
 
 module API
   # Projects API
@@ -103,7 +104,7 @@ module API
       delete ":id/repository/branches/:branch" do
         authorize_push_project
         result = DeleteBranchService.new(user_project, current_user).
-          execute(params[:branch])
+          execute(URI.unescape(params[:branch]))
 
         if result[:status] == :success
           {


### PR DESCRIPTION
Branch names that contain `/` return a 405 error when being deleted because the slash is escaped to `%2F`
This patch will unescape the param prior to  executing the delete action.

Sorry, I am not a ruby developer and so am not able to create a test for this action.
