### PR TITLE
Puma support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,10 @@ group :unicorn do
   gem "unicorn", '~> 4.8.2'
   gem 'unicorn-worker-killer', '~> 0.4.2'
 end
+group :puma do
+  gem 'puma'
+  gem 'puma_worker_killer'
+end
 
 # State machine
 gem "state_machines-activerecord", '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,11 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    puma (2.11.3)
+      rack (>= 1.1, < 2.0)
+    puma_worker_killer (0.0.3)
+      get_process_mem (~> 0.1)
+      puma (~> 2.7)
     pyu-ruby-sasl (0.0.3.3)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
@@ -882,6 +887,8 @@ DEPENDENCIES
   pg (~> 0.18.2)
   poltergeist (~> 1.6.0)
   pry-rails
+  puma
+  puma_worker_killer
   quiet_assets (~> 1.0.2)
   rack-attack (~> 4.3.0)
   rack-cors (~> 0.4.0)

--- a/config.ru
+++ b/config.ru
@@ -12,6 +12,24 @@ if defined?(Unicorn)
   end
 end
 
+if defined?(Puma)
+  require 'puma'
+
+  if ENV['RAILS_ENV'] == 'production' || ENV['RAILS_ENV'] == 'staging'
+    # Puma self-process killer
+    require 'puma_worker_killer'
+
+    # Max memory size (RSS) per worker
+    PumaWorkerKiller.config do |config|
+      config.ram = 250 # RSS limit in MB
+      config.frequency = 30 # period check seconds
+      config.percent_usage = 0.93 # max percentage
+      config.rolling_restart_frequency = (1 * 3600).to_i # restart every 1 hour
+    end
+    PumaWorkerKiller.start
+  end
+end
+
 require ::File.expand_path('../config/environment',  __FILE__)
 
 map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do

--- a/config/puma.rb.example
+++ b/config/puma.rb.example
@@ -1,0 +1,98 @@
+#!/usr/bin/env puma
+
+# Start Puma with next command:
+# RAILS_ENV=production bundle exec puma -C ./config/puma.rb
+
+# uncomment and customize to run in non-root path
+# note that config/gitlab.yml web path should also be changed
+# ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+
+application_path = '/home/git/gitlab'
+directory application_path
+environment 'production'
+daemonize true
+pidfile "#{application_path}/tmp/pids/puma.pid"
+state_path "#{application_path}/tmp/pids/puma.state"
+stdout_redirect "#{application_path}/log/puma.stdout.log", "#{application_path}/log/puma.stderr.log"
+
+# Configure “min” to be the minimum number of threads to use to answer
+# requests and “max” the maximum.
+#
+# The default is “0, 16”.
+#
+# threads 0, 16
+threads 0, 4
+
+# Bind the server to “url”. “tcp://”, “unix://” and “ssl://” are the only
+# accepted protocols.
+#
+#
+# The default is “tcp://0.0.0.0:9292”.
+#
+# bind 'tcp://0.0.0.0:9292'
+# bind 'unix:///var/run/puma.sock'
+# bind 'unix:///var/run/puma.sock?umask=0777'
+# bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
+#
+## Comment the next line if you use apache.
+bind "unix://#{application_path}/tmp/sockets/gitlab.socket"
+
+# Instead of “bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'” you
+# can also use the “ssl_bind” option.
+#
+# ssl_bind '127.0.0.1', '9292', { key: path_to_key, cert: path_to_cert }
+
+# Code to run before doing a restart. This code should
+# close log files, database connections, etc.
+#
+# This can be called multiple times to add code each time.
+#
+# on_restart do
+#   puts 'On restart...'
+# end
+
+# Command to use to restart puma. This should be just how to
+# load puma itself (ie. 'ruby -Ilib bin/puma'), not the arguments
+# to puma, as those are the same as the original process.
+#
+# restart_command '/u/app/lolcat/bin/restart_puma'
+
+# === Cluster mode ===
+
+# How many worker processes to run.
+#
+# The default is “0”.
+#
+# workers 2
+workers 0
+
+# GitLab cluster mode recommendations
+# If you have more than 1 GB RAM, uncomment one of the following lines:
+#
+# workers 2 # if you have at least 1.5 GB RAM
+# workers 3 # if you have at least 2   GB RAM
+# workers 4 # if you have at least 2.5 GB RAM
+
+# Code to run when a worker boots to setup the process before booting
+# the app.
+#
+# This can be called multiple times to add hooks.
+#
+# on_worker_boot do
+#   puts 'On worker boot...'
+# end
+
+# === Puma control rack application ===
+
+# Start the puma control rack application on “url”. This application can
+# be communicated with to control the main server. Additionally, you can
+# provide an authentication token, so all requests to the control server
+# will need to include that token as a query parameter. This allows for
+# simple authentication.
+#
+# Check out https://github.com/puma/puma/blob/master/lib/puma/app/status.rb
+# to see what the app has available.
+#
+# activate_control_app 'unix:///var/run/pumactl.sock'
+# activate_control_app 'unix:///var/run/pumactl.sock', { auth_token: '12345' }
+# activate_control_app 'unix:///var/run/pumactl.sock', { no_token: true }

