### PR TITLE
Add 'mergeable?' param to merge request entity in API responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@ v 8.4.0 (unreleased)
   - Swap position of Assignee and Author selector on Issuables (Zeger-Jan van de Weg)
   - Add system hook messages for project rename and transfer (Steve Norman)
   - Fix version check image in Safari
+  - Add "mergeable?" param to merge request entity in API responses
   - Show 'All' tab by default in the builds page
   - Add Open Graph and Twitter Card data to all pages
   - Fix API project lookups when querying with a namespace with dots (Stan Hu)

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -173,6 +173,7 @@ module API
       expose :label_names, as: :labels
       expose :description
       expose :work_in_progress?, as: :work_in_progress
+      expose :mergeable?, as: :mergeable
       expose :milestone, using: Entities::Milestone
       expose :merge_when_build_succeeds
     end

--- a/spec/requests/api/merge_requests_spec.rb
+++ b/spec/requests/api/merge_requests_spec.rb
@@ -125,6 +125,22 @@ describe API::API, api: true  do
       expect(json_response.first['id']).to eq merge_request.id
     end
 
+    it "should return mergeable merge request" do
+      allow_any_instance_of(MergeRequest).to receive(:mergeable?).and_return(true)
+      get api("/projects/#{project.id}/merge_request/#{merge_request.id}", user)
+      expect(response.status).to eq(200)
+      expect(json_response['iid']).to eq(merge_request.iid)
+      expect(json_response['mergeable']).to eq(true)
+    end
+
+    it "should return unmergeable merge request" do
+      allow_any_instance_of(MergeRequest).to receive(:mergeable?).and_return(false)
+      get api("/projects/#{project.id}/merge_request/#{merge_request.id}", user)
+      expect(response.status).to eq(200)
+      expect(json_response['iid']).to eq(merge_request.iid)
+      expect(json_response['mergeable']).to eq(false)
+    end
+
     it "should return a 404 error if merge_request_id not found" do
       get api("/projects/#{project.id}/merge_request/999", user)
       expect(response.status).to eq(404)


### PR DESCRIPTION
Issue #9929
