### PR TITLE
Add migration to change web_hooks url field to text type from string.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ v 8.4.0 (unreleased)
   - Add system hook messages for project rename and transfer (Steve Norman)
   - Fix version check image in Safari
   - Show 'All' tab by default in the builds page
+  - Change web_hooks url column to text from string so there isn't a size limit
   - Fix API project lookups when querying with a namespace with dots (Stan Hu)
   - Update version check images to use SVG
   - Validate README format before displaying

--- a/db/migrate/20160105084704_make_web_hook_url_a_text_field.rb
+++ b/db/migrate/20160105084704_make_web_hook_url_a_text_field.rb
@@ -1,0 +1,5 @@
+class MakeWebHookUrlATextField < ActiveRecord::Migration
+  def change
+    change_column :web_hooks, :url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151229112614) do
+ActiveRecord::Schema.define(version: 20160105084704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -874,7 +874,7 @@ ActiveRecord::Schema.define(version: 20151229112614) do
   add_index "users_star_projects", ["user_id"], name: "index_users_star_projects_on_user_id", using: :btree
 
   create_table "web_hooks", force: :cascade do |t|
-    t.string   "url",                     limit: 255
+    t.text     "url"
     t.integer  "project_id"
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
Before this commit The webhook url was a string field which is limited
by default to 255 characters. In some cases this might be too short for
the desired webhook url. After this it is changed to a text field which
is unbounded to allow urls of any length.
