### PR TITLE
Change default smpt port to 465 (default smtps port)

### DIFF
--- a/config/initializers/smtp_settings.rb.sample
+++ b/config/initializers/smtp_settings.rb.sample
@@ -12,7 +12,7 @@ if Rails.env.production?
 
   ActionMailer::Base.smtp_settings = {
     address: "email.server.com",
-    port: 456,
+    port: 465,
     user_name: "smtp",
     password: "123456",
     domain: "gitlab.company.com",


### PR DESCRIPTION
Current default value 456 is confusing. It differ with default SMTPS port number 465 only by digits order.
I think it's good idea to change this value to some correct SMTP port number (25 or 465).
