### PR TITLE
Refactor note edit feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
     rack-attack (4.3.0)
       rack
     rack-cors (0.2.9)
-    rack-mini-profiler (0.9.0)
+    rack-mini-profiler (0.9.6)
       rack (>= 1.1.3)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
@@ -873,6 +873,3 @@ DEPENDENCIES
   virtus
   webmock (~> 1.21.0)
   wikicloth (= 0.8.1)
-
-BUNDLED WITH
-   1.10.5

--- a/app/assets/javascripts/notes.js.coffee
+++ b/app/assets/javascripts/notes.js.coffee
@@ -29,7 +29,6 @@ class @Notes
     $(document).on "ajax:success", "form.edit_note", @updateNote
 
     # Edit note link
-    $(document).on "click", ".js-note-edit", @showEditForm
     $(document).on "click", ".note-edit-cancel", @cancelEdit
 
     # Reopen and close actions for Issue/MR combined with note form submit
@@ -73,7 +72,6 @@ class @Notes
     $(document).off "ajax:success", ".js-main-target-form"
     $(document).off "ajax:success", ".js-discussion-note-form"
     $(document).off "ajax:success", "form.edit_note"
-    $(document).off "click", ".js-note-edit"
     $(document).off "click", ".note-edit-cancel"
     $(document).off "click", ".js-note-delete"
     $(document).off "click", ".js-note-attachment-delete"
@@ -290,14 +288,15 @@ class @Notes
   Adds a hidden div with the original content of the note to fill the edit note form with
   if the user cancels
   ###
-  showEditForm: (e) ->
-    e.preventDefault()
-    note = $(this).closest(".note")
-    note.find(".note-body > .note-text").hide()
+  showEditForm: (id, formHTML) ->
+    note = $("##{id}")
+    nodeText = note.find(".note-text");
+    nodeText.hide()
     note.find(".note-header").hide()
-    base_form = note.find(".note-edit-form")
-    form = base_form.clone().insertAfter(base_form)
-    form.addClass('current-note-edit-form gfm-form')
+    note.find('.note-edit-form').remove()
+    nodeText.after(formHTML)
+    note.find('.note-edit-form').show()
+    note.find('.note-edit-form').addClass('current-note-edit-form gfm-form')
     form.find('.div-dropzone').remove()
 
     # Show the attachment delete link

--- a/app/controllers/projects/notes_controller.rb
+++ b/app/controllers/projects/notes_controller.rb
@@ -3,7 +3,7 @@ class Projects::NotesController < Projects::ApplicationController
   before_action :authorize_read_note!
   before_action :authorize_create_note!, only: [:create]
   before_action :authorize_admin_note!, only: [:update, :destroy]
-  before_action :find_current_user_notes, except: [:destroy, :delete_attachment]
+  before_action :find_current_user_notes, except: [:destroy, :edit, :delete_attachment]
 
   def index
     current_fetched_at = Time.now.to_i
@@ -27,6 +27,11 @@ class Projects::NotesController < Projects::ApplicationController
       format.json { render_note_json(@note) }
       format.html { redirect_to :back }
     end
+  end
+
+  def edit
+    @note = note
+    render layout: false
   end
 
   def update

--- a/app/views/projects/notes/_note.html.haml
+++ b/app/views/projects/notes/_note.html.haml
@@ -10,7 +10,7 @@
       .note-header
         - if note_editable?(note)
           .note-actions
-            = link_to '#', title: 'Edit comment', class: 'js-note-edit' do
+            = link_to edit_namespace_project_note_path(note.project.namespace, note.project, note), title: 'Edit comment', class: 'note-edit', remote: true do
               = icon('pencil-square-o')
 
             = link_to namespace_project_note_path(note.project.namespace, note.project, note), title: 'Remove comment', method: :delete, data: { confirm: 'Are you sure you want to remove this comment?' }, remote: true, class: 'js-note-delete danger' do
@@ -59,7 +59,6 @@
         .note-text
           = preserve do
             = markdown(note.note, {no_header_anchors: true})
-        = render 'projects/notes/edit_form', note: note
 
       - if note.attachment.url
         .note-attachment

--- a/app/views/projects/notes/_notes_with_form.html.haml
+++ b/app/views/projects/notes/_notes_with_form.html.haml
@@ -7,4 +7,4 @@
   = render "projects/notes/form", view: params[:view]
 
 :javascript
-  new Notes("#{namespace_project_notes_path(namespace_id: @project.namespace, target_id: @noteable.id, target_type: @noteable.class.name.underscore)}", #{@notes.map(&:id).to_json}, #{Time.now.to_i}, "#{params[:view]}")
+  window._notes = new Notes("#{namespace_project_notes_path(namespace_id: @project.namespace, target_id: @noteable.id, target_type: @noteable.class.name.underscore)}", #{@notes.map(&:id).to_json}, #{Time.now.to_i}, "#{params[:view]}")

--- a/app/views/projects/notes/edit.js.erb
+++ b/app/views/projects/notes/edit.js.erb
@@ -1,0 +1,1 @@
+_notes.showEditForm('<%= dom_id(@note) %>', '<%= escape_javascript(render('edit_form', note: @note)) %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -518,7 +518,7 @@ Gitlab::Application.routes.draw do
           end
         end
 
-        resources :notes, only: [:index, :create, :destroy, :update], constraints: { id: /\d+/ } do
+        resources :notes, only: [:index, :create, :edit, :destroy, :update], constraints: { id: /\d+/ } do
           member do
             delete :delete_attachment
           end

--- a/features/steps/shared/note.rb
+++ b/features/steps/shared/note.rb
@@ -126,7 +126,7 @@ module SharedNote
   step 'I edit the last comment with a +1' do
     page.within(".notes") do
       find(".note").hover
-      find('.js-note-edit').click
+      find('.note-edit').click
     end
 
     page.within(".current-note-edit-form") do

--- a/spec/features/notes_on_merge_requests_spec.rb
+++ b/spec/features/notes_on_merge_requests_spec.rb
@@ -65,16 +65,10 @@ describe 'Comments', feature: true do
     end
 
     describe 'when editing a note', js: true do
-      it 'should contain the hidden edit form' do
-        page.within("#note_#{note.id}") do
-          is_expected.to have_css('.note-edit-form', visible: false)
-        end
-      end
-
       describe 'editing the note' do
         before do
           find('.note').hover
-          find(".js-note-edit").click
+          find(".note-edit").click
         end
 
         it 'should show the note edit form and hide the note body' do
@@ -111,7 +105,7 @@ describe 'Comments', feature: true do
       describe 'deleting an attachment' do
         before do
           find('.note').hover
-          find('.js-note-edit').click
+          find('.note-edit').click
         end
 
         it 'shows the delete link' do


### PR DESCRIPTION
I have changed `_note.haml`, removed render edit form, use RJS instead.

This change will reduce about 1~2ms render time for each note.
