### PR TITLE
Disable turbolinks for omniauth link to avoid rendering problems

### DIFF
--- a/app/views/devise/shared/_omniauth_box.html.haml
+++ b/app/views/devise/shared/_omniauth_box.html.haml
@@ -7,4 +7,4 @@
       - if default_providers.include?(provider)
         = link_to oauth_image_tag(provider), omniauth_authorize_path(resource_name, provider), class: 'oauth-image-link'
       - else
-        = link_to provider.to_s.titleize, omniauth_authorize_path(resource_name, provider), class: "btn"
+        = link_to provider.to_s.titleize, omniauth_authorize_path(resource_name, provider), class: "btn", "data-no-turbolink" => "true"


### PR DESCRIPTION
This is a rather important fix for omniauth.  When using a 3rd party provider like Crowd, the omniauth login page loads without proper styling due to turbolink.

As such, this pull requests simply disables turbolink for this particular link.

Cheers
Fotis
