### PR TITLE
Added user preference to change layout width

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ v 8.1.0 (unreleased)
   - Hide password in the service settings form
   - Fix anchors to comments in diffs
   - Move CI web hooks page to project settings area
+  - Add user preference to change layout width (Peter Göbel)
 
 v 8.0.3
   - Fix URL shown in Slack notifications

--- a/app/controllers/profiles/preferences_controller.rb
+++ b/app/controllers/profiles/preferences_controller.rb
@@ -31,6 +31,7 @@ class Profiles::PreferencesController < Profiles::ApplicationController
   def preferences_params
     params.require(:user).permit(
       :color_scheme_id,
+      :layout,
       :dashboard,
       :project_view,
       :theme_id

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -26,7 +26,7 @@ module PageLayoutHelper
 
   def fluid_layout(enabled = false)
     if @fluid_layout.nil?
-      @fluid_layout = (current_user && current_user.layout == "wide") || enabled
+      @fluid_layout = (current_user && current_user.layout == "fluid") || enabled
     else
       @fluid_layout
     end

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -26,7 +26,7 @@ module PageLayoutHelper
 
   def fluid_layout(enabled = false)
     if @fluid_layout.nil?
-      @fluid_layout = enabled
+      @fluid_layout = (current_user && current_user.layout == "wide") || enabled
     else
       @fluid_layout
     end

--- a/app/helpers/preferences_helper.rb
+++ b/app/helpers/preferences_helper.rb
@@ -2,8 +2,8 @@
 module PreferencesHelper
   def layout_choices
     [
-        ['Small', :small],
-        ['Wide', :wide]
+        ['Fixed', :fixed],
+        ['Fluid', :fluid]
     ]
   end
 

--- a/app/helpers/preferences_helper.rb
+++ b/app/helpers/preferences_helper.rb
@@ -1,5 +1,12 @@
 # Helper methods for per-User preferences
 module PreferencesHelper
+  def layout_choices
+    [
+        ['Small', :small],
+        ['Wide', :wide]
+    ]
+  end
+
   # Maps `dashboard` values to more user-friendly option text
   DASHBOARD_CHOICES = {
     projects: 'Your Projects (default)',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,7 +173,7 @@ class User < ActiveRecord::Base
   after_destroy :post_destroy_hook
 
   # User's Layout preference
-  enum layout: [:small, :wide]
+  enum layout: [:fixed, :fluid]
 
   # User's Dashboard preference
   # Note: When adding an option, it MUST go on the end of the array.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,7 @@
 #  public_email               :string(255)      default(""), not null
 #  dashboard                  :integer          default(0)
 #  project_view               :integer          default(0)
+#  layout                     :integer          default(0)
 #
 
 require 'carrierwave/orm/activerecord'
@@ -170,6 +171,9 @@ class User < ActiveRecord::Base
   after_initialize :set_projects_limit
   after_create :post_create_hook
   after_destroy :post_destroy_hook
+
+  # User's Layout preference
+  enum layout: [:small, :wide]
 
   # User's Dashboard preference
   # Note: When adding an option, it MUST go on the end of the array.

--- a/app/views/profiles/preferences/show.html.haml
+++ b/app/views/profiles/preferences/show.html.haml
@@ -33,6 +33,13 @@
       Behavior
     .panel-body
       .form-group
+        = f.label :layout, class: 'control-label' do
+          Layout width
+        .col-sm-10
+          = f.select :layout, layout_choices, {}, class: 'form-control'
+          .help-block
+            Choose between small (max. 1200px) and wide (100%) application layout
+      .form-group
         = f.label :dashboard, class: 'control-label' do
           Default Dashboard
           = link_to('(?)', help_page_path('profile', 'preferences') + '#default-dashboard', target: '_blank')

--- a/app/views/profiles/preferences/show.html.haml
+++ b/app/views/profiles/preferences/show.html.haml
@@ -38,7 +38,7 @@
         .col-sm-10
           = f.select :layout, layout_choices, {}, class: 'form-control'
           .help-block
-            Choose between small (max. 1200px) and wide (100%) application layout
+            Choose between fixed (max. 1200px) and fluid (100%) application layout
       .form-group
         = f.label :dashboard, class: 'control-label' do
           Default Dashboard

--- a/app/views/profiles/preferences/update.js.erb
+++ b/app/views/profiles/preferences/update.js.erb
@@ -2,6 +2,13 @@
 $('body').removeClass('<%= Gitlab::Themes.body_classes %>')
 $('body').addClass('<%= user_application_theme %>')
 
+// Toggle container-fluid class
+if ('<%= current_user.layout %>' === 'wide') {
+  $('.content-wrapper').find('.container-fluid').removeClass('container-limited')
+} else {
+  $('.content-wrapper').find('.container-fluid').addClass('container-limited')
+}
+
 // Re-enable the "Save" button
 $('input[type=submit]').enable()
 

--- a/app/views/profiles/preferences/update.js.erb
+++ b/app/views/profiles/preferences/update.js.erb
@@ -3,7 +3,7 @@ $('body').removeClass('<%= Gitlab::Themes.body_classes %>')
 $('body').addClass('<%= user_application_theme %>')
 
 // Toggle container-fluid class
-if ('<%= current_user.layout %>' === 'wide') {
+if ('<%= current_user.layout %>' === 'fluid') {
   $('.content-wrapper').find('.container-fluid').removeClass('container-limited')
 } else {
   $('.content-wrapper').find('.container-fluid').addClass('container-limited')

--- a/db/migrate/20151005150751_add_layout_option_for_users.rb
+++ b/db/migrate/20151005150751_add_layout_option_for_users.rb
@@ -1,0 +1,5 @@
+class AddLayoutOptionForUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :layout, :integer, :default => 0
+  end
+end

--- a/db/migrate/20151005150751_add_layout_option_for_users.rb
+++ b/db/migrate/20151005150751_add_layout_option_for_users.rb
@@ -1,5 +1,5 @@
 class AddLayoutOptionForUsers < ActiveRecord::Migration
   def change
-    add_column :users, :layout, :integer, :default => 0
+    add_column :users, :layout, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150930095736) do
+ActiveRecord::Schema.define(version: 20151005150751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -753,6 +753,7 @@ ActiveRecord::Schema.define(version: 20150930095736) do
     t.integer  "dashboard",                  default: 0
     t.integer  "project_view",               default: 0
     t.integer  "consumed_timestep"
+    t.integer  "layout",                     default: 0
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree


### PR DESCRIPTION
As discussed [here](https://twitter.com/Go_Peter/status/646259409807646720), I've added an option to choose between a small and a wide application layout. Old MR: #9696 

To achieve this, I've added a new column to the user table which stores the layout option and extended the `fluid_layout` function which now uses the user preference.

Screenshot before:

![before](https://cloud.githubusercontent.com/assets/1242960/10279486/563aecb0-6b66-11e5-97cb-cf61078a7fa2.png)

Screenshot after:

![after](https://cloud.githubusercontent.com/assets/1242960/10279489/5b394414-6b66-11e5-8003-c98ccd822d74.png)
