### PR TITLE
Use .md as extention for wiki pages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ v 7.12.0 (unreleased)
   - Update Asciidoctor gem to version 1.5.2. (Jakub Jirutka)
   - Fix resolving of relative links to repository files in AsciiDoc documents. (Jakub Jirutka)
   - Use the user list from the target project in a merge request (Stan Hu)
+  - Default extention for wiki pages is now .md instead of .markdown (Jeroen van Baarsen)
 
 v 7.11.2
   - no changes

--- a/app/models/project_wiki.rb
+++ b/app/models/project_wiki.rb
@@ -2,7 +2,7 @@ class ProjectWiki
   include Gitlab::ShellAdapter
 
   MARKUPS = {
-    'Markdown' => :markdown,
+    'Markdown' => :md,
     'RDoc'     => :rdoc,
     'AsciiDoc' => :asciidoc
   } unless defined?(MARKUPS)


### PR DESCRIPTION
**What does this do?**
It makes sure that when you create a wiki page via the web interface, the
extention is .md instead of .markdown

**Why is this needed?**
When you're using Gollum locally, it will create pages with the .md extention.
Also .md is the best known extention for markdown. This fix will make sure that
if you're using gollum or the webinterface, the extention will be the same.

**What issues does this fix?**
Fixes https://github.com/gitlabhq/gitlabhq/issues/5204
