### PR TITLE
Fix problem with API Transfer Project

### DIFF
--- a/app/services/projects/transfer_service.rb
+++ b/app/services/projects/transfer_service.rb
@@ -4,7 +4,7 @@
 #
 # Ex.
 #   # Move projects to namespace with ID 17 by user
-#   Projects::TransferService.new(project, user, namespace_id: 17).execute
+#   Projects::TransferService.new(project, user, new_namespace_id: 17).execute
 #
 module Projects
   class TransferService < BaseService

--- a/lib/api/groups.rb
+++ b/lib/api/groups.rb
@@ -76,7 +76,7 @@ module API
         authenticated_as_admin!
         group = Group.find(params[:id])
         project = Project.find(params[:project_id])
-        result = ::Projects::TransferService.new(project, current_user, namespace_id: group.id).execute
+        result = ::Projects::TransferService.new(project, current_user, new_namespace_id: group.id).execute
 
         if result
           present group


### PR DESCRIPTION
I had issues while trying to transfer project to group through api. So I found out that method execute use new_namespace_id param instead of namespace_id. But in API method's called with namespace_id param.