--- a/lib/support/rc.d/gitlab
+++ b/lib/support/rc.d/gitlab
@@ -1,0 +1,234 @@
+#!/bin/sh
+#
+# Written by Denis Vazhenin <denis.vazhenin@me.com>
+#
+# This script was ported from Debian/Ubuntu version of start script for Gitlab:
+# https://raw.github.com/gitlabhq/gitlabhq/master/lib/support/init.d/gitlab
+#
+# PROVIDE: gitlab
+# REQUIRE: NETWORKING SERVERS DAEMON LOGIN
+# KEYWORD: shutdown
+#
+# Requirements:
+#
+# Before using this script, please install gitlab using guidelines from here:
+# https://github.com/gitlabhq/gitlabhq/blob/master/doc/install/installation.md
+#
+# This file should be placed to: /usr/local/etc/rc.d/gitlab
+#
+# Add the following lines to /etc/rc.conf to enable gitlab:
+#
+# Required:
+# gitlab_enable="YES"
+#
+# Optional:
+# gitlab_dir
+# gitlab_user
+# gitlab_env
+
+. /etc/rc.subr
+
+name="gitlab"
+rcvar=gitlab_enable
+extra_commands="status restart"
+
+load_rc_config $name
+
+###############################################################################
+# Set default values (overrides should be placed in /etc/rc.conf )
+###############################################################################
+
+: ${gitlab_enable:=NO}
+: ${gitlab_dir:=/usr/home/git/gitlab}
+: ${gitlab_user:=git}
+: ${gitlab_group:=git}
+: ${gitlab_env:=production}
+
+required_dirs="${gitlib_dir}"
+
+_grep=`command -v grep 2>&1 >/dev/null && command -v grep`
+_pgrep=`command -v pgrep 2>&1 >/dev/null && command -v pgrep`
+_sh=`command -v sh 2>&1 >/dev/null && command -v sh`
+_ps=`command -v ps 2>&1 >/dev/null && command -v ps`
+_wc=`command -v wc 2>&1 >/dev/null && command -v wc`
+_printf=`command -v printf 2>&1 >/dev/null && command -v printf`
+_mkdir=`command -v mkdir 2>&1 >/dev/null && command -v mkdir`
+_rm=`command -v rm 2>&1 >/dev/null && command -v rm`
+
+DAEMON_OPTS="-C ${gitlab_dir}/config/puma.rb -e ${gitlab_env}"
+PID_PATH="${gitlab_dir}/tmp/pids"
+WEB_SERVER_PID="${PID_PATH}/puma.pid"
+SIDEKIQ_PID="${PID_PATH}/sidekiq.pid"
+STOP_SIDEKIQ="RAILS_ENV=${gitlab_env} ${_bundle} exec rake sidekiq:stop"
+START_SIDEKIQ="RAILS_ENV=${gitlab_env} ${_bundle} exec rake sidekiq:start"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+restart_cmd="${name}_restart"
+status_cmd="${name}_status"
+
+###############################################################################
+# Helper functions
+###############################################################################
+
+__pid=0
+__spid=0
+__status=0
+__skiqstat=0
+
+_bundle=/usr/local/bin/bundle
+
+gitlab_findbundler(){
+  __path='/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin'
+
+  if [ ! -f $_bundle ]; then
+    # clearing any custom path
+    __oldpath=$PATH
+    unset PATH
+    export PATH=$__path
+    
+    _bundle=`command -v bundle 2>&1 >/dev/null && command -v bundle`
+    unset PATH
+    export PATH=$__oldpath
+
+    if [ x"${_bundle}" = x ]; then
+      $_printf 'Unable to find %s command' 'bundle'
+      exit 1
+    fi
+  fi
+}
+
+gitlab_execute(){
+  su ${gitlab_user} -c "$1"
+}
+
+gitlab_check_if_running(){
+
+  # checking if bundle gem is installed before doing anything
+  gitlab_findbundler
+
+      # check if process is already running
+  if [ -f $WEB_SERVER_PID ]; then
+    __pid=`${_pgrep} -F $WEB_SERVER_PID`
+
+    if [ x"${__pid}" != x ]; then
+      __status=`${_ps} aux | ${_grep} ${__pid} | ${_grep} -v "grep" | ${_wc} -l`
+    else
+      __pid=0
+    fi
+  fi
+
+  # check if sidekiq process is already running
+  if [ -f $SIDEKIQ_PID ]; then
+    __spid=`${_pgrep} -F $SIDEKIQ_PID`
+
+    if [ x"${__spid}" != x ]; then
+      __skiqstat=`${_ps} aux | ${_grep} ${__spid} | ${_grep} -v "grep" | ${_wc} -l`
+    else
+      __spid=0
+    fi
+  fi 
+}
+
+gitlab_check_if_root(){
+  if [ `id -u` -ne 0 ]; then
+    ${_printf} 'Must be a root user (current is %s)\n' `whoami`
+    exit 1
+  fi
+}
+
+###############################################################################
+# Public functions
+###############################################################################
+
+gitlab_prestart_check(){
+  gitlab_check_if_running
+
+  # if process is already running, exit with code 1
+  if [ ${__pid} -ne 0 ] && [ ${__status} -ne 0 ]; then
+    ${_printf} '%s is already running...pid is %s\n' ${name} ${__pid}
+    exit 1
+  fi
+
+  gitlab_check_if_root
+}
+
+gitlab_prestop_check(){
+  gitlab_check_if_running
+
+  # if process is not running, exit with code 1
+  if [ ${__pid} -eq 0 ] && [ ${__status} -eq 0 ]; then
+    ${_printf} '%s not started\n' ${name}
+    exit 1
+  fi
+
+  gitlab_check_if_root
+}
+
+gitlab_start(){
+  gitlab_prestart_check
+
+  cd ${gitlab_dir}
+  gitlab_execute "RAILS_ENV=${gitlab_env} ${_bundle} exec puma $DAEMON_OPTS"
+  gitlab_execute "${_mkdir} -p $PID_PATH && $START_SIDEKIQ > /dev/null 2>&1 &"
+  ${_printf} '%s started\n' ${name}
+}
+
+gitlab_stop(){
+  gitlab_prestop_check
+
+  cd ${gitlab_dir}
+  kill -QUIT `${_pgrep} -F ${WEB_SERVER_PID}`
+  gitlab_execute "${_mkdir} -p $PID_PATH && $STOP_SIDEKIQ > /dev/null 2>&1 &"
+  ${_rm} "$WEB_SERVER_PID" >> /dev/null
+  ${_printf} '%s stopped\n' ${name}
+}
+
+gitlab_restart(){
+  gitlab_check_if_root
+
+  cd ${gitlab_dir}
+  ${_printf} 'Restarting %s service...\n' ${name}
+
+  gitlab_check_if_running
+
+  # check if gitlab puma service is running, if not then don't kill it
+  if [ ${__pid} -ne 0 ] && [ ${__status} -ne 0 ]; then
+#   kill -USR2 `${_pgrep} -F $WEB_SERVER_PID`
+    kill -QUIT `${_pgrep} -F ${WEB_SERVER_PID}`
+    ${_rm} "$WEB_SERVER_PID" >> /dev/null
+  fi
+
+  # check if background task manager sidekiq is running, if not then don't kill it 
+  if [ ${__spid} -ne 0 ] && [ ${__skiqstat} -ne 0 ]; then
+    gitlab_execute "${_mkdir} -p $PID_PATH && $STOP_SIDEKIQ > /dev/null 2>&1 &"
+  fi
+
+  # start services normally
+  gitlab_execute "RAILS_ENV=${gitlab_env} ${_bundle} exec puma $DAEMON_OPTS"
+  gitlab_execute "${_mkdir} -p $PID_PATH && $START_SIDEKIQ > /dev/null 2>&1 &"
+  ${_printf} 'Service %s restarted.\n' ${name}
+}
+
+gitlab_status(){
+  cd ${gitlab_dir}
+  gitlab_check_if_running
+
+  # checking if gitlab puma service is running
+  if [ ${__pid} -ne 0 ] && [ ${__status} -ne 0 ]; then
+    ${_printf} '%s service puma is running with pid %s\n' ${name} ${__pid}
+  else
+    ${_printf} '%s service puma is not running\n' ${name}
+  fi
+
+  # checking if gitlab puma service is running
+  if [ ${__spid} -ne 0 ] && [ ${__skiqstat} -ne 0 ]; then
+    ${_printf} '%s service sidekiq is running with pid %s\n' ${name} ${__spid}
+  else
+    ${_printf} '%s service sidekiq is not running\n' ${name}
+  fi
+
+}
+
+PATH="${PATH}:/usr/local/bin"
+run_rc_command "$1"

