### PR TITLE
capitalize URL in "Home page URL"

### DIFF
--- a/app/views/admin/application_settings/_form.html.haml
+++ b/app/views/admin/application_settings/_form.html.haml
@@ -90,7 +90,7 @@
         = f.text_area :restricted_signup_domains_raw, placeholder: 'domain.com', class: 'form-control'
         .help-block Only users with e-mail addresses that match these domain(s) will be able to sign-up. Wildcards allowed. Use separate lines for multiple entries. Ex: domain.com, *.domain.com
     .form-group
-      = f.label :home_page_url, class: 'control-label col-sm-2'
+      = f.label :home_page_url, 'Home page URL', class: 'control-label col-sm-2'
       .col-sm-10
         = f.text_field :home_page_url, class: 'form-control', placeholder: 'http://company.example.com', :'aria-describedby' => 'home_help_block'
         %span.help-block#home_help_block We will redirect non-logged in users to this page

--- a/features/steps/admin/settings.rb
+++ b/features/steps/admin/settings.rb
@@ -6,7 +6,7 @@ class Spinach::Features::AdminSettings < Spinach::FeatureSteps
 
   step 'I modify settings and save form' do
     uncheck 'Gravatar enabled'
-    fill_in 'Home page url', with: 'https://about.gitlab.com/'
+    fill_in 'Home page URL', with: 'https://about.gitlab.com/'
     click_button 'Save'
   end
 


### PR DESCRIPTION
URL is an acronym and as such should be capitalized

I'm failing to find where else this is defined... can someone point me to the right location?
