### PR TITLE
Add ignore whitespace change option to commit view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ v 8.3.0 (unreleased)
   - Fix 500 error when update group member permission
   - Fix: Raw private snippets access workflow
   - Trim leading and trailing whitespace of milestone and issueable titles (Jose Corcuera)
+  - Add ignore whitespace change option to commit view
 
 v 8.2.1
   - Forcefully update builds that didn't want to update with state machine

--- a/app/controllers/projects/commit_controller.rb
+++ b/app/controllers/projects/commit_controller.rb
@@ -67,7 +67,12 @@ class Projects::CommitController < Projects::ApplicationController
   end
 
   def define_show_vars
-    @diffs = commit.diffs
+    if params[:w].to_i == 1
+      @diffs = commit.diffs({ ignore_whitespace_change: true })
+    else
+      @diffs = commit.diffs
+    end
+
     @notes_count = commit.notes.count
     
     @builds = ci_commit.builds if ci_commit

--- a/spec/controllers/commit_controller_spec.rb
+++ b/spec/controllers/commit_controller_spec.rb
@@ -69,6 +69,21 @@ describe Projects::CommitController do
 
         expect(response.body).to start_with("diff --git")
       end
+      
+      it "should really only be a git diff without whitespace changes" do
+        get(:show,
+            namespace_id: project.namespace.to_param,
+            project_id: project.to_param,
+            id: '66eceea0db202bb39c4e445e8ca28689645366c5',
+            # id: commit.id,
+            format: format,
+            w: 1)
+
+        expect(response.body).to start_with("diff --git")
+        # without whitespace option, there are more than 2 diff_splits
+        diff_splits = assigns(:diffs)[0].diff.split("\n")
+        expect(diff_splits.length).to be <= 2
+      end
     end
 
     describe "as patch" do


### PR DESCRIPTION
I added a ignore whitespace option to commit view with adding `?w=1` on URL.
It is mentioned before. (https://github.com/gitlabhq/gitlabhq/pull/9757)
@silversens check this out!
