### PR TITLE
confirm=no patch for user creation via REST API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 7.11.0 (unreleased)
   -
   - Improve new project command options (Ben Bodenmiller)
   - Prevent sending empty messages to HipChat (Chulki Lee)
+  - Fix confirm=no for user creation via REST API (Bastian Ballmann)
 
 v 7.10.0 (unreleased)
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -68,7 +68,7 @@ module API
         user = User.build_user(attrs)
         user.admin = admin unless admin.nil?
         user.skip_confirmation! unless confirm
-	user.confirmed_at = DateTime.now unless confirm
+        user.confirmed_at = DateTime.now unless confirm
 
         identity_attrs = attributes_for_keys [:provider, :extern_uid]
         if identity_attrs.any?

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module API
   # Users API
   class Users < Grape::API
@@ -60,12 +62,13 @@ module API
       post do
         authenticated_as_admin!
         required_attributes! [:email, :password, :name, :username]
-        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :bio, :can_create_group, :admin, :confirm]
+        attrs = attributes_for_keys [:email, :name, :password, :skype, :linkedin, :twitter, :projects_limit, :username, :bio, :can_create_group, :admin]
         admin = attrs.delete(:admin)
         confirm = !(attrs.delete(:confirm) =~ (/(false|f|no|0)$/i))
         user = User.build_user(attrs)
         user.admin = admin unless admin.nil?
         user.skip_confirmation! unless confirm
+	user.confirmed_at = DateTime.now unless confirm
 
         identity_attrs = attributes_for_keys [:provider, :extern_uid]
         if identity_attrs.any?


### PR DESCRIPTION
Using confirm=no in user creation via REST API resulted always in an internal server error. The confirm field dont exist in the database. Therefore I removed it from the attribute keys and set confirmed_at field to now.
Maybe it's kinda hacky, but now the user creation without confirmation works for me.
I append the stacktrace produces when using confirm=no with the original code

`ActiveRecord::UnknownAttributeError (unknown attribute: confirm):
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/attribute_assignment.rb:50:in `rescue in _assign_attribute'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/attribute_assignment.rb:45:in `_assign_attribute'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/attribute_assignment.rb:32:in `block in assign_attributes'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/attribute_assignment.rb:26:in `each'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/attribute_assignment.rb:26:in `assign_attributes'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/core.rb:452:in `init_attributes'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/core.rb:195:in `initialize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/default_value_for-3.0.0/lib/default_value_for.rb:142:in `initialize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/devise-3.2.4/lib/devise/models/confirmable.rb:47:in `initialize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/state_machine-1.2.0/lib/state_machine/integrations/active_record.rb:470:in `initialize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/inheritance.rb:30:in `new'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/inheritance.rb:30:in `new'
  /local/home/git/gitlab/app/models/user.rb:229:in `build_user'
  /local/home/git/gitlab/lib/api/users.rb:64:in `block (2 levels) in <class:Users>'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:31:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:31:in `block in generate_api_method'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:401:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:401:in `run'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:154:in `block in call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:24:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:24:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:18:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:24:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:18:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-oauth2-1.0.8/lib/rack/oauth2/server/resource.rb:20:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-oauth2-1.0.8/lib/rack/oauth2/server/resource/bearer.rb:8:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/error.rb:26:in `block in call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/error.rb:25:in `catch'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/error.rb:25:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/middleware/base.rb:18:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:155:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/endpoint.rb:145:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:152:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:96:in `block in recognize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:68:in `optimized_each'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-mount-0.8.3/lib/rack/mount/code_generation.rb:95:in `recognize'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-mount-0.8.3/lib/rack/mount/route_set.rb:141:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/api.rb:525:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/api.rb:42:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/grape-0.6.1/lib/grape/api.rb:38:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/journey/router.rb:73:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/journey/router.rb:59:in `each'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/journey/router.rb:59:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/routing/route_set.rb:685:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/omniauth-1.1.4/lib/omniauth/strategy.rb:184:in `call!'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/omniauth-1.1.4/lib/omniauth/strategy.rb:164:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/request_store-1.0.5/lib/request_store/middleware.rb:9:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-cors-0.2.9/lib/rack/cors.rb:54:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-attack-4.2.0/lib/rack/attack.rb:104:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/warden-1.2.3/lib/warden/manager.rb:35:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/warden-1.2.3/lib/warden/manager.rb:34:in `catch'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/warden-1.2.3/lib/warden/manager.rb:34:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/etag.rb:23:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/conditionalget.rb:35:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/flash.rb:254:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:225:in `context'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:220:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/cookies.rb:562:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/query_cache.rb:36:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activerecord-4.1.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:621:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activesupport-4.1.9/lib/active_support/callbacks.rb:82:in `run_callbacks'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/remote_ip.rb:76:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/rack/logger.rb:38:in `call_app'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/rack/logger.rb:20:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activesupport-4.1.9/lib/active_support/tagged_logging.rb:68:in `block in tagged'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activesupport-4.1.9/lib/active_support/tagged_logging.rb:26:in `tagged'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/activesupport-4.1.9/lib/active_support/tagged_logging.rb:68:in `tagged'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/rack/logger.rb:20:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/actionpack-4.1.9/lib/action_dispatch/middleware/request_id.rb:21:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/methodoverride.rb:21:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/runtime.rb:17:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/lock.rb:17:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/sendfile.rb:112:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/engine.rb:514:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/application.rb:144:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/railtie.rb:194:in `public_send'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/railties-4.1.9/lib/rails/railtie.rb:194:in `method_missing'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-4.6.3/lib/unicorn/http_server.rb:552:in `process_client'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-worker-killer-0.4.2/lib/unicorn/worker_killer.rb:51:in `process_client'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-4.6.3/lib/unicorn/http_server.rb:632:in `worker_loop'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-4.6.3/lib/unicorn/http_server.rb:500:in `spawn_missing_workers'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-4.6.3/lib/unicorn/http_server.rb:142:in `start'
  /local/home/git/gitlab/vendor/bundle/ruby/gems/unicorn-4.6.3/bin/unicorn_rails:209:in `<top (required)>'
  /local/home/git/gitlab/vendor/bundle/ruby/bin/unicorn_rails:23:in `load'
  /local/home/git/gitlab/vendor/bundle/ruby/bin/unicorn_rails:23:in `<main>'`
