### PR TITLE
improve new project options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v 7.11.0 (unreleased)
   -
   -
   -
+  - Improve new project command options (Ben Bodenmiller)
 
 v 7.10.0 (unreleased)
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/app/views/projects/empty.html.haml
+++ b/app/views/projects/empty.html.haml
@@ -27,20 +27,19 @@
     %legend Create a new repository
     %pre.dark
       :preserve
-        mkdir #{@project.path}
+        git clone #{ content_tag(:span, default_url_to_repo, class: 'clone')}
         cd #{@project.path}
-        git init
         touch README.md
         git add README.md
-        git commit -m "first commit"
-        git remote add origin #{ content_tag(:span, default_url_to_repo, class: 'clone')}
+        git commit -m "add README"
         git push -u origin master
 
   %fieldset
-    %legend Push an existing Git repository
+    %legend Existing folder or Git repository
     %pre.dark
       :preserve
-        cd existing_git_repo
+        cd existing_folder
+        git init
         git remote add origin #{ content_tag(:span, default_url_to_repo, class: 'clone')}
         git push -u origin master
 


### PR DESCRIPTION
- Simplify new repo commands
- Include directions for how to add an existing folder that is either already a repo or not yet a repo

Replaces #7918.

Before:
![image](https://cloud.githubusercontent.com/assets/1192780/7036557/89638088-dd4b-11e4-8ddc-5b81637d4761.png)

After:
![image](https://cloud.githubusercontent.com/assets/1192780/7036660/2d521b6e-dd4c-11e4-82ca-f52f39be755f.png)

[No harm in initing an already inited repo](https://git-scm.herokuapp.com/docs/git-init):

> Running git init in an existing repository is safe. It will not overwrite things that are already there. 
