### PR TITLE
Fix #6417: users with group permission should be able to create groups via API

### DIFF
--- a/doc/api/groups.md
+++ b/doc/api/groups.md
@@ -35,7 +35,7 @@ Parameters:
 
 ## New group
 
-Creates a new project group. Available only for admin.
+Creates a new project group. Available only for users who can create groups.
 
 ```
 POST /groups

--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -20,7 +20,7 @@ module API
         present @groups, with: Entities::Group
       end
 
-      # Create group. Available only for admin
+      # Create group. Available only for users who can create groups.
       #
       # Parameters:
       #   name (required) - The name of the group
@@ -28,7 +28,7 @@ module API
       # Example Request:
       #   POST /groups
       post do
-        authenticated_as_admin!
+        authorize! :create_group, current_user
         required_attributes! [:name, :path]
 
         attrs = attributes_for_keys [:name, :path, :description]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,6 +22,7 @@ FactoryGirl.define do
     password "12345678"
     confirmed_at { Time.now }
     confirmation_token { nil }
+    can_create_group true
 
     trait :admin do
       admin true


### PR DESCRIPTION
This is updated and slightly modified patch from #7529 that fixes #6417.
