### PR TITLE
removed twitter and linkedin links

### DIFF
--- a/app/views/admin/users/_profile.html.haml
+++ b/app/views/admin/users/_profile.html.haml
@@ -16,11 +16,11 @@
     - unless user.linkedin.blank?
       %li
         %span.light LinkedIn:
-        %strong= link_to user.linkedin, "https://www.linkedin.com/in/#{user.linkedin}"
+        %strong= link_to user.linkedin, "#{user.linkedin}"
     - unless user.twitter.blank?
       %li
         %span.light Twitter:
-        %strong= link_to user.twitter, "https://twitter.com/#{user.twitter}"
+        %strong= link_to user.twitter, "#{user.twitter}"
     - unless user.website_url.blank?
       %li
         %span.light Website:

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -57,11 +57,11 @@
                 = icon('skype')
           - unless @user.linkedin.blank?
             .profile-link-holder.middle-dot-divider
-              = link_to "https://www.linkedin.com/in/#{@user.linkedin}", title: "LinkedIn" do
+              = link_to "#{@user.linkedin}", title: "LinkedIn" do
                 = icon('linkedin-square')
           - unless @user.twitter.blank?
             .profile-link-holder.middle-dot-divider
-              = link_to "https://twitter.com/#{@user.twitter}", title: "Twitter" do
+              = link_to "#{@user.twitter}", title: "Twitter" do
                 = icon('twitter-square')
           - unless @user.website_url.blank?
             .profile-link-holder.middle-dot-divider


### PR DESCRIPTION
Removed Twitter And Linkedin Links Before User Profile As It Was Confusing,
User Expects Himself To Fill In The Profile Form With His Social Links, Not Just Profile ID, Unless He/She Sees A Social Media Logo And Slash After That Logo, So I Think It's Better To Remove The Links, And Let The User Fill The Form With The Complete Link, Or Just Use A Logo And Slash After The Logo Then He/She Just Uses ID.