### PR TITLE
List generic commit statuses individually in MergeRequests#show

### DIFF
--- a/app/assets/javascripts/merge_request_widget.js.coffee
+++ b/app/assets/javascripts/merge_request_widget.js.coffee
@@ -9,6 +9,7 @@ class @MergeRequestWidget
   #
   constructor: (@opts) ->
     modal = $('#modal_merge_info').modal(show: false)
+    $('.mr-state-widget .mr-widget-heading a').click @toggleCiDetails
 
   mergeInProgress: (deleteSourceBranch = false)->
     $.ajax
@@ -58,3 +59,12 @@ class @MergeRequestWidget
 
   setMergeButtonClass: (css_class) ->
     $('.accept_merge_request').removeClass("btn-create").addClass(css_class)
+
+  toggleCiDetails: (e) ->
+    e.preventDefault()
+    if $('.mr-widget-ci-details').is(':visible')
+      $('.mr-widget-ci-details').slideUp(250)
+      $(e.currentTarget).text('Show details')
+    else
+      $('.mr-widget-ci-details').slideDown(250)
+      $(e.currentTarget).text('Hide details')

--- a/app/assets/stylesheets/pages/merge_requests.scss
+++ b/app/assets/stylesheets/pages/merge_requests.scss
@@ -119,6 +119,15 @@
   .ci-coverage {
     float: right;
   }
+
+  .mr-widget-ci-details {
+    display: none;
+    background: white;
+
+    .ci_widget {
+      padding: 10px 15px;
+    }
+  }
 }
 
 .mr_source_commit,

--- a/app/helpers/ci_status_helper.rb
+++ b/app/helpers/ci_status_helper.rb
@@ -54,4 +54,8 @@ module CiStatusHelper
     project.runners.blank? &&
       Ci::Runner.shared.blank?
   end
+
+  def ci_widget_summary(commit)
+    "#{commit.statuses_with_matching_status} of #{commit.latest_generic_statuses.length + 1} checks #{commit.human_status}"
+  end
 end

--- a/app/views/projects/merge_requests/widget/_heading.html.haml
+++ b/app/views/projects/merge_requests/widget/_heading.html.haml
@@ -1,15 +1,27 @@
 - if @ci_commit
   .mr-widget-heading
     .ci_widget{class: "ci-#{@ci_commit.status}"}
-      = ci_status_icon(@ci_commit)
-      %span
-        Build
-        = ci_status_label(@ci_commit)
-      for
+      = ci_icon_for_status(@ci_commit.status)
+      = ci_widget_summary(@ci_commit)
+      = link_to "Show defails", '#'
+  .mr-widget-ci-details
+    .ci_widget{class: "ci-#{@ci_commit.ci_status}"}
+      = ci_icon_for_status(@ci_commit.ci_status)
+      %span CI Build #{@ci_commit.ci_status}
       = succeed "." do
         = link_to @ci_commit.short_sha, namespace_project_commit_path(@merge_request.source_project.namespace, @merge_request.source_project, @ci_commit.sha), class: "monospace"
       %span.ci-coverage
-      = link_to "View details", builds_namespace_project_merge_request_path(@project.namespace, @project, @merge_request), class: "js-show-tab", data: {action: 'builds'}
+      = link_to "View build details", builds_namespace_project_merge_request_path(@project.namespace, @project, @merge_request), class: "js-show-tab", data: {action: 'builds'}
+    - @ci_commit.latest_generic_statuses.each do |status|
+      .ci_widget{class: "ci-#{status.status}"}
+        = ci_icon_for_status(status.status)
+        %span
+          - if status.description.present?
+            #{status.name} #{status.status}: #{status.description}.
+          - else
+            #{status.name} #{status.status}.
+          - if status.target_url.present?
+            = link_to "View details", status.target_url, target: '_blank'
 
 - elsif @merge_request.has_ci?
   - # Compatibility with old CI integrations (ex jenkins) when you request status from CI server via AJAX


### PR DESCRIPTION
The GitLab 8.1 added the commit status API, this is my attempt to expose the external commit statuses to the user.

This changes the status indicator of a MergeRequest, before all CommitStatuses were grouped into one status which did not show information about the status of external (GenericCommitStatuses) statuses. Now CI::Build statuses are still grouped together, but GenericCommitStatuses are shown individually including the description and link to the status/build information.

**Before**, one could not see which commit status failed and which succeeded:
<img width="1075" alt="screenshot 2015-10-25 11 12 16" src="https://cloud.githubusercontent.com/assets/20943/10715102/5295d996-7b09-11e5-99cc-107b12faa127.png">

**After**, external commit statuses are shown individually:
![out](https://cloud.githubusercontent.com/assets/20943/11164922/daa2f840-8aff-11e5-93be-505c8450e8bf.gif)
<img width="882" alt="screenshot 2015-11-14 17 30 44" src="https://cloud.githubusercontent.com/assets/20943/11164926/f37423a8-8aff-11e5-9f41-a6052a0deba4.png">
<img width="882" alt="screenshot 2015-11-14 17 30 51" src="https://cloud.githubusercontent.com/assets/20943/11164927/f6afd652-8aff-11e5-8707-4bda52441220.png">
<img width="880" alt="screenshot 2015-11-14 17 31 06" src="https://cloud.githubusercontent.com/assets/20943/11164928/fb5092c8-8aff-11e5-81b3-c23be48f1896.png">
<img width="876" alt="screenshot 2015-11-14 18 22 28" src="https://cloud.githubusercontent.com/assets/20943/11164930/00bb537e-8b00-11e5-8b24-125b9a49d56e.png">
<img width="883" alt="screenshot 2015-11-14 18 22 35" src="https://cloud.githubusercontent.com/assets/20943/11164931/02b904fa-8b00-11e5-89d8-1d959eff3fe5.png">
