### PR TITLE
Inform "per_page" and "page" default values

### DIFF
--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -4,7 +4,7 @@
 
 Get all merge requests for this project. 
 The `state` parameter can be used to get only merge requests with a given state (`opened`, `closed`, or `merged`) or all of them (`all`). 
-The pagination parameters `page` and `per_page` can be used to restrict the list of merge requests.
+The pagination parameters `page` (default value `1`) and `per_page` (default value `20`) can be used to restrict the list of merge requests.
 
 ```
 GET /projects/:id/merge_requests


### PR DESCRIPTION
Inform the default values of the parameters "per_page" and "page". If this information is not explicit, the developers could lose a considerable amount of time wondering why a specific merge request is not being returned (specifically the 21st).
