### PR TITLE
`authorization_code` is case sensitive

### DIFF
--- a/doc/api/oauth2.md
+++ b/doc/api/oauth2.md
@@ -35,7 +35,7 @@ Where REDIRECT_URI is the URL in your app where users will be sent after authori
 To request the access token, you should use the returned code and exchange it for an access token. To do that you can use any HTTP client. In this case, I used rest-client:
 
 ```
-parameters = 'client_id=APP_ID&client_secret=APP_SECRET&code=RETURNED_CODE&grant_type=AUTHORIZATION_CODE&redirect_uri=REDIRECT_URI'
+parameters = 'client_id=APP_ID&client_secret=APP_SECRET&code=RETURNED_CODE&grant_type=authorization_code&redirect_uri=REDIRECT_URI'
 RestClient.post 'http://localhost:3000/oauth/token', parameters
 
 # The response will be


### PR DESCRIPTION
I was following the docs to implement OAuth for our app and noticed that the example URL has `grant_type` set to be `authorization_code` but in the wrong case.

Hopefully this makes it easier for the next integrator
