### PR TITLE
Fixed issue where email address was missing from API calls.

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -5,7 +5,7 @@ module API
     end
 
     class UserBasic < UserSafe
-      expose :id, :state, :avatar_url
+      expose :id, :state, :avatar_url, :email
     end
 
     class User < UserBasic


### PR DESCRIPTION
The email address attribute was missing from group and project memberships, this used to appear on a previous release and this pull request is just adding the attribute back in.
