### PR TITLE
Add missing character

### DIFF
--- a/app/views/projects/ci_settings/_no_runners.html.haml
+++ b/app/views/projects/ci_settings/_no_runners.html.haml
@@ -5,4 +5,4 @@
     You can add Specific runner for this project on Runners page
 
     - if current_user.admin
-      or add Shared runner for whole application in admin are.
+      or add Shared runner for whole application in admin area.


### PR DESCRIPTION
This adds the missing character `a` to the help-text in the CI-Settings of a project when no runners are configured.
