### PR TITLE
Add a project service for LetsChat including tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ v 7.13.0 (unreleased)
   - Users with guest access level can not set assignee, labels or milestones for issue and merge request
   - Reporter role can manage issue tracker now: edit any issue, set assignee or milestone and manage labels
   - Better performance for pages with events list, issues list and commits list
+  - Lets Chat service added (Arifumi Matsumoto)
 
 v 7.12.0
   - Fix Error 500 when one user attempts to access a personal, internal snippet (Stan Hu)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,6 +77,7 @@ class Project < ActiveRecord::Base
   has_one :irker_service, dependent: :destroy
   has_one :pivotaltracker_service, dependent: :destroy
   has_one :hipchat_service, dependent: :destroy
+  has_one :letschat_service, dependent: :destroy
   has_one :flowdock_service, dependent: :destroy
   has_one :assembla_service, dependent: :destroy
   has_one :asana_service, dependent: :destroy

--- a/app/models/project_services/letschat_service.rb
+++ b/app/models/project_services/letschat_service.rb
@@ -1,0 +1,243 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id                    :integer          not null, primary key
+#  type                  :string(255)
+#  title                 :string(255)
+#  project_id            :integer
+#  created_at            :datetime
+#  updated_at            :datetime
+#  active                :boolean          default(FALSE), not null
+#  properties            :text
+#  template              :boolean          default(FALSE)
+#  push_events           :boolean          default(TRUE)
+#  issues_events         :boolean          default(TRUE)
+#  merge_requests_events :boolean          default(TRUE)
+#  tag_push_events       :boolean          default(TRUE)
+#  note_events           :boolean          default(TRUE), not null
+#
+
+class LetschatService < Service
+  MAX_COMMITS = 3
+
+  prop_accessor :token, :room, :server, :notify, :color, :api_version
+  validates :token, presence: true, if: :activated?
+
+  def title
+    'LetsChat'
+  end
+
+  def description
+    'Private group chat and IM'
+  end
+
+  def to_param
+    'letschat'
+  end
+
+  def fields
+    [
+      { type: 'text', name: 'token',     placeholder: 'Account token' },
+      { type: 'text', name: 'room',      placeholder: 'Room ID' },
+      { type: 'text', name: 'server',    placeholder: 'Server URL' }
+    ]
+  end
+
+  def supported_events
+    %w(push issue merge_request note tag_push)
+  end
+
+  def execute(data)
+    return unless supported_events.include?(data[:object_kind])
+    message = create_message(data)
+    return unless message.present?
+
+    HTTParty.post(
+      server+'/messages',
+      query: {
+        "text" => message,
+        "room" => room 
+      },
+      headers: { "Authorization" => "Bearer " + token }
+    )
+  end
+
+  private
+
+  def message_options
+    { notify: notify.present? && notify == '1', color: color || 'yellow' }
+  end
+
+  def create_message(data)
+    object_kind = data[:object_kind]
+
+    message = \
+      case object_kind
+      when "push", "tag_push"
+        create_push_message(data)
+      when "issue"
+        create_issue_message(data) unless is_update?(data)
+      when "merge_request"
+        create_merge_request_message(data) unless is_update?(data)
+      when "note"
+        create_note_message(data)
+      end
+  end
+
+  def create_push_message(push)
+    ref_type = Gitlab::Git.tag_ref?(push[:ref]) ? 'tag' : 'branch'
+    ref = Gitlab::Git.ref_name(push[:ref])
+
+    before = push[:before]
+    after = push[:after]
+
+    message = "[#{project_name}]"
+    message << " #{push[:user_name]} "
+    if Gitlab::Git.blank_ref?(before)
+      message << "pushed new #{ref_type} "\
+                 "#{project_url}/commits/#{URI.escape(ref)} #{ref}\n"
+    elsif Gitlab::Git.blank_ref?(after)
+      message << "removed #{ref_type} #{ref}\n"
+    else
+      message << "pushed to #{ref_type} "\
+                  "#{project.web_url}/commits/#{URI.escape(ref)} #{ref} "
+      message << "(#{project.web_url}/compare/#{before}...#{after} Compare changes)"
+
+      push[:commits].take(MAX_COMMITS).each do |commit|
+        message << " - #{commit[:message].lines.first} (#{commit[:url]} #{commit[:id][0..5]})"
+      end
+
+      if push[:commits].count > MAX_COMMITS
+        message << "... #{push[:commits].count - MAX_COMMITS} more commits"
+      end
+    end
+
+    message
+  end
+
+  def format_body(body)
+    if body
+      body = body.truncate(200, separator: ' ', omission: '...')
+    end
+
+    "#{body}"
+  end
+
+  def create_issue_message(data)
+    user_name = data[:user][:name]
+
+    obj_attr = data[:object_attributes]
+    obj_attr = HashWithIndifferentAccess.new(obj_attr)
+    title = obj_attr[:title]
+    state = obj_attr[:state]
+    issue_iid = obj_attr[:iid]
+    issue_url = obj_attr[:url]
+    description = obj_attr[:description]
+
+    message = "[#{project_name}] #{user_name} #{state} issue ##{issue_iid} #{issue_url}"
+    message << "\ntitle:#{title}"
+
+    if description
+      description = format_body(description)
+      message << "\n"+description
+    end
+
+    message
+  end
+
+  def create_merge_request_message(data)
+    user_name = data[:user][:name]
+
+    obj_attr = data[:object_attributes]
+    obj_attr = HashWithIndifferentAccess.new(obj_attr)
+    merge_request_id = obj_attr[:iid]
+    source_branch = obj_attr[:source_branch]
+    target_branch = obj_attr[:target_branch]
+    state = obj_attr[:state]
+    description = obj_attr[:description]
+    title = obj_attr[:title]
+
+    merge_request_url = "#{project_url}/merge_requests/#{merge_request_id}"
+    merge_request_num = "merge request ##{merge_request_id}"
+    message = "[#{project_name}] #{user_name} #{state} #{merge_request_num} #{merge_request_url}"
+    message << "\ntitle:#{title}"
+
+    if description
+      description = format_body(description)
+      message << "\n"+description
+    end
+
+    message
+  end
+
+  def format_title(title)
+    title.lines.first.chomp
+  end
+
+  def create_note_message(data)
+    data = HashWithIndifferentAccess.new(data)
+    user_name = data[:user][:name]
+
+    repo_attr = HashWithIndifferentAccess.new(data[:repository])
+
+    obj_attr = HashWithIndifferentAccess.new(data[:object_attributes])
+    note = obj_attr[:note]
+    note_url = obj_attr[:url]
+    noteable_type = obj_attr[:noteable_type]
+
+    case noteable_type
+    when "Commit"
+      commit_attr = HashWithIndifferentAccess.new(data[:commit])
+      subject_desc = commit_attr[:id]
+      subject_desc = Commit.truncate_sha(subject_desc)
+      subject_type = "commit"
+      title = format_title(commit_attr[:message])
+    when "Issue"
+      subj_attr = HashWithIndifferentAccess.new(data[:issue])
+      subject_id = subj_attr[:iid]
+      subject_desc = "##{subject_id}"
+      subject_type = "issue"
+      title = format_title(subj_attr[:title])
+    when "MergeRequest"
+      subj_attr = HashWithIndifferentAccess.new(data[:merge_request])
+      subject_id = subj_attr[:iid]
+      subject_desc = "##{subject_id}"
+      subject_type = "merge request"
+      title = format_title(subj_attr[:title])
+    when "Snippet"
+      subj_attr = HashWithIndifferentAccess.new(data[:snippet])
+      subject_id = subj_attr[:id]
+      subject_desc = "##{subject_id}"
+      subject_type = "snippet"
+      title = format_title(subj_attr[:title])
+    end
+
+    subject_html = "#{subject_type} #{subject_desc} #{note_url}"
+    message = "[#{project_name}] #{user_name} commented on #{subject_html}"
+    message << "\ntitle:"+title+""
+
+    if note
+      note = format_body(note)
+      message << "\n"+note
+    end
+
+    message
+  end
+
+  def project_name
+    project.name_with_namespace.gsub(/\s/, '')
+  end
+
+  def project_url
+    project.web_url
+  end
+
+  def project_link
+    "#{project_name} ( #{project_url} )"
+  end
+
+  def is_update?(data)
+    data[:object_attributes][:action] == 'update'
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -135,6 +135,7 @@ class Service < ActiveRecord::Base
       gemnasium
       gitlab_ci
       hipchat
