### PR TITLE
Ignoring hidden refs when checking for repository emptiness

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,7 @@ v 8.0.5
   - Correct lookup-by-email for LDAP logins
   - Fix loading spinner sometimes not being hidden on Merge Request tab switches
   - Animate the logo on hover
+  - Show "Empty Repository Page" for repository without branches (#9728)
 
 v 8.0.4
   - Fix Message-ID header to be RFC 2111-compliant to prevent e-mails being dropped (Stan Hu)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -567,7 +567,7 @@ class Project < ActiveRecord::Base
   end
 
   def empty_repo?
-    !repository.exists? || repository.empty?
+    !repository.exists? || !repository.has_visible_content?
   end
 
   def repo

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -44,6 +44,19 @@ class Repository
     raw_repository.empty?
   end
 
+  #
+  # Git repository can contains some hidden refs like:
+  #   /refs/notes/*
+  #   /refs/git-as-svn/*
+  #   /refs/pulls/*
+  # This refs by default not visible in project page and not cloned to client side.
+  #
+  # This method return true if repository contains some content visible in project page.
+  #
+  def has_visible_content?
+    !raw_repository.branches.empty?
+  end
+
   def commit(id = 'HEAD')
     return nil unless raw_repository
     commit = Gitlab::Git::Commit.find(raw_repository, id)


### PR DESCRIPTION
I use https://github.com/bozaro/git-as-svn project for access to git repositories via svn protocol.

This project create ref `git-as-svn/v1/master` for store:
- subversion revision to git commit mapping;
- subversion repository guid.

This ref created event on empty repository.

Before this change GitLab fail on empty project page with error:

```
ActionController::UrlGenerationError at /root/bar1

No route matches {:action=>"show", :controller=>"projects/commits", :id=>nil, :namespace_id=>#<Namespace id: 1, name: "root", path: "root", owner_id: 1, created_at: "2015-09-26 17:02:43", updated_at: "2015-09-26 17:02:43", type: nil, description: "", avatar: nil>, :project_id=>#<Project id: 11, name: "bar1", path: "bar1", description: "", created_at: "2015-09-27 05:30:51", updated_at: "2015-09-27 05:30:51", creator_id: 1, issues_enabled: true, wall_enabled: false, merge_requests_enabled: true, wiki_enabled: true, namespace_id: 1, issues_tracker: "gitlab", issues_tracker_id: nil, snippets_enabled: false, last_activity_at: "2015-09-27 05:30:51", import_url: "", visibility_level: 10, archived: false, avatar: nil, import_status: "none", repository_size: 0.0, star_count: 0, import_type: nil, import_source: nil, commit_count: 0>} missing required keys: [:id]
```

After this change it show correct page for empty repository.
