### PR TITLE
Hide wiki edit button when user is already on the edit view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,8 @@ v 7.13.3
   - Allow users to send abuse reports
   - Remove satellites 
   - Link username to profile on Group Members page (Tom Webster)
+  - Add fetch command to the MR page.
+  - Hide wiki edit button when user is already on edit view (Daryl Chan)
 
 v 7.13.2
   - Fix randomly failed spec

--- a/app/views/projects/wikis/_main_links.html.haml
+++ b/app/views/projects/wikis/_main_links.html.haml
@@ -2,7 +2,7 @@
   - if (@page && @page.persisted?)
     = link_to history_namespace_project_wiki_path(@project.namespace, @project, @page), class: "btn btn-grouped" do
       Page History
-    - if can?(current_user, :create_wiki, @project)
+    - if (can?(current_user, :create_wiki, @project) && params[:action] != "edit")
       = link_to edit_namespace_project_wiki_path(@project.namespace, @project, @page), class: "btn btn-grouped" do
         %i.fa.fa-pencil-square-o
         Edit


### PR DESCRIPTION
Fixes #9476 where the edit button may confuse users who are editing a wiki page. 

When a user is editing a wiki page, the edit button should be hidden so that the user does not unintentionally click on it again, causing a page refresh and loss of all unsaved changes. 
