### PR TITLE
Sorted autocomplete users list by name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@ v 8.0.0 (unreleased)
   - Fix highlighting of deleted lines in diffs.
   - Added service API endpoint to retrieve service parameters (Petheő Bence)
   - Add FogBugz project import (Jared Szechy)
+  - Sort users autocomplete lists by user (Allister Antosik)
 
 v 7.14.3
   - No changes

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -32,6 +32,7 @@ class AutocompleteController < ApplicationController
     @users ||= User.none
     @users = @users.search(params[:search]) if params[:search].present?
     @users = @users.active
+    @users = @users.reorder(:name)
     @users = @users.page(params[:page]).per(PER_PAGE)
 
     unless params[:search].present?


### PR DESCRIPTION
Currently when Gitlab gets a list of users (For example in the Assignee field for a merge request) for a autocomplete select field it orders them by date created, it would be must more elegant if this was sorted by the users name.

It looks like this was previously the case, but the code has been changed since then:
#3645

This is a re-pull request of https://github.com/gitlabhq/gitlabhq/pull/9522 - due to CI not running on it.
