### PR TITLE
Updated the SSH readme with a test section and improved the custom configuration

### DIFF
--- a/doc/ssh/README.md
+++ b/doc/ssh/README.md
@@ -8,7 +8,6 @@ already has one by running the following command:
 ```bash
 cat ~/.ssh/id_rsa.pub
 ```
-
 If you see a long string starting with `ssh-rsa` or `ssh-dsa`, you can skip the `ssh-keygen` step.
 
 Note: It is a best practice to use a password for an SSH key, but it is not
@@ -74,6 +73,30 @@ information.
 
 Deploy keys can be shared between projects, you just need to add them to each project.
 
+## Test your key
+
+After you have set up your SSH key, you'll have to make sure that you can connect to GitLab. If you have created a passphrase, you will be asked to enter it after the first step:
+
+1. Open a Terminal and run:
+
+		ssh -T git@gitlab.com
+
+2. After you verify the authenticity of the fingerprint in this message:
+
+		The authenticity of host 'gitlab.com (WWW.XXX.YYY.ZZZ)' can't be established.
+		ECDSA key fingerprint is SHA256:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.
+		Are you sure you want to continue connecting (yes/no)?
+
+	type `yes` to confirm.
+
+3. If everything went well and your username has been recognized you'll see this welcome message with your full name:
+
+		Welcome to GitLab, John Smith!
+
+	In case you get an "access denied" error, try debugging the connection using this command:
+
+		ssh -Tv git@gitlab.com
+
 ## Applications
 
 ### Eclipse
@@ -89,9 +112,10 @@ If, for whatever reason, you decide to specify a non-default location and filena
 # Main gitlab.com server
 #
 Host gitlab.com
-RSAAuthentication yes
-IdentityFile ~/my-ssh-key-directory/my-gitlab-private-key-filename
-User mygitlabusername
+	User git
+	Hostname gitlab.com
+	RSAAuthentication yes
+	IdentityFile ~/my-ssh-key-directory/my-gitlab-private-key-filename
 ```
 
 Another example
@@ -100,11 +124,10 @@ Another example
 # Our company's internal Gitlab server
 #
 Host my-gitlab.company.com
-RSAAuthentication yes
-IdentityFile ~/my-ssh-key-directory/company-com-private-key-filename
+	Host my-gitlab.company.com
+	RSAAuthentication yes
+	IdentityFile ~/my-ssh-key-directory/company-com-private-key-filename
 ```
-
-Note in the gitlab.com example above a username was specified to override the default chosen by OpenSSH (your local username). This is only required if your local and remote usernames differ.
 
 Due to the wide variety of SSH clients and their very large number of configuration options, further explanation of these topics is beyond the scope of this document.
 

--- a/doc/ssh/README.md
+++ b/doc/ssh/README.md
@@ -75,7 +75,7 @@ Deploy keys can be shared between projects, you just need to add them to each pr
 
 ## Test your key
 
-After you have set up your SSH key, you'll have to make sure that you can connect to GitLab. If you have created a passphrase, you will be asked to enter it after the first step:
+After you have set up your SSH key, you'll have to make sure that you can connect to GitLab. If you have created a passphrase, you will be asked to enter it after the first step.
 
 1. Open a Terminal and run:
 
@@ -97,39 +97,42 @@ After you have set up your SSH key, you'll have to make sure that you can connec
 
 		ssh -Tv git@gitlab.com
 
-## Applications
+## Custom SSH configuration
 
-### Eclipse
+If you happen to have a custom location and filename for your GitLab SSH key pair, you must configure your SSH client to find your GitLab SSH private key for connections to your GitLab server (perhaps gitlab.com). For OpenSSH clients, this is handled in the `~/.ssh/config` file.
 
-How to add your ssh key to Eclipse: http://wiki.eclipse.org/EGit/User_Guide#Eclipse_SSH_Configuration
+Your gitlab.com configuration would look something like this:
 
-## Tip: Non-default OpenSSH key file names or locations
+	#
+	# Main gitlab.com server
+	#
+	Host gitlab.com
+		User git
+		Hostname gitlab.com
+		RSAAuthentication yes
+		IdentityFile ~/my-ssh-key-directory/my-gitlab-private-key-filename
 
-If, for whatever reason, you decide to specify a non-default location and filename for your Gitlab SSH key pair, you must configure your SSH client to find your Gitlab SSH private key for connections to your Gitlab server (perhaps gitlab.com). For OpenSSH clients, this is handled in the `~/.ssh/config` file with a stanza similar to the following:
+Note: You should connect using the `git` username, connections with your GitLab username will be refused and you will get an "access denied" error.
 
-```
-#
-# Main gitlab.com server
-#
-Host gitlab.com
-	User git
-	Hostname gitlab.com
-	RSAAuthentication yes
-	IdentityFile ~/my-ssh-key-directory/my-gitlab-private-key-filename
-```
+And for your self-hosted GitLab server the configuration will look like this:
 
-Another example
-```
-#
-# Our company's internal Gitlab server
-#
-Host my-gitlab.company.com
+	#
+	# Our company's internal GitLab server
+	#
 	Host my-gitlab.company.com
-	RSAAuthentication yes
-	IdentityFile ~/my-ssh-key-directory/company-com-private-key-filename
-```
+		Host my-gitlab.company.com
+		RSAAuthentication yes
+		IdentityFile ~/my-ssh-key-directory/company-com-private-key-filename
+
+You can find more information on custom SSH configuration in the [official documentation](http://linux.die.net/man/5/ssh_config).
 
 Due to the wide variety of SSH clients and their very large number of configuration options, further explanation of these topics is beyond the scope of this document.
 
 Public SSH keys need to be unique, as they will bind to your account. Your SSH key is the only identifier you'll
 have when pushing code via SSH. That's why it needs to uniquely map to a single user.
+
+## Applications
+
+### Eclipse
+
+How to add your ssh key to Eclipse: http://wiki.eclipse.org/EGit/User_Guide#Eclipse_SSH_Configuration


### PR DESCRIPTION
The SSH readme did not have a section where it explained how to test the SSH keys.

Also, the sample config file stated that the user should use their username for the connection, which threw an access denied error. The SSH connections work with the `git` username.
