### PR TITLE
List of default web hooks could be setted up

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,18 +50,17 @@ class Project < ActiveRecord::Base
   default_value_for :wall_enabled, false
   default_value_for :snippets_enabled, gitlab_config_features.snippets
 
-  # set last_activity_at to the same as created_at
-  after_create :set_last_activity_at
-  def set_last_activity_at
-    update_column(:last_activity_at, self.created_at)
-  end
-
-  # create default hooks if they are presented
   after_create :create_default_web_hooks, if: -> { !!gitlab_config_features.auto_web_hooks }
   def create_default_web_hooks
     gitlab_config_features.auto_web_hooks.each do |web_hook_url|
       hooks.create(url: web_hook_url)
     end
+  end
+
+  # set last_activity_at to the same as created_at
+  after_create :set_last_activity_at
+  def set_last_activity_at
+    update_column(:last_activity_at, self.created_at)
   end
 
   ActsAsTaggableOn.strict_case_match = true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,14 @@ class Project < ActiveRecord::Base
     update_column(:last_activity_at, self.created_at)
   end
 
+  # create default hooks if they are presented
+  after_create :create_default_web_hooks, if: -> { !!gitlab_config_features.auto_web_hooks }
+  def create_default_web_hooks
+    gitlab_config_features.auto_web_hooks.each do |web_hook_url|
+      hooks.create(url: web_hook_url)
+    end
+  end
+
   ActsAsTaggableOn.strict_case_match = true
   acts_as_taggable_on :tags
 

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -80,6 +80,11 @@ production: &base
       wiki: true
       snippets: false
 
+      ## Default web hooks settings
+      # There are hooks which will be added to each created project (default: no hooks)
+      # auto_web_hooks:
+      #   - http://example.com/my-jira-hook
+
     ## Webhook settings
     # Number of seconds to wait for HTTP response after sending webhook HTTP POST request (default: 10)
     # webhook_timeout: 10

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -130,6 +130,7 @@ Settings.gitlab.default_projects_features['issues']         = true if Settings.g
 Settings.gitlab.default_projects_features['merge_requests'] = true if Settings.gitlab.default_projects_features['merge_requests'].nil?
 Settings.gitlab.default_projects_features['wiki']           = true if Settings.gitlab.default_projects_features['wiki'].nil?
 Settings.gitlab.default_projects_features['snippets']       = false if Settings.gitlab.default_projects_features['snippets'].nil?
+Settings.gitlab.default_projects_features['auto_web_hooks'] = nil if Settings.gitlab.default_projects_features['auto_web_hooks'].nil?
 Settings.gitlab.default_projects_features['visibility_level']    = Settings.send(:verify_constant, Gitlab::VisibilityLevel, Settings.gitlab.default_projects_features['visibility_level'], Gitlab::VisibilityLevel::PRIVATE)
 Settings.gitlab['repository_downloads_path'] = File.absolute_path(Settings.gitlab['repository_downloads_path'] || 'tmp/repositories', Rails.root)
 Settings.gitlab['restricted_signup_domains'] ||= []


### PR DESCRIPTION
Now we can setup our GitLab for auto create web hooks for each new project
