### PR TITLE
add repository field to issue hook data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@ v 8.0.0 (unreleased)
   - Added service API endpoint to retrieve service parameters (Petheő Bence)
   - Add FogBugz project import (Jared Szechy)
   - Sort users autocomplete lists by user (Allister Antosik)
+  - Webhook for issue now contains repository field (Jungkook Park)
 
 v 7.14.3
   - No changes

--- a/app/models/concerns/issuable.rb
+++ b/app/models/concerns/issuable.rb
@@ -140,6 +140,12 @@ module Issuable
     {
       object_kind: self.class.name.underscore,
       user: user.hook_attrs,
+      repository: {
+          name: project.name,
+          url: project.url_to_repo,
+          description: project.description,
+          homepage: project.web_url
+      },
       object_attributes: hook_attrs
     }
   end

--- a/doc/web_hooks/web_hooks.md
+++ b/doc/web_hooks/web_hooks.md
@@ -121,6 +121,12 @@ X-Gitlab-Event: Issue Hook
     "username": "root",
     "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
   },
+  "repository": {
+    "name": "Gitlab Test",
+    "url": "http://example.com/gitlabhq/gitlab-test.git",
+    "description": "Aut reprehenderit ut est.",
+    "homepage": "http://example.com/gitlabhq/gitlab-test"
+  },
   "object_attributes": {
     "id": 301,
     "title": "New API: create/update/delete file",

--- a/spec/models/concerns/issuable_spec.rb
+++ b/spec/models/concerns/issuable_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Issue, "Issuable" do
   let(:issue) { create(:issue) }
+  let(:user) { create(:user) }
 
   describe "Associations" do
     it { is_expected.to belong_to(:project) }
@@ -64,6 +65,21 @@ describe Issue, "Issuable" do
       allow(issue).to receive(:today?).and_return(true)
       issue.touch
       expect(issue.new?).to be_falsey
+    end
+  end
+
+
+  describe "#to_hook_data" do
+    let(:hook_data) { issue.to_hook_data(user) }
+
+    it "returns correct hook data" do
+      expect(hook_data[:object_kind]).to eq("issue")
+      expect(hook_data[:user]).to eq(user.hook_attrs)
+      expect(hook_data[:repository][:name]).to eq(issue.project.name)
+      expect(hook_data[:repository][:url]).to eq(issue.project.url_to_repo)
+      expect(hook_data[:repository][:description]).to eq(issue.project.description)
+      expect(hook_data[:repository][:homepage]).to eq(issue.project.web_url)
+      expect(hook_data[:object_attributes]).to eq(issue.hook_attrs)
     end
   end
 end


### PR DESCRIPTION
**What does this do?**
Webhooks for issue now contains repository field which is in the same manner as comment events.

**Why is this needed?**
Webhook provides the ability to update an external issue tracker, but there is no way to figure out the repository name of an issue when issue events are occured. Actually we can do it using project_id, but other webhook events provides both repository info and project_id.
