### PR TITLE
Add scoverage (Scala) example regex for finding test coverage

### DIFF
--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -156,6 +156,9 @@
                     %li
                       phpunit --coverage-text --colors=never (PHP) -
                       %code ^\s*Lines:\s*\d+.\d+\%
+                    %li
+                      scoverage (Scala) -
+                      %code Coverage was \[\d+.\d+\%\]
 
               .form-group
                 .col-sm-offset-2.col-sm-10


### PR DESCRIPTION
Adds an example regex on the `Project Setting > Continous Integration > Test coverage parsing` page for Scala test coverage measuring with scoverage.

See below for how a scoverage output would look like when e.g. running `sbt clean coverage test coverageReport`:

![image](https://cloud.githubusercontent.com/assets/2210857/13293389/ca6bdde6-db1f-11e5-9fe2-ab525cec3f03.png)
