### PR TITLE
[WIP] Use rails-bootstrap-forms gem for form rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -193,6 +193,7 @@ gem 'jquery-turbolinks'
 
 gem 'addressable'
 gem 'bootstrap-sass',     '~> 3.0'
+gem 'bootstrap_form'
 gem 'font-awesome-rails', '~> 4.2'
 gem 'gitlab_emoji',       '~> 0.1'
 gem 'gon',                '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    bootstrap_form (2.3.0)
     brakeman (3.0.1)
       erubis (~> 2.6)
       fastercsv (~> 1.5)
@@ -749,6 +750,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass (~> 3.0)
+  bootstrap_form
   brakeman
   browser (~> 0.8.0)
   byebug
@@ -875,6 +877,3 @@ DEPENDENCIES
   virtus
   webmock (~> 1.21.0)
   wikicloth (= 0.8.1)
-
-BUNDLED WITH
-   1.10.5

--- a/app/assets/javascripts/admin.js.coffee
+++ b/app/assets/javascripts/admin.js.coffee
@@ -10,7 +10,7 @@ class @Admin
 
     $('body').on 'click', '.js-toggle-colors-link', (e) ->
       e.preventDefault()
-      $('.js-toggle-colors-link').hide()
+      $('.js-toggle-colors-link').parents('.form-group').hide()
       $('.js-toggle-colors-container').show()
 
     $('input#broadcast_message_color').on 'input', ->

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
  *= require_self
  *= require dropzone/basic
  *= require cal-heatmap
+ *= require rails_bootstrap_forms
 */
 
 

--- a/app/assets/stylesheets/base/gl_variables.scss
+++ b/app/assets/stylesheets/base/gl_variables.scss
@@ -81,21 +81,13 @@ $pagination-disabled-border:           transparent;
 //
 //## Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             #fff;
-$state-success-bg:               $brand-success;
-$state-success-border:           $brand-success;
+$state-success-text:             $brand-success;
 
-$state-info-text:                #fff;
-$state-info-bg:                  $brand-info;
-$state-info-border:              $brand-info;
+$state-info-text:                $brand-info;
 
-$state-warning-text:             #fff;
-$state-warning-bg:               $brand-warning;
-$state-warning-border:           $brand-warning;
+$state-warning-text:             $brand-warning;
 
-$state-danger-text:              #fff;
-$state-danger-bg:                $brand-danger;
-$state-danger-border:            $brand-danger;
+$state-danger-text:              $brand-danger;
 
 
 //== Alerts
@@ -104,6 +96,21 @@ $state-danger-border:            $brand-danger;
 
 $alert-border-radius:            0;
 
+$alert-success-text:             #fff;
+$alert-success-bg:               $brand-success;
+$alert-success-border:           $brand-success;
+
+$alert-info-text:                #fff;
+$alert-info-bg:                  $brand-info;
+$alert-info-border:              $brand-info;
+
+$alert-warning-text:             #fff;
+$alert-warning-bg:               $brand-warning;
+$alert-warning-border:           $brand-warning;
+
+$alert-danger-text:              #fff;
+$alert-danger-bg:                $brand-danger;
+$alert-danger-border:            $brand-danger;
 
 //== Panels
 //

