### PR TITLE
Add ability to create directories in the editor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
+development
+  - Adds ability to create directories using the web editor
+
 v 8.2.0 (unreleased)
   - Show last project commit to default branch on project home page
   - Highlight comment based on anchor in URL

--- a/app/assets/stylesheets/pages/editor.scss
+++ b/app/assets/stylesheets/pages/editor.scss
@@ -50,7 +50,7 @@
   .editor-file-name {
     .new-file-name {
       display: inline-block;
-      width: 200px;
+      width: 450px;
     }
 
     .form-control {

--- a/app/controllers/projects/blob_controller.rb
+++ b/app/controllers/projects/blob_controller.rb
@@ -161,7 +161,7 @@ class Projects::BlobController < Projects::ApplicationController
         if params[:file].present?
           params[:file_name] = params[:file].original_filename
         end
-        File.join(@path, File.basename(params[:file_name]))
+        File.join(@path, params[:file_name])
       else
         @path
       end

--- a/app/services/files/create_dir_service.rb
+++ b/app/services/files/create_dir_service.rb
@@ -5,5 +5,16 @@ module Files
     def commit
       repository.commit_dir(current_user, @file_path, @commit_message, @target_branch)
     end
+
+    def validate
+      super
+
+      unless @file_path =~ Gitlab::Regex.file_path_regex
+        raise_error(
+          'Your changes could not be committed, because the file path ' +
+          Gitlab::Regex.file_path_regex_message
+        )
+      end
+    end
   end
 end

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -16,10 +16,10 @@ module Files
         )
       end
 
-      unless @file_path =~ Gitlab::Regex.file_name_regex
+      unless @file_path =~ Gitlab::Regex.file_path_regex
         raise_error(
           'Your changes could not be committed, because the file name ' +
-          Gitlab::Regex.file_name_regex_message
+          Gitlab::Regex.file_path_regex_message
         )
       end
 

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -9,6 +9,13 @@ module Files
     def validate
       super
 
+      if @file_path =~ Gitlab::Regex.directory_traversal_regex
+        raise_error(
+          'Your changes could not be committed, because the file name ' +
+          Gitlab::Regex.directory_traversal_regex_message
+        )
+      end
+
       unless @file_path =~ Gitlab::Regex.file_name_regex
         raise_error(
           'Your changes could not be committed, because the file name ' +

--- a/app/services/files/create_service.rb
+++ b/app/services/files/create_service.rb
@@ -9,9 +9,7 @@ module Files
     def validate
       super
 
-      file_name = File.basename(@file_path)
-
-      unless file_name =~ Gitlab::Regex.file_name_regex
+      unless @file_path =~ Gitlab::Regex.file_name_regex
         raise_error(
           'Your changes could not be committed, because the file name ' +
           Gitlab::Regex.file_name_regex_message

--- a/features/project/source/browse_files.feature
+++ b/features/project/source/browse_files.feature
@@ -91,6 +91,16 @@ Feature: Project Source Browse Files
     And I see a commit error message
 
   @javascript
+  Scenario: I can create file with a directory name
+    Given I click on "New file" link in repo
+    And I fill the new file name with a new directory
+    And I edit code
+    And I fill the commit message
+    And I click on "Commit changes"
+    Then I am redirected to the new file with directory
+    And I should see its new content
+
+  @javascript
   Scenario: I can edit file
     Given I click on ".gitignore" file in repo
     And I click button "Edit"

--- a/features/steps/project/source/browse_files.rb
+++ b/features/steps/project/source/browse_files.rb
@@ -78,6 +78,10 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
     fill_in :file_name, with: 'Spaces Not Allowed'
   end
 
+  step 'I fill the new file name with a new directory' do
+    fill_in :file_name, with: new_file_name_with_directory
+  end
+
   step 'I fill the commit message' do
     fill_in :commit_message, with: 'Not yet a commit message.', visible: true
   end
@@ -238,6 +242,11 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
       @project.namespace, @project, 'master/' + new_file_name))
   end
 
+  step 'I am redirected to the new file with directory' do
+    expect(current_path).to eq(namespace_project_blob_path(
+      @project.namespace, @project, 'master/' + new_file_name_with_directory))
+  end
+
   step 'I am redirected to the new file on new branch' do
     expect(current_path).to eq(namespace_project_blob_path(
       @project.namespace, @project, 'new_branch_name/' + new_file_name))
@@ -333,6 +342,12 @@ class Spinach::Features::ProjectSourceBrowseFiles < Spinach::FeatureSteps
   # not a filename present at root of the seed repository.
   def new_file_name
     'not_a_file.md'
+  end
+
+  # Constant value that is a valid filename with directory and
+  # not a filename present at root of the seed repository.
+  def new_file_name_with_directory
+    'foo/bar/baz.txt'
   end
 
   # Constant value that is a valid directory and

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -52,7 +52,7 @@ module Gitlab
     end
 
     def file_path_regex
-      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
+      @file_path_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
     end
 
     def file_path_regex_message

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -44,12 +44,21 @@ module Gitlab
 
 
     def file_name_regex
-      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
+      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.]*\z/.freeze
     end
 
     def file_name_regex_message
+      "can contain only letters, digits, '_', '-' and '.'. "
+    end
+
+    def file_path_regex
+      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
+    end
+
+    def file_path_regex_message
       "can contain only letters, digits, '_', '-' and '.'. Separate directories with a '/'. "
     end
+
 
     def directory_traversal_regex
       @directory_traversal_regex ||= /\.{2}/.freeze
@@ -58,6 +67,7 @@ module Gitlab
     def directory_traversal_regex_message
       "cannot include directory traversal. "
     end
+
 
     def archive_formats_regex
       #                           |zip|tar|    tar.gz    |         tar.bz2         |

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -51,6 +51,13 @@ module Gitlab
       "can contain only letters, digits, '_', '-' and '.'. Separate directories with a '/'. "
     end
 
+    def directory_traversal_regex
+      @directory_traversal_regex ||= /\.{2}/.freeze
+    end
+
+    def directory_traversal_regex_message
+      "cannot include directory traversal. "
+    end
 
     def archive_formats_regex
       #                           |zip|tar|    tar.gz    |         tar.bz2         |

--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -44,11 +44,11 @@ module Gitlab
 
 
     def file_name_regex
-      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.]*\z/.freeze
+      @file_name_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
     end
 
     def file_name_regex_message
-      "can contain only letters, digits, '_', '-' and '.'. "
+      "can contain only letters, digits, '_', '-' and '.'. Separate directories with a '/'. "
     end
 
 


### PR DESCRIPTION
Simply type a name with a `/` directory separator and new directories
will be created. This does not do the fancy UI work that github.com
does, but it will get the job done.

I could not find tests for file creation, so I didn't add a test for
this slight behaviour modification. I did test directory traversals
though, using both absolute paths like `/tmp/foo.txt` and relative paths
like `../../foo.txt`. Neither case escaped the repository, though
attempting to traverse with a relative path resulted in a 500 error that
did not affect application stability upon reload.
