### PR TITLE
Set user as default sort order for user auto-complete lists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -141,6 +141,7 @@ v 7.13.3
   - Allow users to send abuse reports
   - Remove satellites
   - Link username to profile on Group Members page (Tom Webster)
+  - Sort users autocomplete lists by user (Allister Antosik)
 
 v 7.13.2
   - Fix randomly failed spec

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -32,6 +32,7 @@ class AutocompleteController < ApplicationController
     @users ||= User.none
     @users = @users.search(params[:search]) if params[:search].present?
     @users = @users.active
+    @users = @users.reorder(:name)
     @users = @users.page(params[:page]).per(PER_PAGE)
 
     unless params[:search].present?


### PR DESCRIPTION
Currently when Gitlab gets a list of users (For example in the Assignee field for a merge request) for a autocomplete select field it orders them by date created, it would be must more elegant if this was sorted by the users name.

It looks like this was previously the case, but the code has been changed since then:
https://github.com/gitlabhq/gitlabhq/pull/3645
