### PR TITLE
Fix event-title max-width in the dashboard

### DIFF
--- a/app/assets/stylesheets/pages/events.scss
+++ b/app/assets/stylesheets/pages/events.scss
@@ -45,7 +45,8 @@
   padding: 12px 0px;
   border-bottom: 1px solid #eee;
   .event-title {
-    @include str-truncated(72%);
+    max-width: 70%;
+    @include str-truncated(calc(100% - 174px));
     font-weight: 500;
     font-size: 14px;
     .author_name {


### PR DESCRIPTION
For view port sizes between 1260px and 1200px pixels the event-title was
too wide, thus not truncated and got pushed into a second line.

100% - 174px was chosen as the max-width because 141px is the widest
.event-item-timestamp can get (with 'less than a minute ago') + 24px for
the avatar + 8px avatar margin + 1px to fit into the gap.

Before:
![before](https://cloud.githubusercontent.com/assets/20943/6953629/df4ab348-d8ca-11e4-8592-557d23a4abd0.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/20943/6953631/e53b5320-d8ca-11e4-9559-5ae7a530052a.jpg)

For browsers that do not support `calc`, 70% width is the widest possible percentage value which prevents the title from wrapping into the second line.
