### PR TITLE
Add email to user profile view

### DIFF
--- a/app/controllers/profiles/emails_controller.rb
+++ b/app/controllers/profiles/emails_controller.rb
@@ -3,6 +3,7 @@ class Profiles::EmailsController < ApplicationController
 
   def index
     @primary = current_user.email
+    @public_email = current_user.public_email
     @emails = current_user.emails
   end
 
@@ -19,7 +20,8 @@ class Profiles::EmailsController < ApplicationController
     @email.destroy
 
     current_user.set_notification_email
-    current_user.save if current_user.notification_email_changed?
+    current_user.set_public_email
+    current_user.save if current_user.notification_email_changed? or current_user.public_email_changed?
 
     respond_to do |format|
       format.html { redirect_to profile_emails_url }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -67,9 +67,10 @@ class ProfilesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-      :email, :password, :password_confirmation, :bio, :name, :username,
-      :skype, :linkedin, :twitter, :website_url, :color_scheme_id, :theme_id,
-      :avatar, :hide_no_ssh_key, :hide_no_password, :location
+      :email, :email_display_in_profile, :password, :password_confirmation,
+      :bio, :name, :username, :skype, :linkedin, :twitter, :website_url,
+      :color_scheme_id, :theme_id, :avatar, :hide_no_ssh_key, :hide_no_password,
+      :location
     )
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,6 +8,7 @@ class ProfilesController < ApplicationController
   layout 'profile'
 
   def show
+    @emails = current_user.emails
   end
 
   def design
@@ -67,10 +68,10 @@ class ProfilesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-      :email, :email_display_in_profile, :password, :password_confirmation,
-      :bio, :name, :username, :skype, :linkedin, :twitter, :website_url,
-      :color_scheme_id, :theme_id, :avatar, :hide_no_ssh_key, :hide_no_password,
-      :location
+      :email, :password, :password_confirmation, :bio, :name,
+      :username, :skype, :linkedin, :twitter, :website_url,
+      :color_scheme_id, :theme_id, :avatar, :hide_no_ssh_key,
+      :hide_no_password, :location, :public_email
     )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,9 +16,9 @@ class UsersController < ApplicationController
     @title = @user.name
     @title_url = user_path(@user)
 
-    # Handle email display
-    if current_user and (current_user.id === @user.id or current_user.admin)
-      @user.email_display_in_profile = true
+    # Handle email display if user doesn't have public email
+    if @user.public_email == '' and current_user and (current_user.id === @user.id or current_user.admin)
+      @user.public_email = @user.email
     end
 
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,11 @@ class UsersController < ApplicationController
     @title = @user.name
     @title_url = user_path(@user)
 
+    # Handle email display
+    if current_user and (current_user.id === @user.id or current_user.admin)
+      @user.email_display_in_profile = true
+    end
+
     respond_to do |format|
       format.html
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@
 #  password_automatically_set    :boolean          default(FALSE)
 #  bitbucket_access_token        :string(255)
 #  bitbucket_access_token_secret :string(255)
-#  email_display_in_profile      :boolean          default(FALSE), not null
+#  public_email                  :string(255)      default(""), not null
 #
 
 require 'carrierwave/orm/activerecord'
@@ -124,6 +124,7 @@ class User < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true, email: { strict_mode: true }, uniqueness: true
   validates :notification_email, presence: true, email: { strict_mode: true }
+  validates :public_email, presence: true, email: { strict_mode: true }, allow_blank: true, uniqueness: true
   validates :bio, length: { maximum: 255 }, allow_blank: true
   validates :projects_limit, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :username,
@@ -143,6 +144,7 @@ class User < ActiveRecord::Base
   before_validation :generate_password, on: :create
   before_validation :sanitize_attrs
   before_validation :set_notification_email, if: ->(user) { user.email_changed? }
+  before_validation :set_public_email, if: ->(user) { user.public_email_changed? }
 
   before_save :ensure_authentication_token
   after_save :ensure_namespace_correct
@@ -433,6 +435,12 @@ class User < ActiveRecord::Base
   def set_notification_email
     if self.notification_email.blank? || !self.all_emails.include?(self.notification_email)
       self.notification_email = self.email
+    end
+  end
+
+  def set_public_email
+    if self.public_email.blank? || !self.all_emails.include?(self.public_email)
+      self.public_email = ''
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@
 #  password_automatically_set    :boolean          default(FALSE)
 #  bitbucket_access_token        :string(255)
 #  bitbucket_access_token_secret :string(255)
+#  email_display_in_profile      :boolean          default(FALSE), not null
 #
 
 require 'carrierwave/orm/activerecord'

