### PR TITLE
Fix grammar in admin area labels when no labels exist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 8.1.0 (unreleased)
   - Show CI status on Your projects page and Starred projects page
   - Remove "Continuous Integration" page from dashboard
   - Add notes and SSL verification entries to hook APIs (Ben Boeckel)
+  - Fix grammar in admin area "labels" .nothing-here-block when no labels exist.
 
 v 8.0.2 (unreleased)
   - Fix default avatar not rendering in network graph (Stan Hu)

--- a/app/views/admin/labels/index.html.haml
+++ b/app/views/admin/labels/index.html.haml
@@ -12,5 +12,5 @@
     = paginate @labels, theme: 'gitlab'
   - else
     .light-well
-      .nothing-here-block There are no any labels yet
+      .nothing-here-block There are no labels yet
       

--- a/features/steps/admin/labels.rb
+++ b/features/steps/admin/labels.rb
@@ -38,7 +38,7 @@ class Spinach::Features::AdminIssuesLabels < Spinach::FeatureSteps
 
   step 'I should see labels help message' do
     page.within '.labels' do
-      expect(page).to have_content 'There are no any labels yet'
+      expect(page).to have_content 'There are no labels yet'
     end
   end
 


### PR DESCRIPTION
Spoke to @dblessing in IRC re: this change. Noticed a grammar error when using GitLab, changed "...no any..." to "...not any...". 
