### PR TITLE
Amend jira service api docs [ci skip]

### DIFF
--- a/doc/api/services.md
+++ b/doc/api/services.md
@@ -503,6 +503,8 @@ Parameters:
 - `project_url` (**required**) - Project url
 - `issues_url` (**required**) - Issue url
 - `description` (optional) - Jira issue tracker
+- `username` (optional) - Jira username
+- `password` (optional) - Jira password
 
 ### Delete JIRA service
 


### PR DESCRIPTION
Add `username` and `password` parameters to "Create/Edit JIRA service" in the api docs.
