### PR TITLE
Bootlint integration

### DIFF
--- a/app/views/layouts/_bootlint.haml
+++ b/app/views/layouts/_bootlint.haml
@@ -1,0 +1,4 @@
+:javascript
+  jQuery(document).ready(function() {
+    javascript:(function(){var s=document.createElement("script");s.onload=function(){bootlint.showLintReportForCurrentDocument([], {hasProblems: false, problemFree: false});};s.src="https://maxcdn.bootstrapcdn.com/bootlint/latest/bootlint.min.js";document.body.appendChild(s)})();
+  });

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -16,6 +16,7 @@
 
   = render 'layouts/google_analytics' if extra_config.has_key?('google_analytics_id')
   = render 'layouts/piwik' if extra_config.has_key?('piwik_url') && extra_config.has_key?('piwik_site_id')
+  = render 'layouts/bootlint' if Rails.env == 'development'
 
   -# Atom feed
   - if current_user


### PR DESCRIPTION
As Gitlab theme is based on Twitter Bootstrap, it could be useful to have bootlint on dev env in order to fix and optimize bootstrap integration.

> Bootlint is a tool that checks for several common HTML mistakes in webpages that are using Bootstrap in a fairly "vanilla" way. Vanilla Bootstrap's components/widgets require their parts of the DOM to conform to certain structures. Bootlint checks that instances of Bootstrap components have correctly-structured HTML. Optimal usage of Bootstrap also requires that your pages include certain <meta> tags, an HTML5 doctype declaration, etc.; Bootlint checks that these are present.

Related repository: https://github.com/twbs/bootlint

Bootlint will produce error and warning on chrome debugger.

I disable alert notification to not be so annoyed while working onto another fix/feature.

What do you think?

Thanks.
