### PR TITLE
Avoid allocations in Ability class.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -132,14 +132,14 @@ class Ability
     end
 
     def public_project_rules
-      project_guest_rules + [
+      @public_project_rules ||= project_guest_rules + [
         :download_code,
         :fork_project
       ]
     end
 
     def project_guest_rules
-      [
+      @project_guest_rules ||= [
         :read_project,
         :read_wiki,
         :read_issue,
@@ -157,7 +157,7 @@ class Ability
     end
 
     def project_report_rules
-      project_guest_rules + [
+      @project_report_rules ||= project_guest_rules + [
         :create_commit_status,
         :read_commit_statuses,
         :download_code,
@@ -170,7 +170,7 @@ class Ability
     end
 
     def project_dev_rules
-      project_report_rules + [
+      @project_dev_rules ||= project_report_rules + [
         :admin_merge_request,
         :create_merge_request,
         :create_wiki,
@@ -181,7 +181,7 @@ class Ability
     end
 
     def project_archived_rules
-      [
+      @project_archived_rules ||= [
         :create_merge_request,
         :push_code,
         :push_code_to_protected_branches,
@@ -191,7 +191,7 @@ class Ability
     end
 
     def project_master_rules
-      project_dev_rules + [
+      @project_master_rules ||= project_dev_rules + [
         :push_code_to_protected_branches,
         :update_project_snippet,
         :update_merge_request,
@@ -206,7 +206,7 @@ class Ability
     end
 
     def project_admin_rules
-      project_master_rules + [
+      @project_admin_rules ||= project_master_rules + [
         :change_namespace,
         :change_visibility_level,
         :rename_project,
@@ -332,7 +332,7 @@ class Ability
       end
 
       if snippet.public? || snippet.internal?
-        rules << :read_personal_snippet 
+        rules << :read_personal_snippet
       end
 
       rules


### PR DESCRIPTION
It won't change anything after they are first invoke, so add method cache to avoid allocations and avoid GC.
#### Benchmarks:

```
Calculating -------------------------------------
project_guest_rules without method cache
                        79.352k i/100ms
project_guest_rules with method cache
                        93.634k i/100ms
-------------------------------------------------
project_guest_rules without method cache
                          2.865M (±32.5%) i/s -     11.982M
project_guest_rules with method cache
                          4.419M (± 7.4%) i/s -     22.004M

Comparison:
project_guest_rules with method cache:  4418908.0 i/s
project_guest_rules without method cache:  2864514.0 i/s - 1.54x slower

Calculating -------------------------------------
project_report_rules without method cache
                        53.126k i/100ms
project_report_rules with method cache
                        97.473k i/100ms
-------------------------------------------------
project_report_rules without method cache
                          1.093M (±36.5%) i/s -      4.675M
project_report_rules with method cache
                          4.420M (± 7.2%) i/s -     22.029M
Comparison:
project_report_rules with method cache:  4420054.3 i/s
project_report_rules without method cache:  1092509.6 i/s - 4.05x slower
```
#### Benchark case:

https://gist.github.com/huacnlee/b04788ae6df42fe769e4
