### PR TITLE
Fixed problem with non-existing user not being detected.

### DIFF
--- a/app/workers/post_receive.rb
+++ b/app/workers/post_receive.rb
@@ -28,17 +28,17 @@ class PostReceive
     changes.each do |change|
       oldrev, newrev, ref = change.strip.split(' ')
 
-      @user ||= identify(identifier, project, newrev)
+      user ||= identify(identifier, project, newrev)
 
-      unless @user
+      unless user
         log("Triggered hook for non-existing user \"#{identifier} \"")
         return false
       end
 
       if Gitlab::Git.tag_ref?(ref)
-        GitTagPushService.new.execute(project, @user, oldrev, newrev, ref)
+        GitTagPushService.new.execute(project, user, oldrev, newrev, ref)
       else
-        GitPushService.new.execute(project, @user, oldrev, newrev, ref)
+        GitPushService.new.execute(project, user, oldrev, newrev, ref)
       end
     end
   end


### PR DESCRIPTION
The effect I saw in production was that a "random" user was being shown in the activity log instead of the correct one. I think I found the reason for this. The change was not tested, and I do not really know Ruby but I hope I got the change from member to local variable right.

"@user" being a member variable, there normally was a @user object active, and ||= would keep it around if identify returns nil. Changing @user to a local variable fixes that and now non-existing users will actually be detected.