--- a/app/assets/stylesheets/generic/forms.scss
+++ b/app/assets/stylesheets/generic/forms.scss
@@ -43,6 +43,10 @@ label {
   &.inline-label {
     margin: 0;
   }
+
+  &.required:after {
+    content:" *";
+  }
 }
 
 .inline-input-group {

--- a/app/views/admin/application_settings/_form.html.haml
+++ b/app/views/admin/application_settings/_form.html.haml
@@ -1,16 +1,9 @@
-= form_for @application_setting, url: admin_application_settings_path, html: { class: 'form-horizontal fieldset-form' } do |f|
-  - if @application_setting.errors.any?
-    #error_explanation
-      .alert.alert-danger
-        - @application_setting.errors.full_messages.each do |msg|
-          %p= msg
+= bootstrap_form_for @application_setting, url: admin_application_settings_path, layout: :horizontal, html: { class: 'fieldset-form' } do |f|
+  = f.alert_message 'Please check your form for possible errors.'
 
   %fieldset
     %legend Visibility and Access Controls
-    .form-group
-      = f.label :default_branch_protection, class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.select :default_branch_protection, options_for_select(Gitlab::Access.protection_options, @application_setting.default_branch_protection), {}, class: 'form-control'
+    = f.select :default_branch_protection, options_for_select(Gitlab::Access.protection_options, @application_setting.default_branch_protection)
     .form-group.project-visibility-level-holder
       = f.label :default_project_visibility, class: 'control-label col-sm-2'
       .col-sm-10
@@ -27,83 +20,33 @@
           - restricted_level_checkboxes('restricted-visibility-help').each do |level|
             = level
         %span.help-block#restricted-visibility-help Selected levels cannot be used by non-admin users for projects or snippets
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .checkbox
-          = f.label :version_check_enabled do
-            = f.check_box :version_check_enabled
-            Version check enabled
+    = f.form_group :version_check_enabled do
+      = f.check_box :version_check_enabled
 
   %fieldset
     %legend Account and Limit Settings
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .checkbox
-          = f.label :gravatar_enabled do
-            = f.check_box :gravatar_enabled
-            Gravatar enabled
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .checkbox
-          = f.label :twitter_sharing_enabled do
-            = f.check_box :twitter_sharing_enabled, :'aria-describedby' => 'twitter_help_block'
-            Twitter enabled
-          %span.help-block#twitter_help_block Show users a button to share their newly created public or internal projects on twitter
-    .form-group
-      = f.label :default_projects_limit, class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.number_field :default_projects_limit, class: 'form-control'
-    .form-group
-      = f.label :max_attachment_size, 'Maximum attachment size (MB)', class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.number_field :max_attachment_size, class: 'form-control'
-    .form-group
-      = f.label :session_expire_delay, 'Session duration (minutes)', class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.number_field :session_expire_delay, class: 'form-control'
-        %span.help-block#session_expire_delay_help_block GitLab restart is required to apply changes
-    .form-group
-      = f.label :user_oauth_applications, 'User OAuth applications', class: 'control-label col-sm-2'
-      .col-sm-10
-        .checkbox
-          = f.label :user_oauth_applications do
-            = f.check_box :user_oauth_applications
-            Allow users to register any application to use GitLab as an OAuth provider
+    = f.form_group :gravatar_enabled do
+      = f.check_box :gravatar_enabled
+    = f.form_group :twitter_sharing_enabled, help: 'Show users a button to share their newly created public or internal projects on twitter' do
+      = f.check_box :twitter_sharing_enabled, label: 'Twitter enabled'
+    = f.number_field :default_projects_limit
+    = f.number_field :max_attachment_size, label: 'Maximum attachment size (MB)'
+    = f.number_field :session_expire_delay, label: 'Session duration (minutes)', help: 'GitLab restart is required to apply changes'
+    = f.form_group :user_oauth_applications, help: 'Allow users to register any application to use GitLab as an OAuth provider' do
+      = f.check_box :user_oauth_applications, label: 'User OAuth applications'
 
   %fieldset
     %legend Sign-in Restrictions
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .checkbox
-          = f.label :signup_enabled do
-            = f.check_box :signup_enabled
-            Sign-up enabled
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .checkbox
-          = f.label :signin_enabled do
-            = f.check_box :signin_enabled
-            Sign-in enabled
-    .form-group
-      = f.label :restricted_signup_domains, 'Restricted domains for sign-ups', class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.text_area :restricted_signup_domains_raw, placeholder: 'domain.com', class: 'form-control'
-        .help-block Only users with e-mail addresses that match these domain(s) will be able to sign-up. Wildcards allowed. Use separate lines for multiple entries. Ex: domain.com, *.domain.com
-    .form-group
-      = f.label :home_page_url, class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.text_field :home_page_url, class: 'form-control', placeholder: 'http://company.example.com', :'aria-describedby' => 'home_help_block'
-        %span.help-block#home_help_block We will redirect non-logged in users to this page
-    .form-group
-      = f.label :after_sign_out_path, class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.text_field :after_sign_out_path, class: 'form-control', placeholder: 'http://company.example.com', :'aria-describedby' => 'after_sign_out_path_help_block'
-        %span.help-block#after_sign_out_path_help_block We will redirect users to this page after they sign out
-    .form-group
-      = f.label :sign_in_text, class: 'control-label col-sm-2'
-      .col-sm-10
-        = f.text_area :sign_in_text, class: 'form-control', rows: 4
-        .help-block Markdown enabled
+    = f.form_group :signup_enabled do
+      = f.check_box :signup_enabled, label: 'Sign-up enabled'
+    = f.form_group :signin_enabled do
+      = f.check_box :signin_enabled, label: 'Sign-in enabled'
+    = f.text_area :restricted_signup_domains_raw, placeholder: 'domain.com',
+    label: 'Restricted domains for sign-ups',
+    help: 'Only users with e-mail addresses that match these domain(s) will be able to sign-up. Wildcards allowed. Use separate lines for multiple entries. Ex: domain.com, *.domain.com'
+    = f.text_field :home_page_url, placeholder: 'http://company.example.com', help: 'We will redirect non-logged in users to this page'
+    = f.text_field :after_sign_out_path, placeholder: 'http://company.example.com', help: 'We will redirect users to this page after they sign out'
+    = f.text_area :sign_in_text, rows: 4, help: 'Markdown enabled'
 
   .form-actions
-    = f.submit 'Save', class: 'btn btn-primary'
+    = f.primary 'Save'

--- a/app/views/admin/applications/_delete_form.html.haml
+++ b/app/views/admin/applications/_delete_form.html.haml
@@ -1,4 +1,3 @@
-- submit_btn_css ||= 'btn btn-link btn-remove btn-sm'
-= form_tag admin_application_path(application) do
-  %input{:name => "_method", :type => "hidden", :value => "delete"}/
-  = submit_tag 'Destroy', onclick: "return confirm('Are you sure?')", class: submit_btn_css
+- submit_btn_css ||= 'btn btn-remove btn-sm'
+= bootstrap_form_tag url: admin_application_path(application), method: 'delete' do |f|
+  = f.submit 'Destroy', onclick: "return confirm('Are you sure?')", class: submit_btn_css

--- a/app/views/admin/applications/_form.html.haml
+++ b/app/views/admin/applications/_form.html.haml
@@ -1,26 +1,9 @@
-= form_for [:admin, @application], url: @url, html: {class: 'form-horizontal', role: 'form'} do |f|
-  - if application.errors.any?
-    .alert.alert-danger
-      %button{ type: "button", class: "close", "data-dismiss" => "alert"} &times;
-      - application.errors.full_messages.each do |msg|
-        %p= msg
-  = content_tag :div, class: 'form-group' do
-    = f.label :name, class: 'col-sm-2 control-label'
-    .col-sm-10
-      = f.text_field :name, class: 'form-control'
-      = doorkeeper_errors_for application, :name
-  = content_tag :div, class: 'form-group' do
-    = f.label :redirect_uri, class: 'col-sm-2 control-label'
-    .col-sm-10
-      = f.text_area :redirect_uri, class: 'form-control'
-      = doorkeeper_errors_for application, :redirect_uri
-      %span.help-block
-        Use one line per URI
-      - if Doorkeeper.configuration.native_redirect_uri
-        %span.help-block
-          Use
-          %code= Doorkeeper.configuration.native_redirect_uri
-          for local tests
+= bootstrap_form_for [:admin, @application], url: @url, layout: :horizontal do |f|
+  = f.alert_message 'Please check your form for possible errors.'
+
+  = f.text_field :name
+  = f.text_area :redirect_uri, help: 'Use one line per URI'
+
   .form-actions
-    = f.submit 'Submit', class: "btn btn-primary wide"
-    = link_to "Cancel", admin_applications_path, class: "btn btn-default"
+    = f.primary 'Submit'
+    = link_to 'Cancel', admin_applications_path, class: 'btn btn-default'

--- a/app/views/admin/broadcast_messages/index.html.haml
+++ b/app/views/admin/broadcast_messages/index.html.haml
@@ -7,36 +7,20 @@
   %i.fa.fa-bullhorn
   %span Your message here
 
-= form_for [:admin, @broadcast_message], html: { class: 'broadcast-message-form form-horizontal'} do |f|
-  -if @broadcast_message.errors.any?
-    .alert.alert-danger
-      - @broadcast_message.errors.full_messages.each do |msg|
-        %p= msg
-  .form-group
-    = f.label :message, class: 'control-label'
-    .col-sm-10
-      = f.text_area :message, class: "form-control", rows: 2, required: true
-      %div
-        = link_to '#', class: 'js-toggle-colors-link' do
-          Customize colors
-  .form-group.js-toggle-colors-container.hide
-    = f.label :color, "Background Color", class: 'control-label'
-    .col-sm-10
-      = f.color_field :color, value: "#eb9532", class: "form-control"
-  .form-group.js-toggle-colors-container.hide
-    = f.label :font, "Font Color", class: 'control-label'
-    .col-sm-10
-      = f.color_field :font, value: "#FFFFFF", class: "form-control"
-  .form-group
-    = f.label :starts_at, class: 'control-label'
-    .col-sm-10.datetime-controls
-      = f.datetime_select :starts_at
-  .form-group
-    = f.label :ends_at, class: 'control-label'
-    .col-sm-10.datetime-controls
-      = f.datetime_select :ends_at
+= bootstrap_form_for [:admin, @broadcast_message], layout: :horizontal do |f|
+  = f.alert_message 'Please check your form for possible errors.'
+
+  = f.text_area :message, required: true
+  = f.static_control label: 'Colors' do
+    = link_to 'Customize colors', '#', class: 'js-toggle-colors-link'
+  .js-toggle-colors-container.hide
+    = f.color_field :color, value: '#eb9532'
+    = f.color_field :font, value: '#FFFFFF'
+  = f.datetime_select :starts_at
+  = f.datetime_select :ends_at
+
   .form-actions
-    = f.submit "Add broadcast message", class: "btn btn-create"
+    = f.submit 'Add broadcast message', class: 'btn btn-create'
 
 -if @broadcast_messages.any?
   %ul.bordered-list.broadcast-messages

--- a/app/views/admin/deploy_keys/new.html.haml
+++ b/app/views/admin/deploy_keys/new.html.haml
@@ -3,25 +3,12 @@
 %hr
 
 %div
-  = form_for [:admin, @deploy_key], html: { class: 'deploy-key-form form-horizontal' } do |f|
-    -if @deploy_key.errors.any?
-      .alert.alert-danger
-        %ul
-          - @deploy_key.errors.full_messages.each do |msg|
-            %li= msg
+  = bootstrap_form_for [:admin, @deploy_key], layout: :horizontal, html: { class: 'deploy-key-form' } do |f|
+    = f.alert_message 'Please check your form for possible errors.'
 
-    .form-group
-      = f.label :title, class: "control-label"
-      .col-sm-10= f.text_field :title, class: 'form-control'
-    .form-group
-      = f.label :key, class: "control-label"
-      .col-sm-10
-        %p.light
-          Paste a machine public key here. Read more about how to generate it
-          = link_to "here", help_page_path("ssh", "README")
-        = f.text_area :key, class: "form-control thin_area", rows: 5
+    = f.text_field :title
+    = f.text_area :key, rows: 5, help: 'Paste a machine public key here. Read more about how to generate it on ssh doc.'
 
     .form-actions
-      = f.submit 'Create', class: "btn-create btn"
-      = link_to "Cancel", admin_deploy_keys_path, class: "btn btn-cancel"
-
+      = f.submit 'Create', class: 'btn-create btn'
+      = link_to 'Cancel', admin_deploy_keys_path, class: 'btn btn-cancel'

--- a/app/views/admin/groups/_form.html.haml
+++ b/app/views/admin/groups/_form.html.haml
@@ -1,26 +1,22 @@
-= form_for [:admin, @group], html: { class: "form-horizontal" } do |f|
-  - if @group.errors.any?
-    .alert.alert-danger
-      %span= @group.errors.full_messages.first
+= bootstrap_form_for [:admin, @group], layout: :horizontal do |f|
+  = f.alert_message 'Please check your form for possible errors.'
 
   = render 'shared/group_form', f: f
 
-  .form-group.group-description-holder
-    = f.label :avatar, "Group avatar", class: 'control-label'
-    .col-sm-10
-      = render 'shared/choose_group_avatar_button', f: f
+  = f.form_group :avatar, label: { text: 'Group avatar' } do
+    = render 'shared/choose_group_avatar_button', f: f
 
   - if @group.new_record?
-    .form-group
-      .col-sm-offset-2.col-sm-10
-        .alert.alert-info
-          = render 'shared/group_tips'
+    = f.form_group do
+      .alert.alert-info
+        = render 'shared/group_tips'
+
     .form-actions
-      = f.submit 'Create group', class: "btn btn-create"
-      = link_to  'Cancel', admin_groups_path, class: "btn btn-cancel"
+      = f.submit 'Create group', class: 'btn btn-create'
+      = link_to 'Cancel', admin_groups_path, class: 'btn btn-cancel'
 
   - else
     .form-actions
-      = f.submit 'Save changes', class: "btn btn-primary"
-      = link_to  'Cancel', admin_group_path(@group), class: "btn btn-cancel"
+      = f.primary 'Save changes'
+      = link_to 'Cancel', admin_group_path(@group), class: 'btn btn-cancel'
 

--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -8,15 +8,14 @@
   Use groups for uniting related projects.
 
 %hr
-= form_tag admin_groups_path, method: :get, class: 'form-inline' do
-  = hidden_field_tag :sort, @sort
-  .form-group
-    = text_field_tag :name, params[:name], class: "form-control"
-  = button_tag "Search", class: "btn submit btn-primary"
+= bootstrap_form_tag url: admin_groups_path, method: :get, layout: :inline do |f|
+  = f.hidden_field :sort, value: @sort
+  = f.text_field :name, value: params[:name], hide_label: true
+  = f.primary 'Search'
 
   .pull-right
     .dropdown.inline
-      %a.dropdown-toggle.btn{href: '#', "data-toggle" => "dropdown"}
+      %a.dropdown-toggle.btn{href: '#', 'data-toggle' => 'dropdown'}
         %span.light sort:
         - if @sort.present?
           = sort_options_hash[@sort]

--- a/app/views/admin/groups/show.html.haml
+++ b/app/views/admin/groups/show.html.haml
@@ -59,13 +59,12 @@
           Read more about project permissions
           %strong= link_to "here", help_page_path("permissions", "permissions"), class: "vlink"
 
-        = form_tag members_update_admin_group_path(@group), id: "new_project_member", class: "bulk_import", method: :put  do
-          %div
+        = bootstrap_form_tag url: members_update_admin_group_path(@group), id: 'new_project_member', class: 'bulk_import', method: :put do |f|
+          = f.form_group do
             = users_select_tag(:user_ids, multiple: true, email_user: true, scope: :all)
-          %div.prepend-top-10
-            = select_tag :access_level, options_for_select(GroupMember.access_level_roles), class: "project-access-select select2"
+          = f.select :access_level, options_for_select(GroupMember.access_level_roles), hide_label: true, class: 'project-access-select select2'
           %hr
-          = button_tag 'Add users to group', class: "btn btn-create"
+          = f.submit 'Add users to group', class: "btn btn-create"
     .panel.panel-default
       .panel-heading
         %h3.panel-title

--- a/app/views/admin/hooks/index.html.haml
+++ b/app/views/admin/hooks/index.html.haml
@@ -8,18 +8,14 @@
 
 %hr
 
+= bootstrap_form_for @hook, as: :hook, url: admin_hooks_path, layout: :horizontal do |f|
+  = f.alert_message 'Please check your form for possible errors.'
 
-= form_for @hook, as: :hook, url: admin_hooks_path, html: { class: 'form-horizontal' } do |f|
-  -if @hook.errors.any?
-    .alert.alert-danger
-      - @hook.errors.full_messages.each do |msg|
-        %p= msg
-  .form-group
-    = f.label :url, "URL:", class: 'control-label'
-    .col-sm-10
-      = f.text_field :url, class: "form-control"
+  = f.text_field :url, label: 'URL'
+
   .form-actions
-    = f.submit "Add System Hook", class: "btn btn-create"
+    = f.submit 'Add System Hook', class: 'btn btn-create'
+
 %hr
 
 -if @hooks.any?

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -4,36 +4,20 @@
 .row
   %aside.col-md-3
     .admin-filter
-      = form_tag admin_namespaces_projects_path, method: :get, class: '' do
-        .form-group
-          = label_tag :name, 'Name:'
-          = text_field_tag :name, params[:name], class: "form-control"
-
-        .form-group
-          = label_tag :namespace_id, "Namespace"
+      = bootstrap_form_tag url: admin_namespaces_projects_path, method: :get do |f|
+        = f.text_field :name, value: params[:name]
+        = f.form_group label: { text: 'Namespace' } do
           = namespace_select_tag :namespace_id, selected: params[:namespace_id], class: 'input-large'
 
-        .form-group
-          %strong Activity
-          .checkbox
-            = label_tag :with_push do
-              = check_box_tag :with_push, 1, params[:with_push]
-              %span Projects with push events
-          .checkbox
-            = label_tag :abandoned do
-              = check_box_tag :abandoned, 1, params[:abandoned]
-              %span No activity over 6 month
+        = f.form_group label: { text: 'Activity' } do
+          = f.check_box :with_push, name: :with_push, label: 'Projects with push events', checked: params[:with_push]
+          = f.check_box :abandoned, name: :abandoned, label: 'No activity over 6 month', checked: params[:abandoned]
 
-        %fieldset
-          %strong Visibility level:
-          .visibility-levels
-            - Project.visibility_levels.each do |label, level|
-              .checkbox
-                %label
-                  = check_box_tag 'visibility_levels[]', level, params[:visibility_levels].present? && params[:visibility_levels].include?(level.to_s)
-                  %span.descr
-                    = visibility_level_icon(level)
-                    = label
+        = f.form_group label: { text: 'Visibility level' } do
+          - Project.visibility_levels.each do |label, level|
+            -# TODO: Put back `visibility_level_icon(level)`
+            = f.check_box :visibility_levels, name: 'visibility_levels[]', label: label, value: level, checked: params[:visibility_levels].present? && params[:visibility_levels].include?(level.to_s)
+
         %hr
         = hidden_field_tag :sort, params[:sort]
         = button_tag "Search", class: "btn submit btn-primary"

--- a/app/views/admin/projects/show.html.haml
+++ b/app/views/admin/projects/show.html.haml
@@ -85,15 +85,13 @@
       .panel-heading
         Transfer project
       .panel-body
-        = form_for @project, url: transfer_admin_namespace_project_path(@project.namespace, @project), method: :put, html: { class: 'form-horizontal' } do |f|
-          .form-group
-            = f.label :new_namespace_id, "Namespace", class: 'control-label'
-            .col-sm-10
-              = namespace_select_tag :new_namespace_id, selected: params[:namespace_id], class: 'input-large'
+        = bootstrap_form_for @project, url: transfer_admin_namespace_project_path(@project.namespace, @project), method: :put, layout: :horizontal do |f|
 
-          .form-group
-            .col-sm-offset-2.col-sm-10
-              = f.submit 'Transfer', class: 'btn btn-primary'
+          = f.form_group :new_namespace_id, label: { text: 'Namespace' } do
+            = namespace_select_tag :new_namespace_id, selected: params[:namespace_id], class: 'input-large'
+
+          = f.form_group do
+            = f.submit 'Transfer', class: 'btn btn-primary'
 
   .col-md-6
     - if @group

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -1,90 +1,49 @@
 .user_new
-  = form_for [:admin, @user], html: { class: 'form-horizontal fieldset-form' } do |f|
-    -if @user.errors.any?
-      #error_explanation
-        .alert.alert-danger
-          - @user.errors.full_messages.each do |msg|
-            %p= msg
+  = bootstrap_form_for [:admin, @user], layout: :horizontal, html: { class: 'fieldset-form' } do |f|
+    = f.alert_message 'Please check your form for possible errors.'
 
     %fieldset
       %legend Account
-      .form-group
-        = f.label :name, class: 'control-label'
-        .col-sm-10
-          = f.text_field :name, required: true, autocomplete: "off", class: 'form-control'
-          %span.help-inline * required
-      .form-group
-        = f.label :username, class: 'control-label'
-        .col-sm-10
-          = f.text_field :username, required: true, autocomplete: "off", class: 'form-control'
-          %span.help-inline * required
-      .form-group
-        = f.label :email, class: 'control-label'
-        .col-sm-10
-          = f.text_field :email, required: true, autocomplete: "off", class: 'form-control'
-          %span.help-inline * required
+      = f.text_field :name, required: true, autocomplete: 'off'
+      = f.text_field :username, required: true, autocomplete: 'off'
+      = f.text_field :email, required: true, autocomplete: 'off'
 
     - if @user.new_record?
       %fieldset
         %legend Password
-        .form-group
-          = f.label :password, class: 'control-label'
-          .col-sm-10
-            %strong
-              Reset link will be generated and sent to the user.
-              %br
-              User will be forced to set the password on first sign in.
+        = f.static_control :password do
+          %strong
+            Reset link will be generated and sent to the user.
+            %br
+            User will be forced to set the password on first sign in.
+
     - else
       %fieldset
         %legend Password
-        .form-group
-          = f.label :password, class: 'control-label'
-          .col-sm-10= f.password_field :password, disabled: f.object.force_random_password, class: 'form-control'
-        .form-group
-          = f.label :password_confirmation, class: 'control-label'
-          .col-sm-10= f.password_field :password_confirmation, disabled: f.object.force_random_password, class: 'form-control'
+        = f.password_field :password, disabled: f.object.force_random_password
+        = f.password_field :password_confirmation, disabled: f.object.force_random_password
 
     %fieldset
       %legend Access
-      .form-group
-        = f.label :projects_limit, class: 'control-label'
-        .col-sm-10= f.number_field :projects_limit, class: 'form-control'
+      = f.number_field :projects_limit
+      = f.form_group :can_create_group, label: { text: 'Can create group' } do
+        = f.check_box :can_create_group
 
-      .form-group
-        = f.label :can_create_group, class: 'control-label'
-        .col-sm-10= f.check_box :can_create_group
+      = f.form_group :admin, label: { text: 'Admin' },  help: current_user == @user ? 'You cannot remove your own admin rights' : '' do
+        = f.check_box :admin, disabled: current_user == @user
 
-      .form-group
-        = f.label :admin, class: 'control-label'
-        - if current_user == @user
-          .col-sm-10= f.check_box :admin, disabled: true
-          .col-sm-10 You cannot remove your own admin rights
-        - else
-          .col-sm-10= f.check_box :admin
     %fieldset
       %legend Profile
-      .form-group
-        = f.label :avatar, class: 'control-label'
-        .col-sm-10
-          = f.file_field :avatar
-
-      .form-group
-        = f.label :skype, class: 'control-label'
-        .col-sm-10= f.text_field :skype, class: 'form-control'
-      .form-group
-        = f.label :linkedin, class: 'control-label'
-        .col-sm-10= f.text_field :linkedin, class: 'form-control'
-      .form-group
-        = f.label :twitter, class: 'control-label'
-        .col-sm-10= f.text_field :twitter, class: 'form-control'
-      .form-group
-        = f.label :website_url, 'Website', class: 'control-label'
-        .col-sm-10= f.text_field :website_url, class: 'form-control'
+      = f.file_field :avatar
+      = f.text_field :skype
+      = f.text_field :linkedin
+      = f.text_field :twitter
+      = f.text_field :website_url
 
     .form-actions
       - if @user.new_record?
-        = f.submit 'Create user', class: "btn btn-create"
-        = link_to 'Cancel', admin_users_path, class: "btn btn-cancel"
+        = f.submit 'Create user', class: 'btn btn-create'
+        = link_to 'Cancel', admin_users_path, class: 'btn btn-cancel'
       - else
-        = f.submit 'Save changes', class: "btn btn-save"
-        = link_to 'Cancel', admin_user_path(@user), class: "btn btn-cancel"
+        = f.submit 'Save changes', class: 'btn btn-save'
+        = link_to 'Cancel', admin_user_path(@user), class: 'btn btn-cancel'

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -30,9 +30,8 @@
             Without projects
             %small.pull-right= User.without_projects.count
       %hr
-      = form_tag admin_users_path, method: :get, class: 'form-inline' do
-        .form-group
-          = search_field_tag :name, params[:name], placeholder: 'Name, email or username', class: 'form-control'
+      = bootstrap_form_tag url: admin_users_path, method: :get, layout: :inline do |f|
+        = f.search_field :name, value: params[:name], hide_label: true, placeholder: 'Name, email or username'
         = button_tag class: 'btn btn-primary' do
           %i.fa.fa-search
       %hr

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -3,24 +3,22 @@
     %strong= @group.name
     group settings:
   .panel-body
-    = form_for @group, html: { multipart: true, class: "form-horizontal" }, authenticity_token: true do |f|
-      - if @group.errors.any?
-        .alert.alert-danger
-          %span= @group.errors.full_messages.first
+    = bootstrap_form_for @group, layout: :horizontal, html: { multipart: true }, authenticity_token: true do |f|
+      = f.alert_message 'Please check your form for possible errors.'
+
       = render 'shared/group_form', f: f
 
-      .form-group
-        .col-sm-offset-2.col-sm-10
-          = image_tag group_icon(@group), alt: '', class: 'avatar group-avatar s160'
-          %p.light
-            - if @group.avatar?
-              You can change your group avatar here
-            - else
-              You can upload a group avatar here
-          = render 'shared/choose_group_avatar_button', f: f
+      = f.form_group :avatar, label: { text: 'Group avatar' } do
+        = image_tag group_icon(@group), alt: '', class: 'avatar group-avatar s160'
+        %p.light
           - if @group.avatar?
-            %hr
-            = link_to 'Remove avatar', group_avatar_path(@group.to_param), data: { confirm: "Group avatar will be removed. Are you sure?"}, method: :delete, class: "btn btn-remove btn-sm remove-avatar"
+            You can change your group avatar here
+          - else
+            You can upload a group avatar here
+        = render 'shared/choose_group_avatar_button', f: f
+        - if @group.avatar?
+          %hr
+          = link_to 'Remove avatar', group_avatar_path(@group.to_param), data: { confirm: "Group avatar will be removed. Are you sure?"}, method: :delete, class: "btn btn-remove btn-sm remove-avatar"
 
       .form-actions
         = f.submit 'Save group', class: "btn btn-save"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,20 +1,15 @@
 - page_title    'New Group'
 - header_title  'New Group'
-= form_for @group, html: { class: 'group-form form-horizontal' } do |f|
-  - if @group.errors.any?
-    .alert.alert-danger
-      %span= @group.errors.full_messages.first
+= bootstrap_form_for @group, layout: :horizontal do |f|
+  = f.alert_message 'Please check your form for possible errors.'
 
   = render 'shared/group_form', f: f, autofocus: true
 
-  .form-group.group-description-holder
-    = f.label :avatar, "Group avatar", class: 'control-label'
-    .col-sm-10
-      = render 'shared/choose_group_avatar_button', f: f
+  = f.form_group :avatar, label: { text: 'Group avatar' } do
+    = render 'shared/choose_group_avatar_button', f: f
 
-  .form-group
-    .col-sm-offset-2.col-sm-10
-      = render 'shared/group_tips'
+  = f.static_control label: 'Group tips', hide_label: true do
+    = render 'shared/group_tips'
 
   .form-actions
-    = f.submit 'Create group', class: "btn btn-create", tabindex: 3
+    = f.submit 'Create group', class: 'btn btn-create'

--- a/app/views/shared/_choose_group_avatar_button.html.haml
+++ b/app/views/shared/_choose_group_avatar_button.html.haml
@@ -3,5 +3,5 @@
   %span Choose File ...
 &nbsp;
 %span.file_name.js-avatar-filename File name...
-= f.file_field :avatar, class: 'js-group-avatar-input hidden'
+= f.file_field_without_bootstrap :avatar, class: 'js-group-avatar-input hidden'
 .light The maximum file size allowed is 200KB.

--- a/app/views/shared/_field.html.haml
+++ b/app/views/shared/_field.html.haml
@@ -7,18 +7,15 @@
 - default_choice = field[:default_choice]
 - help = field[:help]
 
-.form-group
-  = form.label name, title, class: "control-label"
-  .col-sm-10
-    - if type == 'text'
-      = form.text_field name, class: "form-control", placeholder: placeholder
-    - elsif type == 'textarea'
-      = form.text_area name, rows: 5, class: "form-control", placeholder: placeholder
-    - elsif type == 'checkbox'
-      = form.check_box name
-    - elsif type == 'select'
-      = form.select name, options_for_select(choices, value ? value : default_choice), {}, { class: "form-control" }
-    - elsif type == 'password'
-      = form.password_field name, placeholder: value, class: 'form-control'
-    - if help
-      %span.help-block= help
+- case type
+- when 'textarea'
+  = form.text_area name, label: title, help: help, rows: 5, placeholder: placeholder
+- when 'checkbox'
+  = form.form_group name, label: { text: title }, help: help do
+    = form.check_box name, label: title
+- when 'select'
+  = form.select name, options_for_select(choices, value ? value : default_choice), { label: title, help: help }, {}
+- when 'password'
+  = form.password_field name, label: title, help: help
+- else
+  = form.text_field name, label: title, help: help, placeholder: placeholder

--- a/app/views/shared/_group_form.html.haml
+++ b/app/views/shared/_group_form.html.haml
@@ -1,29 +1,15 @@
 - if @group.persisted?
-  .form-group
-    = f.label :name, class: 'control-label' do
-      Group name
-    .col-sm-10
-      = f.text_field :name, placeholder: 'open-source', class: 'form-control'
+  = f.text_field :name, label: 'Group name', placeholder: 'open-source'
 
-.form-group
-  = f.label :path, class: 'control-label' do
-    Group path
-  .col-sm-10
-    .input-group
-      .input-group-addon
-        = root_url
-      = f.text_field :path, placeholder: 'open-source', class: 'form-control',
-          autofocus: local_assigns[:autofocus] || false
-    - if @group.persisted?
-      .alert.alert-warning.prepend-top-10
-        %ul
-          %li Changing group path can have unintended side effects.
-          %li Renaming group path will rename directory for all related projects
-          %li It will change web url for access group and group projects.
-          %li It will change the git path to repositories under this group.
+= f.text_field :path, label: 'Group path', placeholder: 'open-source', prepend: root_url, autofocus: local_assigns[:autofocus] || false
 
-.form-group.group-description-holder
-  = f.label :description, 'Details', class: 'control-label'
-  .col-sm-10
-    = f.text_area :description, maxlength: 250,
-        class: 'form-control js-gfm-input', rows: 4
+- if @group.persisted?
+  = f.form_group do
+    .alert.alert-warning.prepend-top-10
+      %ul
+        %li Changing group path can have unintended side effects.
+        %li Renaming group path will rename directory for all related projects
+        %li It will change web url for access group and group projects.
+        %li It will change the git path to repositories under this group.
+
+= f.text_area :description, label: 'Details', maxlength: 250, class: 'js-gfm-input', rows: 4


### PR DESCRIPTION
This PR is related to #8470.

The goal is to use `rails-bootstrap-form` gem to simplify form rendering on bootstrap.

To do:
- [x] Install rails-bootstrap-form gem
- [ ] Rewrite all form rendering with bootstrap-form helpers (**admin section only** for the moment, next with another pull requests)
- [ ] Wait for `btn-group` forms management: bootstrap-ruby/rails-bootstrap-forms#132
- [ ] Wait "HTML help block" issue answer: https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/211. Concern those forms:
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/applications/_form.html.haml#L17-L21
- [ ] Wait "Static control without label" issue answer: https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/212. Concern those forms:
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/broadcast_messages/index.html.haml#L14-L20
- [ ] Wait "Unwanted space with hide_label option on inline form" answer: https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/214. Concern those forms:
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/groups/show.html.haml#L61-L67
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/users/index.html.haml#L24-L28
- [ ] Wait "Unwanted hidden input on check_box helper with bootstrap_form_tag" answer: https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/215. Concern those forms:
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/projects/index.html.haml#L6-L24
- [ ] Wait "Ability to create radio button without label?" answer: https://github.com/bootstrap-ruby/rails-bootstrap-forms/issues/161. Concern those forms:
  - https://github.com/gitlabhq/gitlabhq/blob/master/app/views/admin/services/_form.html.haml
- [ ] Fix weird css issue: https://github.com/gitlabhq/gitlabhq/pull/9055#issuecomment-88881347
- [ ] Fix bad visibility form rendering on application settings: https://github.com/gitlabhq/gitlabhq/pull/9055#issuecomment-120387485
- [ ] Add some notes on UI best practices documentation [form_for / form_tag / alert_messages / f.primary]
- [ ] All tests should be green
- [ ] Update CHANGELOG file

Pending questions:
- Should we remove `.form-fieldset` class and add padding by default on `fieldset` element?
- Is the new form error rendering correct?
- Can Rubocop have custom rules detection? Could be useful to have a `form_for` usage detection, isn't it? (make `bootstrap_form_for` required. Use `text_field_without_bootstrap` is necessary)
- Should I use static control field for special subforms? (https://github.com/gitlabhq/gitlabhq/pull/9055#issuecomment-87835413)
  - No, use `form_group` instead.
- OK for using required label css trick? (https://github.com/gitlabhq/gitlabhq/pull/9055#issuecomment-89258863)

Externals links:
- https://github.com/bootstrap-ruby/rails-bootstrap-forms

Please tell me if I have some other task to do on this subject.

Thanks.
