### PR TITLE
Bamboo Service: Fix missing credentials & URL handling

### DIFF
--- a/app/models/project_services/bamboo_service.rb
+++ b/app/models/project_services/bamboo_service.rb
@@ -112,8 +112,19 @@ class BambooService < CiService
   def execute(data)
     return unless supported_events.include?(data[:object_kind])
 
-    # Bamboo requires a GET and does not take any data.
+    # Bamboo requires a GET and does take authentification
     url = URI.join(bamboo_url, "/updateAndBuild.action?buildKey=#{build_key}").to_s
-    self.class.get(url, verify: false)
+
+    if username.blank? && password.blank?
+      HTTParty.get(url, verify: false)
+    else
+      url << '&os_authType=basic'
+      auth = {
+        username: username,
+        password: password
+      }
+      HTTParty.get(url, verify: false, basic_auth: auth)
+    end
+
   end
 end

--- a/app/models/project_services/bamboo_service.rb
+++ b/app/models/project_services/bamboo_service.rb
@@ -61,7 +61,11 @@ class BambooService < CiService
   end
 
   def build_info(sha)
-    url = URI.join(bamboo_url, "/rest/api/latest/result?label=#{sha}").to_s
+    # URI.join only works correctly, if the bamboo_url has
+    #  - at least one or more  trailing '/'
+    #  - the appended parts are not prefixed with '/'
+    # otherwise a bamboo_url 'http://foo.bar/bamboo' will break
+    url = URI.join("#{bamboo_url}/", "rest/api/latest/result?label=#{sha}").to_s
 
     if username.blank? && password.blank?
       @response = HTTParty.get(url, verify: false)
@@ -80,11 +84,11 @@ class BambooService < CiService
 
     if @response.code != 200 || @response['results']['results']['size'] == '0'
       # If actual build link can't be determined, send user to build summary page.
-      URI.join(bamboo_url, "/browse/#{build_key}").to_s
+      URI.join("#{bamboo_url}/", "browse/#{build_key}").to_s
     else
       # If actual build link is available, go to build result page.
       result_key = @response['results']['results']['result']['planResultKey']['key']
-      URI.join(bamboo_url, "/browse/#{result_key}").to_s
+      URI.join("#{bamboo_url}/", "browse/#{result_key}").to_s
     end
   end
 
@@ -113,7 +117,7 @@ class BambooService < CiService
     return unless supported_events.include?(data[:object_kind])
 
     # Bamboo requires a GET and does take authentification
-    url = URI.join(bamboo_url, "/updateAndBuild.action?buildKey=#{build_key}").to_s
+    url = URI.join("#{bamboo_url}/", "updateAndBuild.action?buildKey=#{build_key}").to_s
 
     if username.blank? && password.blank?
       HTTParty.get(url, verify: false)


### PR DESCRIPTION
_Update:_ Added another fix which fixes an error introduced in the latest changes using `URI.join()`  in favour to `URL.parse()` and rebased to the latest master.

This improves the Bamboo Service and provides two fixes:
1. One for the situation, where the build trigger won't work because Bamboo is requiring authentication credentials for the trigger GET: https://github.com/gitlabhq/gitlabhq/pull/9428/commits/8f25aca307b49ee006172b8c2985a878800aa6b6
2. One which fixes the way how the configured Bamboo base URL is assembled to the final REST URL. https://github.com/gitlabhq/gitlabhq/pull/9428/commits/fe9eb30d7ebe4a83eefea7e06f8b69b135dad15d
## Regarding credentials

The change now does provide additional HTTP Basic Auth parameters if user credentials were provided and appends an request parameter indicating the HTTP Basic Authentication should be used. This aligns interaction with Bamboo with the other calls this service executes.
## Regarding URL handling

If one had configured a `bamboo_url` like http://foo.bar/bamboo in the previous implementation the plugin directed it's request i.e. to http://foo.bar/rest/... instead of http://foo.bar/bamboo/rest/...

This i probably an unwanted side effect of how Ruby's `URI.join` is working. It will only work correctly, if 
- ... the prefix URL has at least one or more  trailing `/`
- .. the appendix parts are _not_ prefixed with `/`

Backported & tested successfully in our environment.
