### PR TITLE
Fix Resource Owner Password Authentication Flow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -101,7 +101,8 @@ v 7.10.0 (unreleased)
   - Remove truncation from issue titles on milestone page (Jason Blanchard)
   - Fix stuck Merge Request merging events from old installations (Ben Bodenmiller)
   - Fix merge request comments on files with multiple commits
-
+  - Fix Resource Owner Password Authentication Flow
+  
 v 7.9.4
   - Security: Fix project import URL regex to prevent arbitary local repos from being imported
   - Fixed issue where only 25 commits would load in file listings

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do |routes|
-    u = User.find_by(email: params[:username])
+    u = User.find_by(email: params[:username]) || User.find_by(username: params[:username])
     u if u && u.valid_password?(params[:password])
   end
 
@@ -83,7 +83,7 @@ Doorkeeper.configure do
   #
   # If not specified, Doorkeeper enables all the four grant flows.
   #
-  # grant_flows %w(authorization_code implicit password client_credentials)
+  grant_flows %w(authorization_code password client_credentials)
 
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.


### PR DESCRIPTION
As per the documentation here:
<code>https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Resource-Owner-Password-Credentials-flow</code>
to make "password" type grant_flow work once should add
<code>Doorkeeper.configuration.token_grant_types << "password"</code>
after Doorkeeper.configure do block

I have also added a check against username field such that OAUTH can be used with both email and username field.
