### PR TITLE
add image content-type header 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ v 8.0.0 (unreleased)
   - Refactored service API and added automatically service docs generator (Kirill Zaitsev) 
   - Added web_url key project hook_attrs (Kirill Zaitsev)
   - Add ability to get user information by ID of an SSH key via the API
+  - Fix bug which IE cannot show image at markdown when the image is raw file	of gitlab  
 
 v 7.14.1
   - Improve abuse reports management from admin area

--- a/app/controllers/projects/raw_controller.rb
+++ b/app/controllers/projects/raw_controller.rb
@@ -29,6 +29,8 @@ class Projects::RawController < Projects::ApplicationController
   def get_blob_type
     if @blob.text?
       'text/plain; charset=utf-8'
+    elsif @blob.image?
+      @blob.content_type
     else
       'application/octet-stream'
     end

--- a/spec/controllers/projects/raw_controller_spec.rb
+++ b/spec/controllers/projects/raw_controller_spec.rb
@@ -19,5 +19,19 @@ describe Projects::RawController do
             to eq("inline")
       end
     end
+
+    context 'image header' do
+      let(:id) { 'master/files/images/6049019_460s.jpg' }
+
+      it 'set image content type header' do
+        get(:show,
+            namespace_id: public_project.namespace.to_param,
+            project_id: public_project.to_param,
+            id: id)
+
+        expect(response.status).to eq(200)
+        expect(response.header['Content-Type']).to eq('image/jpeg')
+      end
+    end
   end
 end


### PR DESCRIPTION
When I use image in Markdown, I find a bug.
If I link image in MD file from gitlab raw data, it would not show on IE. 
(eg. https://gitlab.com/user_id/repo_name/raw/master/image.png)

issue : https://gitlab.com/gitlab-org/gitlab-ce/issues/2376   

It is because of content-type of headers.
If the blob is not text, the content-type is always application/octet-stream. 
And IE cannot resolve it to image so it will be cracked. (I test it IE 10, 11) 
So I add code to change content-type if blob type is image. 

```
modified:   app/controllers/projects/raw_controller.rb
```
