### PR TITLE
Tweak issue page a bit 

### DIFF
--- a/app/assets/stylesheets/pages/issues.scss
+++ b/app/assets/stylesheets/pages/issues.scss
@@ -25,17 +25,8 @@
       display: inline-block;
     }
 
-    .issue-actions {
-      display: none;
-      position: absolute;
-      top: 10px;
-      right: 15px;
-    }
-
-    &:hover {
-      .issue-actions {
-        display: block;
-      }
+    .issue-no-comments {
+      opacity: 0.5;
     }
   }
 }

--- a/app/assets/stylesheets/pages/merge_requests.scss
+++ b/app/assets/stylesheets/pages/merge_requests.scss
@@ -91,11 +91,16 @@
     .merge-request-info {
       color: #999;
       font-size: 13px;
-
-      .merge-request-labels {
-        display: inline-block;
-      }
     }
+
+  }
+
+  .merge-request-labels {
+    display: inline-block;
+  }
+
+  .merge-request-no-comments {
+    opacity: 0.5;
   }
 }
 

--- a/app/views/projects/issues/_issue.html.haml
+++ b/app/views/projects/issues/_issue.html.haml
@@ -6,24 +6,34 @@
   .issue-title
     %span.str-truncated
       = link_to_gfm issue.title, issue_path(issue), class: "row_title"
+    .issue-labels
+      - issue.labels.each do |label|
+        = link_to namespace_project_issues_path(issue.project.namespace, issue.project, label_name: label.name) do
+          = render_colored_label(label)
     .pull-right.light
       - if issue.closed?
         %span
           CLOSED
+      - if issue.assignee
+        = link_to_member(@project, issue.assignee, name: false)
       - note_count = issue.notes.user.count
       - if note_count > 0
         &nbsp;
         %span
           %i.fa.fa-comments
           = note_count
+      - else
+        &nbsp;
+        %span.issue-no-comments
+          %i.fa.fa-comments
+          = 0
 
   .issue-info
-    = link_to "##{issue.iid}", issue_path(issue), class: "light"
-    - if issue.assignee
-      assigned to #{link_to_member(@project, issue.assignee)}
+    = "##{issue.iid} opened #{time_ago_with_tooltip(issue.created_at, 'bottom')} by #{link_to_member(@project, issue.author, avatar: false)}".html_safe
     - if issue.votes_count > 0
       = render 'votes/votes_inline', votable: issue
     - if issue.milestone
+      &nbsp;
       %span
         %i.fa.fa-clock-o
         = issue.milestone.title
@@ -33,20 +43,3 @@
 
     .pull-right.issue-updated-at
       %small updated #{time_ago_with_tooltip(issue.updated_at, 'bottom', 'issue_update_ago')}
-
-    .issue-labels
-      - issue.labels.each do |label|
-        = link_to namespace_project_issues_path(issue.project.namespace, issue.project, label_name: label.name) do
-          = render_colored_label(label)
-
-  .issue-actions
-    - if can? current_user, :modify_issue, issue
-      - if issue.closed?
-        = link_to 'Reopen', issue_path(issue, issue: {state_event: :reopen }, status_only: true), method: :put,  class: "btn btn-sm btn-grouped reopen_issue btn-reopen", remote: true
-      - else
-        = link_to 'Close', issue_path(issue, issue: {state_event: :close }, status_only: true), method: :put, class: "btn btn-sm btn-grouped close_issue btn-close", remote: true
-      = link_to edit_namespace_project_issue_path(issue.project.namespace, issue.project, issue), class: "btn btn-sm edit-issue-link btn-grouped" do
-        %i.fa.fa-pencil-square-o
-        Edit
-
-

--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -2,6 +2,10 @@
   .merge-request-title
     %span.str-truncated
       = link_to_gfm merge_request.title, merge_request_path(merge_request), class: "row_title"
+    .merge-request-labels
+      - merge_request.labels.each do |label|
+        = link_to namespace_project_merge_requests_path(merge_request.project.namespace, merge_request.project, label_name: label.name) do
+          = render_colored_label(label)
     .pull-right.light
       - if merge_request.merged?
         %span
@@ -17,20 +21,26 @@
             %i.fa.fa-code-fork
             %span= merge_request.target_branch
       - note_count = merge_request.mr_and_commit_notes.user.count
+      - if merge_request.assignee
+        &nbsp;
+        = link_to_member(merge_request.source_project, merge_request.assignee, name: false)
       - if note_count > 0
         &nbsp;
         %span
           %i.fa.fa-comments
           = note_count
+      - else
+        &nbsp;
+        %span.merge-request-no-comments
+          %i.fa.fa-comments
+          = 0
+
   .merge-request-info
-    = link_to "##{merge_request.iid}", merge_request_path(merge_request), class: "light"
-    - if merge_request.assignee
-      assigned to #{link_to_member(merge_request.source_project, merge_request.assignee)}
-    - else
-      Unassigned
+    = "##{merge_request.iid} opened #{time_ago_with_tooltip(merge_request.created_at, 'bottom')} by #{link_to_member(@project, merge_request.author, avatar: false)}".html_safe
     - if merge_request.votes_count > 0
       = render 'votes/votes_inline', votable: merge_request
     - if merge_request.milestone_id?
+      &nbsp;
       %span
         %i.fa.fa-clock-o
         = merge_request.milestone.title
@@ -38,11 +48,5 @@
       %span.task-status
         = merge_request.task_status
 
-
     .pull-right.hidden-xs
       %small updated #{time_ago_with_tooltip(merge_request.updated_at, 'bottom', 'merge_request_updated_ago')}
-
-    .merge-request-labels
-      - merge_request.labels.each do |label|
-        = link_to namespace_project_merge_requests_path(merge_request.project.namespace, merge_request.project, label_name: label.name) do
-          = render_colored_label(label)

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -21,7 +21,7 @@ describe 'Issues', feature: true do
     end
 
     before do
-      visit namespace_project_issues_path(project.namespace, project)
+      visit edit_namespace_project_issue_path(project.namespace, project, issue)
       click_link "Edit"
     end
 


### PR DESCRIPTION
<del>**I pulled from gitlab.com so there are more commits then I intended to. When master is up to date this pull request should be okay.**
- Include creation time
- Include author without avatar
- Move assignee to the right
- Remove action buttons. IMO they are useless and a bit annoying
- Include comments counter by default, gray it out when there are 0 comments.
- Include opened/closed icons before the title
- Gray out closed issues

![screenshot from 2015-03-31 17-14-35](https://cloud.githubusercontent.com/assets/1961699/6922402/26815e52-d7cb-11e4-8d06-33e9efcb94d5.png)

![screenshot from 2015-03-31 17-15-51](https://cloud.githubusercontent.com/assets/1961699/6922407/2ead9bb8-d7cb-11e4-8d7c-33d7f8956e18.png)
