### PR TITLE
Add notify and color options to HipchatService

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ v 7.11.0 (unreleased)
   - Improve new project command options (Ben Bodenmiller)
   - Prevent sending empty messages to HipChat (Chulki Lee)
   - Improve UI for mobile phones on dashboard and project pages
+  - Add room notification and message color option for HipChat
 
 v 7.10.0
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -6,7 +6,8 @@ class Projects::ServicesController < Projects::ApplicationController
                     :description, :issues_url, :new_issue_url, :restrict_to_branch, :channel,
                     :colorize_messages, :channels,
                     :push_events, :issues_events, :merge_requests_events, :tag_push_events,
-                    :note_events, :send_from_committer_email, :disable_diffs, :external_wiki_url]
+                    :note_events, :send_from_committer_email, :disable_diffs, :external_wiki_url,
+                    :notify, :color]
   # Authorize
   before_action :authorize_admin_project!
   before_action :service, only: [:edit, :update, :test]

--- a/spec/models/project_services/hipchat_service_spec.rb
+++ b/spec/models/project_services/hipchat_service_spec.rb
@@ -213,5 +213,21 @@ describe HipchatService do
             "<pre>snippet note</pre>")
       end
     end
+
+    context "#message_options" do
+      it "should be set to the defaults" do
+        expect(hipchat.send(:message_options)).to eq({notify: false, color: 'yellow'})
+      end
+
+      it "should set notfiy to true" do
+        hipchat.stub(notify: '1')
+        expect(hipchat.send(:message_options)).to eq({notify: true, color: 'yellow'})
+      end
+
+      it "should set the color" do
+        hipchat.stub(color: 'red')
+        expect(hipchat.send(:message_options)).to eq({notify: false, color: 'red'})
+      end
+    end
   end
 end


### PR DESCRIPTION
When notify is set to true send messages will trigger a notification for all room members.
Color changes the background color of the message.
