### PR TITLE
Allow user to choose which email to be public

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@ v 7.10.0 (unreleased)
   - Automatically setup GitLab CI project for forks if origin project has GitLab CI enabled
   - Bust group page project list cache when namespace name or path changes.
   - Explicitly set image alt-attribute to prevent graphical glitches if gravatars could not be loaded
+  - Allow user to choose a public email to show on public profile
 
 v 7.9.3
   - Contains no changes

--- a/app/controllers/profiles/emails_controller.rb
+++ b/app/controllers/profiles/emails_controller.rb
@@ -3,6 +3,7 @@ class Profiles::EmailsController < ApplicationController
 
   def index
     @primary = current_user.email
+    @public_email = current_user.public_email
     @emails = current_user.emails
   end
 
@@ -19,7 +20,8 @@ class Profiles::EmailsController < ApplicationController
     @email.destroy
 
     current_user.set_notification_email
-    current_user.save if current_user.notification_email_changed?
+    current_user.set_public_email
+    current_user.save if current_user.notification_email_changed? or current_user.public_email_changed?
 
     respond_to do |format|
       format.html { redirect_to profile_emails_url }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -67,9 +67,10 @@ class ProfilesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-      :email, :password, :password_confirmation, :bio, :name, :username,
-      :skype, :linkedin, :twitter, :website_url, :color_scheme_id, :theme_id,
-      :avatar, :hide_no_ssh_key, :hide_no_password, :location
+      :email, :password, :password_confirmation, :bio, :name,
+      :username, :skype, :linkedin, :twitter, :website_url,
+      :color_scheme_id, :theme_id, :avatar, :hide_no_ssh_key,
+      :hide_no_password, :location, :public_email
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@
 #  password_automatically_set    :boolean          default(FALSE)
 #  bitbucket_access_token        :string(255)
 #  bitbucket_access_token_secret :string(255)
+#  public_email                  :string(255)      default(""), not null
 #
 
 require 'carrierwave/orm/activerecord'
@@ -123,6 +124,7 @@ class User < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true, email: { strict_mode: true }, uniqueness: true
   validates :notification_email, presence: true, email: { strict_mode: true }
+  validates :public_email, presence: true, email: { strict_mode: true }, allow_blank: true, uniqueness: true
   validates :bio, length: { maximum: 255 }, allow_blank: true
   validates :projects_limit, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :username,
@@ -142,6 +144,7 @@ class User < ActiveRecord::Base
   before_validation :generate_password, on: :create
   before_validation :sanitize_attrs
   before_validation :set_notification_email, if: ->(user) { user.email_changed? }
+  before_validation :set_public_email, if: ->(user) { user.public_email_changed? }
 
   before_save :ensure_authentication_token
   after_save :ensure_namespace_correct
@@ -440,6 +443,12 @@ class User < ActiveRecord::Base
   def set_notification_email
     if self.notification_email.blank? || !self.all_emails.include?(self.notification_email)
       self.notification_email = self.email
+    end
+  end
+
+  def set_public_email
+    if self.public_email.blank? || !self.all_emails.include?(self.public_email)
+      self.public_email = ''
     end
   end
 

--- a/app/views/profiles/emails/index.html.haml
+++ b/app/views/profiles/emails/index.html.haml
@@ -20,9 +20,13 @@
     %li
       %strong= @primary
       %span.label.label-success Primary Email
+      - if @primary === @public_email
+        %span.label.label-info Public Email
     - @emails.each do |email|
       %li
         %strong= email.email
+        - if email.email === @public_email
+          %span.label.label-info Public Email
         %span.cgray
           added #{time_ago_with_tooltip(email.created_at)}
         = link_to 'Remove', profile_email_path(email), data: { confirm: 'Are you sure?'}, method: :delete, class: 'btn btn-sm btn-remove pull-right'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -42,6 +42,11 @@
             - else
               %span.help-block We also use email for avatar detection if no avatar is uploaded.
       .form-group
+        = f.label :public_email, class: "control-label"
+        .col-sm-10
+          = f.select :public_email, options_for_select(@user.all_emails, selected: @user.public_email), {include_blank: 'Do not show in profile'}, class: "form-control"
+          %span.help-block This email will be displayed on your public profile.
+      .form-group
         = f.label :skype, class: "control-label"
         .col-sm-10= f.text_field :skype, class: "form-control"
       .form-group

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -5,6 +5,10 @@
     %li
       %span.light Member since
       %strong= user.created_at.stamp("Aug 21, 2011")
+    - unless user.public_email.blank?
+      %li
+        %span.light E-mail:
+        %strong= link_to user.public_email, "mailto:#{user.public_email}"
     - unless user.skype.blank?
       %li
         %span.light Skype:

--- a/db/migrate/20150413192223_add_public_email_to_users.rb
+++ b/db/migrate/20150413192223_add_public_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddPublicEmailToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :public_email, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150411180045) do
+ActiveRecord::Schema.define(version: 20150413192223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -476,6 +476,7 @@ ActiveRecord::Schema.define(version: 20150411180045) do
     t.string   "bitbucket_access_token"
     t.string   "bitbucket_access_token_secret"
     t.string   "location"
+    t.string   "public_email",                  default: "",    null: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree


### PR DESCRIPTION
This commit allows user to show one of their emails in profile page,
or don't show email in this page.

Inspired by PR #9119 

Screenshots:

![screenshot from 2015-04-14 00 36 40](https://cloud.githubusercontent.com/assets/4176091/7120382/7ca67212-e23f-11e4-85b0-3d05db988240.png)

![screenshot from 2015-04-14 00 43 47](https://cloud.githubusercontent.com/assets/4176091/7120387/81acf45c-e23f-11e4-9b67-0960f77ab0c9.png)

![screenshot from 2015-04-14 00 44 11](https://cloud.githubusercontent.com/assets/4176091/7120388/84433852-e23f-11e4-95c6-98e0dcf08889.png)
