### PR TITLE
Update noteable after a new note is added

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -31,7 +31,7 @@ class Note < ActiveRecord::Base
   participant :author, :mentioned_users
 
   belongs_to :project
-  belongs_to :noteable, polymorphic: true
+  belongs_to :noteable, polymorphic: true, touch: true
   belongs_to :author, class_name: "User"
 
   delegate :name, to: :project, prefix: true

--- a/spec/lib/gitlab/note_data_builder_spec.rb
+++ b/spec/lib/gitlab/note_data_builder_spec.rb
@@ -36,6 +36,7 @@ describe 'Gitlab::NoteDataBuilder' do
     let(:note) { create(:note_on_issue, noteable_id: issue.id) }
 
     it 'returns the note and issue-specific data' do
+      data[:issue]["updated_at"] = fixed_time
       expect(data).to have_key(:issue)
       expect(data[:issue]).to eq(issue.hook_attrs)
     end
@@ -46,6 +47,7 @@ describe 'Gitlab::NoteDataBuilder' do
     let(:note) { create(:note_on_merge_request, noteable_id: merge_request.id) }
 
     it 'returns the note and merge request data' do
+      data[:merge_request]["updated_at"] = fixed_time
       expect(data).to have_key(:merge_request)
       expect(data[:merge_request]).to eq(merge_request.hook_attrs)
     end
@@ -56,6 +58,7 @@ describe 'Gitlab::NoteDataBuilder' do
     let(:note) { create(:note_on_merge_request_diff, noteable_id: merge_request.id) }
 
     it 'returns the note and merge request diff data' do
+      data[:merge_request]["updated_at"] = fixed_time
       expect(data).to have_key(:merge_request)
       expect(data[:merge_request]).to eq(merge_request.hook_attrs)
     end
@@ -66,6 +69,7 @@ describe 'Gitlab::NoteDataBuilder' do
     let!(:note) { create(:note_on_project_snippet, noteable_id: snippet.id) }
 
     it 'returns the note and project snippet data' do
+      data[:snippet]["updated_at"] = fixed_time
       expect(data).to have_key(:snippet)
       expect(data[:snippet]).to eq(snippet.hook_attrs)
     end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -22,7 +22,7 @@ require 'spec_helper'
 describe Note do
   describe 'associations' do
     it { is_expected.to belong_to(:project) }
-    it { is_expected.to belong_to(:noteable) }
+    it { is_expected.to belong_to(:noteable).touch(true) }
     it { is_expected.to belong_to(:author).class_name('User') }
   end
 


### PR DESCRIPTION
**What does this do?**
It makes sure that whenever a new note is added to a `noteable` item, the
`updated_at` of that item is also updated.

**Why is this needed?**
At this moment when you post a comment on an issue or add a label to an issue,
the `updated_at` is not changed. Because of this the filtering for least recently
updated is not really useful (since it only takes in account the original text
from the noteable).
