### PR TITLE
Add support for Russian letters in markdown heading anchors

### DIFF
--- a/lib/redcarpet/render/gitlab_html.rb
+++ b/lib/redcarpet/render/gitlab_html.rb
@@ -40,7 +40,7 @@ class Redcarpet::Render::GitlabHTML < Redcarpet::Render::HTML
       "<h#{level}>#{text}</h#{level}>"
     else
       id = ActionController::Base.helpers.strip_tags(h.gfm(text)).downcase() \
-          .gsub(/[^a-z0-9_-]/, '-').gsub(/-+/, '-').gsub(/^-/, '').gsub(/-$/, '')
+          .gsub(/[^a-zа-яё0-9_-]/, '-').gsub(/-+/, '-').gsub(/^-/, '').gsub(/-$/, '')
       "<h#{level} id=\"#{id}\">#{text}<a href=\"\##{id}\"></a></h#{level}>"
     end
   end


### PR DESCRIPTION
Current version of GitLab doesn't work properly in generating anchors for wiki pages if headers consist of Russian letters only.

I've changed the `header(text, level)` function in [gitlab_html.rb](lib/redcarpet/render/gitlab_html.rb) to support Russian letters.

Maybe there is more elegant way to support non-latin UTF-symbols.
