### PR TITLE
Use relative path in doc

### DIFF
--- a/doc/workflow/importing/import_projects_from_bitbucket.md
+++ b/doc/workflow/importing/import_projects_from_bitbucket.md
@@ -1,6 +1,6 @@
 # Import your project from Bitbucket to GitLab
 
-It takes just a few steps to import your existing Bitbucket projects to GitLab. But keep in mind that it is possible only if Bitbucket support is enabled on your GitLab instance. You can read more about Bitbucket support [here](doc/integration/bitbucket.md).
+It takes just a few steps to import your existing Bitbucket projects to GitLab. But keep in mind that it is possible only if Bitbucket support is enabled on your GitLab instance. You can read more about Bitbucket support [here](../../integration/bitbucket.md).
 
 * Sign in to GitLab.com and go to your dashboard
 

--- a/doc/workflow/protected_branches.md
+++ b/doc/workflow/protected_branches.md
@@ -12,7 +12,7 @@ A protected branch does three simple things:
 
 You can make any branch a protected branch. GitLab makes the master branch a protected branch by default.
 
-To protect a branch, user needs to have at least a Master permission level, see [permissions document](doc/permissions/permissions.md).
+To protect a branch, user needs to have at least a Master permission level, see [permissions document](../permissions/permissions.md).
 
 ![protected branches page](protected_branches/protected_branches1.png)
 


### PR DESCRIPTION
Broken links which it fixes (in file):
~~\* `doc/permissions/permissions.md`
   https://github.com/gitlabhq/gitlabhq/blob/master/doc/permissions/doc/workflow/add-user/add-user.md~~
~~\* `doc/workflow/add-user/add-user.md`
  https://github.com/gitlabhq/gitlabhq/blob/master/doc/workflow/add-user/doc/permissions/permissions.md~~
- `doc/workflow/importing/import_projects_from_bitbucket.md`
  https://github.com/gitlabhq/gitlabhq/blob/master/doc/workflow/importing/doc/integration/bitbucket.md
- `doc/workflow/protected_branches.md`
  https://github.com/gitlabhq/gitlabhq/blob/master/doc/workflow/doc/permissions/permissions.md

EDIT: Strikeouts because of changes in master later on.
