### PR TITLE
Fix missing X-UA-Compatible meta tag

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -1,5 +1,6 @@
 %head
   %meta{charset: "utf-8"}
+  %meta{'http-equiv' => 'X-UA-Compatible', content: 'IE=edge'}
   %meta{content: "GitLab Community Edition", name: "description"}
 
   %title


### PR DESCRIPTION
Fixes bootlint [W002](https://github.com/twbs/bootlint/wiki/W002) issue.
