### PR TITLE
Add merged label on branches page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@ v 7.14.0 (unreleased)
   - Fix bug causing error when the target branch of a symbolic ref was deleted
   - Include branch/tag name in archive file and directory name
   - Add dropzone upload progress
+  - Add a label for merged branches on branches page (Florent Baldino)
 
 v 7.13.3
   - Fix bug causing Bitbucket importer to crash when OAuth application had been removed.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -364,6 +364,17 @@ class Repository
     @root_ref ||= raw_repository.root_ref
   end
 
+  def merged_to_root_ref?(branch_name)
+    branch_commit = commit(branch_name)
+    root_ref_commit = commit(root_ref)
+
+    if branch_commit
+      rugged.merge_base(root_ref_commit.id, branch_commit.id) == branch_commit.id
+    else
+      nil
+    end
+  end
+
   def search_files(query, ref)
     offset = 2
     args = %W(git grep -i -n --before-context #{offset} --after-context #{offset} #{query} #{ref || root_ref})

--- a/app/views/projects/branches/_branch.html.haml
+++ b/app/views/projects/branches/_branch.html.haml
@@ -5,6 +5,11 @@
       %strong.str-truncated= branch.name
       - if branch.name == @repository.root_ref
         %span.label.label-info default
+      - elsif @repository.merged_to_root_ref? branch.name
+        %span.label.label-primary.has_tooltip(title="Merged into #{@repository.root_ref}")
+          %i.fa.fa-check
+          merged
+
       - if @project.protected_branch? branch.name
         %span.label.label-success
           %i.fa.fa-lock

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -34,6 +34,26 @@ describe Repository do
     end
   end
 
+  describe :merged_to_root_ref? do
+    context 'merged branch' do
+      subject { repository.merged_to_root_ref?('improve/awesome') }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'non merged branch' do
+      subject { repository.merged_to_root_ref?('fix') }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'non existent branch' do
+      subject { repository.merged_to_root_ref?('non_existent_branch') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "search_files" do
     let(:results) { repository.search_files('feature', 'master') }
     subject { results }


### PR DESCRIPTION
On branches page, this PR add a `merged` label beside each branch that have been merged into the project's default branch.

![Branch merged label](https://cloud.githubusercontent.com/assets/1597384/9156351/1a6d4892-3ed7-11e5-9b18-d8aa4f75dbc8.png)
