### PR TITLE
Define GIT_TEMPLATE_DIR environment variable in TestEnv

### DIFF
--- a/spec/support/test_env.rb
+++ b/spec/support/test_env.rb
@@ -85,7 +85,7 @@ module TestEnv
     end
 
     # We must copy bare repositories because we will push to them.
-    system(*%W(git clone -q --bare #{factory_repo_path} #{factory_repo_path_bare}))
+    system(git_env, *%W(git clone -q --bare #{factory_repo_path} #{factory_repo_path_bare}))
   end
 
   def copy_repo(project)
@@ -112,5 +112,11 @@ module TestEnv
 
   def factory_repo_name
     'gitlab-test'
+  end
+
+  # Prevent developer git configurations from being persisted to test
+  # repositories
+  def git_env
+    {'GIT_TEMPLATE_DIR' => ''}
   end
 end


### PR DESCRIPTION
See http://schacon.github.io/git/git-init.html#_template_directory

Without this variable, any global git hooks a developer might have in
`~/.git_template` would be linked in the `.git/hooks` folder for every
test repository that gets checked out by TestEnv, and would cause
certain specs to fail due to pre-existing hook files.

For example, using the dotfiles from [thoughtbot](https://github.com/thoughtbot/dotfiles), a spec run spits out errors like this:

```
Failures:

  1) Project find_with_namespace with namespace
     Failure/Error: @project = create(:project, name: 'gitlabhq', namespace: @group)
     Errno::EEXIST:
       File exists @ sys_fail2 - (/Users/tsigo/dotfiles/git_template/hooks/ctags, /Users/tsigo/Code/rails/gitlab-development-kit/gitlab/tmp/tests/repositories/gitlab/gitlabhq.git/./hooks/ctags)
     # ./spec/support/test_env.rb:95:in `copy_repo'
     # ./spec/factories/projects.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/models/project_spec.rb:156:in `block (4 levels) in <top (required)>'

  2) Project find_with_namespace with namespace
     Failure/Error: @project = create(:project, name: 'gitlabhq', namespace: @group)
     Errno::EEXIST:
       File exists @ sys_fail2 - (/Users/tsigo/dotfiles/git_template/hooks/ctags, /Users/tsigo/Code/rails/gitlab-development-kit/gitlab/tmp/tests/repositories/gitlab/gitlabhq.git/./hooks/ctags)
     # ./spec/support/test_env.rb:95:in `copy_repo'
     # ./spec/factories/projects.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/models/project_spec.rb:156:in `block (4 levels) in <top (required)>'

Finished in 6.86 seconds
67 examples, 2 failures

Failed examples:

rspec ./spec/models/project_spec.rb:159 # Project find_with_namespace with namespace
rspec ./spec/models/project_spec.rb:160 # Project find_with_namespace with namespace
```

The argument could be made that since it's the developer's setup that's breaking the tests, it's up to the developer to fix their setup, but this fix is simpler and I think it's valid because the purpose of TestEnv is to ensure a clean testing environment for the underlying Git operations.