--- a/lib/support/rc.d/gitlab-unicorn
+++ b/lib/support/rc.d/gitlab-unicorn
@@ -1,0 +1,299 @@
+#! /bin/sh
+
+# GITLAB
+# Maintainer: @charlienewey
+# Authors: @charlienewey, rovanion.luckey@gmail.com, @randx
+
+# PROVIDE: ghost
+# KEYWORD: shutdown
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+
+. /etc/rc.subr
+
+name="gitlab"
+rcvar="gitlab_enable"
+extra_commands="status"
+
+load_rc_config gitlab
+: ${gitlab_enable:="NO"}
+
+status_cmd="print_status"
+start_cmd="start_gitlab"
+stop_cmd="stop_gitlab"
+restart_cmd="restart_gitlab"
+
+### Environment variables
+RAILS_ENV="production"
+
+# Script variable names should be lower-case not to conflict with
+# internal /bin/sh variables such as PATH, EDITOR or SHELL.
+app_user="git"
+app_root="/home/$app_user/gitlab"
+pid_path="$app_root/tmp/pids"
+socket_path="$app_root/tmp/sockets"
+web_server_pid_path="$pid_path/unicorn.pid"
+sidekiq_pid_path="$pid_path/sidekiq.pid"
+
+# Read configuration variable file if it is present
+test -f /etc/default/gitlab && . /etc/default/gitlab
+
+# Switch to the app_user if it is not he/she who is running the script.
+if [ "$USER" != "$app_user" ]; then
+  eval su - "$app_user" -c $(echo \")$0 "$@"$(echo \"); exit;
+fi
+
+# Switch to the gitlab path, exit on failure.
+if ! cd "$app_root" ; then
+ echo "Failed to cd into $app_root, exiting!";  exit 1
+fi
+
+
+### Init Script functions
+
+## Gets the pids from the files
+check_pids(){
+  if ! mkdir -p "$pid_path"; then
+    echo "Could not create the path $pid_path needed to store the pids."
+    exit 1
+  fi
+  # If there exists a file which should hold the value of the Unicorn pid: read it.
+  if [ -f "$web_server_pid_path" ]; then
+    wpid=$(cat "$web_server_pid_path")
+  else
+    wpid=0
+  fi
+  if [ -f "$sidekiq_pid_path" ]; then
+    spid=$(cat "$sidekiq_pid_path")
+  else
+    spid=0
+  fi
+}
+
+## Called when we have started the two processes and are waiting for their pid files.
+wait_for_pids(){
+  # We are sleeping a bit here mostly because sidekiq is slow at writing it's pid
+  i=0;
+  while [ ! -f $web_server_pid_path -o ! -f $sidekiq_pid_path ]; do
+    sleep 0.1;
+    i=$((i+1))
+    if [ $((i%10)) = 0 ]; then
+      echo -n "."
+    elif [ $((i)) = 301 ]; then
+      echo "Waited 30s for the processes to write their pids, something probably went wrong."
+      exit 1;
+    fi
+  done
+  echo
+}
+
+# We use the pids in so many parts of the script it makes sense to always check them.
+# Only after start() is run should the pids change. Sidekiq sets it's own pid.
+check_pids
+
+
+## Checks whether the different parts of the service are already running or not.
+check_status(){
+  check_pids
+  # If the web server is running kill -0 $wpid returns true, or rather 0.
+  # Checks of *_status should only check for == 0 or != 0, never anything else.
+  if [ $wpid -ne 0 ]; then
+    kill -0 "$wpid" 2>/dev/null
+    web_status="$?"
+  else
+    web_status="-1"
+  fi
+  if [ $spid -ne 0 ]; then
+    kill -0 "$spid" 2>/dev/null
+    sidekiq_status="$?"
+  else
+    sidekiq_status="-1"
+  fi
+  if [ $web_status = 0 -a $sidekiq_status = 0 ]; then
+    gitlab_status=0
+  else
+    # http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
+    # code 3 means 'program is not running'
+    gitlab_status=3
+  fi
+}
+
+## Check for stale pids and remove them if necessary.
+check_stale_pids(){
+  check_status
+  # If there is a pid it is something else than 0, the service is running if
+  # *_status is == 0.
+  if [ "$wpid" != "0" -a "$web_status" != "0" ]; then
+    echo "Removing stale Unicorn web server pid. This is most likely caused by the web server crashing the last time it ran."
+    if ! rm "$web_server_pid_path"; then
+      echo "Unable to remove stale pid, exiting."
+      exit 1
+    fi
+  fi
+  if [ "$spid" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "Removing stale Sidekiq job dispatcher pid. This is most likely caused by Sidekiq crashing the last time it ran."
+    if ! rm "$sidekiq_pid_path"; then
+      echo "Unable to remove stale pid, exiting"
+      exit 1
+    fi
+  fi
+}
+
+## If no parts of the service is running, bail out.
+exit_if_not_running(){
+  check_stale_pids
+  if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "GitLab is not running."
+    exit
+  fi
+}
+
+## Starts Unicorn and Sidekiq if they're not running.
+start_gitlab() {
+  check_stale_pids
+
+  if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo -n "Starting both the GitLab Unicorn and Sidekiq"
+  elif [ "$web_status" != "0" ]; then
+    echo -n "Starting GitLab Unicorn"
+  elif [ "$sidekiq_status" != "0" ]; then
+    echo -n "Starting GitLab Sidekiq"
+  fi
+
+  # Then check if the service is running. If it is: don't start again.
+  if [ "$web_status" = "0" ]; then
+    echo "The Unicorn web server already running with pid $wpid, not restarting."
+  else
+    # Remove old socket if it exists
+    rm -f "$socket_path"/gitlab.socket 2>/dev/null
+    # Start the web server
+    RAILS_ENV=$RAILS_ENV bin/web start
+  fi
+
+  # If sidekiq is already running, don't start it again.
+  if [ "$sidekiq_status" = "0" ]; then
+    echo "The Sidekiq job dispatcher is already running with pid $spid, not restarting"
+  else
+    RAILS_ENV=$RAILS_ENV bin/background_jobs start &
+  fi
+
+  # Wait for the pids to be planted
+  wait_for_pids
+  # Finally check the status to tell wether or not GitLab is running
+  print_status
+}
+
+## Asks the Unicorn and the Sidekiq if they would be so kind as to stop, if not kills them.
+stop_gitlab() {
+  exit_if_not_running
+
+  if [ "$web_status" = "0" -a "$sidekiq_status" = "0" ]; then
+    echo -n "Shutting down both Unicorn and Sidekiq"
+  elif [ "$web_status" = "0" ]; then
+    echo -n "Shutting down Unicorn"
+  elif [ "$sidekiq_status" = "0" ]; then
+    echo -n "Shutting down Sidekiq"
+  fi
+
+  # If the Unicorn web server is running, tell it to stop;
+  if [ "$web_status" = "0" ]; then
+     RAILS_ENV=$RAILS_ENV bin/web stop
+  fi
+  # And do the same thing for the Sidekiq.
+  if [ "$sidekiq_status" = "0" ]; then
+    RAILS_ENV=$RAILS_ENV bin/background_jobs stop
+  fi
+
+  # If something needs to be stopped, lets wait for it to stop. Never use SIGKILL in a script.
+  while [ "$web_status" = "0" -o "$sidekiq_status" = "0" ]; do
+    sleep 1
+    check_status
+    printf "."
+    if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+      printf "\n"
+      break
+    fi
+  done
+
+  sleep 1
+  # Cleaning up unused pids
+  rm "$web_server_pid_path" 2>/dev/null
+  # rm "$sidekiq_pid_path" # Sidekiq seems to be cleaning up it's own pid.
+
+  print_status
+}
+
+## Prints the status of GitLab and it's components.
+print_status() {
+  check_status
+  if [ "$web_status" != "0" -a "$sidekiq_status" != "0" ]; then
+    echo "GitLab is not running."
+    return
+  fi
+  if [ "$web_status" = "0" ]; then
+      echo "The GitLab Unicorn web server with pid $wpid is running."
+  else
+      printf "The GitLab Unicorn web server is \033[31mnot running\033[0m.\n"
+  fi
+  if [ "$sidekiq_status" = "0" ]; then
+      echo "The GitLab Sidekiq job dispatcher with pid $spid is running."
+  else
+      printf "The GitLab Sidekiq job dispatcher is \033[31mnot running\033[0m.\n"
+  fi
+  if [ "$web_status" = "0" -a "$sidekiq_status" = "0" ]; then
+    printf "GitLab and all its components are \033[32mup and running\033[0m.\n"
+  fi
+}
+
+## Tells unicorn to reload it's config and Sidekiq to restart
+reload_gitlab(){
+  exit_if_not_running
+  if [ "$wpid" = "0" ];then
+    echo "The GitLab Unicorn Web server is not running thus its configuration can't be reloaded."
+    exit 1
+  fi
+  printf "Reloading GitLab Unicorn configuration... "
+  RAILS_ENV=$RAILS_ENV bin/web reload
+  echo "Done."
+  echo "Restarting GitLab Sidekiq since it isn't capable of reloading its config..."
+  RAILS_ENV=$RAILS_ENV bin/background_jobs restart
+
+  wait_for_pids
+  print_status
+}
+
+## Restarts Sidekiq and Unicorn.
+restart_gitlab(){
+  check_status
+  if [ "$web_status" = "0" -o "$sidekiq_status" = "0" ]; then
+    stop_gitlab
+  fi
+  start_gitlab
+}
+
+
+### Finally the input handling.
+
+case "$1" in
+  start)
+        start_gitlab
+        ;;
+  stop)
+        stop_gitlab
+        ;;
+  restart)
+        restart_gitlab
+        ;;
+  reload|force-reload)
+        reload_gitlab
+        ;;
+  status)
+        print_status
+        exit $gitlab_status
+        ;;
+  *)
+        echo "Usage: service gitlab {start|stop|restart|reload|status}"
+        exit 1
+        ;;
+esac
+
+exit

