### PR TITLE
Use LDAP/AD stored avatar thumbnail in preference to Gravatar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 v 8.3.0 (unreleased)
   - Fix: Assignee selector is empty when 'Unassigned' is selected (Jose Corcuera)
   - Fix 500 error when update group member permission
+  - Add LDAP provider option, preempt_gravatar_with_ldap, to lookup users avatar thumbnail from AD/LDAP (Scott McGillivray)
 
 v 8.2.1
   - Forcefully update builds that didn't want to update with state machine

--- a/Gemfile
+++ b/Gemfile
@@ -296,3 +296,7 @@ gem 'oauth2', '~> 1.0.0'
 
 # Soft deletion
 gem "paranoia", "~> 2.0"
+
+# LDAP avatar thumbnail resizing
+gem 'rmagick', '~> 2.15.4'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,6 +575,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rinku (1.7.3)
+    rmagick (2.15.4)
     rotp (2.1.1)
     rouge (1.10.1)
     rqrcode (0.7.0)
@@ -943,3 +944,4 @@ DEPENDENCIES
 
 BUNDLED WITH
    1.10.6
+

--- a/app/services/gravatar_service.rb
+++ b/app/services/gravatar_service.rb
@@ -1,14 +1,22 @@
-class GravatarService
+require 'ldapavatar_service'
+
+class GravatarService < LDAPAvatarService
   include Gitlab::CurrentSettings
+
+  def initialize
+    @img_size, @user_email, @email_hash = nil, nil, nil
+  end
 
   def execute(email, size = nil)
     if current_application_settings.gravatar_enabled? && email.present?
-      size = 40 if size.nil? || size <= 0
+      @img_size   = size.nil? || size <= 0 ? 40 : size
+      @user_email = email
+      @email_hash = Digest::MD5.hexdigest(@user_email.strip.downcase)
 
-      sprintf gravatar_url,
-        hash: Digest::MD5.hexdigest(email.strip.downcase),
-        size: size,
-        email: email.strip
+      sprintf lookup_url,
+        hash:  @email_hash,
+        size:  @img_size,
+        email: @user_email.strip
     end
   end
 
@@ -20,6 +28,31 @@ class GravatarService
     Gitlab.config.gravatar
   end
 
+  # Only queries first defined ldap provider. For EE, if multiple providers are defined
+  # then this needs extended to lookup users ldap provider given known user info.
+  def provider
+    "ldap#{Gitlab.config.ldap.servers.keys.first}"
+  end
+
+  def provider_adapter_options
+    Gitlab::LDAP::Config.new(provider).adapter_options
+  end
+
+  def provider_options
+    Gitlab::LDAP::Config.new(provider).options
+  end
+
+  def lookup_url
+    url = ldap_url if Gitlab::LDAP::Config.enabled? && provider_options['preempt_gravatar_with_ldap']
+    url.nil? || defined?(url).nil? ? gravatar_url : url
+  end
+
+  def ldap_url
+    if lookup_user_avatar_in_ldap
+      gitlab_config.https ? provider_options['avatar_secure_url'] : provider_options['avatar_plain_url']
+    end
+  end
+
   def gravatar_url
     if gitlab_config.https
       gravatar_config.ssl_url
@@ -28,3 +61,4 @@ class GravatarService
     end
   end
 end
+

--- a/app/services/ldapavatar_service.rb
+++ b/app/services/ldapavatar_service.rb
@@ -1,0 +1,41 @@
+require 'rmagick'
+
+class LDAPAvatarService
+  def lookup_user_avatar_in_ldap()
+    unless File.exist?(provider_options['local_avatar_storage_path'])
+      Rails.logger.warn("LDAP avatar directory path, #{provider_options['local_avatar_storage_path']}, does not exist")
+      return false
+    end
+
+    img_blob = nil
+    path     = File.join(provider_options['local_avatar_storage_path'], "#{@email_hash}_#{@img_size}.jpg")
+    ldap     = Net::LDAP.new(provider_adapter_options)
+    filter   = Net::LDAP::Filter.eq('mail', @user_email)
+    attrs    = %w(thumbnailphoto)
+    results  = ldap.search(:base => provider_options['base'], :filter => filter, :attributes => attrs)
+
+    if results.nil?
+      response = ldap.get_operation_result
+      unless response.code.zero?
+        Rails.logger.warn("LDAP search error in avatar lookup: #{response.message}")
+      end
+    else
+      results.select { |result| result.attribute_names.include?(:thumbnailphoto) }.each do |entry|
+        img_blob = entry.thumbnailphoto.first
+      end
+    end
+
+    unless img_blob.nil?
+      begin
+        img = Magick::Image.from_blob(img_blob).first
+        img.crop_resized! @img_size, @img_size, Magick::CenterGravity unless img.columns == @img_size
+        img_blob = img.to_blob { self.format = 'jpeg' }
+      rescue => e
+        Rails.logger.warn("Failed to resize ldap avatar to #{@img_size}x#{@img_size}. #{e.message}")
+      end
+    end
+
+    File.open(path, 'wb') { |f| f.write(img_blob) }.nonzero?
+  end
+end
+

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -251,6 +251,15 @@ production: &base
           first_name: 'givenName'
           last_name:  'sn'
 
