### PR TITLE
Possibility to query ldap user on realtime.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -500,7 +500,11 @@ class User < ActiveRecord::Base
     if !Gitlab.config.ldap.enabled
       false
     elsif ldap_user?
-      !last_credential_check_at || (last_credential_check_at + 1.hour) < Time.now
+      if Gitlab.config.ldap.servers.main.check_cache
+         !last_credential_check_at || (last_credential_check_at + 1.hour) < Time.now
+      else
+         true
+      end
     else
       false
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -500,11 +500,7 @@ class User < ActiveRecord::Base
     if !Gitlab.config.ldap.enabled
       false
     elsif ldap_user?
-      if Gitlab.config.ldap.servers.main.check_cache
-         !last_credential_check_at || (last_credential_check_at + 1.hour) < Time.now
-      else
-         true
-      end
+      !last_credential_check_at || (last_credential_check_at + Gitlab.config.ldap.servers.main.check_expiraton_time.seconds) < Time.now
     else
       false
     end

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -131,7 +131,7 @@ production: &base
         method: 'plain' # "tls" or "ssl" or "plain"
         bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
         password: '_the_password_of_the_bind_user'
-        check_cache: true
+        check_expiraton_time: 3600 # Considering 0 disabled and another numer as LDAP cache. 3600 default value (1 Hour)
 
         # This setting specifies if LDAP server is Active Directory LDAP server.
         # For non AD servers it skips the AD specific queries.

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -131,6 +131,7 @@ production: &base
         method: 'plain' # "tls" or "ssl" or "plain"
         bind_dn: '_the_full_dn_of_the_user_you_will_bind_with'
         password: '_the_password_of_the_bind_user'
+        check_cache: true
 
         # This setting specifies if LDAP server is Active Directory LDAP server.
         # For non AD servers it skips the AD specific queries.


### PR DESCRIPTION
Sometimes we need a realtime query on ldap. LDAP was developed to receive to many read queries per seconds. 1 hour of query is too much time if one bad developer.  As example my ldap filter:

user_filter: '(&(&(VCS=1)(disabled=0))(objectClass=SkoobServices))'

If I set VCS (Version Control System = 0 or disabled = 1), I still can commit via SSH protocol due the cache connection.

I gave the possibility to cache if wanted.  
