### PR TITLE
Clarify Project Limit Reached

### DIFF
--- a/app/assets/javascripts/user.js.coffee
+++ b/app/assets/javascripts/user.js.coffee
@@ -2,3 +2,9 @@ class @User
   constructor: ->
     $('.profile-groups-avatars').tooltip("placement": "top")
     new ProjectsList()
+
+    $('.hide-project-limit-message').on 'click', (e) ->
+      path = '/'
+      $.cookie('hide_project_limit_message', 'false', { path: path })
+      $(@).parents('.project-limit-message').remove()
+      e.preventDefault()

--- a/app/assets/stylesheets/pages/projects.scss
+++ b/app/assets/stylesheets/pages/projects.scss
@@ -5,7 +5,7 @@
     font-weight: normal;
   }
 }
-.no-ssh-key-message {
+.no-ssh-key-message, .project-limit-message {
   background-color: #f28d35;
   margin-bottom: 16px;
 }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -70,6 +70,7 @@ class ProfilesController < Profiles::ApplicationController
       :email,
       :hide_no_password,
       :hide_no_ssh_key,
+      :hide_project_limit,
       :linkedin,
       :location,
       :name,

--- a/app/views/dashboard/_projects_head.html.haml
+++ b/app/views/dashboard/_projects_head.html.haml
@@ -1,3 +1,6 @@
+= content_for :flash_message do
+  = render 'shared/project_limit'
+
 %ul.center-top-menu
   = nav_link(path: ['projects#index', 'root#index']) do
     = link_to dashboard_projects_path, title: 'Home', class: 'shortcuts-activity', data: {placement: 'right'} do

--- a/app/views/shared/_project_limit.html.haml
+++ b/app/views/shared/_project_limit.html.haml
@@ -1,0 +1,8 @@
+- if cookies[:hide_project_limit_message].blank? && !current_user.hide_project_limit && !current_user.can_create_project?
+  .project-limit-message.alert.alert-warning.hidden-xs
+    You won't be able to create new projects because you have reached your project limit.
+
+    .pull-right
+      = link_to "Don't show again", profile_path(user: {hide_project_limit: true}), method: :put, class: 'alert-link'
+      |
+      = link_to 'Remind later', '#', class: 'hide-project-limit-message alert-link'

--- a/db/migrate/20151203162133_add_hide_project_limit_to_users.rb
+++ b/db/migrate/20151203162133_add_hide_project_limit_to_users.rb
@@ -1,0 +1,5 @@
+class AddHideProjectLimitToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :hide_project_limit, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151118162244) do
+ActiveRecord::Schema.define(version: 20151203162133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -814,6 +814,7 @@ ActiveRecord::Schema.define(version: 20151118162244) do
     t.integer  "project_view",               default: 0
     t.integer  "consumed_timestep"
     t.integer  "layout",                     default: 0
+    t.boolean  "hide_project_limit",         default: false
   end
 
   add_index "users", ["admin"], name: "index_users_on_admin", using: :btree


### PR DESCRIPTION
Issue #9874 points at that realizing your project limit has been reached can be difficult.  Ideally, the user needs to be notified in some way.  This pull request adds an alert to the user's dashboard when they have reached their project limit.

![project-limit](https://cloud.githubusercontent.com/assets/650603/11578385/05cc7422-99f3-11e5-8c55-11627ddd9050.PNG)

This functions the same way as the alerts for when a user does not have an SSH key or a password and can be hidden temporarily or permanently.  This is accomplished using Javascript to create a cookie when the user clicks `Remind later` and a boolean field on the `User` model (`hide_project_limit`) when the user clicks `Don't show again`.  Based on the truthiness of these two values and the status of `User.can_create_project?` the message will be displayed or not.

If accepted, a follow up pull request will need to be issued to address the repetitive code.  This will be the third time that similar code is used and it should be abstracted.  I thought adding that to this pull request would be too much, but could visit it now if you'd like.
