### PR TITLE
update file path regex for unicode letters

### DIFF
--- a/lib/gitlab/regex.rb
+++ b/lib/gitlab/regex.rb
@@ -52,7 +52,7 @@ module Gitlab
     end
 
     def file_path_regex
-      @file_path_regex ||= /\A[a-zA-Z0-9_\-\.\/]*\z/.freeze
+      @file_path_regex ||= /\A[\p{L}\p{N}_\-\.\/]*\z/.freeze
     end
 
     def file_path_regex_message


### PR DESCRIPTION
When I upload a file, there is a issue if filename hava a unicode letters.(ex: korean or japanese or chinese characters).
It can't pass file_path_regex.
`[a-zA-Z0-9_\-\.\/]`

So how about this?
`[\p{L}\p{N}_\-\.\/]`
`\p{L}` means unicode letter and `\p{N}` is number.
http://ruby-doc.org/core-2.1.7/Regexp.html#class-Regexp-label-Character+Properties
