### PR TITLE
Mention channel/key bug in irkerd docs

### DIFF
--- a/app/models/project_services/irker_service.rb
+++ b/app/models/project_services/irker_service.rb
@@ -73,9 +73,10 @@ class IrkerService < Service
         'irc[s]://irc.network.net[:port]/#channel. Special cases: if '\
         'you want the channel to be a nickname instead, append ",isnick" to ' \
         'the channel name; if the channel is protected by a secret password, ' \
-        ' append "?key=secretpassword" to the URI. Note that if you specify a ' \
-        ' default IRC URI to prepend before each recipient, you can just give ' \
-        ' a channel name.'  },
+        ' append "?key=secretpassword" to the URI (Note that due to a bug, if you ' \
+        ' want to use a password, you have to omit the "#" on the channel). If you ' \
+        ' specify a default IRC URI to prepend before each recipient, you can just ' \
+        ' give a channel name.'  },
       { type: 'checkbox', name: 'colorize_messages' },
     ]
   end


### PR DESCRIPTION
Per this issue: https://gitlab.com/esr/irker/issues/2

A documentation update was added to irkerd (https://gitlab.com/esr/irker/commit/190808c37d4ab5f0f16fe35352ff36863c2732d5) but the bug is still there. Making a note of it here could save someone a lot of hassle. 

This could probably be worded better if someone else wants to take a stab at it.
