### PR TITLE
Disabled autocapitalize and autocorrect on login field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ v 7.14.0 (unreleased)
   - Add support for destroying project milestones (Stan Hu)
   - Add fetch command to the MR page
   - Fix bug causing Bitbucket importer to crash when OAuth application had been removed.
+  - Disabled autocapitalize and autocorrect on login field (Daryl Chan)
 
 v 7.13.1
   - Fix: Label modifications are not reflected in existing notes and in the issue list

--- a/app/views/devise/sessions/_new_base.html.haml
+++ b/app/views/devise/sessions/_new_base.html.haml
@@ -1,5 +1,5 @@
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  = f.text_field :login, class: "form-control top", placeholder: "Username or Email", autofocus: "autofocus"
+  = f.text_field :login, class: "form-control top", placeholder: "Username or Email", autofocus: "autofocus", autocapitalize: "off", autocorrect: "off"
   = f.password_field :password, class: "form-control bottom", placeholder: "Password"
   - if devise_mapping.rememberable?
     .remember-me.checkbox


### PR DESCRIPTION
**Motive**
I tried logging in on iOS Safari and it kept autocorrecting my username to something that was in the dictionary, and it was pretty annoying. Fixed this by disabling autocapitalize and autocorrect on the login field. 
