### PR TITLE
Change merging notification to sound more natural

### DIFF
--- a/app/views/projects/merge_requests/show/_state_widget.html.haml
+++ b/app/views/projects/merge_requests/show/_state_widget.html.haml
@@ -29,7 +29,7 @@
       %h4
         Merge in progress...
       %p
-        GitLab tries to merge it right now. During this time merge request is locked and can not be closed.
+        Merging is in progress. While merging this request is locked and cannot be closed.
 
     - unless @commits.any?
       %h4 Nothing to merge


### PR DESCRIPTION
This changes some of the wording that appears when a user navigates to a merge request where the merge is currently in progress to sound more natural.
