### PR TITLE
Faster merge request processing for large repository

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ v 7.10.0 (unreleased)
   - Link note avatar to user.
   - Make Git-over-SSH errors more descriptive.
   - Send EmailsOnPush email when branch or tag is created or deleted.
+  - Faster merge request processing for large repository
 
 v 7.9.0
   - Add HipChat integration documentation (Stan Hu)

--- a/lib/gitlab/satellite/satellite.rb
+++ b/lib/gitlab/satellite/satellite.rb
@@ -99,11 +99,7 @@ module Gitlab
         heads = repo.heads.map(&:name)
 
         # update or create the parking branch
-        if heads.include? PARKING_BRANCH
-          repo.git.checkout({}, PARKING_BRANCH)
-        else
-          repo.git.checkout(default_options({ b: true }), PARKING_BRANCH)
-        end
+        repo.git.checkout(default_options({ B: true }), PARKING_BRANCH)
 
         # remove the parking branch from the list of heads ...
         heads.delete(PARKING_BRANCH)


### PR DESCRIPTION
I have large repository (~10GB) on my own GitLab server.
This repository has long history (1-2 years) and large commits (~100MB).

It takes a few minutes to merge testing and auto merging.
I found that `git checkout __parking_branch` takes a long time.
Because `__parking_branch` is never updated, there is large difference between `master` and `__parking_branch`.

I tried following commands, and `git checkout` got significantly faster.

``` bash
sudo su git
cd /home/git/gitlab-satellites/path/to/repos
git checkout -B __parking_branch master
git checkout master
```

This pull request may fix this problem,
by reseting `__parking_branch` to `HEAD` everytime.
