### PR TITLE
Feature/control import options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ v 8.0.0 (unreleased)
   - Faster merge
   - Ability to fetch merge requests from refs/merge-requests/:id
   - Allow displaying of archived projects in the admin interface (Artem Sidorenko)
+  - Allow configuration of import sources for new projects (Artem Sidorenko)
 
 v 7.14.0 (unreleased)
   - Update default robots.txt rules to disallow crawling of irrelevant pages (Ben Bodenmiller)

--- a/app/controllers/admin/application_settings_controller.rb
+++ b/app/controllers/admin/application_settings_controller.rb
@@ -29,6 +29,15 @@ class Admin::ApplicationSettingsController < Admin::ApplicationController
       end
     end
 
+    import_sources = params[:application_setting][:import_sources]
+    if import_sources.nil?
+      params[:application_setting][:import_sources] = []
+    else
+      import_sources.map! do |source|
+        source.to_str
+      end
+    end
+
     params.require(:application_setting).permit(
       :default_projects_limit,
       :default_branch_protection,
@@ -47,6 +56,7 @@ class Admin::ApplicationSettingsController < Admin::ApplicationController
       :version_check_enabled,
       :user_oauth_applications,
       restricted_visibility_levels: [],
+      import_sources: []
     )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper_method :abilities, :can?, :current_application_settings
-  helper_method :github_import_enabled?, :gitlab_import_enabled?, :bitbucket_import_enabled?
+  helper_method :import_sources_enabled?, :github_import_enabled?, :github_import_configured?, :gitlab_import_enabled?, :gitlab_import_configured?, :bitbucket_import_enabled?, :bitbucket_import_configured?, :gitorious_import_enabled?, :google_code_import_enabled?, :git_import_enabled?
 
   rescue_from Encoding::CompatibilityError do |exception|
     log_exception(exception)
@@ -298,15 +298,43 @@ class ApplicationController < ActionController::Base
     @issuable_finder.execute
   end
 
+  def import_sources_enabled?
+    !current_application_settings.import_sources.empty?
+  end
+
   def github_import_enabled?
+    current_application_settings.import_sources.include?('github')
+  end
+
+  def github_import_configured?
     Gitlab::OAuth::Provider.enabled?(:github)
   end
 
   def gitlab_import_enabled?
+    request.host != 'gitlab.com' && current_application_settings.import_sources.include?('gitlab')
+  end
+
+  def gitlab_import_configured?
     Gitlab::OAuth::Provider.enabled?(:gitlab)
   end
 
   def bitbucket_import_enabled?
+    current_application_settings.import_sources.include?('bitbucket')
+  end
+
+  def bitbucket_import_configured?
     Gitlab::OAuth::Provider.enabled?(:bitbucket) && Gitlab::BitbucketImport.public_key.present?
+  end
+
+  def gitorious_import_enabled?
+    current_application_settings.import_sources.include?('gitorious')
+  end
+
+  def google_code_import_enabled?
+    current_application_settings.import_sources.include?('google_code')
+  end
+
+  def git_import_enabled?
+    current_application_settings.import_sources.include?('git')
   end
 end

--- a/app/controllers/import/gitorious_controller.rb
+++ b/app/controllers/import/gitorious_controller.rb
@@ -1,4 +1,5 @@
 class Import::GitoriousController < Import::BaseController
+  before_action :verify_gitorious_import_enabled
 
   def new
     redirect_to client.authorize_url(callback_import_gitorious_url)
@@ -38,6 +39,10 @@ class Import::GitoriousController < Import::BaseController
 
   def client
     @client ||= Gitlab::GitoriousImport::Client.new(session[:gitorious_repos])
+  end
+
+  def verify_gitorious_import_enabled
+    not_found! unless gitorious_import_enabled?
   end
 
 end

--- a/app/controllers/import/google_code_controller.rb
+++ b/app/controllers/import/google_code_controller.rb
@@ -1,4 +1,5 @@
 class Import::GoogleCodeController < Import::BaseController
+  before_action :verify_google_code_import_enabled
   before_action :user_map, only: [:new_user_map, :create_user_map]
 
   def new
@@ -102,6 +103,10 @@ class Import::GoogleCodeController < Import::BaseController
 
   def client
     @client ||= Gitlab::GoogleCodeImport::Client.new(session[:google_code_dump])
+  end
+
+  def verify_google_code_import_enabled
+    not_found! unless google_code_import_enabled?
   end
 
   def user_map

