### PR TITLE
Fix unintuitive logic in which a canceled Allowed To Fail build will …

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -114,7 +114,7 @@ class CommitStatus < ActiveRecord::Base
   end
 
   def ignored?
-    failed? && allow_failure?
+    allow_failure? && (failed? || canceled?)
   end
 
   def duration


### PR DESCRIPTION
…always fail the build.

TL;DR this commit expands the meaning of "Allowed to fail" to also include "Allowed to be canceled", which in my opinion as a user is far more intuitive.

For background, I was extremely surprised and frustrated when I found that by canceling a build marked "Allowed to fail", my build still failed even though all of the other test suites passed. My kneejerk understanding of the "Allowed to fail" tag is that under no circumstances will that build cause the entire combined status to be a failure. This is not the case apparently, as "Canceled" status takes precedence and will cause the entire build to fail.

See how the "fail" status becomes "ignored", which them becomes "success" within lib/ci/status.rb, whereas canceled ends up as "canceled" even if they are marked as allowed to fail.
