### PR TITLE
Renamed Buildbox to Buildkite.

### DIFF
--- a/app/models/project_services/buildbox_service.rb
+++ b/app/models/project_services/buildbox_service.rb
@@ -20,7 +20,11 @@
 
 require "addressable/uri"
 
+# Buildbox renamed to Buildkite, but for backwards compatability with the STI
+# of Services, the class name is kept as "Buildbox"
 class BuildboxService < CiService
+  ENDPOINT = "https://buildkite.com"
+
   prop_accessor :project_url, :token
 
   validates :project_url, presence: true, if: :activated?
@@ -29,7 +33,7 @@ class BuildboxService < CiService
   after_save :compose_service_hook, if: :activated?
 
   def webhook_url
-    "#{buildbox_endpoint('webhook')}/deliver/#{webhook_token}"
+    "#{buildkite_endpoint('webhook')}/deliver/#{webhook_token}"
   end
 
   def compose_service_hook
@@ -59,7 +63,7 @@ class BuildboxService < CiService
   end
 
   def commit_status_path(sha)
-    "#{buildbox_endpoint('gitlab')}/status/#{status_token}.json?commit=#{sha}"
+    "#{buildkite_endpoint('gitlab')}/status/#{status_token}.json?commit=#{sha}"
   end
 
   def build_page(sha, ref)
@@ -71,11 +75,11 @@ class BuildboxService < CiService
   end
 
   def status_img_path
-    "#{buildbox_endpoint('badge')}/#{status_token}.svg"
+    "#{buildkite_endpoint('badge')}/#{status_token}.svg"
   end
 
   def title
-    'Buildbox'
+    'Buildkite'
   end
 
   def description
@@ -83,18 +87,18 @@ class BuildboxService < CiService
   end
 
   def to_param
-    'buildbox'
+    'buildkite'
   end
 
   def fields
     [
       { type: 'text',
         name: 'token',
-        placeholder: 'Buildbox project GitLab token' },
+        placeholder: 'Buildkite project GitLab token' },
 
       { type: 'text',
         name: 'project_url',
-        placeholder: 'https://buildbox.io/example/project' }
+        placeholder: "#{ENDPOINT}/example/project" }
     ]
   end
 
@@ -116,11 +120,9 @@ class BuildboxService < CiService
     end
   end
 
-  def buildbox_endpoint(subdomain = nil)
-    endpoint = 'https://buildbox.io'
-
+  def buildkite_endpoint(subdomain = nil)
     if subdomain.present?
-      uri = Addressable::URI.parse(endpoint)
+      uri = Addressable::URI.parse(ENDPOINT)
       new_endpoint = "#{uri.scheme || 'http'}://#{subdomain}.#{uri.host}"
 
       if uri.port.present?
@@ -129,7 +131,7 @@ class BuildboxService < CiService
         new_endpoint
       end
     else
-      endpoint
+      ENDPOINT
     end
   end
 end

--- a/spec/models/project_services/buildbox_service_spec.rb
+++ b/spec/models/project_services/buildbox_service_spec.rb
@@ -36,7 +36,7 @@ describe BuildboxService do
       @service.stub(
         project: @project,
         service_hook: true,
-        project_url: 'https://buildbox.io/account-name/example-project',
+        project_url: 'https://buildkite.com/account-name/example-project',
         token: 'secret-sauce-webhook-token:secret-sauce-status-token'
       )
     end
@@ -44,7 +44,7 @@ describe BuildboxService do
     describe :webhook_url do
       it 'returns the webhook url' do
         expect(@service.webhook_url).to eq(
-          'https://webhook.buildbox.io/deliver/secret-sauce-webhook-token'
+          'https://webhook.buildkite.com/deliver/secret-sauce-webhook-token'
         )
       end
     end
@@ -52,7 +52,7 @@ describe BuildboxService do
     describe :commit_status_path do
       it 'returns the correct status page' do
         expect(@service.commit_status_path('2ab7834c')).to eq(
-          'https://gitlab.buildbox.io/status/secret-sauce-status-token.json?commit=2ab7834c'
+          'https://gitlab.buildkite.com/status/secret-sauce-status-token.json?commit=2ab7834c'
         )
       end
     end
@@ -60,7 +60,7 @@ describe BuildboxService do
     describe :build_page do
       it 'returns the correct build page' do
         expect(@service.build_page('2ab7834c', nil)).to eq(
-          'https://buildbox.io/account-name/example-project/builds?commit=2ab7834c'
+          'https://buildkite.com/account-name/example-project/builds?commit=2ab7834c'
         )
       end
     end
@@ -68,14 +68,14 @@ describe BuildboxService do
     describe :builds_page do
       it 'returns the correct path to the builds page' do
         expect(@service.builds_path).to eq(
-          'https://buildbox.io/account-name/example-project/builds?branch=default-brancho'
+          'https://buildkite.com/account-name/example-project/builds?branch=default-brancho'
         )
       end
     end
 
     describe :status_img_path do
       it 'returns the correct path to the status image' do
-        expect(@service.status_img_path).to eq('https://badge.buildbox.io/secret-sauce-status-token.svg')
+        expect(@service.status_img_path).to eq('https://badge.buildkite.com/secret-sauce-status-token.svg')
       end
     end
   end


### PR DESCRIPTION
Buildbox recently changed their name to Buildkite, so this PR updates the URL's and the text descriptions. It doesn't change the class name for backwards compatibility.
