### PR TITLE
Include creator_id in project info of API

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -63,6 +63,7 @@ Parameters:
     "snippets_enabled": false,
     "created_at": "2013-09-30T13: 46: 02Z",
     "last_activity_at": "2013-09-30T13: 46: 02Z",
+    "creator_id": 3,
     "namespace": {
       "created_at": "2013-09-30T13: 46: 02Z",
       "description": "",
@@ -103,6 +104,7 @@ Parameters:
     "snippets_enabled": false,
     "created_at": "2013-09-30T13:46:02Z",
     "last_activity_at": "2013-09-30T13:46:02Z",
+    "creator_id": 3,
     "namespace": {
       "created_at": "2013-09-30T13:46:02Z",
       "description": "",
@@ -190,6 +192,7 @@ Parameters:
   "snippets_enabled": false,
   "created_at": "2013-09-30T13: 46: 02Z",
   "last_activity_at": "2013-09-30T13: 46: 02Z",
+  "creator_id": 3,
   "namespace": {
     "created_at": "2013-09-30T13: 46: 02Z",
     "description": "",

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -54,6 +54,7 @@ module API
       expose :name, :name_with_namespace
       expose :path, :path_with_namespace
       expose :issues_enabled, :merge_requests_enabled, :wiki_enabled, :snippets_enabled, :created_at, :last_activity_at
+      expose :creator_id
       expose :namespace
       expose :forked_from_project, using: Entities::ForkedFromProject, if: lambda{ | project, options | project.forked? }
       expose :avatar_url


### PR DESCRIPTION
Hey guys,

I recently crawled over our Gitlab instance by using the API to find empty repositories to contact their creators to either fill them with live or to delete them. The owner wasn't always available as the projects were created inside a group, so I had no good information about the real creator.

I used one of the owners of the namespace to workaround it for now, but I propose to add the creator_id to the project info of the public API.

Since we're not deleting users from the tool, but only disable them this could also be sufficient to find out if a project's creator is not available anymore by simply getting the user through the API and fetching its status. If he was the only contributor, a project might get lost, because it won't be maintained anymore. With that little info you could eventually find new main contributor(s) for a project - or at least you would know that the initial creator isn't available anymore.

Cheers
