### PR TITLE
do not send empty message to hipchat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ v 7.11.0 (unreleased)
   -
   -
   - Improve new project command options (Ben Bodenmiller)
+  - Prevent sending empty messages to HipChat (Chulki Lee)
 
 v 7.10.0 (unreleased)
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/app/models/project_services/hipchat_service.rb
+++ b/app/models/project_services/hipchat_service.rb
@@ -50,8 +50,9 @@ class HipchatService < Service
 
   def execute(data)
     return unless supported_events.include?(data[:object_kind])
-
-    gate[room].send('GitLab', create_message(data))
+    message = create_message(data)
+    return unless message.present?
+    gate[room].send('GitLab', message)
   end
 
   private


### PR DESCRIPTION
hipchat gem does not handle nil or empty message, which will result in 400 error.
