### PR TITLE
Avoid to show the original password field when password is automatically seted

### DIFF
--- a/app/controllers/profiles/passwords_controller.rb
+++ b/app/controllers/profiles/passwords_controller.rb
@@ -50,6 +50,7 @@ class Profiles::PasswordsController < Profiles::ApplicationController
       flash[:notice] = "Password was successfully updated. Please login with it"
       redirect_to new_user_session_path
     else
+      @user.reload
       render 'edit'
     end
   end

--- a/spec/features/profiles/password_spec.rb
+++ b/spec/features/profiles/password_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'Profile > Password', feature: true do
+  let(:user) { create(:user, password_automatically_set: true) }
+
+  before do
+    login_as(user)
+    visit edit_profile_password_path
+  end
+
+  def fill_passwords(password, confirmation)
+    fill_in 'New password',          with: password
+    fill_in 'Password confirmation', with: confirmation
+
+    click_button 'Save password'
+  end
+
+  context 'User with password automatically seted' do
+    describe 'User puts different passwords in the field and in the confirmation' do
+      it 'shows an error message' do
+        fill_passwords('mypassword', 'mypassword2')
+
+        page.within('.alert-danger') do
+          expect(page).to have_content("Password confirmation doesn't match Password")
+        end
+      end
+
+      it 'does not contains the current password field after an error' do
+        fill_passwords('mypassword', 'mypassword2')
+
+        expect(page).to have_no_field('user[current_password]')
+      end
+    end
+
+    describe 'User puts the same passwords in the field and in the confirmation' do
+      it 'shows a success message' do
+        fill_passwords('mypassword', 'mypassword')
+
+        page.within('.flash-notice') do
+          expect(page).to have_content('Password was successfully updated. Please login with it')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi, 
When I create an account using an Omniauth provider, it sets automatically a password for me. And gitlab suggests to set a password to be able to pull/push via HTTP.
<img width="1054" alt="screen shot 2016-01-24 at 3 41 11 am" src="https://cloud.githubusercontent.com/assets/771411/12537794/00f77460-c2a7-11e5-8196-935347b52e43.png">
And when I click to set the password, the page is fine with the `new password` and `confirmation` field.
<img width="1049" alt="screen shot 2016-01-24 at 3 41 21 am" src="https://cloud.githubusercontent.com/assets/771411/12537797/2f431bbc-c2a7-11e5-8e4a-5e23a9b1eb4b.png">

But if I accidentally put different passwords on both fields, it loads the page with the `original password` (that I don't have).
<img width="1048" alt="screen shot 2016-01-24 at 3 41 44 am" src="https://cloud.githubusercontent.com/assets/771411/12537802/547ee4ce-c2a7-11e5-8748-29ff4a68811a.png">

This PR will change this behave. When an error occurs it will show only the `New password` and `confirmation` when password is automatically seted.

<img width="1052" alt="screen shot 2016-01-24 at 1 11 25 pm" src="https://cloud.githubusercontent.com/assets/771411/12537805/9458ff94-c2a7-11e5-88da-c4d54dfb9986.png">

Thanks so much, 
:beers:
