### PR TITLE
Fix inconsistency with no ssh key message

### DIFF
--- a/app/views/projects/empty.html.haml
+++ b/app/views/projects/empty.html.haml
@@ -1,4 +1,4 @@
-.alert_holder
+= content_for :flash_message do
   - if current_user && can?(current_user, :download_code, @project)
     = render 'shared/no_ssh'
     = render 'shared/no_password'


### PR DESCRIPTION
When a user has not added an SSH key, the alert message is inconsistent depending on if the project is empty or not.

Currently:

![screen shot 2015-12-08 at 6 27 44 pm](https://cloud.githubusercontent.com/assets/650603/11671905/89e1f306-9dd9-11e5-922e-c2e6d8403eab.png)

This update will fix the message to match the show action by passing it as `content_for :flash_message`.  The result will be a more consistent look that has the additional space and appropriate link styling matching the non-empty project display.

![screen shot 2015-12-08 at 6 26 41 pm](https://cloud.githubusercontent.com/assets/650603/11671931/b6dc6030-9dd9-11e5-9066-e99b0a1af4cf.png)
