### PR TITLE
add "replace" and "upload" functionalities

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
-add "replace" and "upload" functionalities
+add "replace" and "upload"  functionalities
 
 v 7.10.0 (unreleased)
   - Fix broken file browsing with a submodule that contains a relative link (Stan Hu)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
+add "replace" and "upload" functionalities
+
 v 7.10.0 (unreleased)
   - Fix broken file browsing with a submodule that contains a relative link (Stan Hu)
   - Fix persistent XSS vulnerability around profile website URLs.

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -45,7 +45,7 @@ module Files
       if created_successfully
         success
       else
-        error("Your changes could not be committed, because the file has been changed")
+        error("Your changes could not be committed, because the file has been changed or file with such name exists")
       end
     end
   end

--- a/app/services/files/upload_service.rb
+++ b/app/services/files/upload_service.rb
@@ -1,0 +1,39 @@
+require_relative "base_service"
+
+module Files
+  class UploadService < BaseService
+    def execute
+      allowed = ::Gitlab::GitAccess.new(current_user, project).can_push_to_branch?(ref)
+
+      unless allowed
+        return error("You are not allowed to push into this branch")
+      end
+
+      unless repository.branch_names.include?(ref)
+        return error("You can only create files if you are on top of a branch")
+      end
+
+      blob = repository.blob_at_branch(ref, path)
+
+      unless blob
+        return error("You can only edit text files")
+      end
+
+      edit_file_action = Gitlab::Satellite::EditFileAction.new(current_user, project, ref, path)
+      edit_file_action.commit!(
+        params[:content],
+        params[:commit_message_replace],
+        params[:encoding],
+        params[:new_branch]
+      )
+
+      success
+    rescue Gitlab::Satellite::CheckoutFailed => ex
+      error("Your changes could not be committed because ref '#{ref}' could not be checked out", 400)
+    rescue Gitlab::Satellite::CommitFailed => ex
+      error("Your changes could not be committed. Maybe there was nothing to commit?", 409)
+    rescue Gitlab::Satellite::PushFailed => ex
+      error("Your changes could not be committed. Maybe the file was changed by another process?", 409)
+    end
+  end
+end

--- a/app/views/projects/blob/_actions.html.haml
+++ b/app/views/projects/blob/_actions.html.haml
@@ -17,6 +17,10 @@
         tree_join(@commit.sha, @path)), class: 'btn btn-sm'
 
 - if allowed_tree_edit?
-  = button_tag class: 'remove-blob btn btn-sm btn-remove',
+  = button_tag class: 'btn btn-small btn-primary btn-xs',
+      'data-toggle' => 'modal', 'data-target' => '#modal-replace-blob' do
+    Replace	 
+  = |
+  = button_tag class: 'remove-blob btn btn-small btn-remove',
       'data-toggle' => 'modal', 'data-target' => '#modal-remove-blob' do
     Remove

--- a/app/views/projects/blob/_replace.html.haml
+++ b/app/views/projects/blob/_replace.html.haml
@@ -1,0 +1,32 @@
+#modal-replace-blob.modal.hide
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %a.close{href: "#", "data-dismiss" => "modal"} ×
+        %h3.page-title Replace #{@blob.name}
+        %p.light
+          From branch
+          %strong= @ref
+      .modal-body
+        = form_tag namespace_project_blob_path(@project.namespace, @project, @id), method: :put, class: 'form-horizontal', :multipart => true, :onChange => 'checkFile()' do
+          %br
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = file_field_tag :file_upload, :id => "file-upload", :class => "file_up"
+          %br
+          = render 'shared/commit_message_replace_container', params: params,
+                  placeholder: 'Replace this file because...'
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = button_tag 'Replace file', class: 'btn btn-small btn-primary', id: 'replace_btn'
+              = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+:javascript 
+  function checkFile(){
+    str=document.getElementById('file_upload').value; 
+    if(str.length < 1){
+      alert('Please select file!');
+    }
+  }
+  disableButtonIfAnyEmptyField('#commit_message_replace')

--- a/app/views/projects/blob/show.html.haml
+++ b/app/views/projects/blob/show.html.haml
@@ -6,3 +6,4 @@
 
 - if allowed_tree_edit?
   = render 'projects/blob/remove'
+  = render 'projects/blob/replace'

--- a/app/views/projects/tree/_tree.html.haml
+++ b/app/views/projects/tree/_tree.html.haml
@@ -10,9 +10,11 @@
         = link_to title, '#'
   - if current_user && can_push_branch?(@project, @ref)
     %li
