### PR TITLE
Fix: 500 error returned if destroy request without HTTP referer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v 8.2.0 (unreleased)
   - Fix: Inability to reply to code comments in the MR view, if the MR comes from a fork
   - Use git follow flag for commits page when retrieve history for file or directory
   - Show merge request CI status on merge requests index page
+  - Fix: 500 error returned if destroy request without HTTP referer (Kazuki Shimizu)
 
 v 8.1.0
   - Ensure MySQL CI limits DB migrations occur after the fields have been created (Stan Hu)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -124,7 +124,7 @@ class ProjectsController < ApplicationController
     ::Projects::DestroyService.new(@project, current_user, {}).execute
     flash[:alert] = "Project '#{@project.name}' was deleted."
 
-    if request.referer.include?('/admin')
+    if request.referer.present? && request.referer.include?('/admin')
       redirect_to admin_namespaces_projects_path
     else
       redirect_to dashboard_projects_path

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -124,11 +124,7 @@ class ProjectsController < ApplicationController
     ::Projects::DestroyService.new(@project, current_user, {}).execute
     flash[:alert] = "Project '#{@project.name}' was deleted."
 
-    if request.referer.present? && request.referer.include?('/admin')
-      redirect_to admin_namespaces_projects_path
-    else
-      redirect_to dashboard_projects_path
-    end
+    redirect_back_or_default(default: dashboard_projects_path, options: {})
   rescue Projects::DestroyService::DestroyError => ex
     redirect_to edit_project_path(@project), alert: ex.message
   end


### PR DESCRIPTION
This pull request is a fix for 500 error when gitlab received a destroy request which has no HTTP referer.

Error on logs:

```
NoMethodError (undefined method `include?' for nil:NilClass):
  app/controllers/projects_controller.rb:113:in `destroy'
```