--- a/app/views/profiles/emails/index.html.haml
+++ b/app/views/profiles/emails/index.html.haml
@@ -20,9 +20,13 @@
     %li
       %strong= @primary
       %span.label.label-success Primary Email
+      - if @primary === @public_email
+        %span.label.label-info Public Email
     - @emails.each do |email|
       %li
         %strong= email.email
+        - if email.email === @public_email
+          %span.label.label-info Public Email
         %span.cgray
           added #{time_ago_with_tooltip(email.created_at)}
         = link_to 'Remove', profile_email_path(email), data: { confirm: 'Are you sure?'}, method: :delete, class: 'btn btn-sm btn-remove pull-right'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -41,8 +41,14 @@
 
             - else
               %span.help-block We also use email for avatar detection if no avatar is uploaded.
-          = f.check_box(:email_display_in_profile)
-          = f.label(:email_display_in_profile, "Display this email in my public profile")
+      .form-group
+        = f.label :public_email, class: "control-label"
+        .col-sm-10
+          %select.form-control{:name => "user[public_email]", :id => :user_public_email}
+            %option{:value => "", :selected => @user.public_email.blank?}= "Do not show in profile"
+            %option{:value => @user.email, :selected => @user.email == @user.public_email}= @user.email
+            - @emails.each do |email|
+              %option{:value => email.email, :selected => email.email == @user.public_email}= email.email
       .form-group
         = f.label :skype, class: "control-label"
         .col-sm-10= f.text_field :skype, class: "form-control"

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -41,6 +41,8 @@
 
             - else
               %span.help-block We also use email for avatar detection if no avatar is uploaded.
+          = f.check_box(:email_display_in_profile)
+          = f.label(:email_display_in_profile, "Display this email in my public profile")
       .form-group
         = f.label :skype, class: "control-label"
         .col-sm-10= f.text_field :skype, class: "form-control"

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -5,10 +5,10 @@
     %li
       %span.light Member since
       %strong= user.created_at.stamp("Aug 21, 2011")
-    - if user.email_display_in_profile and not user.email.blank?
+    - unless user.public_email.blank?
       %li
         %span.light E-mail:
-        %strong= link_to user.email, "mailto:#{user.email}"
+        %strong= link_to user.public_email, "mailto:#{user.public_email}"
     - unless user.skype.blank?
       %li
         %span.light Skype:

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -5,6 +5,10 @@
     %li
       %span.light Member since
       %strong= user.created_at.stamp("Aug 21, 2011")
+    - if user.email_display_in_profile and not user.email.blank?
+      %li
+        %span.light E-mail:
+        %strong= link_to user.email, "mailto:#{user.email}"
     - unless user.skype.blank?
       %li
         %span.light Skype:

--- a/db/migrate/20150411214929_add_email_display_in_profile.rb
+++ b/db/migrate/20150411214929_add_email_display_in_profile.rb
@@ -1,0 +1,5 @@
+class AddEmailDisplayInProfile < ActiveRecord::Migration
+  def change
+    add_column :users, :email_display_in_profile, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20150413192223_add_public_email_to_users.rb
+++ b/db/migrate/20150413192223_add_public_email_to_users.rb
@@ -1,0 +1,6 @@
+class AddPublicEmailToUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :email_display_in_profile
+    add_column :users, :public_email, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150328132231) do
+ActiveRecord::Schema.define(version: 20150411214929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -475,6 +475,7 @@ ActiveRecord::Schema.define(version: 20150328132231) do
     t.string   "bitbucket_access_token"
     t.string   "bitbucket_access_token_secret"
     t.string   "location"
+    t.boolean  "email_display_in_profile",      default: false,  null: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150411214929) do
+ActiveRecord::Schema.define(version: 20150413192223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -475,7 +475,7 @@ ActiveRecord::Schema.define(version: 20150411214929) do
     t.string   "bitbucket_access_token"
     t.string   "bitbucket_access_token_secret"
     t.string   "location"
-    t.boolean  "email_display_in_profile",      default: false,  null: false
+    t.string   "public_email",                  default: "",    null: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree


### PR DESCRIPTION
Current version of GitLab doesn't display user email on user profile page, which is very inconvenient.

This commit added email field to user profile view. 

Before
![screenshot from 2015-04-11 20 35 31](https://cloud.githubusercontent.com/assets/4176091/7101394/99bd4346-e08a-11e4-82f9-c0ecc7d5203e.png)

After
![screenshot from 2015-04-11 20 35 21](https://cloud.githubusercontent.com/assets/4176091/7101396/a2e53bc2-e08a-11e4-8843-eb21a9976adc.png)