--- a/app/helpers/application_settings_helper.rb
+++ b/app/helpers/application_settings_helper.rb
@@ -39,4 +39,21 @@ module ApplicationSettingsHelper
       end
     end
   end
+
+  # Return a group of checkboxes that use Bootstrap's button plugin for a
+  # toggle button effect.
+  def import_sources_checkboxes(help_block_id)
+    Gitlab::ImportSources.options.map do |name, source|
+      checked = current_application_settings.import_sources.include?(source)
+      css_class = 'btn'
+      css_class += ' active' if checked
+      checkbox_name = 'application_setting[import_sources][]'
+
+      label_tag(checkbox_name, class: css_class) do
+        check_box_tag(checkbox_name, source, checked,
+                      autocomplete: 'off',
+                      'aria-describedby' => help_block_id) + name
+      end
+    end
+  end
 end

--- a/app/views/admin/application_settings/_form.html.haml
+++ b/app/views/admin/application_settings/_form.html.haml
@@ -28,6 +28,20 @@
             = level
         %span.help-block#restricted-visibility-help Selected levels cannot be used by non-admin users for projects or snippets
     .form-group
+      = f.label :import_sources, class: 'control-label col-sm-2'
+      .col-sm-10
+        - data_attrs = { toggle: 'buttons' }
+        .btn-group{ data: data_attrs }
+          - import_sources_checkboxes('import-sources-help').each do |source|
+            = source
+        %span.help-block#import-sources-help
+          Enabled sources for code import during project creation. OmniAuth must be configured for GitHub
+          = link_to "(?)", help_page_path("integration", "github")
+          , Bitbucket
+          = link_to "(?)", help_page_path("integration", "bitbucket")
+          and GitLab.com
+          = link_to "(?)", help_page_path("integration", "gitlab")
+    .form-group
       .col-sm-offset-2.col-sm-10
         .checkbox
           = f.label :version_check_enabled do

--- a/app/views/projects/_bitbucket_import_modal.html.haml
+++ b/app/views/projects/_bitbucket_import_modal.html.haml
@@ -5,9 +5,9 @@
         %a.close{href: "#", "data-dismiss" => "modal"} ×
         %h3 Import projects from Bitbucket
       .modal-body
-        To enable importing projects from Bitbucket, 
+        To enable importing projects from Bitbucket,
         - if current_user.admin?
-          you need to
+          as administrator you need to configure
         - else
-          your GitLab administrator needs to
-        == #{link_to 'setup OAuth integration', 'https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/integration/bitbucket.md'}.
+          ask your GitLab administrator to configure
+        == #{link_to 'OAuth integration', help_page_path("integration", "bitbucket")}.

--- a/app/views/projects/_github_import_modal.html.haml
+++ b/app/views/projects/_github_import_modal.html.haml
@@ -5,9 +5,9 @@
         %a.close{href: "#", "data-dismiss" => "modal"} ×
         %h3 Import projects from GitHub
       .modal-body
-        To enable importing projects from GitHub, 
+        To enable importing projects from GitHub,
         - if current_user.admin?
-          you need to
+          as administrator you need to configure
         - else
-          your GitLab administrator needs to
-        == #{link_to 'setup OAuth integration', 'https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/integration/github.md'}.
+          ask your Gitlab administrator to configure
+        == #{link_to 'OAuth integration', help_page_path("integration", "github")}.

--- a/app/views/projects/_gitlab_import_modal.html.haml
+++ b/app/views/projects/_gitlab_import_modal.html.haml
@@ -5,9 +5,9 @@
         %a.close{href: "#", "data-dismiss" => "modal"} ×
         %h3 Import projects from GitLab.com
       .modal-body
-        To enable importing projects from GitLab.com, 
+        To enable importing projects from GitLab.com,
         - if current_user.admin?
-          you need to
+          as administrator you need to configure
         - else
-          your GitLab administrator needs to
-        == #{link_to 'setup OAuth integration', 'https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/integration/gitlab.md'}.
+          ask your GitLab administrator to configure
+        == #{link_to 'OAuth integration', help_page_path("integration", "gitlab")}.

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -22,70 +22,75 @@
           .col-sm-10
             = f.select :namespace_id, namespaces_options(params[:namespace_id] || :current_user), {}, {class: 'select2', tabindex: 2}
 
-      %hr
+      - if import_sources_enabled?
+        %hr
 
