### PR TITLE
Don’t read otp_secret_encryption_key from hardcoded path in models/user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ActiveRecord::Base
   default_value_for :theme_id, gitlab_config.default_theme
 
   devise :two_factor_authenticatable,
-         otp_secret_encryption_key: File.read(Rails.root.join('.secret')).chomp
+         otp_secret_encryption_key: Gitlab::Application.config.secret_key_base
   alias_attribute :two_factor_enabled, :otp_required_for_login
 
   devise :two_factor_backupable, otp_number_of_backup_codes: 10


### PR DESCRIPTION
Variable `Gitlab::Application.config.secret_key_base` is set in `config/initializers/secret_token.rb`. It’s very bad practice to use hard-coded paths inside an application and really unnecessary in this case.
