### PR TITLE
Ensure that the first added admin performs repository imports

### DIFF
--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -35,7 +35,7 @@ namespace :gitlab do
         if project
           puts " * #{project.name} (#{repo_path}) exists"
         else
-          user = User.admins.first
+          user = User.admins.reorder("id").first
 
           project_params = {
             name: name,


### PR DESCRIPTION
A little change to ensure that the older administrator account is used for imports.  Typically this is the root account which often makes the most sense when performing an action from the CLI.

I noticed this problem after I imported some repositories and they were owned by our newest admin instead of root.

Thanks for your help!
Fotis