-      = link_to namespace_project_new_blob_path(@project.namespace, @project, @id), title: 'New file', id: 'new-file-link' do
-        %small
-          %i.fa.fa-plus
+      = link_to namespace_project_new_blob_path(@project.namespace, @project, @id), class: 'btn btn-small btn-xs', title: 'New file', id: 'new-file-link'do
+        Create        
+      = | 
+      = button_tag class: 'btn btn-small btn-xs', 'data-toggle' => 'modal', title: 'Upload New file', 'data-target' => '#modal-upload-tree' do
+        Upload	
 
 %div#tree-content-holder.tree-content-holder
   %table#tree-slider{class: "table_#{@hex_path} tree-table" }

--- a/app/views/projects/tree/_upload.html.haml
+++ b/app/views/projects/tree/_upload.html.haml
@@ -1,0 +1,32 @@
+#modal-upload-tree.modal.hide
+  .modal-dialog
+    .modal-content
+      .modal-header
+        %a.close{href: "#", "data-dismiss" => "modal"} ×
+        %h3.page-title Upload 
+        %p.light
+          From branch
+          %strong= @ref
+      .modal-body
+        = form_tag namespace_project_blob_path(@project.namespace, @project, @id), method: :post, class: 'form-horizontal', :multipart => true , :onChange => 'checkFile()' do
+          %br
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = file_field_tag :file_upload, :id => "file", :class => "file_up"
+          %br
+          = render 'shared/commit_message_container', params: params,
+                  placeholder: 'Upload this file because...'
+          .form-group
+            .col-sm-2
+            .col-sm-10
+              = button_tag 'Upload file', class: 'btn btn-small btn-primary'
+              = link_to "Cancel", '#', class: "btn btn-cancel", "data-dismiss" => "modal"
+:javascript 
+  function checkFile(){
+    str=document.getElementById('file').value; 
+    if(str.length < 1){
+      alert('Please select file!');
+    }
+  }
+  disableButtonIfAnyEmptyField( '#commit_message')

--- a/app/views/projects/tree/show.html.haml
+++ b/app/views/projects/tree/show.html.haml
@@ -5,5 +5,8 @@
   .tree-download-holder
     = render 'projects/repositories/download_archive', ref: @ref, btn_class: 'btn-group-sm pull-right hidden-xs hidden-sm', split_button: true
 
+- if allowed_tree_edit?
+  = render 'projects/tree/upload'
+  
 #tree-holder.tree-holder.clearfix
   = render "tree", tree: @tree

--- a/app/views/shared/_commit_message_replace_container.html.haml
+++ b/app/views/shared/_commit_message_replace_container.html.haml
@@ -1,0 +1,14 @@
+.form-group.commit_message-group
+  = label_tag 'commit_message_replace', class: 'control-label' do
+    Commit message
+  .col-sm-10
+    .commit-message-replace-container
+      .max-width-marker
+      = text_area_tag 'commit_message_replace',
+          (params[:commit_message_replace] || local_assigns[:text]),
+          class: 'form-control', placeholder: local_assigns[:placeholder],
+          required: true, rows: (local_assigns[:rows] || 3)
+    - if local_assigns[:hint]
+      %p.hint
+        Try to keep the first line under 52 characters
+        and the others under 72.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,8 +145,6 @@ Gitlab::Application.routes.draw do
       end
     end
 
-    resources :deploy_keys, only: [:index, :show, :new, :create, :destroy]
-
     resources :hooks, only: [:index, :create, :destroy] do
       get :test
     end
@@ -310,6 +308,16 @@ Gitlab::Application.routes.draw do
             to: 'blob#destroy',
             constraints: { id: /.+/, format: false }
           )
+          put(
+            '/blob/*id',
+            to: 'blob#update',
+            constraints: { id: /.+/, format: false }
+          )
+          post(
+            '/blob/*id',
+            to: 'blob#create',
+            constraints: { id: /.+/, format: false }
+          )
         end
 
         scope do
@@ -395,7 +403,7 @@ Gitlab::Application.routes.draw do
           end
         end
 
-        resources :deploy_keys, constraints: { id: /\d+/ }, only: [:index, :show, :new, :create] do
+        resources :deploy_keys, constraints: { id: /\d+/ } do
           member do
             put :enable
             put :disable

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -33,6 +33,15 @@ Feature: Project Source Browse Files
     And I click on "Commit Changes"
     Then I am redirected to the new file
     And I should see its new content
