### PR TITLE
fix: 24982- Remove'Signed in successfully' message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -43,7 +43,7 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."
     sessions:
-      signed_in: "Signed in successfully."
+      signed_in: ""
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:


### PR DESCRIPTION
After this change the sign-in-success flash message will not be shown
issue#24982

Hi, I've read your message here:) I already have an account on GitLab. I tried to fork the project from my GitLab account but it got failed on the first-time, the next time it started and didn't finished for a long-time(already passed 45 mins and counting). So I am pushing it from GitHub. This is my first push to your repo and this is a simple change which would solve the issue. 

I will try to create a new issue regarding the forking large projects part failing on GitLab later and will work on to give a fix for the same.