### PR TITLE
Change mysql database collate to utf8mb4, fix #9030

### DIFF
--- a/config/database.yml.mysql
+++ b/config/database.yml.mysql
@@ -3,8 +3,8 @@
 #
 production:
   adapter: mysql2
-  encoding: utf8
-  collation: utf8_general_ci
+  encoding: utf8mb4
+  collation: utf8mb4_general_ci
   reconnect: false
   database: gitlabhq_production
   pool: 10

--- a/db/migrate/20150326042242_change_mysql_collate_to_utf8mb4.rb
+++ b/db/migrate/20150326042242_change_mysql_collate_to_utf8mb4.rb
@@ -1,0 +1,55 @@
+class ChangeMysqlCollateToUtf8mb4 < ActiveRecord::Migration
+  def up
+    return unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /^mysql/
+    [:users, :subscriptions, :schema_migrations, :oauth_applications, :oauth_access_tokens, :oauth_access_grants, :namespaces, :keys, :emails].each do |table|
+      ActiveRecord::Base.connection.indexes(table).each do |index|
+        remove_index table, :name => index.name if index.name != :id
+      end
+      execute "ALTER TABLE `#{table}` CONVERT TO character set utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    end
+
+    [:email, :authentication_token, :reset_password_token, :confirmation_token].each do |col|
+      add_index :users, col, unique: true, length: 190
+    end
+    [:name, :username].each do |col|
+      add_index :users, col, length: 190
+    end
+    add_index :users, [:created_at, :id]
+    add_index :users, :admin
+    add_index :users, :current_sign_in_at
+
+    add_index :subscriptions, [:subscribable_id, :subscribable_type, :user_id], length: {:subscribable_type => 170}, name: :subscriptions_user_id_and_ref_fields
+
+    add_index :schema_migrations, :version, length: 190, length: 190, unique: true
+
+    add_index :oauth_applications, :uid, unique: true, length: 190
+    add_index :oauth_applications, [:owner_id, :owner_type], length: {:owner_type => 180}
+
+    add_index :oauth_access_tokens, :token, unique: true, length: 190
+    add_index :oauth_access_tokens, :refresh_token, unique: true, length: 190
+    add_index :oauth_access_tokens, :resource_owner_id
+
+    add_index :oauth_access_grants, :token, unique: true, length: 190
+
+    add_index :namespaces, :name, unique: true, length: 190
+    add_index :namespaces, :path, unique: true, length: 190
+    add_index :namespaces, :owner_id
+    add_index :namespaces, :type, length: 190
+    add_index :namespaces, [:created_at, :id]
+    
+    add_index :keys, :user_id
+    add_index :keys, [:created_at, :id]
+
+    add_index :emails, :email, unique: true, length: 190
+    add_index :emails, :user_id
+
+
+
+    ['web_hooks', 'users_star_projects', 'users', 'tags', 'taggings', 'subscriptions', 'snippets', 'services', 'schema_migrations', 'protected_branches', 'projects', 'oauth_applications', 'oauth_access_tokens', 'oauth_access_grants', 'notes', 'namespaces', 'milestones', 'merge_requests', 'merge_request_diffs', 'members', 'labels', 'label_links', 'keys', 'issues', 'identities', 'forked_project_links', 'events', 'emails', 'deploy_keys_projects', 'broadcast_messages', 'application_settings'].each do |table|
+      execute "ALTER TABLE `#{table}` CONVERT TO character set utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    end
+  end
+  def down
+    return unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /^mysql/
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150324155957) do
+ActiveRecord::Schema.define(version: 20150326082223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "home_page_url"
-    t.integer  "default_branch_protection",    default: 2
-    t.boolean  "twitter_sharing_enabled",      default: true
+    t.integer  "default_branch_protection",                     default: 2
+    t.boolean  "twitter_sharing_enabled",                       default: true
     t.text     "restricted_visibility_levels"
   end
 
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.datetime "updated_at"
   end
 
-  add_index "emails", ["email"], name: "index_emails_on_email", unique: true, using: :btree
+  add_index "emails", ["email"], name: "index_emails_on_email", unique: true, length: {"email"=>190}, using: :btree
   add_index "emails", ["user_id"], name: "index_emails_on_user_id", using: :btree
 
   create_table "events", force: true do |t|
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   add_index "events", ["created_at"], name: "index_events_on_created_at", using: :btree
   add_index "events", ["project_id"], name: "index_events_on_project_id", using: :btree
   add_index "events", ["target_id"], name: "index_events_on_target_id", using: :btree
-  add_index "events", ["target_type"], name: "index_events_on_target_type", using: :btree
+  add_index "events", ["target_type"], name: "index_events_on_target_type", length: {"target_type"=>191}, using: :btree
 
   create_table "forked_project_links", force: true do |t|
     t.integer  "forked_to_project_id",   null: false
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.integer  "project_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "position",     default: 0
+    t.integer  "position",                      default: 0
     t.string   "branch_name"
     t.text     "description"
     t.integer  "milestone_id"
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   add_index "issues", ["milestone_id"], name: "index_issues_on_milestone_id", using: :btree
   add_index "issues", ["project_id", "iid"], name: "index_issues_on_project_id_and_iid", unique: true, using: :btree
   add_index "issues", ["project_id"], name: "index_issues_on_project_id", using: :btree
-  add_index "issues", ["title"], name: "index_issues_on_title", using: :btree
+  add_index "issues", ["title"], name: "index_issues_on_title", length: {"title"=>191}, using: :btree
 
   create_table "keys", force: true do |t|
     t.integer  "user_id"
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   end
 
   add_index "label_links", ["label_id"], name: "index_label_links_on_label_id", using: :btree
-  add_index "label_links", ["target_id", "target_type"], name: "index_label_links_on_target_id_and_target_type", using: :btree
+  add_index "label_links", ["target_id", "target_type"], name: "index_label_links_on_target_id_and_target_type", length: {"target_id"=>nil, "target_type"=>191}, using: :btree
 
   create_table "labels", force: true do |t|
     t.string   "title"
@@ -170,15 +170,15 @@ ActiveRecord::Schema.define(version: 20150324155957) do
 
   add_index "members", ["access_level"], name: "index_members_on_access_level", using: :btree
   add_index "members", ["created_at", "id"], name: "index_members_on_created_at_and_id", using: :btree
-  add_index "members", ["source_id", "source_type"], name: "index_members_on_source_id_and_source_type", using: :btree
-  add_index "members", ["type"], name: "index_members_on_type", using: :btree
+  add_index "members", ["source_id", "source_type"], name: "index_members_on_source_id_and_source_type", length: {"source_id"=>nil, "source_type"=>191}, using: :btree
+  add_index "members", ["type"], name: "index_members_on_type", length: {"type"=>191}, using: :btree
   add_index "members", ["user_id"], name: "index_members_on_user_id", using: :btree
 
   create_table "merge_request_diffs", force: true do |t|
     t.string   "state"
     t.text     "st_commits"
     t.text     "st_diffs"
-    t.integer  "merge_request_id", null: false
+    t.integer  "merge_request_id",                    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -186,9 +186,9 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   add_index "merge_request_diffs", ["merge_request_id"], name: "index_merge_request_diffs_on_merge_request_id", unique: true, using: :btree
 
   create_table "merge_requests", force: true do |t|
-    t.string   "target_branch",                 null: false
-    t.string   "source_branch",                 null: false
-    t.integer  "source_project_id",             null: false
+    t.string   "target_branch",                                  null: false
+    t.string   "source_branch",                                  null: false
+    t.integer  "source_project_id",                              null: false
     t.integer  "author_id"
     t.integer  "assignee_id"
     t.string   "title"
@@ -197,10 +197,10 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.integer  "milestone_id"
     t.string   "state"
     t.string   "merge_status"
-    t.integer  "target_project_id",             null: false
+    t.integer  "target_project_id",                              null: false
     t.integer  "iid"
     t.text     "description"
-    t.integer  "position",          default: 0
+    t.integer  "position",                           default: 0
     t.datetime "locked_at"
   end
 
@@ -209,16 +209,16 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   add_index "merge_requests", ["created_at", "id"], name: "index_merge_requests_on_created_at_and_id", using: :btree
   add_index "merge_requests", ["created_at"], name: "index_merge_requests_on_created_at", using: :btree
   add_index "merge_requests", ["milestone_id"], name: "index_merge_requests_on_milestone_id", using: :btree
-  add_index "merge_requests", ["source_branch"], name: "index_merge_requests_on_source_branch", using: :btree
-  add_index "merge_requests", ["source_project_id"], name: "index_merge_requests_on_source_project_id", using: :btree
-  add_index "merge_requests", ["target_branch"], name: "index_merge_requests_on_target_branch", using: :btree
+  add_index "merge_requests", ["source_branch"], name: "index_merge_requests_on_source_branch", length: {"source_branch"=>191}, using: :btree
+  add_index "merge_requests", ["source_project_id"], name: "index_merge_requests_on_project_id", using: :btree
+  add_index "merge_requests", ["target_branch"], name: "index_merge_requests_on_target_branch", length: {"target_branch"=>191}, using: :btree
   add_index "merge_requests", ["target_project_id", "iid"], name: "index_merge_requests_on_target_project_id_and_iid", unique: true, using: :btree
-  add_index "merge_requests", ["title"], name: "index_merge_requests_on_title", using: :btree
+  add_index "merge_requests", ["title"], name: "index_merge_requests_on_title", length: {"title"=>191}, using: :btree
 
   create_table "milestones", force: true do |t|
-    t.string   "title",       null: false
-    t.integer  "project_id",  null: false
-    t.text     "description"
+    t.string   "title",                        null: false
+    t.integer  "project_id",                   null: false
+    t.text     "description", limit: 16777215
     t.date     "due_date"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -243,10 +243,10 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   end
 
   add_index "namespaces", ["created_at", "id"], name: "index_namespaces_on_created_at_and_id", using: :btree
-  add_index "namespaces", ["name"], name: "index_namespaces_on_name", unique: true, using: :btree
+  add_index "namespaces", ["name"], name: "index_namespaces_on_name", unique: true, length: {"name"=>190}, using: :btree
   add_index "namespaces", ["owner_id"], name: "index_namespaces_on_owner_id", using: :btree
-  add_index "namespaces", ["path"], name: "index_namespaces_on_path", unique: true, using: :btree
-  add_index "namespaces", ["type"], name: "index_namespaces_on_type", using: :btree
+  add_index "namespaces", ["path"], name: "index_namespaces_on_path", unique: true, length: {"path"=>190}, using: :btree
+  add_index "namespaces", ["type"], name: "index_namespaces_on_type", length: {"type"=>190}, using: :btree
 
   create_table "notes", force: true do |t|
     t.text     "note"
@@ -259,32 +259,32 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.string   "line_code"
     t.string   "commit_id"
     t.integer  "noteable_id"
-    t.boolean  "system",        default: false, null: false
     t.text     "st_diff"
+    t.boolean  "system",                           default: false, null: false
   end
 
   add_index "notes", ["author_id"], name: "index_notes_on_author_id", using: :btree
-  add_index "notes", ["commit_id"], name: "index_notes_on_commit_id", using: :btree
+  add_index "notes", ["commit_id"], name: "index_notes_on_commit_id", length: {"commit_id"=>191}, using: :btree
   add_index "notes", ["created_at", "id"], name: "index_notes_on_created_at_and_id", using: :btree
   add_index "notes", ["created_at"], name: "index_notes_on_created_at", using: :btree
-  add_index "notes", ["noteable_id", "noteable_type"], name: "index_notes_on_noteable_id_and_noteable_type", using: :btree
-  add_index "notes", ["noteable_type"], name: "index_notes_on_noteable_type", using: :btree
-  add_index "notes", ["project_id", "noteable_type"], name: "index_notes_on_project_id_and_noteable_type", using: :btree
+  add_index "notes", ["noteable_id", "noteable_type"], name: "index_notes_on_noteable_id_and_noteable_type", length: {"noteable_id"=>nil, "noteable_type"=>191}, using: :btree
+  add_index "notes", ["noteable_type"], name: "index_notes_on_noteable_type", length: {"noteable_type"=>191}, using: :btree
+  add_index "notes", ["project_id", "noteable_type"], name: "index_notes_on_project_id_and_noteable_type", length: {"project_id"=>nil, "noteable_type"=>191}, using: :btree
   add_index "notes", ["project_id"], name: "index_notes_on_project_id", using: :btree
   add_index "notes", ["updated_at"], name: "index_notes_on_updated_at", using: :btree
 
   create_table "oauth_access_grants", force: true do |t|
-    t.integer  "resource_owner_id", null: false
-    t.integer  "application_id",    null: false
-    t.string   "token",             null: false
-    t.integer  "expires_in",        null: false
-    t.text     "redirect_uri",      null: false
-    t.datetime "created_at",        null: false
+    t.integer  "resource_owner_id",                  null: false
+    t.integer  "application_id",                     null: false
+    t.string   "token",                              null: false
+    t.integer  "expires_in",                         null: false
+    t.text     "redirect_uri",                       null: false
+    t.datetime "created_at",                         null: false
     t.datetime "revoked_at"
     t.string   "scopes"
   end
 
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, length: {"token"=>190}, using: :btree
 
   create_table "oauth_access_tokens", force: true do |t|
     t.integer  "resource_owner_id"
@@ -293,28 +293,28 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",        null: false
+    t.datetime "created_at"
     t.string   "scopes"
   end
 
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, length: {"refresh_token"=>190}, using: :btree
   add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, length: {"token"=>190}, using: :btree
 
   create_table "oauth_applications", force: true do |t|
-    t.string   "name",                      null: false
-    t.string   "uid",                       null: false
-    t.string   "secret",                    null: false
-    t.text     "redirect_uri",              null: false
-    t.string   "scopes",       default: "", null: false
+    t.string   "name",                                       null: false
+    t.string   "uid",                                        null: false
+    t.string   "secret",                                     null: false
+    t.text     "redirect_uri",                               null: false
+    t.string   "scopes",                        default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "owner_id"
     t.string   "owner_type"
   end
 
-  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", length: {"owner_id"=>nil, "owner_type"=>180}, using: :btree
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, length: {"uid"=>190}, using: :btree
 
   create_table "projects", force: true do |t|
     t.string   "name"
@@ -323,24 +323,24 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "creator_id"
-    t.boolean  "issues_enabled",         default: true,     null: false
-    t.boolean  "wall_enabled",           default: true,     null: false
-    t.boolean  "merge_requests_enabled", default: true,     null: false
-    t.boolean  "wiki_enabled",           default: true,     null: false
+    t.boolean  "issues_enabled",                          default: true,     null: false
+    t.boolean  "wall_enabled",                            default: true,     null: false
+    t.boolean  "merge_requests_enabled",                  default: true,     null: false
+    t.boolean  "wiki_enabled",                            default: true,     null: false
     t.integer  "namespace_id"
-    t.string   "issues_tracker",         default: "gitlab", null: false
+    t.string   "issues_tracker",                          default: "gitlab", null: false
     t.string   "issues_tracker_id"
-    t.boolean  "snippets_enabled",       default: true,     null: false
+    t.boolean  "snippets_enabled",                        default: true,     null: false
     t.datetime "last_activity_at"
     t.string   "import_url"
-    t.integer  "visibility_level",       default: 0,        null: false
-    t.boolean  "archived",               default: false,    null: false
-    t.string   "avatar"
+    t.integer  "visibility_level",                        default: 0,        null: false
+    t.boolean  "archived",                                default: false,    null: false
     t.string   "import_status"
-    t.float    "repository_size",        default: 0.0
-    t.integer  "star_count",             default: 0,        null: false
+    t.float    "repository_size",                         default: 0.0
+    t.integer  "star_count",                              default: 0,        null: false
     t.string   "import_type"
     t.string   "import_source"
+    t.string   "avatar"
   end
 
   add_index "projects", ["created_at", "id"], name: "index_projects_on_created_at_and_id", using: :btree
@@ -352,8 +352,8 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   create_table "protected_branches", force: true do |t|
     t.integer  "project_id",                          null: false
     t.string   "name",                                null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime 
+    t.datetime 
     t.boolean  "developers_can_push", default: false, null: false
   end
 
@@ -363,16 +363,16 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.string   "type"
     t.string   "title"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "active",                default: false, null: false
+    t.datetime "created_at",                                             null: false
+    t.datetime "updated_at",                                             null: false
+    t.boolean  "active",                                 default: false, null: false
     t.text     "properties"
-    t.boolean  "template",              default: false
-    t.boolean  "push_events",           default: true
-    t.boolean  "issues_events",         default: true
-    t.boolean  "merge_requests_events", default: true
-    t.boolean  "tag_push_events",       default: true
-    t.boolean  "note_events",           default: true,  null: false
+    t.boolean  "template",                               default: false
+    t.boolean  "push_events",                            default: true
+    t.boolean  "issues_events",                          default: true
+    t.boolean  "merge_requests_events",                  default: true
+    t.boolean  "tag_push_events",                        default: true
+    t.boolean  "note_events",                            default: true,  null: false
   end
 
   add_index "services", ["created_at", "id"], name: "index_services_on_created_at_and_id", using: :btree
@@ -381,14 +381,14 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   create_table "snippets", force: true do |t|
     t.string   "title"
     t.text     "content"
-    t.integer  "author_id",                    null: false
+    t.integer  "author_id",                                       null: false
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
     t.string   "file_name"
     t.datetime "expires_at"
     t.string   "type"
-    t.integer  "visibility_level", default: 0, null: false
+    t.integer  "visibility_level",                    default: 0, null: false
   end
 
   add_index "snippets", ["author_id"], name: "index_snippets_on_author_id", using: :btree
@@ -407,7 +407,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.datetime "updated_at"
   end
 
-  add_index "subscriptions", ["subscribable_id", "subscribable_type", "user_id"], name: "subscriptions_user_id_and_ref_fields", unique: true, using: :btree
+  add_index "subscriptions", ["subscribable_id", "subscribable_type", "user_id"], name: "subscriptions_user_id_and_ref_fields", length: {"subscribable_id"=>nil, "subscribable_type"=>170, "user_id"=>nil}, using: :btree
 
   create_table "taggings", force: true do |t|
     t.integer  "tag_id"
@@ -420,7 +420,7 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   end
 
   add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", length: {"taggable_id"=>nil, "taggable_type"=>191, "context"=>191}, using: :btree
 
   create_table "tags", force: true do |t|
     t.string "name"
@@ -437,8 +437,8 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
     t.string   "name"
     t.boolean  "admin",                         default: false, null: false
     t.integer  "projects_limit",                default: 10
@@ -473,18 +473,17 @@ ActiveRecord::Schema.define(version: 20150324155957) do
     t.boolean  "password_automatically_set",    default: false
     t.string   "bitbucket_access_token"
     t.string   "bitbucket_access_token_secret"
-    t.string   "location"
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree
-  add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
-  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
+  add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, length: {"authentication_token"=>190}, using: :btree
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, length: {"confirmation_token"=>190}, using: :btree
   add_index "users", ["created_at", "id"], name: "index_users_on_created_at_and_id", using: :btree
   add_index "users", ["current_sign_in_at"], name: "index_users_on_current_sign_in_at", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["name"], name: "index_users_on_name", using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-  add_index "users", ["username"], name: "index_users_on_username", using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, length: {"email"=>190}, using: :btree
+  add_index "users", ["name"], name: "index_users_on_name", length: {"name"=>190}, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, length: {"reset_password_token"=>190}, using: :btree
+  add_index "users", ["username"], name: "index_users_on_username", length: {"username"=>190}, using: :btree
 
   create_table "users_star_projects", force: true do |t|
     t.integer  "project_id", null: false
@@ -500,8 +499,8 @@ ActiveRecord::Schema.define(version: 20150324155957) do
   create_table "web_hooks", force: true do |t|
     t.string   "url"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
     t.string   "type",                  default: "ProjectHook"
     t.integer  "service_id"
     t.boolean  "push_events",           default: true,          null: false


### PR DESCRIPTION
This commit should fix #9030, which allows to insert and update strings that contain emoji or other special unicode characters in mysql schema.