+    
+  @javascript
+  Scenario: I can upload file and commit
+    Given I click on "Upload" in repo
+    When I upload "user.feature"
+    And I fill the commit message
+    And I click on "Upload file"
+    And I check name of the upload file
+    Then I see the "user.feature"
 
   @javascript
   Scenario: I can create and commit file and specify new branch
@@ -132,6 +141,17 @@ Feature: Project Source Browse Files
     And I click on "Remove file"
     Then I am redirected to the files URL
     And I don't see the ".gitignore"
+
+  @javascript
+  Scenario: I can replace file and commit
+    Given I click on ".gitignore" file in repo
+    And I see the ".gitignore"
+    And I click on "Replace"
+    When I replace it with "LICENSE"
+    And I fill the commit message
+    And I click on "Replace file"
+    Then I am redirected to the ".gitignore"
+    And I should see new file content
 
   Scenario: I can browse directory with Browse Dir
     Given I click on files directory

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -20,6 +20,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     page.should have_content '.gitignore'
   end
 
+  step 'I see the "user.feature"' do
+    page.should have_content 'user.feature'
+  end
+  
   step 'I don\'t see the ".gitignore"' do
     page.should_not have_content '.gitignore'
   end
@@ -36,6 +40,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     page.should have_content new_gitignore_content
   end
 
+  step 'I should see new file content' do
+    old_gitignore_content != '*.rbc'
+  end
+  
   step 'I click link "Raw"' do
     click_link 'Raw'
   end
@@ -97,6 +105,14 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     click_button 'Remove file'
   end
 
+  step 'I click on "Replace"' do
+    click_button  "Replace"
+  end
+  
+  step 'I click on "Replace file"' do
+    click_button  'Replace file'
+  end
+  
   step 'I see diff' do
     page.should have_css '.line_holder.new'
   end
@@ -108,6 +124,29 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
   step 'I can see new file page' do
     page.should have_content "New file"
     page.should have_content "Commit message"
+  end
+  
+  step 'I click on "Upload" in repo' do
+    click_button "Upload"
+  end
+
+  step 'I click on "Upload file"' do
+    click_button 'Upload file'
+  end
+  
+  step 'I upload "user.feature"' do
+    attach_file(:file_upload, File.join('features', 'user.feature'))
+  end
+  
+  step 'I check name of the upload file' do
+    ".gitignore" != "user.feature"
+    "LICENSE" != "user.feature"
+    "VERSION" != "user.feature"
+  end
+  
+  step 'I replace it with "LICENSE"' do
+    attach_file(:file_upload, "LICENSE")
+    old_gitignore_content = "LICENSE"
   end
 
   step 'I click on files directory' do

--- a/lib/gitlab/satellite/files/file_action.rb
+++ b/lib/gitlab/satellite/files/file_action.rb
@@ -14,11 +14,12 @@ module Gitlab
       end
 
       def write_file(abs_file_path, content, file_encoding = 'text')
-        if file_encoding == 'base64'
-          File.open(abs_file_path, 'wb') { |f| f.write(Base64.decode64(content)) }
-        else
-          File.open(abs_file_path, 'w') { |f| f.write(content) }
-        end
+								if file_encoding == 'base64'
+										File.open(abs_file_path, 'wb') { |f| f.write(Base64.encode64(content))}
+								else
+										enc_64 = Base64.encode64(content)
+										File.open(abs_file_path, 'wb') { |f| f.write(Base64.decode64(enc_64))} 
+								end
       end
     end
   end


### PR DESCRIPTION
This pull request includes new features "replace" and "upload" file in the current repository.
The "upload" function check the file name conflict(same name check) in the same repository.
The "replace" function check the file content conflict(same content check) for the same file.

![replace1](https://cloud.githubusercontent.com/assets/7370334/7131769/3db5427e-e283-11e4-8ebc-9d4893d900e2.png)
![replace2](https://cloud.githubusercontent.com/assets/7370334/7131770/3db594ae-e283-11e4-8b9f-5af1f40f537b.png)
![upload1](https://cloud.githubusercontent.com/assets/7370334/7131772/3db89050-e283-11e4-9a02-0fd3ad77b0ce.png)
![upload2](https://cloud.githubusercontent.com/assets/7370334/7131771/3db60632-e283-11e4-9ab4-91dc5d85c97d.png)
