### PR TITLE
Autoedetct SSL connection to issue tracker.

### DIFF
--- a/app/models/project_services/issue_tracker_service.rb
+++ b/app/models/project_services/issue_tracker_service.rb
@@ -84,7 +84,7 @@ class IssueTrackerService < Service
       url = URI.parse(self.project_url)
 
       if url.host && url.port
-        http = Net::HTTP.start(url.host, url.port, { open_timeout: 5, read_timeout: 5 })
+        http = Net::HTTP.start(url.host, url.port, { open_timeout: 5, read_timeout: 5, use_ssl: url.scheme == 'https' })
         response = http.head("/")
 
         if response


### PR DESCRIPTION
SSL is not used when checking connection to custom issue tracker and the HEAD method can fail with the following sidekiq error:

```
2015-06-03T12:02:46.526Z 22670 TID-84nqo ProjectServiceWorker JID-d2a8ebdda7069fb2788d20ef INFO: start
2015-06-03T12:02:46.526Z 22670 TID-84nqo ProjectServiceWorker JID-d2a8ebdda7069fb2788d20ef INFO: start
2015-06-03T12:02:46.737Z 22670 TID-84nqo ProjectServiceWorker JID-d2a8ebdda7069fb2788d20ef INFO: fail: 0.211 sec
2015-06-03T12:02:46.738Z 22670 TID-84nqo WARN: {"retry"=>true, "queue"=>"project_web_hook", "class"=>"ProjectServiceWorker", "args"=>[26, {"object_kind"=>"push", "before"=>"0dbe82e33bab113da76269f0c57e0293f8f93281", "after"=>"26b5a8a7a8edc5d8437fe7b4dd24bf69bcf37c60", "ref"=>"refs/heads/master", "checkout_sha"=>"26b5a8a7a8edc5d8437fe7b4dd24bf69bcf37c60", "message"=>nil, "user_id"=>1, "user_name"=>"Administrator", "user_email"=>"admin@example.com", "project_id"=>1, "repository"=>{"name"=>"foobar", "url"=>"git@gitlab3.dev:root/foobar.git", "description"=>"", "homepage"=>"http://gitlab3.dev/root/foobar", "git_http_url"=>"http://gitlab3.dev/root/foobar.git", "git_ssh_url"=>"git@gitlab3.dev:root/foobar.git", "visibility_level"=>0}, "commits"=>[{"id"=>"26b5a8a7a8edc5d8437fe7b4dd24bf69bcf37c60", "message"=>"baz\n", "timestamp"=>"2015-06-03T13:58:07+02:00", "url"=>"http://gitlab3.dev/root/foobar/commit/26b5a8a7a8edc5d8437fe7b4dd24bf69bcf37c60", "author"=>{"name"=>"Tomas Golembiovsky", "email"=>"admin@example.com"}}], "total_commits_count"=>1}], "jid"=>"d2a8ebdda7069fb2788d20ef", "enqueued_at"=>1433332736.566763, "error_message"=>"wrong status line: \"<!DOCTYPE HTML PUBLIC \\\"-//IETF//DTD HTML 2.0//EN\\\">\"", "error_class"=>"Net::HTTPBadResponse", "failed_at"=>1433332736.6805906, "retry_count"=>4, "retried_at"=>1433332966.7367425}
2015-06-03T12:02:46.738Z 22670 TID-84nqo WARN: wrong status line: "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">"
2015-06-03T12:02:46.738Z 22670 TID-84nqo WARN: /opt/ruby2.1/lib/ruby/2.1.0/net/http/response.rb:41:in `read_status_line'
/opt/ruby2.1/lib/ruby/2.1.0/net/http/response.rb:28:in `read_new'
/opt/ruby2.1/lib/ruby/2.1.0/net/http.rb:1414:in `block in transport_request'
/opt/ruby2.1/lib/ruby/2.1.0/net/http.rb:1411:in `catch'
/opt/ruby2.1/lib/ruby/2.1.0/net/http.rb:1411:in `transport_request'
/opt/ruby2.1/lib/ruby/2.1.0/net/http.rb:1384:in `request'
/opt/ruby2.1/lib/ruby/2.1.0/net/http.rb:1154:in `head'
/home/git/gitlab/app/models/project_services/issue_tracker_service.rb:88:in `execute'
/home/git/gitlab/app/workers/project_service_worker.rb:8:in `perform'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/processor.rb:75:in `execute_job'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/processor.rb:52:in `block (2 levels) in process'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:127:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:127:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidetiq-0.6.3/lib/sidetiq/middleware/history.rb:8:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/server/active_record.rb:6:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/server/retry_jobs.rb:74:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/server/logging.rb:11:in `block in call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/logging.rb:22:in `with_context'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/server/logging.rb:7:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:132:in `call'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/middleware/chain.rb:132:in `invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/processor.rb:51:in `block in process'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/processor.rb:98:in `stats'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.3.0/lib/sidekiq/processor.rb:50:in `process'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `public_send'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `dispatch'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:122:in `dispatch'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in `block in task'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in `block in initialize'
/home/git/gitlab/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
```

This is because html page is returned warning about not using SSL on SSL enabled port.
