### PR TITLE
Broken URL in long commit message

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -181,6 +181,10 @@ module EventsHelper
     sanitize(text, tags: %w(a img b pre code p span))
   end
 
+  def event_commit_urls(message)
+    URI.extract(message)
+  end
+
   def event_commit_title(message)
     escape_once(truncate(message.split("\n").first, length: 70))
   rescue

--- a/app/views/events/_commit.html.haml
+++ b/app/views/events/_commit.html.haml
@@ -2,4 +2,4 @@
   .commit-row-title
     = link_to truncate_sha(commit[:id]), namespace_project_commit_path(project.namespace, project, commit[:id]), class: "commit_short_id", alt: ''
     &middot;
-    = gfm event_commit_title(commit[:message]), project: project
+    = gfm event_commit_title(commit[:message]), project: project, hrefs: event_commit_urls(commit[:message])

--- a/lib/gitlab/markdown.rb
+++ b/lib/gitlab/markdown.rb
@@ -102,6 +102,13 @@ module Gitlab
         save_options |= Nokogiri::XML::Node::SaveOptions::AS_XHTML
       end
 
+      uri_regex = /^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?$/
+      result[:output].children.select{|klass| klass.name == "a"}.map! do |a_class|
+        unless a_class["href"] =~ uri_regex
+          a_class["href"] = options[:hrefs].select{|url| url.match(a_class["href"])}.first
+        end
+      end
+
       text = result[:output].to_html(save_with: save_options)
 
       text.html_safe


### PR DESCRIPTION
As mentioned here #9388, when a commit contains a long commit message including a URL, after truncating to be shown in dashboard, the URL is broken, therefore, causing a broken link.

**Commit example**
<img width="1339" alt="bildschirmfoto 2015-10-16 um 17 17 59" src="https://cloud.githubusercontent.com/assets/356881/10552384/e7bcf1bc-7429-11e5-9541-a6bd9bb0aa84.png">

**Broken URL**
<img width="1322" alt="bildschirmfoto 2015-10-16 um 17 19 42" src="https://cloud.githubusercontent.com/assets/356881/10552420/20363ef4-742a-11e5-9bbe-bfbe4bcf658a.png">
<img width="928" alt="bildschirmfoto 2015-10-16 um 17 19 34" src="https://cloud.githubusercontent.com/assets/356881/10552419/20338b1e-742a-11e5-8a97-4821910dd75d.png">

**Fixed URL**
<img width="1002" alt="bildschirmfoto 2015-10-16 um 17 20 30" src="https://cloud.githubusercontent.com/assets/356881/10552444/43e862fa-742a-11e5-9d6a-4e39ae9b3752.png">
## 

My first idea was extract the full URLs in the `events_helper.rb` and send them (if more then one) to `gfm`. I'm still now sure if this is a good approach. I'd like some **feedbacks** before writing some tests, do you think it's worth to keep the URL or simply remove the `<a href=""></a>` if the URL is not valid?

Thanks in advance :smile: 
