### PR TITLE
Fix gitlab init script

### DIFF
--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -47,8 +47,6 @@ shell_path="/bin/bash"
 # Read configuration variable file if it is present
 test -f /etc/default/gitlab && . /etc/default/gitlab
 
-cd $gitlab_workhorse_dir
-
 # Switch to the app_user if it is not he/she who is running the script.
 if [ `whoami` != "$app_user" ]; then
   eval su - "$app_user" -s $shell_path -c $(echo \")$0 "$@"$(echo \"); exit;

--- a/lib/support/init.d/gitlab
+++ b/lib/support/init.d/gitlab
@@ -38,7 +38,7 @@ web_server_pid_path="$pid_path/unicorn.pid"
 sidekiq_pid_path="$pid_path/sidekiq.pid"
 mail_room_enabled=false
 mail_room_pid_path="$pid_path/mail_room.pid"
-gitlab_workhorse_dir=$(cd $app_root/../gitlab-workhorse && pwd)
+gitlab_workhorse_dir="$app_root/../gitlab-workhorse"
 gitlab_workhorse_pid_path="$pid_path/gitlab-workhorse.pid"
 gitlab_workhorse_options="-listenUmask 0 -listenNetwork unix -listenAddr $socket_path/gitlab-workhorse.socket -authBackend http://127.0.0.1:8080 -authSocket $rails_socket -documentRoot $app_root/public"
 gitlab_workhorse_log="$app_root/log/gitlab-workhorse.log"
@@ -46,6 +46,8 @@ shell_path="/bin/bash"
 
 # Read configuration variable file if it is present
 test -f /etc/default/gitlab && . /etc/default/gitlab
+
+cd $gitlab_workhorse_dir
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ `whoami` != "$app_user" ]; then

--- a/lib/support/init.d/gitlab.default.example
+++ b/lib/support/init.d/gitlab.default.example
@@ -32,7 +32,7 @@ sidekiq_pid_path="$pid_path/sidekiq.pid"
 
 # The directory where the gitlab-workhorse binaries are. Usually
 # /home/git/gitlab-workhorse .
-gitlab_workhorse_dir=$(cd $app_root/../gitlab-workhorse && pwd)
+gitlab_workhorse_dir="$app_root/../gitlab-workhorse"
 gitlab_workhorse_pid_path="$pid_path/gitlab-workhorse.pid"
 # The -listenXxx settings determine where gitlab-workhorse
 # listens for connections from NGINX. To listen on localhost:8181, write


### PR DESCRIPTION
Actual command (cd $gitlab_workhorse_dir) should not be run during variable declaration.
