### PR TITLE
Add caching for ApplicationSetting, Ci::ApplicationSetting.

### DIFF
--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -68,8 +68,14 @@ class ApplicationSetting < ActiveRecord::Base
     end
   end
 
+  after_commit do
+    Rails.cache.write('application_setting.last', self)
+  end
+
   def self.current
-    ApplicationSetting.last
+    Rails.cache.fetch('application_setting.last') do
+      ApplicationSetting.last
+    end
   end
 
   def self.create_from_defaults

--- a/app/models/ci/application_setting.rb
+++ b/app/models/ci/application_setting.rb
@@ -12,9 +12,15 @@
 module Ci
   class ApplicationSetting < ActiveRecord::Base
     extend Ci::Model
-    
+
+    after_commit do
+      Rails.cache.write('ci_application_setting.last', self)
+    end
+
     def self.current
-      Ci::ApplicationSetting.last
+      Rails.cache.fetch('ci_application_setting.last') do
+        Ci::ApplicationSetting.last
+      end
     end
 
     def self.create_from_defaults


### PR DESCRIPTION
ApplicationSetting.current was called in every pages, cache it and expires it after it updated.

This changes will avoid a SQL query in every pages 

``` SQL
SELECT  "application_settings".* FROM "application_settings"   ORDER BY "application_settings"."id" DESC LIMIT 1
```
