### PR TITLE
Fix contributions calendar empty problem under mysql

### DIFF
--- a/lib/gitlab/contributions_calendar.rb
+++ b/lib/gitlab/contributions_calendar.rb
@@ -17,7 +17,7 @@ module Gitlab
       events = Event.reorder(nil).contributions.where(author_id: user.id).
         where("created_at > ?", date_from).where(project_id: projects).
         group('date(created_at)').
-        select('date(created_at), count(id) as total_amount').
+        select('date(created_at) as date, count(id) as total_amount').
         map(&:attributes)
 
       dates = (1.year.ago.to_date..(Date.today + 1.day)).to_a


### PR DESCRIPTION
When using MySQL as database backend in GitLab, `date` in `date(created_at), count(id) as total_amount` won't return the `date` column (should be `date(created_at)`), as a result, there's no contribution in the user profile page. 
Adding an `as date` can solve this problem.
