### PR TITLE
remove extra scrollbar on background jobs tab

### DIFF
--- a/app/views/admin/background_jobs/show.html.haml
+++ b/app/views/admin/background_jobs/show.html.haml
@@ -41,4 +41,4 @@
 
 
 .panel.panel-default
-  %iframe{src: sidekiq_path, width: '100%', height: 900, style: "border: none"}
+  %iframe{src: sidekiq_path, width: '100%', height: 970, style: "border: none"}


### PR DESCRIPTION
Expand iframe height to fit full sidekiq dashboard

Before:
![image](https://cloud.githubusercontent.com/assets/1192780/6992633/05c51a94-da8e-11e4-980c-aadb3cf96750.png)

After:
![image](https://cloud.githubusercontent.com/assets/1192780/6992636/276bc42c-da8e-11e4-8d92-f33053818a4a.png)
