### PR TITLE
Fix branch labels being underlined as links

### DIFF
--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -1,14 +1,13 @@
 - commit = @repository.commit(branch.target)
 %li(class="js-branch-#{branch.name}")
   %h4
-    = link_to namespace_project_tree_path(@project.namespace, @project, branch.name) do
-      %strong.str-truncated= branch.name
-      - if branch.name == @repository.root_ref
-        %span.label.label-info default
-      - if @project.protected_branch? branch.name
-        %span.label.label-success
-          %i.fa.fa-lock
-          protected
+    %strong= link_to branch.name, namespace_project_tree_path(@project.namespace, @project, branch.name), class: 'str-truncated'
+    - if branch.name == @repository.root_ref
+      %span.label.label-info default
+    - if @project.protected_branch? branch.name
+      %span.label.label-success
+        %i.fa.fa-lock
+        protected
     .pull-right
       - if can?(current_user, :download_code, @project)
         = render 'projects/repositories/download_archive', ref: branch.name, btn_class: 'btn-grouped btn-group-xs'

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -1,7 +1,7 @@
 - commit = @repository.commit(branch.target)
 %li(class="js-branch-#{branch.name}")
   %h4
-    %strong= link_to branch.name, namespace_project_tree_path(@project.namespace, @project, branch.name), class: 'str-truncated'
+    %strong.str-truncated= link_to branch.name, namespace_project_tree_path(@project.namespace, @project, branch.name)
     - if branch.name == @repository.root_ref
       %span.label.label-info default
     - if @project.protected_branch? branch.name

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -1,7 +1,8 @@
 - commit = @repository.commit(branch.target)
 %li(class="js-branch-#{branch.name}")
   %h4
-    %strong.str-truncated= link_to branch.name, namespace_project_tree_path(@project.namespace, @project, branch.name)
+    = link_to namespace_project_tree_path(@project.namespace, @project, branch.name) do
+      %strong.str-truncated>= branch.name
     - if branch.name == @repository.root_ref
       %span.label.label-info default
     - if @project.protected_branch? branch.name


### PR DESCRIPTION
When hovering over the branch labels they are underlined since they are
part of the link to the branch. This does not look very good. Removed
branch labels as being part of the link to the branch.

This could also be fixed with CSS of course but decided to go with this quick
fix instead.

Here is a screen shot of the problem:

![gitlab](https://cloud.githubusercontent.com/assets/3237256/7463837/f5b9cb94-f28a-11e4-8794-2bd80335b450.png)