+        # Enable LDAP/AD to be queried for user avatars and if found
+        # be used in pereference to Gravatar service.
+        #
+        preempt_gravatar_with_ldap: false       # Use LDAP/AD thumbnail avatar image if found (default: false)
+        #local_avatar_storage_path: ''          # Local path to store images (default: /dev/shm/gitlab/avatars)
+        #avatar_plain_url: 'http://...'         # default: 'http://<config defined "host">/avatar/%{hash}_%{size}.jpg'
+        #avatar_secure_url: 'https://...'       # default: 'https://<config defined "host">/avatar/%{hash}_%{size}.jpg'
+        
+
       # GitLab EE only: add more LDAP servers
       # Choose an ID made of a-z and 0-9 . This ID will be stored in the database
       # so that GitLab can remember which LDAP server a user belongs to.

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -112,6 +112,10 @@ if Settings.ldap['enabled'] || Rails.env.test?
     server['attributes'] = {} if server['attributes'].nil?
     server['provider_name'] ||= "ldap#{key}".downcase
     server['provider_class'] = OmniAuth::Utils.camelize(server['provider_name'])
+    server['preempt_gravatar_with_ldap'] = false if server['preempt_gravatar_with_ldap'].nil?
+    server['local_avatar_storage_path'] ||= '/dev/shm/gitlab/avatars'
+    server['avatar_plain_url'] ||= "http://#{Settings.gitlab['host']}/avatar/%{hash}_%{size}.jpg"
+    server['avatar_secure_url'] ||= "https://#{Settings.gitlab['host']}/avatar/%{hash}_%{size}.jpg"
   end
 end
 

--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -192,5 +192,15 @@ server {
     add_header Cache-Control public;
   }
 
+  ## If you enable the option to preempt gravatar by first
+  ## trying to retrieve a users avatar thumbnail from LDAP,
+  ## then this defines the request and local directory path
+  ## used to serve the images.
+  location /avatar {
+    alias /dev/shm/gitlab/avatars;
+    expires 1w;
+    add_header Cache-Control public;
+  }
+
   error_page 502 /502.html;
 }

--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -239,5 +239,15 @@ server {
     add_header Cache-Control public;
   }
 
+  ## If you enable the option to preempt gravatar by first
+  ## trying to retrieve a users avatar thumbnail from LDAP,
+  ## then this defines the request and local directory path
+  ## used to serve the images.
+  location /avatar {
+    alias /dev/shm/gitlab/avatars;
+    expires 1w;
+    add_header Cache-Control public;
+  }
+
   error_page 502 /502.html;
 }


### PR DESCRIPTION
Allow a user’s LDAP/AD stored avatar thumbnail to be queried and if found, used in preference to the Gravatar service.

Note for Enterprise Edition:

For EE, it'll work fine but only on the first defined LDAP provider. As noted in the code, I’m not sure the best way to resolve the users LDAP provider from within gravatar_service.rb but if someone can point me in the right direction then it'll be easy to support multiple LDAP providers. The alternative was to loop through all defined providers for a match but this seemed wasteful if the possibility existed to just resolve the users provider directly.

This feature was also referenced in:
- [http://feedback.gitlab.com/forums/176466-general/suggestions/5158352-use-photo-thumbnail-via-ldap-vs-gravatar](http://feedback.gitlab.com/forums/176466-general/suggestions/5158352-use-photo-thumbnail-via-ldap-vs-gravatar)
- [https://github.com/gitlabhq/gitlabhq/issues/3107](https://github.com/gitlabhq/gitlabhq/issues/3107)
