### PR TITLE
Prevent impersonation if blocked

### DIFF
--- a/app/controllers/admin/impersonation_controller.rb
+++ b/app/controllers/admin/impersonation_controller.rb
@@ -5,14 +5,20 @@ class Admin::ImpersonationController < Admin::ApplicationController
   before_action :authorize_impersonator!
 
   def create
-    session[:impersonator_id] = current_user.username
-    session[:impersonator_return_to] = request.env['HTTP_REFERER']
+    if @user.blocked?
+      flash[:alert] = "You cannot impersonate a blocked user"
 
-    warden.set_user(user, scope: 'user')
+      redirect_to admin_user_path(@user)
+    else
+      session[:impersonator_id] = current_user.username
+      session[:impersonator_return_to] = request.env['HTTP_REFERER']
 
-    flash[:alert] = "You are impersonating #{user.username}."
+      warden.set_user(user, scope: 'user')
 
-    redirect_to root_path
+      flash[:alert] = "You are impersonating #{user.username}."
+
+      redirect_to root_path
+    end
   end
 
   def destroy

--- a/app/controllers/admin/impersonation_controller.rb
+++ b/app/controllers/admin/impersonation_controller.rb
@@ -11,7 +11,7 @@ class Admin::ImpersonationController < Admin::ApplicationController
       redirect_to admin_user_path(@user)
     else
       session[:impersonator_id] = current_user.username
-      session[:impersonator_return_to] = request.env['HTTP_REFERER']
+      session[:impersonator_return_to] = admin_user_path(@user)
 
       warden.set_user(user, scope: 'user')
 

--- a/app/views/admin/users/_head.html.haml
+++ b/app/views/admin/users/_head.html.haml
@@ -6,7 +6,7 @@
     %span.cred (Admin)
 
   .pull-right
-    - unless @user == current_user
+    - unless @user == current_user || @user.blocked?
       = link_to 'Impersonate', impersonate_admin_user_path(@user), method: :post, class: "btn btn-grouped btn-info"
     = link_to edit_admin_user_path(@user), class: "btn btn-grouped" do
       %i.fa.fa-pencil-square-o

--- a/spec/controllers/admin/impersonation_controller_spec.rb
+++ b/spec/controllers/admin/impersonation_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Admin::ImpersonationController do
+  let(:admin) { create(:admin) }
+
+  before do
+    sign_in(admin)
+  end
+
+  describe 'CREATE #impersonation when blocked' do
+    let(:blocked_user) { create(:user, state: :blocked) }
+
+    it 'does not allow impersonation' do
+      post :create, id: blocked_user.username
+
+      expect(flash[:alert]).to eq 'You cannot impersonate a blocked user'
+    end
+  end
+end

--- a/spec/features/admin/admin_users_spec.rb
+++ b/spec/features/admin/admin_users_spec.rb
@@ -128,6 +128,16 @@ describe "Admin::Users", feature: true  do
 
           expect(page).not_to have_content('Impersonate')
         end
+
+        it 'should not show impersonate button for blocked user' do
+          another_user.block
+
+          visit admin_user_path(another_user)
+
+          expect(page).not_to have_content('Impersonate')
+
+          another_user.activate
+        end
       end
 
       context 'when impersonating' do


### PR DESCRIPTION
Issue #9872 notes that impersonating a blocked user will log you out of your account. A more desirable result is for the administrator to be notified that a blocked user cannot be impersonated.  This pull request addresses that in two ways:

When viewing a users page in the administration panel, the Impersonate button will not be present when the user is blocked:

![screen shot 2015-12-02 at 8 11 18 am](https://cloud.githubusercontent.com/assets/650603/11531665/879d8fe0-98cc-11e5-9c30-28aaa235f1b5.png)

If an attempt to post against the impersonate URL for a blocked user occurs, a flash message will display notifying the administrator that a blocked user cannot be impersonated:

![screen shot 2015-12-02 at 8 14 58 am](https://cloud.githubusercontent.com/assets/650603/11531705/d481d532-98cc-11e5-9bfd-c7351dce6afc.png)

Test cases are included for both of these changes.

I have also included a minor change that explicitly defines the `impersonator_return_to` location instead of relying on `HTTP_REFERER`.
