### PR TITLE
update nginx config file hint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@ v 8.3.0 (unreleased)
   - Fix deleting notes on a merge request diff
   - Display referenced merge request statuses in the issue description (Greg Smethells)
   - Implement new sidebar for issue and merge request pages
+  - Improve nginx config example file about gitlab with relative url. 
 
 v 8.2.3
   - Fix application settings cache not expiring after changes (Stan Hu)

--- a/lib/support/nginx/gitlab
+++ b/lib/support/nginx/gitlab
@@ -113,6 +113,7 @@ server {
     proxy_pass http://gitlab;
   }
 
+  ## If you use relative url, please change ^/ to ^/YOUR_RELATIVE_URL/
   location ~ ^/[\w\.-]+/[\w\.-]+/gitlab-lfs/objects {
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
@@ -120,6 +121,7 @@ server {
     return 418;
   }
 
+  ## If you use relative url, please change ^/ to ^/YOUR_RELATIVE_URL/
   location ~ ^/[\w\.-]+/[\w\.-]+/(info/refs|git-upload-pack|git-receive-pack)$ {
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
@@ -127,6 +129,7 @@ server {
     return 418;
   }
 
+  ## If you use relative url, please change ^/ to ^/YOUR_RELATIVE_URL/
   location ~ ^/[\w\.-]+/[\w\.-]+/repository/archive {
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
@@ -134,6 +137,7 @@ server {
     return 418;
   }
 
+  ## If you use relative url, please change ^/ to ^/YOUR_RELATIVE_URL/
   location ~ ^/api/v3/projects/.*/repository/archive {
     client_max_body_size 0;
     # 'Error' 418 is a hack to re-use the @gitlab-workhorse block
@@ -141,6 +145,7 @@ server {
     return 418;
   }
 
+  ## If you use relative url, please change ^/ to ^/YOUR_RELATIVE_URL/
   # Build artifacts should be submitted to this location
   location ~ ^/[\w\.-]+/[\w\.-]+/builds/download {
     client_max_body_size 0;


### PR DESCRIPTION
> I recreate this PR because previous one takes wrong branches.
> # 9882

When use gitlab with relative url, 
user should change location regular expression on nginx config file.

Because example of nginx config file contain this type regular expression.

```
^/[\w\.-]+/[\w\.-]+/(info/refs|git-upload-pack|git-receive-pack)$
```

it will catch some URL like below.

```
/project/repo.git/git-upload-pack
```

However if user set relative url, upper url should be

```
/relative_url/project/repo.git/git-upload-pack
```

so regular expression isn't able to catch.

It makes errors when cloing, pulling, pushing or archiving.  
(ex. it will clone empty repository, even if the repository does not empty.)

I think it is better way that comment to user in example of nginx config file