+      letschat
       irker
       jira
       pivotaltracker

--- a/features/project/service.feature
+++ b/features/project/service.feature
@@ -19,6 +19,12 @@ Feature: Project Services
     And I fill hipchat settings
     Then I should see hipchat service settings saved
 
+  Scenario: Activate letschat service
+    When I visit project "Shop" services page
+    And I click letschat service link
+    And I fill letschat settings
+    Then I should see letschat service settings saved
+
   Scenario: Activate hipchat service with custom server
     When I visit project "Shop" services page
     And I click hipchat service link

--- a/features/steps/project/services.rb
+++ b/features/steps/project/services.rb
@@ -18,6 +18,7 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
     expect(page).to have_content 'JetBrains TeamCity'
     expect(page).to have_content 'Asana'
     expect(page).to have_content 'Irker (IRC gateway)'
+    expect(page).to have_content 'LetsChat'
   end
 
   step 'I click gitlab-ci service link' do
@@ -74,6 +75,22 @@ class Spinach::Features::ProjectServices < Spinach::FeatureSteps
 
   step 'I should see pivotaltracker service settings saved' do
     expect(find_field('Token').value).to eq 'verySecret'
+  end
+
+  step 'I click letschat service link' do
+    click_link 'LetsChat'
+  end
+
+  step 'I fill letschat settings' do
+    check 'Active'
+    fill_in 'Room', with: 'gitlab_custom'
+    fill_in 'Token', with: 'secretCustom'
+    fill_in 'Server', with: 'https://chat.example.com'
+    click_button 'Save'
+  end
+
+  step 'I should see letschat service settings saved' do
+    find_field('Server').value.should == 'https://chat.example.com'
   end
 
   step 'I click Flowdock service link' do

