### PR TITLE
Hide tab-bar in login-box when only one tabs is shown.

### DIFF
--- a/app/views/devise/shared/_signin_box.html.haml
+++ b/app/views/devise/shared/_signin_box.html.haml
@@ -7,26 +7,34 @@
       %h3 Sign in
   .login-body
     - if form_based_providers.any?
-      %ul.nav.nav-tabs
+      - if form_based_providers.count >= 2 || signin_enabled?
+        %ul.nav.nav-tabs
+          - if crowd_enabled?
+            %li.active
+              = link_to "Crowd", "#tab-crowd", 'data-toggle' => 'tab'
+          - @ldap_servers.each_with_index do |server, i|
+            %li{class: (:active if i.zero? && !crowd_enabled?)}
+              = link_to server['label'], "#tab-#{server['provider_name']}", 'data-toggle' => 'tab'
+          - if signin_enabled?
+            %li
+              = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
+        .tab-content
+          - if crowd_enabled?
+            %div.tab-pane.active{id: "tab-crowd"}
+              = render 'devise/sessions/new_crowd'
+          - @ldap_servers.each_with_index do |server, i|
+            %div.tab-pane{id: "tab-#{server['provider_name']}", class: (:active if i.zero? && !crowd_enabled?)}
+              = render 'devise/sessions/new_ldap', server: server
+          - if signin_enabled?
+            %div#tab-signin.tab-pane
+              = render 'devise/sessions/new_base'
+      - else
         - if crowd_enabled?
-          %li.active
-            = link_to "Crowd", "#tab-crowd", 'data-toggle' => 'tab'
-        - @ldap_servers.each_with_index do |server, i|
-          %li{class: (:active if i.zero? && !crowd_enabled?)}
-            = link_to server['label'], "#tab-#{server['provider_name']}", 'data-toggle' => 'tab'
-        - if signin_enabled?
-          %li
-            = link_to 'Standard', '#tab-signin', 'data-toggle' => 'tab'
-      .tab-content
-        - if crowd_enabled?
-          %div.tab-pane.active{id: "tab-crowd"}
-            = render 'devise/sessions/new_crowd'
-        - @ldap_servers.each_with_index do |server, i|
-          %div.tab-pane{id: "tab-#{server['provider_name']}", class: (:active if i.zero? && !crowd_enabled?)}
-            = render 'devise/sessions/new_ldap', server: server
-        - if signin_enabled?
-          %div#tab-signin.tab-pane
-            = render 'devise/sessions/new_base'
+          = render 'devise/sessions/new_crowd'
+        - elsif @ldap_servers.any?
+          = render 'devise/sessions/new_ldap', server: @ldap_servers.first
+        - elsif signin_enabled?
+          = render 'devise/sessions/new_base'
 
     - elsif signin_enabled?
       = render 'devise/sessions/new_base'


### PR DESCRIPTION
When an external auth provider is configured and Sign-in is disabled an tab-bar with only one tab is shown.

<img width="392" alt="screen shot 2015-11-07 at 12 45 28" src="https://cloud.githubusercontent.com/assets/102600/11015010/91ba270a-854d-11e5-9405-a61dd7e20efb.png">

This change hides this tab-bar in this case.

<img width="390" alt="screen shot 2015-11-07 at 12 46 13" src="https://cloud.githubusercontent.com/assets/102600/11015012/ad1b40b0-854d-11e5-8b5a-e89e1a8177bb.png">

In all other case a tab-bar is shown as before.