-      .project-import.js-toggle-container
-        .form-group
-          %label.control-label Import project from
-          .col-sm-10
-            - if github_import_enabled?
-              = link_to status_import_github_path, class: 'btn' do
-                %i.fa.fa-github
-                GitHub
-            - else
-              = link_to '#', class: 'how_to_import_link light btn' do
-                %i.fa.fa-github
-                GitHub
-              = render 'github_import_modal'
-
-
-            - if bitbucket_import_enabled?
-              = link_to status_import_bitbucket_path, class: 'btn', "data-no-turbolink" => "true" do
-                %i.fa.fa-bitbucket
-                Bitbucket
-            - else
-              = link_to '#', class: 'how_to_import_link light btn' do
-                %i.fa.fa-bitbucket
-                Bitbucket
-              = render 'bitbucket_import_modal'
-
-            - unless request.host == 'gitlab.com'
-              - if gitlab_import_enabled?
-                = link_to status_import_gitlab_path, class: 'btn' do
-                  %i.fa.fa-heart
-                  GitLab.com
-              - else
-                = link_to '#', class: 'how_to_import_link light btn' do
-                  %i.fa.fa-heart
-                  GitLab.com
-                = render 'gitlab_import_modal'
-
-            = link_to new_import_gitorious_path, class: 'btn' do
-              %i.icon-gitorious.icon-gitorious-small
-              Gitorious.org
-
-            = link_to new_import_google_code_path, class: 'btn' do
-              %i.fa.fa-google
-              Google Code
-
-            = link_to "#", class: 'btn js-toggle-button' do
-              %i.fa.fa-git
-              %span Any repo by URL
-
-        .js-toggle-content.hide
-          .form-group.import-url-data
-            = f.label :import_url, class: 'control-label' do
-              %span Git repository URL
+        .project-import.js-toggle-container
+          .form-group
+            %label.control-label Import project from
             .col-sm-10
-              = f.text_field :import_url, class: 'form-control', placeholder: 'https://username:password@gitlab.company.com/group/project.git'
-              .well.prepend-top-20
-                %ul
-                  %li
-                    The repository must be accessible over HTTP(S). If it is not publicly accessible, you can add authentication information to the URL: <code>https://username:password@gitlab.company.com/group/project.git</code>.
-                  %li
-                    The import will time out after 4 minutes. For big repositories, use a clone/push combination.
-                  %li
-                    To migrate an SVN repository, check out #{link_to "this document", "http://doc.gitlab.com/ce/workflow/importing/migrating_from_svn.html"}.
+              - if github_import_enabled?
+                - if github_import_configured?
+                  = link_to status_import_github_path, class: 'btn import_github' do
+                    %i.fa.fa-github
+                    GitHub
+                - else
+                  = link_to '#', class: 'how_to_import_link light btn import_github' do
+                    %i.fa.fa-github
+                    GitHub
+                  = render 'github_import_modal'
+
+              - if bitbucket_import_enabled?
+                - if bitbucket_import_configured?
+                  = link_to status_import_bitbucket_path, class: 'btn import_bitbucket', "data-no-turbolink" => "true" do
+                    %i.fa.fa-bitbucket
+                    Bitbucket
+                - else
+                  = link_to status_import_bitbucket_path, class: 'how_to_import_link light btn import_bitbucket', "data-no-turbolink" => "true" do
+                    %i.fa.fa-bitbucket
+                    Bitbucket
+                  = render 'bitbucket_import_modal'
+
+              - if gitlab_import_enabled?
+                - if gitlab_import_configured?
+                  = link_to status_import_gitlab_path, class: 'btn import_gitlab' do
+                    %i.fa.fa-heart
+                    GitLab.com
+                - else
+                  = link_to status_import_gitlab_path, class: 'how_to_import_link light btn import_gitlab' do
+                    %i.fa.fa-heart
+                    GitLab.com
+                  = render 'gitlab_import_modal'
+
+              - if gitorious_import_enabled?
+                = link_to new_import_gitorious_path, class: 'btn import_gitorious' do
+                  %i.icon-gitorious.icon-gitorious-small
+                  Gitorious.org
+
+              - if google_code_import_enabled?
+                = link_to new_import_google_code_path, class: 'btn import_google_code' do
+                  %i.fa.fa-google
+                  Google Code
+
+              - if git_import_enabled?
+                = link_to "#", class: 'btn js-toggle-button import_git' do
+                  %i.fa.fa-git
+                  %span Any repo by URL
+
+          .js-toggle-content.hide
+            .form-group.import-url-data
+              = f.label :import_url, class: 'control-label' do
+                %span Git repository URL
+              .col-sm-10
+                = f.text_field :import_url, class: 'form-control', placeholder: 'https://username:password@gitlab.company.com/group/project.git'
+                .well.prepend-top-20
+                  %ul
+                    %li
+                      The repository must be accessible over HTTP(S). If it is not publicly accessible, you can add authentication information to the URL: <code>https://username:password@gitlab.company.com/group/project.git</code>.
+                    %li
+                      The import will time out after 4 minutes. For big repositories, use a clone/push combination.
+                    %li
+                      To migrate an SVN repository, check out #{link_to "this document", "http://doc.gitlab.com/ce/workflow/importing/migrating_from_svn.html"}.
 
       %hr.prepend-botton-10
 

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -148,6 +148,7 @@ Settings.gitlab.default_projects_features['snippets']       = false if Settings.
 Settings.gitlab.default_projects_features['visibility_level']    = Settings.send(:verify_constant, Gitlab::VisibilityLevel, Settings.gitlab.default_projects_features['visibility_level'], Gitlab::VisibilityLevel::PRIVATE)
 Settings.gitlab['repository_downloads_path'] = File.absolute_path(Settings.gitlab['repository_downloads_path'] || 'tmp/repositories', Rails.root)
 Settings.gitlab['restricted_signup_domains'] ||= []
