### PR TITLE
Export users to CSV file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@ v 7.10.0 (unreleased)
   - Fix git over ssh errors 'fatal: protocol error: bad line length character' 
   - Automatically setup GitLab CI project for forks if origin project has GitLab CI enabled
   - Bust group page project list cache when namespace name or path changes.
+  - Add backup users list to CSV file option (Ben Bodenmiller)
 
 v 7.9.3
   - Contains no changes

--- a/doc/raketasks/backup_restore.md
+++ b/doc/raketasks/backup_restore.md
@@ -146,6 +146,18 @@ If you use an Omnibus package please see the [instructions in the readme to back
 If you have a cookbook installation there should be a copy of your configuration in Chef.
 If you have an installation from source, please consider backing up your `gitlab.yml` file, any SSL keys and certificates, and your [SSH host keys](https://superuser.com/questions/532040/copy-ssh-keys-from-one-server-to-another-server/532079#532079).
 
+## Outputing a CSV list of users
+
+A CSV file of registered users and generic account details can be generated. The output will be written to `users.csv` in the configured backup folder.
+
+```
+# use this command if you've installed GitLab with the Omnibus package
+sudo gitlab-rake gitlab:backup:users
+
+# if you've installed GitLab from source
+sudo -u git -H bundle exec rake gitlab:backup:users RAILS_ENV=production
+```
+
 ## Restore a previously created backup
 
 You can only restore a backup to exactly the same version of GitLab that you created it on, for example 7.2.1.

--- a/lib/backup/users.rb
+++ b/lib/backup/users.rb
@@ -1,0 +1,18 @@
+module Backup
+  class Users
+    attr_reader :user_dump_file
+
+    def initialize
+      @user_dump_file = File.join(Gitlab.config.backup.path, 'users.csv')
+    end
+
+    def dump
+      CSV.open(user_dump_file, "w") do |csv|
+        csv << ["email", "name", "admin", "projects_limit", "username", "can_create_group", "state"]
+        User.all.each do |u|
+          csv << [u.email, u.name, u.admin, u.projects_limit, u.username, u.can_create_group, u.state]
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/gitlab/backup.rake
+++ b/lib/tasks/gitlab/backup.rake
@@ -34,6 +34,17 @@ namespace :gitlab do
 
       backup.cleanup
     end
+    
+    # Export GitLab user details
+    desc "GITLAB | Export basic user account details"
+    task users: :environment do
+      warn_user_is_not_gitlab
+      configure_cron_mode
+
+      $progress.puts "Dumping user details ... ".blue
+      Backup::Users.new.dump
+      $progress.puts "done".green 
+    end
 
     namespace :repo do
       task create: :environment do

--- a/spec/tasks/gitlab/backup_rake_spec.rb
+++ b/spec/tasks/gitlab/backup_rake_spec.rb
@@ -98,6 +98,32 @@ describe 'gitlab:app namespace rake task' do
       expect(temp_dirs).to be_empty
     end
   end # backup_create task
+  
+  describe 'backup_users' do
+    def tars_glob
+      Dir.glob(File.join(Gitlab.config.backup.path, '*_gitlab_backup.tar'))
+    end
+
+    before :all do
+      existing_tars = tars_glob
+
+      # Redirect STDOUT and run the rake task
+      orig_stdout = $stdout
+      $stdout = StringIO.new
+      run_rake_task('gitlab:backup:users')
+      $stdout = orig_stdout
+
+      @backup_tar = (tars_glob - existing_tars).first
+    end
+    
+    it 'should not create a tar file' do
+      expect(@backup_tar).to be_nil
+    end
+    
+    it 'should create users.csv' do
+      expect(File.exist?(File.join(Gitlab.config.backup.path, 'users.csv'))).to be_truthy
+    end
+  end # backup_users task
 
   describe "Skipping items" do
     def tars_glob


### PR DESCRIPTION
This PR adds the ability for a system admin to export a list of users and basic account details via a rake task. The output will be written to `users.csv` in the configured backup folder.

```
# use this command if you've installed GitLab with the Omnibus package
sudo gitlab-rake gitlab:backup:users

# if you've installed GitLab from source
sudo -u git -H bundle exec rake gitlab:backup:users RAILS_ENV=production
```

The motive for adding this feature is so that system administrators can keep a list of users & emails separate from the GitLab installation in case of prolonged downtime. Additionally this allows admins to quickly verify some account details (project limit, can create group, etc.) not yet easily bulk verified in the UI.

As this is related to backups it was added to backup rake file. At this time the generated file is not included in the backup tar file nor generated when `gitlab:backup:create` is run. In the future it may be valuable stored in the backup tar file however at this time the folks I have spoke with see more value in having `users.csv` generated and stored separately.
