### PR TITLE
Make issue preview look like the result

### DIFF
--- a/app/views/projects/_md_preview.html.haml
+++ b/app/views/projects/_md_preview.html.haml
@@ -9,5 +9,5 @@
 %div
   .md-write-holder
     = yield
-  .md-preview-holder.hide
+  .md.md-preview-holder.hide
     .js-md-preview{class: (preview_class if defined?(preview_class))}


### PR DESCRIPTION
Adding the `md` class to the `md-preview-holder` div applies the styles of the markdown formatting `md-typography` mixin. Which makes the preview look like the actual result.

Before: 
![before](https://cloud.githubusercontent.com/assets/20943/7261887/888608fe-e875-11e4-836c-f74a0b0f6bba.png)
After:
![after](https://cloud.githubusercontent.com/assets/20943/7261914/b50fb58c-e875-11e4-82d2-70e44f385ec3.png)
