### PR TITLE
Revert "No need to check if `repository_ref` is present"

### DIFF
--- a/lib/gitlab/project_search_results.rb
+++ b/lib/gitlab/project_search_results.rb
@@ -4,7 +4,11 @@ module Gitlab
 
     def initialize(project_id, query, repository_ref = nil)
       @project = Project.find(project_id)
-      @repository_ref = repository_ref
+      @repository_ref = if repository_ref.present?
+                          repository_ref
+                        else
+                          nil
+                        end
       @query = Shellwords.shellescape(query) if query.present?
     end
 


### PR DESCRIPTION
Reverts gitlabhq/gitlabhq#9368 because of not explicit nil check
