### PR TITLE
Fix a trailing new line

### DIFF
--- a/app/views/projects/merge_requests/show/_how_to_merge.html.haml
+++ b/app/views/projects/merge_requests/show/_how_to_merge.html.haml
@@ -40,7 +40,6 @@
               git merge --no-ff #{@merge_request.source_branch}
               git push origin #{@merge_request.target_branch}
 
-
 :javascript
   $(function(){
     var modal = $('#modal_merge_info').modal({modal: true, show:false});


### PR DESCRIPTION
The "How to Merge" modal included a trailing new line in the code
block. This commit removes that disfigurement.
