### PR TITLE
Remove author information from "post" in merge_requests API.

### DIFF
--- a/doc/api/merge_requests.md
+++ b/doc/api/merge_requests.md
@@ -336,14 +336,6 @@ Parameters:
 
 ```json
 {
-  "author": {
-    "id": 1,
-    "username": "admin",
-    "email": "admin@example.com",
-    "name": "Administrator",
-    "blocked": false,
-    "created_at": "2012-04-29T08:46:00Z"
-  },
   "note": "text1"
 }
 ```


### PR DESCRIPTION
From both experimenting with the API and reading the source code, this appears to not be used at all.

My guess is this was copypasta from somewhere else.
