### PR TITLE
Disabled expansion of top/bottom blobs for new file diffs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 v 7.12.0 (unreleased)
 - Allow to configure location of the `.gitlab_shell_secret` file. (Jakub Jirutka)
+  - Disabled expansion of top/bottom blobs for new file diffs
 
 v 7.11.0 (unreleased)
   - Fix broken view when viewing history of a file that includes a path that used to be another file (Stan Hu)

--- a/app/helpers/diff_helper.rb
+++ b/app/helpers/diff_helper.rb
@@ -101,6 +101,10 @@ module DiffHelper
     (bottom) ? 'js-unfold-bottom' : ''
   end
 
+  def unfold_class(unfold)
+    (unfold) ? 'unfold js-unfold' : ''
+  end
+
   def diff_line_content(line)
     if line.blank?
       " &nbsp;"

--- a/app/views/projects/blob/diff.html.haml
+++ b/app/views/projects/blob/diff.html.haml
@@ -2,7 +2,7 @@
   - if @form.unfold? && @form.since != 1 && !@form.bottom?
     %tr.line_holder{ id: @form.since }
       = render "projects/diffs/match_line", {line: @match_line,
-        line_old: @form.since, line_new: @form.since, bottom: false}
+        line_old: @form.since, line_new: @form.since, bottom: false, new_file: false}
 
   - @lines.each_with_index do |line, index|
     - line_new = index + @form.since
@@ -16,4 +16,4 @@
   - if @form.unfold? && @form.bottom? && @form.to < @blob.loc
     %tr.line_holder{ id: @form.to }
       = render "projects/diffs/match_line", {line: @match_line,
-        line_old: @form.to, line_new: @form.to, bottom: true}
+        line_old: @form.to, line_new: @form.to, bottom: true, new_file: false}

--- a/app/views/projects/diffs/_match_line.html.haml
+++ b/app/views/projects/diffs/_match_line.html.haml
@@ -1,7 +1,7 @@
-%td.old_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_old},
- class: unfold_bottom_class(bottom)}
+%td.old_line.diff-line-num{data: {linenumber: line_old},
+ class: [unfold_bottom_class(bottom), unfold_class(!new_file)]}
   \...
-%td.new_line.diff-line-num.unfold.js-unfold{data: {linenumber: line_new},
- class: unfold_bottom_class(bottom)}
+%td.new_line.diff-line-num{data: {linenumber: line_new},
+ class: [unfold_bottom_class(bottom), unfold_class(!new_file)]}
   \...
 %td.line_content.matched= line

--- a/app/views/projects/diffs/_text_file.html.haml
+++ b/app/views/projects/diffs/_text_file.html.haml
@@ -12,7 +12,7 @@
     %tr.line_holder{ id: line_code, class: "#{type}" }
       - if type == "match"
         = render "projects/diffs/match_line", {line: line.text,
-          line_old: line_old, line_new: line.new_pos, bottom: false}
+          line_old: line_old, line_new: line.new_pos, bottom: false, new_file: diff_file.new_file}
       - else
         %td.old_line
           = link_to raw(type == "new" ? "&nbsp;" : line_old), "##{line_code}", id: line_code
@@ -29,7 +29,7 @@
 
   - if last_line > 0
     = render "projects/diffs/match_line", {line: "",
-      line_old: last_line, line_new: last_line, bottom: true}
+      line_old: last_line, line_new: last_line, bottom: true, new_file: diff_file.new_file}
 
 - if diff_file.diff.blank? && diff_file.mode_changed?
   .file-mode-changed

--- a/spec/helpers/diff_helper_spec.rb
+++ b/spec/helpers/diff_helper_spec.rb
@@ -106,6 +106,16 @@ describe DiffHelper do
     end
   end
 
+  describe 'unfold_class' do
+    it 'returns empty on false' do
+      expect(unfold_class(false)).to eq('')
+    end
+
+    it 'returns a class on true' do
+      expect(unfold_class(true)).to eq('unfold js-unfold')
+    end
+  end
+
   describe 'diff_line_content' do
 
     it 'should return non breaking space when line is empty' do


### PR DESCRIPTION
This is a fix up of https://github.com/gitlabhq/gitlabhq/pull/8755. Added Changelog entry to the correct place so we can merge.

/cc @randx 
