### PR TITLE
Update Flowdock integration to support new Flowdock API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,7 @@ v 7.14.0 (unreleased)
   - Detect .mkd and .mkdn files as markdown (Ben Boeckel)
   - Fix: User search feature in admin area does not respect filters
   - Set max-width for README, issue and merge request description for easier read on big screens
+  - Update Flowdock integration to support new Flowdock API (Boyan Tabakov)
 
 v 7.13.5
   - Satellites reverted

--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ gem 'tinder', '~> 1.9.2'
 gem 'hipchat', '~> 1.5.0'
 
 # Flowdock integration
-gem "gitlab-flowdock-git-hook", "~> 0.4.2"
+gem "gitlab-flowdock-git-hook", "~> 1.0.1"
 
 # Gemnasium integration
 gem "gemnasium-gitlab-service", "~> 0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,9 @@ GEM
     ffi (1.9.8)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
+    flowdock (0.7.0)
+      httparty (~> 0.7)
+      multi_json
     fog (1.25.0)
       fog-brightbox (~> 0.4)
       fog-core (~> 1.25)
@@ -255,7 +258,8 @@ GEM
       racc
     github-markup (1.3.1)
       posix-spawn (~> 0.3.8)
-    gitlab-flowdock-git-hook (0.4.2.2)
+    gitlab-flowdock-git-hook (1.0.1)
+      flowdock (~> 0.7)
       gitlab-grit (>= 2.4.1)
       multi_json
     gitlab-grack (2.0.2)
@@ -779,7 +783,7 @@ DEPENDENCIES
   fuubar (~> 2.0.0)
   gemnasium-gitlab-service (~> 0.2)
   github-markup
-  gitlab-flowdock-git-hook (~> 0.4.2)
+  gitlab-flowdock-git-hook (~> 1.0.1)
   gitlab-grack (~> 2.0.2)
   gitlab-linguist (~> 3.0.1)
   gitlab_emoji (~> 0.1)
@@ -875,4 +879,4 @@ DEPENDENCIES
   wikicloth (= 0.8.1)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/models/project_services/flowdock_service.rb
+++ b/app/models/project_services/flowdock_service.rb
@@ -38,7 +38,7 @@ class FlowdockService < Service
 
   def fields
     [
-      { type: 'text', name: 'token',     placeholder: '' }
+      { type: 'text', name: 'token', placeholder: 'Flowdock Git source token' }
     ]
   end
 

--- a/spec/models/project_services/flowdock_service_spec.rb
+++ b/spec/models/project_services/flowdock_service_spec.rb
@@ -39,15 +39,19 @@ describe FlowdockService do
         token: 'verySecret'
       )
       @sample_data = Gitlab::PushDataBuilder.build_sample(project, user)
-      @api_url = 'https://api.flowdock.com/v1/git/verySecret'
+      @api_url = 'https://api.flowdock.com/v1/messages'
       WebMock.stub_request(:post, @api_url)
     end
 
     it "should call FlowDock API" do
       @flowdock_service.execute(@sample_data)
-      expect(WebMock).to have_requested(:post, @api_url).with(
-        body: /#{@sample_data[:before]}.*#{@sample_data[:after]}.*#{project.path}/
-      ).once
+      @sample_data[:commits].each do |commit|
+        # One request to Flowdock per new commit
+        next if commit[:id] == @sample_data[:before]
+        expect(WebMock).to have_requested(:post, @api_url).with(
+          body: /#{commit[:id]}.*#{project.path}/
+        ).once
+      end
     end
   end
 end


### PR DESCRIPTION
Flowdock API was updated and requires gem upgrade. Users must create Git source in their flows and update the token in Gitlab to the Git source token. The old flow tokens will no longer be supported by Flowdock.

This fix should be trivial to cherry-pick in old supported versions of Gitlab, if you choose to do so.
