### PR TITLE
Allow ability to delete branches with '/` in name

### DIFF
--- a/lib/api/branches.rb
+++ b/lib/api/branches.rb
@@ -100,7 +100,7 @@ module API
       #   branch (required) - The name of the branch
       # Example Request:
       #   DELETE /projects/:id/repository/branches/:branch
-      delete ":id/repository/branches/:branch"
+      delete ":id/repository/branches/:branch",
           requirements: { branch: /.*/ } do
         authorize_push_project
         result = DeleteBranchService.new(user_project, current_user).

--- a/lib/api/branches.rb
+++ b/lib/api/branches.rb
@@ -1,5 +1,4 @@
 require 'mime/types'
-require 'uri'
 
 module API
   # Projects API
@@ -101,10 +100,11 @@ module API
       #   branch (required) - The name of the branch
       # Example Request:
       #   DELETE /projects/:id/repository/branches/:branch
-      delete ":id/repository/branches/:branch" do
+      delete ":id/repository/branches/:branch"
+          requirements: { branch: /.*/ } do
         authorize_push_project
         result = DeleteBranchService.new(user_project, current_user).
-          execute(URI.unescape(params[:branch]))
+          execute(params[:branch])
 
         if result[:status] == :success
           {


### PR DESCRIPTION
I initially thought the problem from my previous merge request was due to the URL escaping of the branch name.

Investigating the fault further and reading other methods in the commit it is actually a grape routing requirement that was missing from the delete method.
