### PR TITLE
Added commands for installing nodejs on Debian Wheezy

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -56,6 +56,9 @@ up-to-date and install it.
 
 Install the required packages (needed to compile Ruby and native extensions to Ruby gems):
 
+    # Debian wheezy users need to add wheezy-backports to get nodejs installed:
+    if [ $(. /etc/os-release; echo $VERSION_ID) = "7" ]; then sudo echo "deb http://ftp.debian.org/debian wheezy-backports main" > /etc/apt/sources.list.d/wheezy-backports; sudo apt-get update; fi
+
     sudo apt-get install -y build-essential zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server redis-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils pkg-config cmake libkrb5-dev nodejs
 
 Make sure you have the right version of Git installed

--- a/doc/update/7.8-to-7.9.md
+++ b/doc/update/7.8-to-7.9.md
@@ -43,6 +43,13 @@ sudo -u git -H git checkout v2.6.0
 ### 4. Install libs, migrations, etc.
 
 ```bash
+# ONLY REQUIRED FOR DEBIAN WHEEZY USERS
+# In Debian Wheezy there are no stable nodejs package available, therefore you have to use
+# the wheezy-backports to be able to install nodejs with your package manager or you 
+# compile nodejs yourself. Debian Jessie already offers nodejs packages by default.
+# Use the following one-liner to get the work done easily:
+if [ $(. /etc/os-release; echo $VERSION_ID) = "7" ]; then sudo echo "deb http://ftp.debian.org/debian wheezy-backports main" > /etc/apt/sources.list.d/wheezy-backports; sudo apt-get update; fi
+
 sudo apt-get install nodejs
 
 cd /home/git/gitlab


### PR DESCRIPTION
The one-liner command does check if the current installation is really a Debian Wheezy installation to prevent users from accidently executing the command on other operating systems or other Debian versions.

I think it's the easiest way to just add wheezy-backports to get the requirement nodejs installed. If (advanced) users don't want to use that way, they could compile nodejs for their own.

This nodejs version will be installed from the debian-backports repository (as of the time of this PR):

<pre>root@git-ce:~# nodejs -v
v0.10.29</pre>
