### PR TITLE
Fix .container position on navbar (reloaded)

### DIFF
--- a/app/assets/stylesheets/generic/header.scss
+++ b/app/assets/stylesheets/generic/header.scss
@@ -10,7 +10,10 @@ header {
     border: none;
     width: 100%;
 
-    .navbar-inner {
+    .container {
+      width: 100% !important;
+      padding: 0;
+
       background: #FFF;
       border-bottom: 1px solid #DDD;
       filter: none;
@@ -121,11 +124,6 @@ header {
         }
       }
     }
-  }
-
-  .container {
-    width: 100% !important;
-    padding: 0px;
   }
 
   /**

--- a/app/assets/stylesheets/generic/mobile.scss
+++ b/app/assets/stylesheets/generic/mobile.scss
@@ -56,7 +56,7 @@
     }
   }
 
-  .navbar-inner .title {
+  .container .title {
     margin-left: 6px !important;
     max-width: 70% !important;
   }

--- a/app/assets/stylesheets/pages/issuable.scss
+++ b/app/assets/stylesheets/pages/issuable.scss
@@ -19,7 +19,7 @@
     &.affix {
       position: fixed;
       top: 70px;
-      width: 220px;
+      margin-right: 35px;
     }
   }
 }

--- a/app/assets/stylesheets/themes/gitlab-theme.scss
+++ b/app/assets/stylesheets/themes/gitlab-theme.scss
@@ -1,19 +1,17 @@
 @mixin gitlab-theme($color-light, $color, $color-darker, $color-dark) {
   header {
     &.navbar-gitlab {
-      .navbar-inner {
-        .app_logo {
-          background-color: $color-darker;
+      .app_logo {
+        background-color: $color-darker;
 
+        a {
+          color: $color-light;
+        }
+
+        &:hover {
+          background-color: $color-dark;
           a {
-            color: $color-light;
-          }
-
-          &:hover {
-            background-color: $color-dark;
-            a {
-              color: #FFF;
-            }
+            color: #FFF;
           }
         }
       }

--- a/app/views/layouts/_empty_head_panel.html.haml
+++ b/app/views/layouts/_empty_head_panel.html.haml
@@ -1,5 +1,4 @@
 %header.navbar.navbar-fixed-top.navbar-gitlab
-  .navbar-inner
-    .container
-      %h4.center
-        = image_tag 'logo-white.png', width: 32, height: 32
+  .container
+    %h4.center
+      = image_tag 'logo-white.png', width: 32, height: 32

--- a/app/views/layouts/_head_panel.html.haml
+++ b/app/views/layouts/_head_panel.html.haml
@@ -1,48 +1,47 @@
 %header.navbar.navbar-fixed-top.navbar-gitlab{ class: nav_header_class }
-  .navbar-inner
-    .container
-      %div.app_logo
-        = link_to root_path, class: 'home', title: 'Dashboard', id: 'js-shortcuts-home', data: {toggle: 'tooltip', placement: 'bottom'} do
-          = brand_header_logo
-          %h3 GitLab
-      %h1.title= title
+  .container
+    %div.app_logo
+      = link_to root_path, class: 'home', title: 'Dashboard', id: 'js-shortcuts-home', data: {toggle: 'tooltip', placement: 'bottom'} do
+        = brand_header_logo
+        %h3 GitLab
+    %h1.title= title
 
-      %button.navbar-toggle{type: 'button', data: {target: '.navbar-collapse', toggle: 'collapse'}}
-        %span.sr-only Toggle navigation
-        = icon('bars')
+    %button.navbar-toggle{type: 'button', data: {target: '.navbar-collapse', toggle: 'collapse'}}
+      %span.sr-only Toggle navigation
+      = icon('bars')
 
-      .navbar-collapse.collapse
-        %ul.nav.navbar-nav
-          %li.hidden-sm.hidden-xs
-            = render 'layouts/search'
-          %li.visible-sm.visible-xs
-            = link_to search_path, title: 'Search', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('search')
+    .navbar-collapse.collapse
+      %ul.nav.navbar-nav
+        %li.hidden-sm.hidden-xs
+          = render 'layouts/search'
+        %li.visible-sm.visible-xs
+          = link_to search_path, title: 'Search', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('search')
+        %li
+          = link_to help_path, title: 'Help', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('question-circle')
+        %li
+          = link_to explore_root_path, title: 'Explore', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('globe')
+        %li
+          = link_to user_snippets_path(current_user), title: 'Your snippets', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('clipboard')
+        - if current_user.is_admin?
           %li
-            = link_to help_path, title: 'Help', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('question-circle')
+            = link_to admin_root_path, title: 'Admin area', data: {toggle: 'tooltip', placement: 'bottom'} do
+              = icon('cogs')
+        - if current_user.can_create_project?
           %li
-            = link_to explore_root_path, title: 'Explore', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('globe')
-          %li
-            = link_to user_snippets_path(current_user), title: 'Your snippets', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('clipboard')
-          - if current_user.is_admin?
-            %li
-              = link_to admin_root_path, title: 'Admin area', data: {toggle: 'tooltip', placement: 'bottom'} do
-                = icon('cogs')
-          - if current_user.can_create_project?
-            %li
-              = link_to new_project_path, title: 'New project', data: {toggle: 'tooltip', placement: 'bottom'} do
-                = icon('plus')
-          %li
-            = link_to profile_path, title: 'Profile settings', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('user')
-          %li
-            = link_to destroy_user_session_path, class: 'logout', method: :delete, title: 'Sign out', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = icon('sign-out')
-          %li.hidden-xs
-            = link_to current_user, class: 'profile-pic', id: 'profile-pic', data: {toggle: 'tooltip', placement: 'bottom'} do
-              = image_tag avatar_icon(current_user.email, 60), alt: 'User activity'
+            = link_to new_project_path, title: 'New project', data: {toggle: 'tooltip', placement: 'bottom'} do
+              = icon('plus')
+        %li
+          = link_to profile_path, title: 'Profile settings', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('user')
+        %li
+          = link_to destroy_user_session_path, class: 'logout', method: :delete, title: 'Sign out', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = icon('sign-out')
+        %li.hidden-xs
+          = link_to current_user, class: 'profile-pic', id: 'profile-pic', data: {toggle: 'tooltip', placement: 'bottom'} do
+            = image_tag avatar_icon(current_user.email, 60), alt: 'User activity'
 
 = render 'shared/outdated_browser'

--- a/app/views/layouts/_public_head_panel.html.haml
+++ b/app/views/layouts/_public_head_panel.html.haml
@@ -1,23 +1,22 @@
 %header.navbar.navbar-fixed-top.navbar-gitlab{ class: nav_header_class }
-  .navbar-inner
-    .container
-      %div.app_logo
-        = link_to explore_root_path, class: "home" do
-          = brand_header_logo
-          %h3 GitLab
-      %h1.title= title
+  .container
+    %div.app_logo
+      = link_to explore_root_path, class: "home" do
+        = brand_header_logo
+        %h3 GitLab
+    %h1.title= title
 
-      %button.navbar-toggle{"data-target" => ".navbar-collapse", "data-toggle" => "collapse", type: "button"}
-        %span.sr-only Toggle navigation
-        %i.fa.fa-bars
+    %button.navbar-toggle{"data-target" => ".navbar-collapse", "data-toggle" => "collapse", type: "button"}
+      %span.sr-only Toggle navigation
+      %i.fa.fa-bars
 
-      - unless current_controller?('sessions')
-        .pull-right.hidden-xs
-          = link_to "Sign in", new_session_path(:user, redirect_to_referer: 'yes'), class: 'btn btn-sign-in btn-new append-right-10'
+    - unless current_controller?('sessions')
+      .pull-right.hidden-xs
+        = link_to "Sign in", new_session_path(:user, redirect_to_referer: 'yes'), class: 'btn btn-sign-in btn-new append-right-10'
 
-        .navbar-collapse.collapse
-          %ul.nav.navbar-nav
-            %li.visible-xs
-              = link_to "Sign in", new_session_path(:user, redirect_to_referer: 'yes')
+      .navbar-collapse.collapse
+        %ul.nav.navbar-nav
+          %li.visible-xs
+            = link_to "Sign in", new_session_path(:user, redirect_to_referer: 'yes')
 
 = render 'shared/outdated_browser'

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -19,7 +19,7 @@ module API
       message << "  " << trace.join("\n  ")
 
       API.logger.add Logger::FATAL, message
-      rack_response({ 'message' => '500 Internal Server Error' }, 500)
+      rack_response({ 'message' => '500 Internal Server Error' }.to_json, 500)
     end
 
     format :json


### PR DESCRIPTION
This is a fixed on improved version of #9208.

I simply remove `navbar-inner` that is not needed anymore.

I also apply changes on `_empty_head_panel` and `_head_panel` templates.

I tested it with both desktop and mobile view on dashboard main page, no apparent side effect.

@jvanbaarsen @randx @Razer6 => Ready for review. :+1: 