--- a/spec/models/project_services/letschat_service_spec.rb
+++ b/spec/models/project_services/letschat_service_spec.rb
@@ -1,0 +1,226 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id                    :integer          not null, primary key
+#  type                  :string(255)
+#  title                 :string(255)
+#  project_id            :integer
+#  created_at            :datetime
+#  updated_at            :datetime
+#  active                :boolean          default(FALSE), not null
+#  properties            :text
+#  template              :boolean          default(FALSE)
+#  push_events           :boolean          default(TRUE)
+#  issues_events         :boolean          default(TRUE)
+#  merge_requests_events :boolean          default(TRUE)
+#  tag_push_events       :boolean          default(TRUE)
+#  note_events           :boolean          default(TRUE), not null
+#
+
+require 'spec_helper'
+require 'pp'
+
+describe LetschatService, models: true do
+  describe 'Associations' do
+    it { is_expected.to belong_to :project }
+    it { is_expected.to have_one :service_hook }
+  end
+
+  describe 'Execute' do
+    let(:letschat) { LetschatService.new }
+    let(:user) { create(:user, username: 'username') }
+    let(:project) { create(:project, name: 'project') }
+    let(:project_name) { project.name_with_namespace.gsub(/\s/, '') }
+    let(:token) { 'verySecret' }
+    let(:server) { 'https://letschat.example.com' }
+
+    before(:each) do
+      letschat.stub(
+        project: project,
+        project_id: project.id,
+        token: token,
+        server: server,
+        room: '123456'
+      )
+      WebMock.stub_request(:post , /#{server}/)
+    end
+
+    context 'push events' do
+      let(:push_sample_data) { Gitlab::PushDataBuilder.build_sample(project, user) }
+
+      it "should call Letschat API for push events" do
+        letschat.execute(push_sample_data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+      end
+
+      it "should create a push message" do
+        message = letschat.send(:create_push_message, push_sample_data)
+
+        branch = push_sample_data[:ref].gsub('refs/heads/', '')
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(project.web_url)
+        expect(message).to include(branch)
+      end
+    end
+
+    context 'tag_push events' do
+      let(:push_sample_data) { Gitlab::PushDataBuilder.build(project, user, Gitlab::Git::BLANK_SHA, '1'*40, 'refs/tags/test', []) }
+
+      it "should call Letschat API for tag push events" do
+        letschat.execute(push_sample_data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+      end
+
+      it "should create a tag push message" do
+        message = letschat.send(:create_push_message, push_sample_data)
+
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(project.web_url)
+      end
+    end
+
+    context 'issue events' do
+      let(:issue) { create(:issue, title: 'Awesome issue', description: 'please fix') }
+      let(:issue_service) { Issues::CreateService.new(project, user) }
+      let(:issues_sample_data) { issue_service.hook_data(issue, 'open') }
+
+      it "should call Letschat API for issue events" do
+        letschat.execute(issues_sample_data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+      end
+
+      it "should create an issue message" do
+        message = letschat.send(:create_issue_message, issues_sample_data)
+
+        obj_attr = issues_sample_data[:object_attributes]
+        iid = obj_attr["iid"]
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include("issue ##{iid}")
+      end
+    end
+
+    context 'merge request events' do
+      let(:merge_request) { create(:merge_request, description: 'please fix', title: 'Awesome merge request', target_project: project, source_project: project) }
+      let(:merge_service) { MergeRequests::CreateService.new(project, user) }
+      let(:merge_sample_data) { merge_service.hook_data(merge_request, 'open') }
+
+      it "should call Letschat API for merge request events" do
+        letschat.execute(merge_sample_data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+      end
+
+      it "should create a merge request message" do
+        message = letschat.send(:create_merge_request_message, merge_sample_data)
+
+        obj_attr = merge_sample_data[:object_attributes]
+        iid = obj_attr["iid"]
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include("merge request ##{iid}")
+      end
+    end
+
+    context 'Note events' do
+      let(:commit_note) { create(:note_on_commit, author: user, project: project, commit_id: project.repository.commit.id, note: 'a comment on a commit') }
+      let(:merge_request) { create(:merge_request, source_project: project, target_project: project) }
+      let(:merge_request_note) { create(:note_on_merge_request, noteable_id: merge_request.id, note: "merge request note") }
+      let(:issue) { create(:issue, project: project) }
+      let(:issue_note) { create(:note_on_issue, noteable_id: issue.id, note: "issue note") }
+      let(:snippet) { create(:project_snippet, project: project) }
+      let(:snippet_note) { create(:note_on_project_snippet, noteable_id: snippet.id, note: "snippet note") }
+
+      it "should call Letschat API for commit comment events" do
+        data = Gitlab::NoteDataBuilder.build(commit_note, user)
+        letschat.execute(data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+
+        message = letschat.send(:create_message, data)
+
+        obj_attr = data[:object_attributes]
+        commit_id = Commit.truncate_sha(data[:commit][:id])
+        title = letschat.send(:format_title, data[:commit][:message])
+
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include(title)
+        expect(message).to include("commit #{commit_id}")
+      end
+
+      it "should call Letschat API for merge request comment events" do
+        data = Gitlab::NoteDataBuilder.build(merge_request_note, user)
+        letschat.execute(data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+
+        message = letschat.send(:create_message, data)
+
+        obj_attr = data[:object_attributes]
+        merge_id = data[:merge_request]['iid']
+        title = data[:merge_request]['title']
+
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include(title)
+        expect(message).to include("merge request ##{merge_id}")
+      end
+
+      it "should call Letschat API for issue comment events" do
+        data = Gitlab::NoteDataBuilder.build(issue_note, user)
+        letschat.execute(data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+
+        message = letschat.send(:create_message, data)
+
+        obj_attr = data[:object_attributes]
+        issue_id = data[:issue]['iid']
+        title = data[:issue]['title']
+
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include("issue ##{issue_id}")
+      end
+
+      it "should call Letschat API for snippet comment events" do
+        data = Gitlab::NoteDataBuilder.build(snippet_note, user)
+        letschat.execute(data)
+        expect(WebMock).to have_requested(:post, /#{server}/).once
+
+        message = letschat.send(:create_message, data)
+
+        obj_attr = data[:object_attributes]
+        snippet_id = data[:snippet]['id']
+        title = data[:snippet]['title']
+
+        expect(message).to include(project_name)
+        expect(message).to include(user.name)
+        expect(message).to include(obj_attr[:url])
+        expect(message).to include("snippet ##{snippet_id}")
+      end
+    end
+
+    context "#message_options" do
+      it "should be set to the defaults" do
+        expect(letschat.send(:message_options)).to eq({ notify: false, color: 'yellow' })
+      end
+
+      it "should set notify to true" do
+        letschat.stub(notify: '1')
+        expect(letschat.send(:message_options)).to eq({ notify: true, color: 'yellow' })
+      end
+
+      it "should set the color" do
+        letschat.stub(color: 'red')
+        expect(letschat.send(:message_options)).to eq({ notify: false, color: 'red' })
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
[Lets Chat](http://sdelements.github.io/lets-chat/) is a open-source self hosted chat software.
This patch adds support for Lets Chat as a project service.

I've almost followed the manner the HipChat service does, including spinach and rspec test code. But, it does not include API and documentation parts yet.
