### PR TITLE
Changed the argument of not_found for 'unprotect'

### DIFF
--- a/lib/api/branches.rb
+++ b/lib/api/branches.rb
@@ -64,7 +64,7 @@ module API
         authorize_admin_project
 
         @branch = user_project.repository.find_branch(params[:branch])
-        not_found!("Branch does not exist") unless @branch
+        not_found!("Branch") unless @branch
         protected_branch = user_project.protected_branches.find_by(name: @branch.name)
         protected_branch.destroy if protected_branch
 


### PR DESCRIPTION
The error message I got when I tried to unprotect a non-existing branch didn't seem right. This pull request will fix that.
