### PR TITLE
Add "created by User" when listing Merge Requests

### DIFF
--- a/app/views/projects/merge_requests/_merge_request.html.haml
+++ b/app/views/projects/merge_requests/_merge_request.html.haml
@@ -24,6 +24,7 @@
           = note_count
   .merge-request-info
     = link_to "##{merge_request.iid}", merge_request_path(merge_request), class: "light"
+    created by #{link_to_member(@project, merge_request.author)}
     - if merge_request.assignee
       assigned to #{link_to_member(merge_request.source_project, merge_request.assignee)}
     - else


### PR DESCRIPTION
I've been using gitlab for a while and I've always missed this tiny information.
I understand that when you open up a merge request you have already that information there.
But sometimes I'm "choosing" whose merge-requests I'd like to review.

Feedbacks are always welcome, just added one single line :smile:

![bildschirmfoto 2015-04-13 um 19 08 47](https://cloud.githubusercontent.com/assets/356881/7126779/9d6dc298-e212-11e4-9778-7b7f052cad5e.png)
