### PR TITLE
Add API request to get slack service parameters from projects/:id/services

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ v 8.0.0 (unreleased)
   - Don't notify users without access to the project when they are (accidentally) mentioned in a note.
   - Retrieving oauth token with LDAP credentials
   - Load Application settings from running database unless env var USE_DB=false
+  - Add API request to get slack service parameters from projects/:id/services/slack (Petheő Bence)
 
 v 7.14.1
   - Improve abuse reports management from admin area

--- a/lib/api/services.rb
+++ b/lib/api/services.rb
@@ -73,6 +73,14 @@ module API
           )
         end
       end
+
+      # Get Slack service settings
+      #
+      # Example Request:
+      #  GET /projects/:id/services/slack
+      get ':id/services/slack' do
+        present user_project.slack_service
+      end
     end
   end
 end


### PR DESCRIPTION
Added a new API endpoint to retrive slack parameters so automated pull sctipts can get those without any extra config and can post to the preconfigured channel.

Related feature request: http://feedback.gitlab.com/forums/176466-general/suggestions/9590679-api-get-slack-parameters
