### PR TITLE
Gitlab -> GitLab

### DIFF
--- a/doc/markdown/markdown.md
+++ b/doc/markdown/markdown.md
@@ -421,7 +421,7 @@ Quote break.
 
 You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
 
-Note that inline HTML is disabled in the default Gitlab configuration, although it is [possible](https://github.com/gitlabhq/gitlabhq/pull/8007/commits) for the system administrator to enable it.
+Note that inline HTML is disabled in the default GitLab configuration, although it is [possible](https://github.com/gitlabhq/gitlabhq/pull/8007/commits) for the system administrator to enable it.
 
 ```no-highlight
 <dl>


### PR DESCRIPTION
Simple `Gitlab` -> `GitLab` typo fix.
