### PR TITLE
Add commit streak to user profile page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ v 7.11.0 (unreleased)
   - Improve UI for mobile phones on dashboard and project pages
   - Add room notification and message color option for HipChat
   - Allow to use non-ASCII letters and dashes in project and namespace name. (Jakub Jirutka)
+  - Add commit streak information to user profile page. (Kelvin Gu)
 
 v 7.10.0
   - Ignore submodules that are defined in .gitmodules but are checked in as directories.

--- a/app/assets/stylesheets/generic/streak.scss
+++ b/app/assets/stylesheets/generic/streak.scss
@@ -1,0 +1,9 @@
+.user-streak {
+  p.light {
+    margin: 0px;
+  }
+
+  h3 {
+    margin: 10px 0px;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,8 @@ class UsersController < ApplicationController
     @projects = @user.personal_projects.
       where(id: authorized_projects_ids).includes(:namespace)
 
+    @streak_info = streak_info
+
     # Collect only groups common for both users
     @groups = @user.groups & GroupsFinder.new.execute(current_user)
 
@@ -45,7 +47,7 @@ class UsersController < ApplicationController
     @events = []
 
     if @calendar_date
-      @events = contributions_calendar.events_by_date(@calendar_date)
+      @events = contributions_calendar.events_by_period(@calendar_date)
     end
 
     render 'calendar_activities', layout: false
@@ -73,6 +75,19 @@ class UsersController < ApplicationController
     # Projects user can view
     @authorized_projects_ids ||=
       ProjectsFinder.new.execute(current_user).pluck(:id)
+  end
+
+  def streak_info
+    @streak_info = {
+      contribution_year: contributions_calendar.events_by_period((Time.now - 1.year), Time.now).count,
+      contribution_year_period: @user.contribution_year_period,
+
+      longest_streak: @user.longest_streak,
+      longest_streak_period: @user.longest_streak_period,
+
+      current_streak: @user.current_streak,
+      current_streak_period: @user.current_streak_period,
+    }
   end
 
   def contributed_projects

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -63,6 +63,10 @@ class Event < ActiveRecord::Base
     end
   end
 
+  def contribute?
+    push? || ((merge_request? || issue?) && [CREATED, CLOSED, MERGED].include?(action))
+  end
+
   def proper?
     if push?
       true

--- a/app/services/event_create_service.rb
+++ b/app/services/event_create_service.rb
@@ -79,6 +79,11 @@ class EventCreateService
       author_id: current_user.id
     )
 
-    Event.create(attributes)
+    event = Event.create(attributes)
+    if event && event.contribute?
+      current_user.streak
+    end
+
+    event
   end
 end

--- a/app/views/users/_streak.html.haml
+++ b/app/views/users/_streak.html.haml
@@ -1,0 +1,24 @@
+.user-streak.row.prepend-top-20.text-center
+  .col-md-4
+    %p.light
+      Contributions in last year
+    %h3
+      #{@streak_info[:contribution_year]} total
+    %p.light
+      #{@streak_info[:contribution_year_period]}
+
+  .col-md-4
+    %p.light
+      Longest streak
+    %h3
+      #{@streak_info[:longest_streak]} days
+    %p.light
+      #{@streak_info[:longest_streak_period]}
+
+  .col-md-4
+    %p.light
+      Current streak
+    %h3
+      #{@streak_info[:current_streak]} days
+    %p.light
+      #{@streak_info[:current_streak_period]}

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -32,6 +32,7 @@
       .user-calendar
         %h4.center.light
           %i.fa.fa-spinner.fa-spin
+      = render 'streak', streak_info: @streak_info
       .user-calendar-activities
       %hr
     %h4

--- a/db/migrate/20150430101032_add_streak_to_users.rb
+++ b/db/migrate/20150430101032_add_streak_to_users.rb
@@ -1,0 +1,8 @@
+class AddStreakToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :longest_streak_start_at, :date
+    add_column :users, :longest_streak_end_at, :date
+    add_column :users, :current_streak, :integer, default: 0
+    add_column :users, :last_contributed_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150425173433) do
+ActiveRecord::Schema.define(version: 20150430101032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -489,6 +489,11 @@ ActiveRecord::Schema.define(version: 20150425173433) do
     t.string   "bitbucket_access_token_secret"
     t.string   "location"
     t.string   "public_email",                  default: "",    null: false
+    t.integer  "longest_streak",                default: 0
+    t.integer  "current_streak",                default: 0
+    t.date     "last_contributed_at"
+    t.date     "longest_streak_start_at"
+    t.date     "longest_streak_end_at"
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree

--- a/lib/gitlab/contributions_calendar.rb
+++ b/lib/gitlab/contributions_calendar.rb
@@ -35,9 +35,11 @@ module Gitlab
       @timestamps
     end
 
-    def events_by_date(date)
+    def events_by_period(start_date, end_date=nil)
+      end_date = end_date || start_date
+
       events = Event.contributions.where(author_id: user.id).
-        where("created_at > ? AND created_at < ?", date.beginning_of_day, date.end_of_day).
+        where("created_at > ? AND created_at < ?", start_date.beginning_of_day, end_date.end_of_day).
         where(project_id: projects)
 
       events.select do |event|


### PR DESCRIPTION
Add commit streak information like Github to user profile page.

Before
![before](https://cloud.githubusercontent.com/assets/1220971/7412950/e5823068-ef79-11e4-8af6-d20d0f4b96b3.png)

After
![after](https://cloud.githubusercontent.com/assets/1220971/7413185/304da062-ef7c-11e4-838d-ec41e9dcfacf.png)

Relevant feature request: 
http://feedback.gitlab.com/forums/176466-general/suggestions/5863108-implement-github-like-commit-streak
