### PR TITLE
Group milestones by title in the dashboard and all other issue views

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ v 7.11.0 (unreleased)
   - Don't crash when an MR from a fork has a cross-reference comment from the target project on of its commits.
   - Include commit comments in MR from a forked project.
   - Fix adding new group members from admin area
+  - Group milestones by title in the dashboard and all other issue views.
   - Add default project and snippet visibility settings to the admin web UI.
   -
   - Fix bug where commit data would not appear in some subdirectories (Stan Hu)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -286,40 +286,15 @@ class ApplicationController < ActionController::Base
     @filter_params
   end
 
-  def set_filter_values(collection)
-    assignee_id = @filter_params[:assignee_id]
-    author_id = @filter_params[:author_id]
-    milestone_id = @filter_params[:milestone_id]
-
-    @sort = @filter_params[:sort]
-    @assignees = User.where(id: collection.pluck(:assignee_id))
-    @authors = User.where(id: collection.pluck(:author_id))
-    @milestones = Milestone.where(id: collection.pluck(:milestone_id))
-
-    if assignee_id.present? && !assignee_id.to_i.zero?
-      @assignee = @assignees.find_by(id: assignee_id)
-    end
-
-    if author_id.present? && !author_id.to_i.zero?
-      @author = @authors.find_by(id: author_id)
-    end
-
-    if milestone_id.present? && !milestone_id.to_i.zero?
-      @milestone = @milestones.find_by(id: milestone_id)
-    end
-  end
-
   def get_issues_collection
     set_filters_params
     issues = IssuesFinder.new.execute(current_user, @filter_params)
-    set_filter_values(issues)
     issues
   end
 
   def get_merge_requests_collection
     set_filters_params
     merge_requests = MergeRequestsFinder.new.execute(current_user, @filter_params)
-    set_filter_values(merge_requests)
     merge_requests
   end
 

--- a/app/finders/issuable_finder.rb
+++ b/app/finders/issuable_finder.rb
@@ -113,8 +113,9 @@ class IssuableFinder
   end
 
   def by_milestone(items)
-    if params[:milestone_id].present?
-      items = items.where(milestone_id: (params[:milestone_id] == NONE ? nil : params[:milestone_id]))
+    if params[:milestone_title].present?
+      milestone_ids = (params[:milestone_title] == NONE ? nil : Milestone.where(title: params[:milestone_title]).pluck(:id))
+      items = items.where(milestone_id: milestone_ids)
     end
 
     items

--- a/app/helpers/milestones_helper.rb
+++ b/app/helpers/milestones_helper.rb
@@ -28,6 +28,7 @@ module MilestonesHelper
         Milestone.where(project_id: @projects)
       end.active
 
-    options_from_collection_for_select(milestones, 'id', 'title', params[:milestone_id])
+    grouped_milestones = Milestones::GroupService.new(milestones).execute
+    options_from_collection_for_select(grouped_milestones, 'title', 'title', params[:milestone_title])
   end
 end

--- a/app/views/shared/_issuable_filter.html.haml
+++ b/app/views/shared/_issuable_filter.html.haml
@@ -15,7 +15,7 @@
           #{state_filters_text_for(:all, @project)}
 
   .issues-details-filters
-    = form_tag page_filter_path(without: [:assignee_id, :author_id, :milestone_id, :label_name]), method: :get, class: 'filter-form' do
+    = form_tag page_filter_path(without: [:assignee_id, :author_id, :milestone_title, :label_name]), method: :get, class: 'filter-form' do
       - if controller.controller_name == 'issues'
         .check-all-holder
           = check_box_tag "check_all_issues", nil, false,
@@ -31,7 +31,7 @@
             placeholder: 'Author', class: 'trigger-submit', any_user: true, first_user: true)
 
         .filter-item.inline.milestone-filter
-          = select_tag('milestone_id', projects_milestones_options, class: "select2 trigger-submit", prompt: 'Milestone')
+          = select_tag('milestone_title', projects_milestones_options, class: "select2 trigger-submit", prompt: 'Milestone')
 
         - if @project
           .filter-item.inline.labels-filter

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -95,7 +95,7 @@ describe 'Issues', feature: true do
     let(:issue) { @issue }
 
     it 'should allow filtering by issues with no specified milestone' do
-      visit namespace_project_issues_path(project.namespace, project, milestone_id: IssuableFinder::NONE)
+      visit namespace_project_issues_path(project.namespace, project, milestone_title: IssuableFinder::NONE)
 
       expect(page).not_to have_content 'foobar'
       expect(page).to have_content 'barbaz'
@@ -103,7 +103,7 @@ describe 'Issues', feature: true do
     end
 
     it 'should allow filtering by a specified milestone' do
-      visit namespace_project_issues_path(project.namespace, project, milestone_id: issue.milestone.id)
+      visit namespace_project_issues_path(project.namespace, project, milestone_title: issue.milestone.title)
 
       expect(page).to have_content 'foobar'
       expect(page).not_to have_content 'barbaz'

--- a/spec/finders/issues_finder_spec.rb
+++ b/spec/finders/issues_finder_spec.rb
@@ -43,7 +43,7 @@ describe IssuesFinder do
       end
 
       it 'should filter by milestone id' do
-        params = { scope: "all", milestone_id: milestone.id, state: 'opened' }
+        params = { scope: "all", milestone_title: milestone.title, state: 'opened' }
         issues = IssuesFinder.new.execute(user, params)
         expect(issues).to eq([issue1])
       end


### PR DESCRIPTION
This groups milestones by title for issue views like it has been done for the milestone dashboard/project overview. Before milestones with the same title would show up multiple times in the filter dropdown and one could only filter per project and milestone. Now the milestone filter is based on the title of the milestone, i.e. all issues marked with the same milestone title are shown.

While working on this I noticed that the variables assigned by `ApplicationController#set_filter_values` seem not to be used by anything anymore, so I removed the method and it's invocations. I included it in this PR because I would have to make changes to it (`milestone_id` vs `milestone_title`) whose consequences I could not test. If I missed something, please correct me, and I will revert the second commit and change it to use the `milestone_label`.

~~The specs do not work very well locally for me, so I am labeling it as WIP until the CI confirms the specs pass.~~

Before:
![before](https://cloud.githubusercontent.com/assets/20943/7423287/2f62ab6c-ef94-11e4-96fd-a2eeab4e1ddf.jpg)
After:
![after](https://cloud.githubusercontent.com/assets/20943/7423290/33c75e5a-ef94-11e4-93b3-22480afd56f1.jpg)
