### PR TITLE
Feature/search for archived projects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v 8.0.0 (unreleased)
   - Better performance for web editor (switched from satellites to rugged)
   - Faster merge
   - Ability to fetch merge requests from refs/merge-requests/:id
+  - Allow displaying of archived projects in the admin interface (Artem Sidorenko)
 
 v 7.14.0 (unreleased)
   - Update default robots.txt rules to disallow crawling of irrelevant pages (Ben Bodenmiller)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -9,6 +9,7 @@ class Admin::ProjectsController < Admin::ApplicationController
     @projects = @projects.where("visibility_level IN (?)", params[:visibility_levels]) if params[:visibility_levels].present?
     @projects = @projects.with_push if params[:with_push].present?
     @projects = @projects.abandoned if params[:abandoned].present?
+    @projects = @projects.non_archived unless params[:with_archived].present?
     @projects = @projects.search(params[:name]) if params[:name].present?
     @projects = @projects.sort(@sort = params[:sort])
     @projects = @projects.includes(:namespace).order("namespaces.path, projects.name ASC").page(params[:page]).per(PER_PAGE)

--- a/app/controllers/explore/projects_controller.rb
+++ b/app/controllers/explore/projects_controller.rb
@@ -7,6 +7,7 @@ class Explore::ProjectsController < Explore::ApplicationController
     @tags = @projects.tags_on(:tags)
     @projects = @projects.tagged_with(params[:tag]) if params[:tag].present?
     @projects = @projects.where(visibility_level: params[:visibility_level]) if params[:visibility_level].present?
+    @projects = @projects.non_archived
     @projects = @projects.search(params[:search]) if params[:search].present?
     @projects = @projects.sort(@sort = params[:sort])
     @projects = @projects.includes(:namespace).page(params[:page]).per(PER_PAGE)
@@ -14,6 +15,7 @@ class Explore::ProjectsController < Explore::ApplicationController
 
   def trending
     @trending_projects = TrendingProjectsFinder.new.execute(current_user)
+    @trending_projects = @trending_projects.non_archived
     @trending_projects = @trending_projects.page(params[:page]).per(PER_PAGE)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -215,7 +215,7 @@ class Project < ActiveRecord::Base
     end
 
     def search(query)
