### PR TITLE
Pass username to Piwik analytics when Piwik is enabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v 8.5.0 (unreleased)
   - Add "visibility" flag to GET /projects api endpoint
   - Upgrade gitlab_git to 7.2.23 to fix commit message mentions in first branch push
   - New UI for pagination
+  - Pass username to Piwik analytics when Piwik is enabled (Senorsen)
 
 v 8.4.0 (unreleased)
   - Allow LDAP users to change their email if it was not set by the LDAP server

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -212,6 +212,7 @@ class ApplicationController < ActionController::Base
 
     if current_user
       gon.current_user_id = current_user.id
+      gon.current_user_username = current_user.username
       gon.api_token = current_user.private_token
     end
   end

--- a/app/views/layouts/_piwik.html.haml
+++ b/app/views/layouts/_piwik.html.haml
@@ -1,6 +1,10 @@
 <!-- Piwik -->
 :javascript
   var _paq = _paq || [];
+  // Pass username to piwik analytics
+  if (gon.current_user_username) {
+    _paq.push(['setUserId', gon.current_user_username]);
+  }
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
Pass username to Piwik, through `setUserId` parameter.
