### PR TITLE
Fix merge errors on CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,7 @@ v 7.10.0 (unreleased)
   - Set Application controller default URL options to ensure all url_for calls are consistent (Stan Hu)
   - Allow HTML tags in Markdown input
   - Fix code unfold not working on Compare commits page (Stan Hu)
-  - Include missing events and fix save functionality in admin service template settings form (Stan Hu)
-  - Fix "Import projects from" button to show the correct instructions (Stan Hu)
   - Fix dots in Wiki slugs causing errors (Stan Hu)
-  - Fix OAuth2 issue importing a new project from GitHub and GitLab (Stan Hu)
   - Update poltergeist to version 1.6.0 to support PhantomJS 2.0 (Zeger-Jan van de Weg)
   - Fix cross references when usernames, milestones, or project names contain underscores (Stan Hu)
   - Disable reference creation for comments surrounded by code/preformatted blocks (Stan Hu)
@@ -39,7 +36,6 @@ v 7.10.0 (unreleased)
   - Add ability to unlink connected accounts
   - Replace commits calendar with faster contribution calendar that includes issues and merge requests
   - Add inifinite scroll to user page activity
-  - Don't show commit comment button when user is not signed in.
   - Don't include system notes in issue/MR comment count.
   - Don't mark merge request as updated when merge status relative to target branch changes.
   - Link note avatar to user.
@@ -51,12 +47,19 @@ v 7.10.0 (unreleased)
   - Prevent holding Control-Enter or Command-Enter from posting comment multiple times.
   - Prevent note form from being cleared when submitting failed.
   - Improve file icons rendering on tree (Sullivan Sénéchal)
-
-v 7.9.0
   - Send EmailsOnPush email when branch or tag is created or deleted.
   - Faster merge request processing for large repository
   - Prevent doubling AJAX request with each commit visit via Turbolink
   - Prevent unnecessary doubling of js events on import pages and user calendar
+
+v 7.9.1
+  - Include missing events and fix save functionality in admin service template settings form (Stan Hu)
+  - Fix "Import projects from" button to show the correct instructions (Stan Hu)
+  - Fix OAuth2 issue importing a new project from GitHub and GitLab (Stan Hu)
+  - Fix for LDAP with commas in DN
+  - Fix missing events and in admin Slack service template settings form (Stan Hu)
+  - Don't show commit comment button when user is not signed in.
+  - Downgrade gemnasium-gitlab-service gem
 
 v 7.9.0
   - Add HipChat integration documentation (Stan Hu)


### PR DESCRIPTION
During merges (d554070a and 497fd75d) changelog was "damaged", I restored the tagged 7.9.1 and added the required changes about 7.10.0 (unreleased). I think we need to ensure all PR are rebased on master before merge.
