### PR TITLE
Don't describe a self-compiled software version as a system version

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -114,7 +114,7 @@ The use of Ruby version managers such as [RVM], [rbenv] or [chruby] with GitLab
 in production, frequently leads to hard to diagnose problems. For example,
 GitLab Shell is called from OpenSSH, and having a version manager can prevent
 pushing and pulling over SSH. Version managers are not supported and we strongly
-advise everyone to follow the instructions below to use a system Ruby.
+advise everyone to follow the instructions below to use a self-compiled Ruby.
 
 Remove the old Ruby 1.8 if present:
 


### PR DESCRIPTION
When talking about a system version of a software I expect to use a packed manager and not compile the software from source.
