### PR TITLE
Validate wiki page creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ v 7.12.0 (unreleased)
   - Fix resolving of relative links to repository files in AsciiDoc documents. (Jakub Jirutka)
   - Use the user list from the target project in a merge request (Stan Hu)
   - Default extention for wiki pages is now .md instead of .markdown (Jeroen van Baarsen)
+  - Add validation to wiki page creation (only [a-zA-Z0-9/_-] are allowed) (Jeroen van Baarsen)
 
 v 7.11.2
   - no changes

--- a/app/assets/javascripts/wikis.js.coffee
+++ b/app/assets/javascripts/wikis.js.coffee
@@ -1,9 +1,17 @@
 class @Wikis
   constructor: ->
-    $('.build-new-wiki').bind "click", ->
+    $('.build-new-wiki').bind "click", (e) ->
+      $('[data-error~=slug]').addClass("hidden")
+      $('p.hint').show()
       field = $('#new_wiki_path')
-      slug = field.val()
-      path = field.attr('data-wikis-path')
+      valid_slug_pattern = /^[\w\/-]+$/
 
-      if(slug.length > 0)
-        location.href = path + "/" + slug
+      slug = field.val()
+      if slug.match valid_slug_pattern
+        path = field.attr('data-wikis-path')
+        if(slug.length > 0)
+          location.href = path + "/" + slug
+      else
+        e.preventDefault()
+        $('p.hint').hide()
+        $('[data-error~=slug]').removeClass("hidden")

--- a/app/views/projects/wikis/_new.html.haml
+++ b/app/views/projects/wikis/_new.html.haml
@@ -8,6 +8,8 @@
         = label_tag :new_wiki_path do
           %span Page slug
         = text_field_tag :new_wiki_path, nil, placeholder: 'how-to-setup', class: 'form-control', required: true, :'data-wikis-path' => namespace_project_wikis_path(@project.namespace, @project)
+        %p.hidden.text-danger{data: { error: "slug" }}
+          The page slug is invalid. Please don't use characters other then: a-z 0-9 _ - and /
         %p.hint
           Please don't use spaces.
       .modal-footer

--- a/features/project/wiki.feature
+++ b/features/project/wiki.feature
@@ -69,6 +69,11 @@ Feature: Project Wiki
     And I click on the "Pages" button
     Then I should see non-escaped link in the pages list
 
+  @javascript @focus
+  Scenario: Creating an invalid new page
+    Given I create a New page with an invalid name
+    Then I should see an error message
+
   @javascript
   Scenario: Edit Wiki page that has a path
     Given I create a New page with paths

--- a/features/steps/project/wiki.rb
+++ b/features/steps/project/wiki.rb
@@ -133,6 +133,16 @@ class Spinach::Features::ProjectWiki < Spinach::FeatureSteps
     current_path.should include 'one/two/three'
   end
 
+  step 'I create a New page with an invalid name' do
+    click_on 'New Page'
+    fill_in 'Page slug', with: 'invalid name'
+    click_on 'Build'
+  end
+
+  step 'I should see an error message' do
+    expect(page).to have_content "The page slug is invalid"
+  end
+
   step 'I should see non-escaped link in the pages list' do
     page.should have_xpath("//a[@href='/#{project.path_with_namespace}/wikis/one/two/three']")
   end


### PR DESCRIPTION
**What does this do?**
It adds validation to the creation of a wiki page, that way the user gets real
feedback instead of just a 404 page if the name of the wiki page was invalid

**Why is this needed?**
There are a lot of characters that are not allowed in the creation of a wiki
page, there is even a small text that is saying: Please don't use spaces.
Although we have that text there, we don't actually validate on this. This
commit adds validation on the title and gives the user actual feedback.

**What issues does this fix?**
Fixes http://github.com/gitlabhq/gitlabhq/issues/5357
Fixes https://github.com/gitlabhq/gitlabhq/issues/8565
Fixes https://github.com/gitlabhq/gitlabhq/issues/3913
Fixes https://github.com/gitlabhq/gitlabhq/issues/8166
