### PR TITLE
Allow "Everyone with access" on private repositories

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -132,12 +132,6 @@ module ProjectsHelper
     # Don't show option "everyone with access" if project is private
     options = project_feature_options
 
-    if @project.private?
-      level = @project.project_feature.send(field)
-      options.delete('Everyone with access')
-      highest_available_option = options.values.max if level == ProjectFeature::ENABLED
-    end
-
     options = options_for_select(options, selected: highest_available_option || @project.project_feature.public_send(field))
 
     content_tag(


### PR DESCRIPTION
This restriction once made sense, but now private repositories can be shared with other groups, rendering the restriction useless and even obstructive.

### Workaround:
1. Set project visibility level to "Internal" or "Public"
2. Save
3. Set project visibility to "Private" but **don't save** yet
4. Set the feature visibility to "Everyone with access"
5. Save

GitLab will again show "Only for team members" in the Web UI, but it will be "Everyone with access" in the database.
Remember to do this dance again every time you edit the project settings, otherwise you'll save "Only for team members" again.

----

> Thank you for taking the time to contribute back to GitLab!
> 
> Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests), we > look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.

I will not create another account or grant gitlab.com special rights to my GitHub account in order to help you improve your software.
If you don't want to accept GitHub PRs here, make a web hook that automatically imports them to GitLab.