### PR TITLE
Fix regex in redis version check

### DIFF
--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -335,7 +335,7 @@ namespace :gitlab do
       print "Redis version >= #{min_redis_version}? ... "
 
       redis_version = run(%W(redis-cli --version))
-      redis_version = redis_version.try(:match, /redis-cli (.*)/)
+      redis_version = redis_version.try(:match, /redis-cli (\d+\.\d+\.\d+)/)
       if redis_version &&
           (Gem::Version.new(redis_version[1]) > Gem::Version.new(min_redis_version))
         puts "yes".green


### PR DESCRIPTION
When i am executing "sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production" i run into an error on the redis version check:

Redis version >= 2.4.0? ... rake aborted!
ArgumentError: Malformed version number string 2.8.19 (git:0a21368c-dirty)
/home/git/gitlab/lib/tasks/gitlab/check.rake:340:in `check_redis_version'
/home/git/gitlab/lib/tasks/gitlab/check.rake:30:in`block (3 levels) in <top (required)>'
Tasks: TOP => gitlab:check => gitlab:app:check
(See full trace by running task with --trace)

On my Debian 7.9 i get the following result when executing "redis-cli --version":
redis-cli 2.8.19 (git:0a21368c-dirty)

The current regex to extract the version number (.*) fails to extract a valid version number in my use case.
So this pull request provides a updated regex to only extract a valid version number.