--- a/lib/tasks/gitlab/check.rake
+++ b/lib/tasks/gitlab/check.rake
@@ -161,7 +161,7 @@ namespace :gitlab do
         return
       end
 
-      script_path = "/etc/init.d/gitlab"
+      script_path = get_init_script_syspath
 
       if File.exists?(script_path)
         puts "yes".green
@@ -185,8 +185,8 @@ namespace :gitlab do
         return
       end
 
-      recipe_path = Rails.root.join("lib/support/init.d/", "gitlab")
-      script_path = "/etc/init.d/gitlab"
+      recipe_path = get_recipe_content_url
+      script_path = get_init_script_syspath
 
       unless File.exists?(script_path)
         puts "can't check because of previous errors".magenta
@@ -843,6 +843,27 @@ namespace :gitlab do
     puts "  For more information see:".blue
     sources.each do |source|
       puts "  #{source}"
+    end
+  end
+
+  def get_init_script_syspath
+    if "#{RUBY_PLATFORM}".include?('freebsd')
+      return "/usr/local/etc/rc.d/gitlab"
+    elsif "#{RUBY_PLATFORM}".include?('darwin')
+      # in case somebody would create a LunchDaemon plist for OS X
+      return "/Library/LaunchDaemons/org.gitlab.daemon.plist"
+    else
+      # default is Linux
+      return "/etc/init.d/gitlab"
+    end
+  end
+
+  def get_recipe_content_url
+    if "#{RUBY_PLATFORM}".include?('freebsd')
+      return Rails.root.join("lib/support/rc.d/", "gitlab")
+    else
+      # default is Linux
+      return Rails.root.join("lib/support/init.d/", "gitlab")
     end
   end
 