+Settings.gitlab['import_sources'] ||= ['github','bitbucket','gitlab','gitorious','google_code','git']
 
 #
 # Gravatar

--- a/db/migrate/20150812080800_add_settings_import_sources.rb
+++ b/db/migrate/20150812080800_add_settings_import_sources.rb
@@ -1,0 +1,11 @@
+require 'yaml'
+
+class AddSettingsImportSources < ActiveRecord::Migration
+  def change
+    unless column_exists?(:application_settings, :import_sources)
+      add_column :application_settings, :import_sources, :text
+      import_sources = YAML::dump(Settings.gitlab['import_sources'])
+      execute("update application_settings set import_sources = '#{import_sources}'")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806104937) do
+ActiveRecord::Schema.define(version: 20150812080800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20150806104937) do
     t.boolean  "user_oauth_applications",      default: true
     t.string   "after_sign_out_path"
     t.integer  "session_expire_delay",         default: 10080, null: false
+    t.text     "import_sources"
   end
 
   create_table "audit_events", force: true do |t|

--- a/features/dashboard/new_project.feature
+++ b/features/dashboard/new_project.feature
@@ -4,10 +4,27 @@ Background:
   Given I sign in as a user
   And I own project "Shop"
   And I visit dashboard page
+  And I click "New project" link
 
   @javascript
   Scenario: I should see New projects page
-  Given I click "New project" link
   Then I see "New project" page
+  Then I see all possible import optios
+
+  @javascript
+  Scenario: I should see instructions on how to import from Git URL
+  Given I see "New project" page
+  When I click on "Any repo by URL"
+  Then I see instructions on how to import from Git URL
+
+  @javascript
+  Scenario: I should see instructions on how to import from GitHub
+  Given I see "New project" page
   When I click on "Import project from GitHub"
   Then I see instructions on how to import from GitHub
+
+  @javascript
+  Scenario: I should see Google Code import page
+  Given I see "New project" page
+  When I click on "Google Code"
+  Then I redirected to Google Code import page

--- a/features/steps/dashboard/new_project.rb
+++ b/features/steps/dashboard/new_project.rb
@@ -13,8 +13,17 @@ class Spinach::Features::NewProject < Spinach::FeatureSteps
     expect(page).to have_content('Project path')
   end
 
+  step 'I see all possible import optios' do
+    expect(page).to have_link('GitHub')
+    expect(page).to have_link('Bitbucket')
+    expect(page).to have_link('GitLab.com')
+    expect(page).to have_link('Gitorious.org')
+    expect(page).to have_link('Google Code')
+    expect(page).to have_link('Any repo by URL')
+  end
+
   step 'I click on "Import project from GitHub"' do
-    first('.how_to_import_link').click
+    first('.import_github').click
   end
 
   step 'I see instructions on how to import from GitHub' do
@@ -26,4 +35,24 @@ class Spinach::Features::NewProject < Spinach::FeatureSteps
       expect(element).not_to be_visible unless element == github_modal
     end
   end
