### PR TITLE
Allow special characters in users bio

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,9 @@ v 7.11.1
 v 7.11.0 
   - Fall back to Plaintext when Syntaxhighlighting doesn't work. Fixes some buggy lexers (Hannes Rosenögger)
   - Get editing comments to work in Chrome 43 again.
+  - Allow special character in users bio. I.e.: I <3 GitLab
+
+v 7.11.0 (unreleased)
   - Fix broken view when viewing history of a file that includes a path that used to be another file (Stan Hu)
   - Don't show duplicate deploy keys
   - Fix commit time being displayed in the wrong timezone in some cases (Hannes Rosenögger)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -483,7 +483,7 @@ class User < ActiveRecord::Base
   end
 
   def sanitize_attrs
-    %w(name username skype linkedin twitter bio).each do |attr|
+    %w(name username skype linkedin twitter).each do |attr|
       value = self.send(attr)
       self.send("#{attr}=", Sanitize.clean(value)) if value.present?
     end

--- a/features/steps/profile/profile.rb
+++ b/features/steps/profile/profile.rb
@@ -7,21 +7,23 @@ class Spinach::Features::Profile < Spinach::FeatureSteps
   end
 
   step 'I change my profile info' do
-    fill_in "user_skype", with: "testskype"
-    fill_in "user_linkedin", with: "testlinkedin"
-    fill_in "user_twitter", with: "testtwitter"
-    fill_in "user_website_url", with: "testurl"
-    fill_in "user_location", with: "Ukraine"
-    click_button "Save changes"
+    fill_in 'user_skype', with: 'testskype'
+    fill_in 'user_linkedin', with: 'testlinkedin'
+    fill_in 'user_twitter', with: 'testtwitter'
+    fill_in 'user_website_url', with: 'testurl'
+    fill_in 'user_location', with: 'Ukraine'
+    fill_in 'user_bio', with: 'I <3 GitLab'
+    click_button 'Save changes'
     @user.reload
   end
 
   step 'I should see new profile info' do
-    @user.skype.should == 'testskype'
-    @user.linkedin.should == 'testlinkedin'
-    @user.twitter.should == 'testtwitter'
-    @user.website_url.should == 'testurl'
-    find("#user_location").value.should == "Ukraine"
+    expect(@user.skype).to eq 'testskype'
+    expect(@user.linkedin).to eq 'testlinkedin'
+    expect(@user.twitter).to eq 'testtwitter'
+    expect(@user.website_url).to eq 'testurl'
+    expect(@user.bio).to eq 'I <3 GitLab'
+    find('#user_location').value.should == 'Ukraine'
   end
 
   step 'I change my avatar' do


### PR DESCRIPTION
**What does this do?**
It removes the very strict sanitation on the users bio field, so that people can
have a bio like "I <3 GitLab"

**Why is this needed?**
Currently when you enter a bio with "I <3 GitLab", we only store "I ". This is
unexpected behaviour, since we want users to have a normal profile, without
having to worry what characters are allowed and which are not.

**Related issues:**
Fixes https://github.com/gitlabhq/gitlabhq/issues/5625
