### PR TITLE
Simplify patch version updates (less steps)

### DIFF
--- a/doc/update/patch_versions.md
+++ b/doc/update/patch_versions.md
@@ -49,9 +49,7 @@ sudo -u git -H bundle install --without development test mysql --deployment
 sudo -u git -H bundle install --without development test postgres --deployment
 
 sudo -u git -H bundle exec rake db:migrate RAILS_ENV=production
-sudo -u git -H bundle exec rake assets:clean RAILS_ENV=production
-sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
-sudo -u git -H bundle exec rake cache:clear RAILS_ENV=production
+sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS_ENV=production
 ```
 
 ### 5. Start application


### PR DESCRIPTION
In the documentations for minor version update docs (e.g. 7.14-to-8.0.md) the rake tasks assets:clean, assets:precompile and cache:clear are already merged into a single rake call:

sudo -u git -H bundle exec rake assets:clean assets:precompile cache:clear RAILS_ENV=production

This pull request updates the patch version documentation and merges 3 steps into a single one for a simpler patch level update process.
