### PR TITLE
Apply new header design for project graphs page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ v 8.2.0 (unreleased)
   - Add "added", "modified" and "removed" properties to commit object in webhook
   - Rename "Back to" links to "Go to" because its not always a case it point to place user come from
   - Allow groups to appear in the search results if the group owner allows it
+  - New design for project graphs page
 
 v 8.1.3
   - Spread out runner contacted_at updates

--- a/app/views/projects/graphs/_head.html.haml
+++ b/app/views/projects/graphs/_head.html.haml
@@ -1,4 +1,4 @@
-%ul.nav.nav-tabs
+%ul.center-top-menu
   = nav_link(action: :show) do
     = link_to 'Contributors', namespace_project_graph_path
   = nav_link(action: :commits) do

--- a/app/views/projects/graphs/ci.html.haml
+++ b/app/views/projects/graphs/ci.html.haml
@@ -1,6 +1,9 @@
 - page_title "Continuous Integration", "Graphs"
 = render "header_title"
 = render 'head'
+.gray-content-block
+  %ul.breadcrumb.repo-breadcrumb
+    = commits_breadcrumbs
 #charts.ci-charts
   = render 'projects/graphs/ci/builds'
   = render 'projects/graphs/ci/build_times'

--- a/app/views/projects/graphs/commits.html.haml
+++ b/app/views/projects/graphs/commits.html.haml
@@ -1,6 +1,6 @@
 - page_title "Commits", "Graphs"
 = render "header_title"
-= redner 'head'
+= render 'head'
 
 .gray-content-block
   .tree-ref-holder

--- a/app/views/projects/graphs/commits.html.haml
+++ b/app/views/projects/graphs/commits.html.haml
@@ -1,8 +1,12 @@
 - page_title "Commits", "Graphs"
 = render "header_title"
-.tree-ref-holder
-  = render 'shared/ref_switcher', destination: 'graphs_commits'
-= render 'head'
+= reder 'head'
+
+.gray-content-block
+  .tree-ref-holder
+    = render 'shared/ref_switcher', destination: 'graphs_commits'
+  %ul.breadcrumb.repo-breadcrumb
+    = commits_breadcrumbs
 
 %p.lead
   Commit statistics for

--- a/app/views/projects/graphs/commits.html.haml
+++ b/app/views/projects/graphs/commits.html.haml
@@ -1,6 +1,6 @@
 - page_title "Commits", "Graphs"
 = render "header_title"
-= reder 'head'
+= redner 'head'
 
 .gray-content-block
   .tree-ref-holder

--- a/app/views/projects/graphs/show.html.haml
+++ b/app/views/projects/graphs/show.html.haml
@@ -1,8 +1,12 @@
 - page_title "Contributors", "Graphs"
 = render "header_title"
-.tree-ref-holder
-  = render 'shared/ref_switcher', destination: 'graphs'
 = render 'head'
+
+.gray-content-block
+  .tree-ref-holder
+    = render 'shared/ref_switcher', destination: 'graphs'
+  %ul.breadcrumb.repo-breadcrumb
+    = commits_breadcrumbs
 
 .loading-graph
   .center


### PR DESCRIPTION
Apply new header design for project graphs page like other pages.

Before : 

![screenshot-gitlab com 2015-11-08 19-06-08](https://cloud.githubusercontent.com/assets/3278827/11021873/d2720ac6-864f-11e5-9719-0af315e288db.png)

After :

![screenshot-git e-keyleo fr 2015-11-08 19-05-44](https://cloud.githubusercontent.com/assets/3278827/11021876/d87ec7c4-864f-11e5-8e09-c9c6e3bdd629.png)

Voilà.
