### PR TITLE
Expose group and project membership email address only to admins.

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -8,6 +8,10 @@ module API
       expose :id, :state, :avatar_url
     end
 
+    class UserBasicForAdmin < UserBasic
+      expose :email
+    end
+
     class User < UserBasic
       expose :created_at
       expose :is_admin?, as: :is_admin
@@ -66,6 +70,12 @@ module API
       end
     end
 
+    class ProjectMemberForAdmin < UserBasicForAdmin
+      expose :access_level do |user, options|
+        options[:project].project_members.find_by(user_id: user.id).access_level
+      end
+    end
+
     class Group < Grape::Entity
       expose :id, :name, :path, :description
     end
@@ -75,6 +85,12 @@ module API
     end
 
     class GroupMember < UserBasic
+      expose :access_level do |user, options|
+        options[:group].group_members.find_by(user_id: user.id).access_level
+      end
+    end
+
+    class GroupMemberForAdmin < UserBasicForAdmin
       expose :access_level do |user, options|
         options[:group].group_members.find_by(user_id: user.id).access_level
       end

--- a/lib/api/group_members.rb
+++ b/lib/api/group_members.rb
@@ -10,7 +10,11 @@ module API
       get ":id/members" do
         group = find_group(params[:id])
         users = group.users
-        present users, with: Entities::GroupMember, group: group
+        if current_user.is_admin?
+          present users, with: Entities::GroupMemberForAdmin, group: group
+        else
+          present users, with: Entities::GroupMember, group: group
+        end
       end
 
       # Add a user to the list of group members

--- a/lib/api/project_members.rb
+++ b/lib/api/project_members.rb
@@ -18,7 +18,11 @@ module API
         else
           @members = paginate user_project.users
         end
-        present @members, with: Entities::ProjectMember, project: user_project
+        if current_user.is_admin?
+          present @members, with: Entities::ProjectMemberForAdmin, project: user_project
+        else
+          present @members, with: Entities::ProjectMember, project: user_project
+        end
       end
 
       # Get a project team members


### PR DESCRIPTION
Further to our discussions regarding https://github.com/gitlabhq/gitlabhq/pull/9291, this pull request only exposes the email address to admin users.
