### PR TITLE
Fix issue9098 clean path

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -61,7 +61,7 @@ class Namespace < ActiveRecord::Base
     def clean_path(path)
       path.gsub!(/@.*\z/,             "")
       path.gsub!(/\.git\z/,           "")
-      path.gsub!(/\A-/,               "")
+      path.gsub!(/\A-+/,              "")
       path.gsub!(/\.+\z/,             "")
       path.gsub!(/[^a-zA-Z0-9_\-\.]/, "")
 

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -62,7 +62,7 @@ class Namespace < ActiveRecord::Base
       path.gsub!(/@.*\z/,             "")
       path.gsub!(/\.git\z/,           "")
       path.gsub!(/\A-/,               "")
-      path.gsub!(/\.\z/,              "")
+      path.gsub!(/\.+\z/,             "")
       path.gsub!(/[^a-zA-Z0-9_\-\.]/, "")
 
       counter = 0

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -62,7 +62,7 @@ class Namespace < ActiveRecord::Base
       path.gsub!(/@.*\z/,             "")
       path.gsub!(/\.git\z/,           "")
       path.gsub!(/\A-/,               "")
-      path.gsub!(/.\z/,               "")
+      path.gsub!(/\.\z/,              "")
       path.gsub!(/[^a-zA-Z0-9_\-\.]/, "")
 
       counter = 0


### PR DESCRIPTION
Namespace.clean_path removed the last character from generated usernames.
This is fixed along with two other changes to drop all trailing dots and all leading dashes (which is what the code most likely should have done).

Due to the ordering of the gsub statements the test in `spec/models/namespace_spec.rb:93` was successful, but only because the filtering for valid characters was done after dropping the last character.

Fixes: https://github.com/gitlabhq/gitlabhq/issues/9098
