### PR TITLE
Update the OmniAuth-integration documentation

### DIFF
--- a/doc/integration/azure.md
+++ b/doc/integration/azure.md
@@ -78,6 +78,8 @@ To enable the Microsoft Azure OAuth2 OmniAuth provider you must register your ap
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
 On the sign in page there should now be a Microsoft icon below the regular sign in form. Click the icon to begin the authentication process. Microsoft will ask the user to sign in and authorize the GitLab application. If everything goes well the user will be returned to GitLab and will be signed in.

--- a/doc/integration/cas.md
+++ b/doc/integration/cas.md
@@ -57,6 +57,8 @@ To enable the CAS OmniAuth provider you must register your application with your
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
 On the sign in page there should now be a CAS tab in the sign in form.

--- a/doc/integration/crowd.md
+++ b/doc/integration/crowd.md
@@ -28,7 +28,7 @@ To enable the Crowd OmniAuth provider you must register your application with Cr
       gitlab_rails['omniauth_providers'] = [
         {
           "name" => "crowd",
-          "args" => { 
+          "args" => {
             "crowd_server_url" => "CROWD",
             "application_name" => "YOUR_APP_NAME",
             "application_password" => "YOUR_APP_PASSWORD"
@@ -52,6 +52,8 @@ To enable the Crowd OmniAuth provider you must register your application with Cr
 1.  Change 'YOUR_APP_PASSWORD' to the application password you've set.
 
 1.  Save the configuration file.
+
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
 
 1.  Restart GitLab for the changes to take effect.
 

--- a/doc/integration/facebook.md
+++ b/doc/integration/facebook.md
@@ -90,6 +90,8 @@ something else descriptive.
 
 1.  Change 'YOUR_APP_SECRET' to the API secret from the Facebook page in step 10.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Save the configuration file.
 
 1.  Restart GitLab for the changes to take effect.

--- a/doc/integration/github.md
+++ b/doc/integration/github.md
@@ -2,7 +2,7 @@
 
 Import projects from GitHub and login to your GitLab instance with your GitHub account.
 
-To enable the GitHub OmniAuth provider you must register your application with GitHub. 
+To enable the GitHub OmniAuth provider you must register your application with GitHub.
 GitHub will generate an application ID and secret key for you to use.
 
 1.  Sign in to GitHub.
@@ -20,7 +20,7 @@ GitHub will generate an application ID and secret key for you to use.
     - Authorization callback URL: 'https://gitlab.company.com/'
 1.  Select "Register application".
 
-1.  You should now see a Client ID and Client Secret near the top right of the page (see screenshot). 
+1.  You should now see a Client ID and Client Secret near the top right of the page (see screenshot).
     Keep this page open as you continue configuration.
     ![GitHub app](img/github_app.png)
 
@@ -72,8 +72,10 @@ GitHub will generate an application ID and secret key for you to use.
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
-On the sign in page there should now be a GitHub icon below the regular sign in form. 
-Click the icon to begin the authentication process. GitHub will ask the user to sign in and authorize the GitLab application. 
+On the sign in page there should now be a GitHub icon below the regular sign in form.
+Click the icon to begin the authentication process. GitHub will ask the user to sign in and authorize the GitLab application.
 If everything goes well the user will be returned to GitLab and will be signed in.

--- a/doc/integration/gitlab.md
+++ b/doc/integration/gitlab.md
@@ -2,7 +2,7 @@
 
 Import projects from GitLab.com and login to your GitLab instance with your GitLab.com account.
 
-To enable the GitLab.com OmniAuth provider you must register your application with GitLab.com. 
+To enable the GitLab.com OmniAuth provider you must register your application with GitLab.com.
 GitLab.com will generate an application ID and secret key for you to use.
 
 1.  Sign in to GitLab.com
@@ -26,8 +26,8 @@ GitLab.com will generate an application ID and secret key for you to use.
 
 1.  Select "Submit".
 
-1.  You should now see a Client ID and Client Secret near the top right of the page (see screenshot). 
-    Keep this page open as you continue configuration. 
+1.  You should now see a Client ID and Client Secret near the top right of the page (see screenshot).
+    Keep this page open as you continue configuration.
     ![GitLab app](img/gitlab_app.png)
 
 1.  On your GitLab server, open the configuration file.
@@ -77,8 +77,10 @@ GitLab.com will generate an application ID and secret key for you to use.
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
-On the sign in page there should now be a GitLab.com icon below the regular sign in form. 
-Click the icon to begin the authentication process. GitLab.com will ask the user to sign in and authorize the GitLab application. 
+On the sign in page there should now be a GitLab.com icon below the regular sign in form.
+Click the icon to begin the authentication process. GitLab.com will ask the user to sign in and authorize the GitLab application.
 If everything goes well the user will be returned to your GitLab instance and will be signed in.

--- a/doc/integration/google.md
+++ b/doc/integration/google.md
@@ -74,6 +74,8 @@ To enable the Google OAuth2 OmniAuth provider you must register your application
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
 On the sign in page there should now be a Google icon below the regular sign in form. Click the icon to begin the authentication process. Google will ask the user to sign in and authorize the GitLab application. If everything goes well the user will be returned to GitLab and will be signed in.

--- a/doc/integration/twitter.md
+++ b/doc/integration/twitter.md
@@ -74,6 +74,8 @@ To enable the Twitter OmniAuth provider you must register your application with 
 
 1.  Save the configuration file.
 
+1.  If you're using the omnibus package, reconfigure GitLab (```gitlab-ctl reconfigure```).
+
 1.  Restart GitLab for the changes to take effect.
 
 On the sign in page there should now be a Twitter icon below the regular sign in form. Click the icon to begin the authentication process. Twitter will ask the user to sign in and authorize the GitLab application. If everything goes well the user will be returned to GitLab and will be signed in.


### PR DESCRIPTION
## What does this MR do?

It adds a line to every OmniAuth integration page saying that GitLab needs to be reconfigured.
## Why was this MR needed?

The old documentation didn't mentioned that GitLab needs to be reconfigured before the OmniAuth provider is available for users.
