### PR TITLE
Redirects to issue show page after branch creation

### DIFF
--- a/app/controllers/projects/branches_controller.rb
+++ b/app/controllers/projects/branches_controller.rb
@@ -51,8 +51,8 @@ class Projects::BranchesController < Projects::ApplicationController
           url_to_autodeploy_setup(project, branch_name),
           notice: view_context.autodeploy_flash_notice(branch_name))
       else
-        redirect_to namespace_project_tree_path(@project.namespace, @project,
-                                                @branch.name)
+        redirect_to namespace_project_issue_path(@project.namespace, @project,
+                                                issue)
       end
     else
       @error = result[:message]


### PR DESCRIPTION
We use gitlab community as a core tool at the company I work at, and have for a year. 

There is only one process in the workflow that has seemed like it could be improved from my end.

After creating a new branch on an issue, it follows the normal restful route of going to the "show" page for the branch, showing a directory of the new branch.

However with the flow, in almost every case I wish to create the branch and remain on the issue page. 

It is my hope with this pull request to bring in that feature. 

I've really enjoyed using this system and hope that my contribution will be seen as helpful.
