### PR TITLE
Remove slash add underscore

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -224,9 +224,9 @@ class Project < ActiveRecord::Base
     end
 
     def find_with_namespace(id)
-      return nil unless id.include?('/')
+      return nil unless id.include?('_')
 
-      id = id.split('/')
+      id = id.split('_')
       namespace = Namespace.find_by(path: id.first)
       return nil unless namespace
 

--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -142,8 +142,8 @@ Parameters:
 
 ### Get single project
 
-Get a specific project, identified by project ID or NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
-If using namespaced projects call make sure that the NAMESPACE/PROJECT_NAME is URL-encoded, eg. `/api/v3/projects/diaspora%2Fdiaspora` (where `/` is represented by `%2F`).
+Get a specific project, identified by project ID or NAMESPACE_PROJECT_NAME, which is owned by the authenticated user.
+If using namespaced projects call make sure that the NAMESPACE_PROJECT_NAME is URL-encoded, eg. `/api/v3/projects/diaspora_diaspora` .
 
 ```
 GET /projects/:id
@@ -151,7 +151,7 @@ GET /projects/:id
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE_PROJECT_NAME of a project
 
 ```json
 {
@@ -213,7 +213,7 @@ GET /projects/:id/events
 
 Parameters:
 
-- `id` (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- `id` (required) - The ID or NAMESPACE_PROJECT_NAME of a project
 
 ```json
 [


### PR DESCRIPTION
Using NAMESPACE/PROJECT_NAME causes problems in apache and needs <code>AllowEncodedSlashes NoDecode</code> parameter enabled in vhost configuration file of apache. In worst case sometimes just enabling this parameter doesn't work.

To avoid this situation i used a different separator  _ (underscore) to make things for simple
