### PR TITLE
Fix gitlab-ssl nginx config to work when multiple server_names are served over https

### DIFF
--- a/lib/support/nginx/gitlab-ssl
+++ b/lib/support/nginx/gitlab-ssl
@@ -56,7 +56,7 @@ server {
   listen [::]:80 ipv6only=on default_server;
   server_name YOUR_SERVER_FQDN; ## Replace this with something like gitlab.example.com
   server_tokens off; ## Don't show the nginx version number, a security best practice
-  return 301 https://$server_name$request_uri;
+  return 301 https://$http_host$request_uri;
   access_log  /var/log/nginx/gitlab_access.log;
   error_log   /var/log/nginx/gitlab_error.log;
 }


### PR DESCRIPTION
In a situation when you have several HTTPS sites served by nginx, you cannot use $server_name in the redirect, because it will always resolve to the first server_name specified in the config.
$http_host works in this scenario.
