### PR TITLE
Add API method for get user by ID of an SSH key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ v 8.0.0 (unreleased)
   - Added Drone CI integration (Kirill Zaitsev)
   - Refactored service API and added automatically service docs generator (Kirill Zaitsev) 
   - Added web_url key project hook_attrs (Kirill Zaitsev)
+  - Add ability to get user information by ID of an SSH key via the API
 
 v 7.14.1
   - Improve abuse reports management from admin area

--- a/doc/api/README.md
+++ b/doc/api/README.md
@@ -21,6 +21,7 @@
 - [Groups](groups.md)
 - [Namespaces](namespaces.md)
 - [Settings](settings.md)
+- [Keys](keys.md)
 
 ## Clients
 

--- a/doc/api/keys.md
+++ b/doc/api/keys.md
@@ -1,0 +1,46 @@
+# Keys
+
+## Get SSH key with user by ID of an SSH key
+
+Get SSH key with user by ID of an SSH key. Note only administrators can lookup SSH key with user by ID of an SSH key.
+
+```
+GET /keys/:id
+```
+
+Parameters:
+
+- `id` (required) - The ID of an SSH key
+
+```json
+{
+  "id": 1,
+  "title": "Sample key 25",
+  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt1256k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
+  "created_at": "2015-09-03T07:24:44.627Z",
+  "user": {
+    "name": "John Smith",
+    "username": "john_smith",
+    "id": 25,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/cfa35b8cd2ec278026357769582fa563?s=40\u0026d=identicon",
+    "web_url": "http://localhost:3000/u/john_smith",
+    "created_at": "2015-09-03T07:24:01.670Z",
+    "is_admin": false,
+    "bio": null,
+    "skype": "",
+    "linkedin": "",
+    "twitter": "",
+    "website_url": "",
+    "email": "john@example.com",
+    "theme_id": 2,
+    "color_scheme_id": 1,
+    "projects_limit": 10,
+    "current_sign_in_at": null,
+    "identities": [],
+    "can_create_group": true,
+    "can_create_project": true,
+    "two_factor_enabled": false
+  }
+}
+```

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -150,51 +150,6 @@ Parameters:
 }
 ```
 
-### Get SSH key with user by ID of an SSH key
-
-Get SSH key with user by ID of an SSH key. Note only administrators can lookup SSH key with user by ID of an SSH key.
-
-```
-GET /keys/:id
-```
-
-Parameters:
-
-- `id` (required) - The ID of an SSH key
-
-```json
-{
-  "id": 1,
-  "title": "Sample key 25",
-  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt1256k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
-  "created_at": "2015-09-03T07:24:44.627Z",
-  "user": {
-    "name": "John Smith",
-    "username": "john_smith",
-    "id": 25,
-    "state": "active",
-    "avatar_url": "http://www.gravatar.com/avatar/cfa35b8cd2ec278026357769582fa563?s=40\u0026d=identicon",
-    "web_url": "http://localhost:3000/u/john_smith",
-    "created_at": "2015-09-03T07:24:01.670Z",
-    "is_admin": false,
-    "bio": null,
-    "skype": "",
-    "linkedin": "",
-    "twitter": "",
-    "website_url": "",
-    "email": "john@example.com",
-    "theme_id": 2,
-    "color_scheme_id": 1,
-    "projects_limit": 10,
-    "current_sign_in_at": null,
-    "identities": [],
-    "can_create_group": true,
-    "can_create_project": true,
-    "two_factor_enabled": false
-  }
-}
-```
-
 ## User creation
 
 Creates a new user. Note only administrators can create new users.

--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -150,6 +150,51 @@ Parameters:
 }
 ```
 
+### Get SSH key with user by ID of an SSH key
+
+Get SSH key with user by ID of an SSH key. Note only administrators can lookup SSH key with user by ID of an SSH key.
+
+```
+GET /keys/:id
+```
+
+Parameters:
+
+- `id` (required) - The ID of an SSH key
+
+```json
+{
+  "id": 1,
+  "title": "Sample key 25",
+  "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt1256k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=",
+  "created_at": "2015-09-03T07:24:44.627Z",
+  "user": {
+    "name": "John Smith",
+    "username": "john_smith",
+    "id": 25,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/cfa35b8cd2ec278026357769582fa563?s=40\u0026d=identicon",
+    "web_url": "http://localhost:3000/u/john_smith",
+    "created_at": "2015-09-03T07:24:01.670Z",
+    "is_admin": false,
+    "bio": null,
+    "skype": "",
+    "linkedin": "",
+    "twitter": "",
+    "website_url": "",
+    "email": "john@example.com",
+    "theme_id": 2,
+    "color_scheme_id": 1,
+    "projects_limit": 10,
+    "current_sign_in_at": null,
+    "identities": [],
+    "can_create_group": true,
+    "can_create_project": true,
+    "two_factor_enabled": false
+  }
+}
+```
+
 ## User creation
 
 Creates a new user. Note only administrators can create new users.

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -50,5 +50,6 @@ module API
     mount Branches
     mount Labels
     mount Settings
+    mount Keys
   end
 end

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -199,6 +199,10 @@ module API
       expose :id, :title, :key, :created_at
     end
 
+    class SSHKeyWithUser < SSHKey
+      expose :user, using: Entities::UserFull
+    end
+
     class Note < Grape::Entity
       expose :id
       expose :note, as: :body

--- a/lib/api/keys.rb
+++ b/lib/api/keys.rb
@@ -1,0 +1,20 @@
+module API
+  # Keys API
+  class Keys < Grape::API
+    before { authenticate! }
+
+    resource :keys do
+      # Get single ssh key by id. Only available to admin users.
+      #
+      # Example Request:
+      #   GET /keys/:id
+      get ":id" do
+        authenticated_as_admin!
+
+        key = Key.find(params[:id])
+
+        present key, with: Entities::SSHKeyWithUser
+      end
+    end
+  end
+end

--- a/spec/requests/api/keys_spec.rb
+++ b/spec/requests/api/keys_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe API::API, api: true  do
+  include ApiHelpers
+
+  let(:user)  { create(:user) }
+  let(:admin) { create(:admin) }
+  let(:key)   { create(:key, user: user) }
+  let(:email)   { create(:email, user: user) }
+
+  describe 'GET /keys/:uid' do
+    before { admin }
+
+    context 'when unauthenticated' do
+      it 'should return authentication error' do
+        get api("/keys/#{key.id}")
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'should return 404 for non-existing key' do
+        get api('/keys/999999', admin)
+        expect(response.status).to eq(404)
+        expect(json_response['message']).to eq('404 Not found')
+      end
+
+      it 'should return single ssh key with user information' do
+        user.keys << key
+        user.save
+        get api("/keys/#{key.id}", admin)
+        expect(response.status).to eq(200)
+        expect(json_response['title']).to eq(key.title)
+        expect(json_response['user']['id']).to eq(user.id)
+        expect(json_response['user']['username']).to eq(user.username)
+      end
+    end
+  end
+end


### PR DESCRIPTION
GL_ID environment variable in hooks can contains value like:
- user-:id
- key-:id

Unfortunately, I have not found a way to get information about the user by ID for the SSH key via current API.
