### PR TITLE
Hotfix note mail with notification

### DIFF
--- a/app/mailers/emails/notes.rb
+++ b/app/mailers/emails/notes.rb
@@ -48,7 +48,7 @@ module Emails
 
       yield
 
-      SentNotification.record(@note, recipient_id, reply_key)
+      SentNotification.record_note(@note, recipient_id, reply_key)
     end
   end
 end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -52,6 +52,9 @@ describe NotificationService, services: true do
         it do
           add_users_with_subscription(note.project, issue)
 
+          # Ensure create SentNotification by noteable = issue 6 times, not noteable = note
+          expect(SentNotification).to receive(:record).with(issue, any_args).exactly(6).times
+
           ActionMailer::Base.deliveries.clear
 
           notification.new_note(note)


### PR DESCRIPTION
Today I found some error log:

``` bash
Email can not be processed: undefined method `note_note_email' for Notify:Class
```

When I reply a Issue comment by Email reply, It will create a new Note into database but not relation with the Issue.  

---

In current 8-3-stable (even in master version), `Emails::Notes` invoked `SentNotification.record`, that will store a bad `noteable` value.

See this file: https://github.com/gitlabhq/gitlabhq/blob/8-0-stable/app/mailers/emails/notes.rb#L46

@YorickPeterse
