### PR TITLE
clone only last revision

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -195,7 +195,7 @@ We recommend using a PostgreSQL database. For MySQL check [MySQL setup guide](da
 ### Clone the Source
 
     # Clone GitLab repository
-    sudo -u git -H git clone https://gitlab.com/gitlab-org/gitlab-ce.git -b 7-12-stable gitlab
+    sudo -u git -H git clone --depth=1 https://gitlab.com/gitlab-org/gitlab-ce.git -b 7-12-stable gitlab
 
 **Note:** You can change `7-12-stable` to `master` if you want the *bleeding edge* version, but never install master on a production server!
 


### PR DESCRIPTION
We don't need to have the full branch history just to install an app from source. The last revision is more than enough.

If you clone the whole branch you need more than 80MB. If you clone only last revision you need less than 7MB.

Not only you are saving your disk space, you are saving github bandwidth and you are saving your time not having to wait for 10 times more MB to download.
