### PR TITLE
Ensure that the first added admin performs repository imports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@ v 7.11.0 (unreleased)
   - Add style for <kbd> element in markdown
   - Spin spinner icon next to "Checking for CI status..." on MR page.
   - Fix reference links in dashboard activity and ATOM feeds.
+  - Ensure that the first added admin performs repository imports
 
 v 7.10.2
   - Fix CI links on MR page

--- a/lib/tasks/gitlab/import.rake
+++ b/lib/tasks/gitlab/import.rake
@@ -35,7 +35,7 @@ namespace :gitlab do
         if project
           puts " * #{project.name} (#{repo_path}) exists"
         else
-          user = User.admins.first
+          user = User.admins.reorder("id").first
 
           project_params = {
             name: name,


### PR DESCRIPTION
This is a fixup from https://github.com/gitlabhq/gitlabhq/pull/9061. I added the changelog entry, so we can merge it in.

/cc @randx 