--- a/lib/tasks/gitlab/task_helpers.rake
+++ b/lib/tasks/gitlab/task_helpers.rake
@@ -45,6 +45,9 @@ namespace :gitlab do
     os_name ||= if File.readable?('/etc/os-release')
                   File.read('/etc/os-release').match(/PRETTY_NAME=\"(.+)\"/)[1]
                 end
+    os_name ||= if bsd_version = run("uname -rs")
+                  "#{bsd_version}"
+                end
     os_name.try(:squish!)
   end
 


### PR DESCRIPTION
- [x] Patches below has few improvements to the gitlab check and "task_helper"
- [x] Support puma_worker_killer|puma_auto_tune to kill a memory leak in the Puma worker
- [ ] Support for `gitlab-workhorse` HTTP (`git-pack-objects`)
- [x] Install Gem without Unicorn
  
  ```
  # Production ready flags (protected overflow/exploit)
  bundle config build "-O2 -pipe -march=native -fstack-protector-strong \
                                    --param=ssp-buffer-size=4 -w"
  
  bundle install --without development test [mysql|postgres] unicorn \
                 --path vendor/bundle --no-deployment
  ```
- [x] Rake scripts to verify whether init script was installed on FreeBSD `lib/support/rc.d/gitlab`(puma);`lib/support/rc.d/gitlab-unicorn` and LaunchDaemons
