### PR TITLE
Add ActiveRecord::Migration.maintain_test_schema! to spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,3 +44,5 @@ RSpec.configure do |config|
     TestEnv.init
   end
 end
+
+ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
New in Rails 4.1, this eliminates spec failures due to forgetting to run
`db:test:prepare`.
