### PR TITLE
Small typo fix when deleting groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -88,7 +88,7 @@ class GroupsController < Groups::ApplicationController
   def destroy
     DestroyGroupService.new(@group, current_user).execute
 
-    redirect_to root_path, alert: "Group '#{@group.name} was deleted."
+    redirect_to root_path, alert: "Group '#{@group.name}' was deleted."
   end
 
   protected

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -88,7 +88,7 @@ class GroupsController < Groups::ApplicationController
   def destroy
     DestroyGroupService.new(@group, current_user).execute
 
-    redirect_to root_path, alert: "Group '#{@group.name}' was deleted."
+    redirect_to root_path, alert: "Group '#{@group.name}' was successfully deleted."
   end
 
   protected


### PR DESCRIPTION
When I tried to delete a group I came across a huge issue that I couldn't possibly ignore. I made a group called "testgroup", and this was the message it gave me when I deleted it: `Group 'testgroup was deleted.`. That weird floating quote is obviously unacceptable for a feature used so often. The message now reads: `Group 'testgroup' was successfully deleted.`(added "successfully" cause that's also used when updating and creating groups)
