### PR TITLE
Add missing init script section

### DIFF
--- a/doc/update/8.4-to-8.5.md
+++ b/doc/update/8.4-to-8.5.md
@@ -81,7 +81,12 @@ There are new configuration options available for [`gitlab.yml`](config/gitlab.y
 ```sh
 git diff origin/8-4-stable:config/gitlab.yml.example origin/8-5-stable:config/gitlab.yml.example
 ```
+#### Init script
 
+```
+cd /home/git/gitlab
+sudo cp lib/support/init.d/gitlab /etc/init.d/gitlab
+```
 ### 8. Start application
 
     sudo service gitlab start


### PR DESCRIPTION
The _Init script_ section is missing on the update documentation, leading to errors while checking the application status.