-      joins(:namespace).where('projects.archived = ?', false).
+      joins(:namespace).
         where('LOWER(projects.name) LIKE :query OR
               LOWER(projects.path) LIKE :query OR
               LOWER(namespaces.name) LIKE :query OR

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -23,6 +23,10 @@
             = label_tag :abandoned do
               = check_box_tag :abandoned, 1, params[:abandoned]
               %span No activity over 6 month
+          .checkbox
+            = label_tag :with_archived do
+              = check_box_tag :with_archived, 1, params[:with_archived]
+              %span Show archived projects
 
         %fieldset
           %strong Visibility level:

--- a/app/views/admin/projects/index.html.haml
+++ b/app/views/admin/projects/index.html.haml
@@ -77,6 +77,8 @@
                 = visibility_level_icon(project.visibility_level)
               = link_to project.name_with_namespace, [:admin, project.namespace.becomes(Namespace), project]
             .pull-right
+              - if project.archived
+                %span.label.label-warning archived
               %span.label.label-gray
                 = repository_size(project)
               = link_to 'Edit', edit_namespace_project_path(project.namespace, project), id: "edit_#{dom_id(project)}", class: "btn btn-sm"

--- a/app/views/groups/projects.html.haml
+++ b/app/views/groups/projects.html.haml
@@ -12,7 +12,8 @@
     - @projects.each do |project|
       %li
         .list-item-name
-          = visibility_level_icon(project.visibility_level)
+          %span{ class: visibility_level_color(project.visibility_level) }
+            = visibility_level_icon(project.visibility_level)
           %strong= link_to project.name_with_namespace, project
         .pull-right
           - if project.archived

--- a/app/views/groups/projects.html.haml
+++ b/app/views/groups/projects.html.haml
@@ -14,9 +14,11 @@
         .list-item-name
           = visibility_level_icon(project.visibility_level)
           %strong= link_to project.name_with_namespace, project
+        .pull-right
+          - if project.archived
+            %span.label.label-warning archived
           %span.label.label-gray
             = repository_size(project)
-        .pull-right
           = link_to 'Members', namespace_project_project_members_path(project.namespace, project), id: "edit_#{dom_id(project)}", class: "btn btn-sm"
           = link_to 'Edit', edit_namespace_project_path(project.namespace, project), id: "edit_#{dom_id(project)}", class: "btn btn-sm"
           = link_to 'Remove', project, data: { confirm: remove_project_message(project)}, method: :delete, class: "btn btn-sm btn-remove"

--- a/features/admin/projects.feature
+++ b/features/admin/projects.feature
@@ -4,9 +4,18 @@ Feature: Admin Projects
     Given I sign in as an admin
     And there are projects in system
 
-  Scenario: Projects list
+  Scenario: I should see non-archived projects in the list
+    Given archived project "Archive"
     When I visit admin projects page
+    Then I should see all non-archived projects
+    And I should not see project "Archive"
+
+  Scenario: I should see all projects in the list
+    Given archived project "Archive"
+    When I visit admin projects page
+    And I check "Show archived projects"
     Then I should see all projects
+    And I should see "archived" label
 
   Scenario: Projects show
     When I visit admin projects page

--- a/features/explore/projects.feature
+++ b/features/explore/projects.feature
@@ -6,10 +6,12 @@ Feature: Explore Projects
     And private project "Enterprise"
 
   Scenario: I visit public area
+    Given archived project "Archive"
     When I visit the public projects area
     Then I should see project "Community"
     And I should not see project "Internal"
     And I should not see project "Enterprise"
+    And I should not see project "Archive"
 
   Scenario: I visit public project page
     When I visit project "Community" page
@@ -37,11 +39,13 @@ Feature: Explore Projects
     And I should see empty public project details with ssh clone info
 
   Scenario: I visit public area as user
-    Given I sign in as a user
+    Given archived project "Archive"
+    And I sign in as a user
     When I visit the public projects area
     Then I should see project "Community"
     And I should see project "Internal"
     And I should not see project "Enterprise"
+    And I should not see project "Archive"
 
   Scenario: I visit internal project page as user
     Given I sign in as a user
@@ -102,15 +106,20 @@ Feature: Explore Projects
     Then I should see list of merge requests for "Internal" project
 
   Scenario: Trending page
-    Given I sign in as a user
+    Given archived project "Archive"
+    And project "Archive" has comments
+    And I sign in as a user
     And project "Community" has comments
     When I visit the explore trending projects
     Then I should see project "Community"
     And I should not see project "Internal"
     And I should not see project "Enterprise"
+    And I should not see project "Archive"
 
   Scenario: Most starred page
-    Given I sign in as a user
+    Given archived project "Archive"
+    And I sign in as a user
     When I visit the explore starred projects
     Then I should see project "Community"
     And I should see project "Internal"
+    And I should see project "Archive"

--- a/features/groups.feature
+++ b/features/groups.feature
@@ -152,3 +152,10 @@ Feature: Groups
     And I click on one group milestone
     Then I should see group milestone with descriptions and expiry date
     And I should see group milestone with all issues and MRs assigned to that milestone
+
+  # Group projects in settings
+  Scenario: I should see all projects in the project list in settings
+    Given Group "Owned" has archived project
+    When I visit group "Owned" projects page
+    Then I should see group "Owned" projects list
+    And I should see "archived" label

--- a/features/steps/admin/projects.rb
+++ b/features/steps/admin/projects.rb
@@ -2,11 +2,27 @@ class Spinach::Features::AdminProjects < Spinach::FeatureSteps
   include SharedAuthentication
   include SharedPaths
   include SharedAdmin
+  include SharedProject
+
+  step 'I should see all non-archived projects' do
+    Project.non_archived.each do |p|
+      expect(page).to have_content p.name_with_namespace
+    end
+  end
 
   step 'I should see all projects' do
     Project.all.each do |p|
       expect(page).to have_content p.name_with_namespace
     end
+  end
+
+  step 'I check "Show archived projects"' do
+    page.check 'Show archived projects'
+    click_button "Search"
+  end
+
+  step 'I should see "archived" label' do
+    expect(page).to have_xpath("//span[@class='label label-warning']", text: 'archived')
   end
 
   step 'I click on first project' do

--- a/features/steps/groups.rb
+++ b/features/steps/groups.rb
@@ -226,6 +226,15 @@ class Spinach::Features::Groups < Spinach::FeatureSteps
     expect(page).to have_link(@mr3.title, href: namespace_project_merge_request_path(@project3.namespace, @project3, @mr3))
   end
 
+  step 'Group "Owned" has archived project' do
+    group = Group.find_by(name: 'Owned')
+    create(:project, namespace: group, archived: true, path: "archived-project")
+  end
+
+  step 'I should see "archived" label' do
+    expect(page).to have_xpath("//span[@class='label label-warning']", text: 'archived')
+  end
+
   protected
 
   def assigned_to_me(key)

--- a/features/steps/shared/paths.rb
+++ b/features/steps/shared/paths.rb
@@ -39,6 +39,10 @@ module SharedPaths
     visit edit_group_path(Group.find_by(name: "Owned"))
   end
 
+  step 'I visit group "Owned" projects page' do
+    visit projects_group_path(Group.find_by(name: "Owned"))
+  end
+
   step 'I visit group "Guest" page' do
     visit group_path(Group.find_by(name: "Guest"))
   end

--- a/features/steps/shared/project.rb
+++ b/features/steps/shared/project.rb
@@ -93,6 +93,29 @@ module SharedProject
   end
 
   # ----------------------------------------
+  # Visibility of archived project
+  # ----------------------------------------
+
+  step 'archived project "Archive"' do
+    create :project, :public, archived: true, name: 'Archive'
+  end
+
+  step 'I should not see project "Archive"' do
+    project = Project.find_by(name: "Archive")
+    expect(page).not_to have_content project.name_with_namespace
+  end
+
+  step 'I should see project "Archive"' do
+    project = Project.find_by(name: "Archive")
+    expect(page).to have_content project.name_with_namespace
+  end
+
+  step 'project "Archive" has comments' do
+    project = Project.find_by(name: "Archive")
+    2.times { create(:note_on_issue, project: project) }
+  end
+
+  # ----------------------------------------
   # Visibility level
   # ----------------------------------------
 


### PR DESCRIPTION
For admins it might be useful to see the archived projects in the project view of admin interface. Currently the archived projects **are not displayed** at all. The idea is to add the option to show archived projects and to label them in the result list.

![admin-projects](https://cloud.githubusercontent.com/assets/1645670/9179196/3b5eee42-3f9b-11e5-9661-27c0d0c3df4f.png)

For group owners it might be useful too. Currently the archived projects **are displayed** without any label or "archived hint". The idea is to have a label like in the admin interface in the result list.

![group-projects](https://cloud.githubusercontent.com/assets/1645670/9179202/41d1def6-3f9b-11e5-8928-e59a3152189a.png)

There is another small change, to have the same styled visibility icons in the admin interface and group project view.

See [this feature request](http://feedback.gitlab.com/forums/176466-general/suggestions/6982953-view-list-of-archived-projects)
