### PR TITLE
update nginx config hint

### DIFF
--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -114,6 +114,9 @@ server {
   }
 
   location ~ ^/[\w\.-]+/[\w\.-]+/gitlab-lfs/objects {
+    ## If you use relative url, please uncomment below line and remove origin line.
+    # location ~ ^/YOUR_RELATIVE_URL/[\w\.-]+/[\w\.-]+/gitlab-lfs/objects {
+
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
     error_page 418 = @gitlab-workhorse;
@@ -121,6 +124,9 @@ server {
   }
 
   location ~ ^/[\w\.-]+/[\w\.-]+/(info/refs|git-upload-pack|git-receive-pack)$ {
+    ## If you use relative url, please uncomment below line and remove upper line.
+    # location ~ ^/YOUR_RELATIVE_URL/(info/refs|git-upload-pack|git-receive-pack)$ {
+
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
     error_page 418 = @gitlab-workhorse;
@@ -128,6 +134,9 @@ server {
   }
 
   location ~ ^/[\w\.-]+/[\w\.-]+/repository/archive {
+    ## If you use relative url, please uncomment below line and remove upper line.
+    # location ~ ^/YOUR_RELATIVE_URL/[\w\.-]+/[\w\.-]+/repository/archive {
+
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
     error_page 418 = @gitlab-workhorse;
@@ -135,6 +144,9 @@ server {
   }
 
   location ~ ^/api/v3/projects/.*/repository/archive {
+    ## If you use relative url, please uncomment below line and remove upper line.
+    # location ~ ^/YOUR_RELATIVE_URL/api/v3/projects/.*/repository/archive {
+
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
     error_page 418 = @gitlab-workhorse;
@@ -143,6 +155,9 @@ server {
 
   # Build artifacts should be submitted to this location
   location ~ ^/[\w\.-]+/[\w\.-]+/builds/download {
+    ## If you use relative url, please uncomment below line and remove upper line.
+    # location ~ ^/YOUR_RELATIVE_URL/[\w\.-]+/[\w\.-]+/builds/download {
+
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
     error_page 418 = @gitlab-workhorse;


### PR DESCRIPTION
When use gitlab with relative url, 
user should change location regular expression on nginx config file.

Because example of nginx config file contain this type regular expression.

```
^/[\w\.-]+/[\w\.-]+/(info/refs|git-upload-pack|git-receive-pack)$
```

it will catch some URL like below.

```
/project/repo.git/git-upload-pack
```

However if user set relative url, upper url should be

```
/relative_url/project/repo.git/git-upload-pack
```

so regular expression isn't able to catch.

It makes errors when cloing, pulling, pushing or archiving.  
(ex. it will clone empty repository, even if the repository does not empty.)

I think it is better way that comment to user in example of nginx config file