+
+  step 'I click on "Any repo by URL"' do
+    first('.import_git').click
+  end
+
+  step 'I see instructions on how to import from Git URL' do
+    git_import_instructions = first('.js-toggle-content')
+    expect(git_import_instructions).to be_visible
+    expect(git_import_instructions).to have_content "Git repository URL"
+    expect(git_import_instructions).to have_content "The repository must be accessible over HTTP(S). If it is not publicly accessible, you can add authentication information to the URL:"
+  end
+
+  step 'I click on "Google Code"' do
+    first('.import_google_code').click
+  end
+
+  step 'I redirected to Google Code import page' do
+    expect(current_path).to eq new_import_google_code_path
+  end
+
 end

--- a/lib/gitlab/current_settings.rb
+++ b/lib/gitlab/current_settings.rb
@@ -22,7 +22,8 @@ module Gitlab
         sign_in_text: Settings.extra['sign_in_text'],
         restricted_visibility_levels: Settings.gitlab['restricted_visibility_levels'],
         max_attachment_size: Settings.gitlab['max_attachment_size'],
-        session_expire_delay: Settings.gitlab['session_expire_delay']
+        session_expire_delay: Settings.gitlab['session_expire_delay'],
+        import_sources: Settings.gitlab['import_sources']
       )
     end
   end

--- a/lib/gitlab/import_sources.rb
+++ b/lib/gitlab/import_sources.rb
@@ -1,0 +1,29 @@
+# Gitlab::ImportSources module
+#
+# Define import sources that can be used
+# during the creation of new project
+#
+module Gitlab
+  module ImportSources
+    extend CurrentSettings
+
+    class << self
+      def values
+        options.values
+      end
+
+      def options
+        {
+          'GitHub'          => 'github',
+          'Bitbucket'       => 'bitbucket',
+          'GitLab.com'      => 'gitlab',
+          'Gitorious.org'   => 'gitorious',
+          'Google Code'     => 'google_code',
+          'Any repo by URL' => 'git',
+        }
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
Import options are displayed by creation of a new project. Currently all possible options are there, which leads to following possible issues:

**Issue 1 - End user confusion: Configuration recommendation outside of own responsibility**
1. Not configured sources(oauth) - which are not usable for the end user of Gitlab installation
2. End user gets probably a hint, which links to the oath configuration steps, which can be done only by Gitlab admin
3. Admin phone is ringing / email inbox gets a new mail / support ticket system gets a new ticket with a support request like "why do we have Github as a source here, but I can't use that?"

**Issue 2: Restricted environments - No internet access:**
1. In some environments with strong security requirements its quite common **NOT** to have Internet access (or not a permanent direct internet connection)
2. In this cases such import functionality won't work at all and can't be realized (because of restrictions)
3. This leads to the Issue 1

**Issue 3: Missing OAuth credentials**
1. Organisation using this particular Gitlab installation doesn't have Github/Bitbucket/\* accounts and has no need to have them
2. For the organisation it doesn't make really sense to create the according accounts only to allow this import
3. This leads to the Issue 1

I've already created the #9553 and here the first code implementation. This MR is marked as [WIP] and I would like to get your feedback in the current state and clarify some questions.
(Please keep in mind, this is my first MR to Gitlab, I want to get feedback and have some ugly code for sure:) )

The idea to solve this issues is to provide a possibility to configure the import sources (and to keep all enabled by default)

Admin interface (new buttons + links to the help pages for admins)
![admin-interface](https://cloud.githubusercontent.com/assets/1645670/9277180/beec227e-42a8-11e5-96bc-f4d572a3d73d.png)

New project interface (same like before, but only the enabled/configured sources are displayed and no admin related help hints for end users)
![new-project](https://cloud.githubusercontent.com/assets/1645670/9277195/d45514ae-42a8-11e5-9ed4-7ee763bdd424.png)

Questions:
- I couldn't disable the "Any repo by URL" code, currently its hidden by the template. 
  - Is it required to do this in this MR? (probably it makes sense to refactor it in some other MR and to move it to the same structure like other importers)
  - If its required, can you please show/explain me the modules/logic/flow? (I was lost at some point in the flow between the modules)

Following points are implemented/todo:
- [x] Settings in the admin interface
- [x] DB migrations
- [x] Handling of import source configuration in "new project"
- [x] Spinach tests fixed/added

Something else?
