### PR TITLE
Add support for MathJax with AsciiDoc

### DIFF
--- a/app/assets/javascripts/blob/edit_blob.js.coffee
+++ b/app/assets/javascripts/blob/edit_blob.js.coffee
@@ -34,6 +34,7 @@ class @EditBlob
       , (response) ->
         currentPane.empty().append response
         currentPane.syntaxHighlight()
+        $(document).trigger('mathjax:typeset')
 
     else
       @editor.focus()

--- a/app/assets/javascripts/mathjax.js.coffee
+++ b/app/assets/javascripts/mathjax.js.coffee
@@ -1,0 +1,40 @@
+# Inspired by http://reed.github.io/turbolinks-compatibility/mathjax.html.
+
+config =
+  tex2jax:
+    inlineMath: [['\\(', '\\)']]  # default for Asciidoctor
+    displayMath: [['\\[', '\\]']]  # default for Asciidoctor
+    ignoreClass: 'page-with-sidebar|navbar|nostem|nolatexmath'
+    processClass: 'wiki'
+  asciimath2jax:
+    delimiters: [['\\$', '\\$']]  # default for Asciidoctor
+    ignoreClass: 'page-with-sidebar|navbar|nostem|nolatexmath'
+    processClass: 'wiki'
+  TeX:
+    equationNumbers:
+      autoNumber: 'none'
+
+isEnabled = ->
+  $('.content').data('mathjax') == 'enabled'
+
+load = ->
+  $.ajax(
+    dataType: 'script'
+    cache: true
+    url: "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=#{gon.mathjax_config}"
+  ).done =>
+    window.MathJax.Hub.Config(config)
+
+typeset = ->
+  window.MathJax?.Hub.Queue(['Typeset', window.MathJax.Hub])
+
+onPageLoad = ->
+  return unless isEnabled()
+  if window.MathJax
+    typeset()
+  else
+    load()
+
+$(document).ready onPageLoad
+$(document).on 'page:load', onPageLoad
+$(document).on 'mathjax:typeset', typeset

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -244,6 +244,10 @@ module ApplicationHelper
     Gitlab::MarkupHelper.asciidoc?(filename)
   end
 
+  def contains_math?(file_name, file_content)
+    asciidoc?(file_name) && Gitlab::Asciidoc.contains_stem?(file_content)
+  end
+
   def promo_host
     'about.gitlab.com'
   end

--- a/app/helpers/gitlab_markdown_helper.rb
+++ b/app/helpers/gitlab_markdown_helper.rb
@@ -67,6 +67,8 @@ module GitlabMarkdownHelper
   end
 
   def asciidoc(text)
+    load_mathjax! if Gitlab::Asciidoc.contains_stem?(text)
+
     Gitlab::Asciidoc.render(
       text,
       project:      @project,

--- a/app/helpers/page_layout_helper.rb
+++ b/app/helpers/page_layout_helper.rb
@@ -121,4 +121,19 @@ module PageLayoutHelper
 
     css_class
   end
+
+  def load_mathjax!
+    @load_mathjax = true
+  end
+
+  def load_mathjax?
+    case extra_config.fetch('mathjax_load', 'never')
+    when 'auto'
+      @load_mathjax
+    when 'always'
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/views/layouts/_page.html.haml
+++ b/app/views/layouts/_page.html.haml
@@ -30,6 +30,6 @@
     = render "layouts/flash"
     = yield :flash_message
     %div{ class: (container_class unless @no_container) }
-      .content
+      %div{ class: 'content', 'data-mathjax' => ('enabled' if load_mathjax?) }
         .clearfix
           = yield

--- a/app/views/projects/blob/edit.html.haml
+++ b/app/views/projects/blob/edit.html.haml
@@ -1,4 +1,5 @@
 - page_title "Edit", @blob.path, @ref
+- load_mathjax! if contains_math?(@blob.name, @blob.data)
 = render "header_title"
 
 .file-editor

--- a/config/gitlab.yml.example
+++ b/config/gitlab.yml.example
@@ -480,6 +480,17 @@ production: &base
     # piwik_url: '_your_piwik_url'
     # piwik_site_id: '_your_piwik_site_id'
 
+    ## MathJax
+    # Load MathJax library for typesetting math?
+    #   never  - this is default
+    #   auto   - when document declares that it contains math (depends on markup)
+    #   always -
+    # mathjax_load: auto
+    #
+    # Name of pre-defined MathJax configuration available on CDN.
+    # See http://docs.mathjax.org/en/latest/config-files.html for options.
+    # mathjax_config: TeX-MML-AM_CHTML
+
   rack_attack:
     git_basic_auth:
       # Rack Attack IP banning enabled

--- a/config/initializers/1_settings.rb
+++ b/config/initializers/1_settings.rb
@@ -326,6 +326,7 @@ Settings.satellites['path'] = File.expand_path(Settings.satellites['path'] || "t
 # Extra customization
 #
 Settings['extra'] ||= Settingslogic.new({})
+Settings.extra['mathjax_config'] ||= 'TeX-MML-AM_CHTML'
 
 #
 # Rack::Attack settings

--- a/lib/gitlab/asciidoc.rb
+++ b/lib/gitlab/asciidoc.rb
@@ -35,5 +35,11 @@ module Gitlab
 
       html.html_safe
     end
+
+    # Does the given document contain a valid :stem: attribute declaration
+    # that activates support for STEM (i.e. math)?
+    def self.contains_stem?(input)
+      input =~ /^:stem:/
+    end
   end
 end

--- a/lib/gitlab/gon_helper.rb
+++ b/lib/gitlab/gon_helper.rb
@@ -8,6 +8,7 @@ module Gitlab
       gon.relative_url_root      = Gitlab.config.gitlab.relative_url_root
       gon.shortcuts_path         = help_shortcuts_path
       gon.user_color_scheme      = Gitlab::ColorSchemes.for_user(current_user).css_class
+      gon.mathjax_config         = Gitlab.config.extra.mathjax_config
 
       if current_user
         gon.current_user_id = current_user.id


### PR DESCRIPTION
This pull requests adds optional (disabled by default) support for MathJax for typesetting of math used in AsciiDoc files with possibility to extending for other markups.

MathJax library is quite big, so it’s not integrated into asset pipeline, but instead loaded from CDN only when actually needed. The detection for AsciiDoc is very simple, because Asciidoctor has a built-in macro for STEM (i.e. math) that must be explicitly enabled for the document using attribute `stem` (i.e. `:stem:`).

It should work everywhere where AsciiDoc works, I’ve tested it in Readme, Files (including preview when editing a file), Wiki and Snippets. It works with turbolinks well.

Related to https://gitlab.com/gitlab-org/gitlab-ce/issues/13690 and #5280.
