### PR TITLE
Add gitlab:ldap:generate_avatars rake task

### DIFF
--- a/lib/gitlab/ldap/adapter.rb
+++ b/lib/gitlab/ldap/adapter.rb
@@ -101,7 +101,7 @@ module Gitlab
       end
 
       def user_attributes
-        %W(#{config.uid} cn mail dn)
+        %W(#{config.uid} cn mail dn jpegPhoto)
       end
     end
   end

--- a/lib/gitlab/ldap/config.rb
+++ b/lib/gitlab/ldap/config.rb
@@ -136,7 +136,8 @@ module Gitlab
           'email'       => %w(mail email userPrincipalName),
           'name'        => 'cn',
           'first_name'  => 'givenName',
-          'last_name'   => 'sn'
+          'last_name'   => 'sn',
+          'photo'       => %w(jpegPhoto thumbnailPhoto)
         }
       end
 

--- a/lib/gitlab/ldap/person.rb
+++ b/lib/gitlab/ldap/person.rb
@@ -43,6 +43,10 @@ module Gitlab
         attribute_value(:email)
       end
 
+      def photo
+        attribute_value(:photo)
+      end
+
       delegate :dn, to: :entry
 
       private

--- a/lib/tasks/gitlab/ldap.rake
+++ b/lib/tasks/gitlab/ldap.rake
@@ -36,5 +36,57 @@ namespace :gitlab do
         puts "Successfully updated #{plural_updated_count} out of #{plural_id_count} total"
       end
     end
+
+    desc "GitLab | LDAP | Generate avatar file for every user using their photo stored in LDAP"
+    task generate_avatars: :environment  do |t, args|
+
+      if Gitlab::LDAP::Config.enabled?
+        generate_user_avatar_from_ldap
+      else
+        puts 'LDAP is disabled in config/gitlab.yml'
+      end
+    end
+
+    def generate_user_avatar_from_ldap
+      servers = Gitlab::LDAP::Config.providers
+      servers.each do |server|
+        puts "Currently querying LDAP server: #{server}"
+        begin
+          Gitlab::LDAP::Adapter.open(server) do |adapter|
+            puts "Iterating over your LDAP users who have access to your GitLab server"
+            users = adapter.users(adapter.config.uid, '*')
+            users.each do |user|
+              puts "Processing user with #{adapter.config.uid} #{user.uid} (DN: #{user.dn})..."
+              if gl_user = User.find_by_email(user.email)
+                avatar_path = "#{Rails.root}/public/uploads/user/avatar/#{gl_user.id}"
+                unless Dir.exist?(avatar_path)
+                  puts "\tAvatar directory #{avatar_path} does not exist, creating it"
+                  FileUtils.mkdir_p avatar_path
+                end
+                if user.photo[0]
+                  puts "\tFound photo in LDAP, saving it under ldap_avatar.jpg"
+                  fb = File.open('/tmp/ldap_avatar.jpg', 'wb')
+                  fb.write user.photo[0]
+                  fb.close
+                  if gl_user.avatar.model.avatar.to_s.empty?
+                    puts "\tNo personal avatar found, using LDAP photo as avatar"
+                    gl_user.avatar = File.open('/tmp/ldap_avatar.jpg')
+                    gl_user.save!
+                  end
+                  File.unlink('/tmp/ldap_avatar.jpg')
+                else
+                  puts "\tNo photo found in LDAP"
+                end
+              else
+                puts "\tLDAP user does not exist yet in gitlab, skipping"
+              end
+              puts
+            end
+          end
+        rescue Net::LDAP::ConnectionRefusedError, Errno::ECONNREFUSED => e
+          puts "Could not connect to the LDAP server: #{e.message}".color(:red)
+        end
+      end
+    end
   end
 end

--- a/spec/tasks/gitlab/ldap_rake_spec.rb
+++ b/spec/tasks/gitlab/ldap_rake_spec.rb
@@ -11,3 +11,53 @@ describe 'gitlab:ldap:rename_provider rake task' do
     run_rake_task('gitlab:ldap:rename_provider', 'ldapmain', 'ldapfoo')
   end
 end
+
+describe 'gitlab:ldap:generate_avatars rake task' do
+  include LdapHelpers
+
+  before do
+    Rake.application.rake_require 'tasks/gitlab/ldap'
+
+    stub_warn_user_is_not_gitlab
+  end
+
+  context 'when LDAP is not enabled' do
+    it 'does not attempt to bind or search for users' do
+      expect(Gitlab::LDAP::Config).not_to receive(:providers)
+      expect(Gitlab::LDAP::Adapter).not_to receive(:open)
+
+      run_rake_task('gitlab:ldap:generate_avatars')
+    end
+  end
+
+  context 'when LDAP is enabled' do
+    let(:ldap) { double(:ldap) }
+    let(:adapter) { ldap_adapter('ldapmain', ldap) }
+
+    before do
+      allow(Gitlab::LDAP::Config)
+        .to receive_messages(
+          enabled?: true,
+          providers: ['ldapmain']
+        )
+      allow(Gitlab::LDAP::Adapter).to receive(:open).and_yield(adapter)
+      allow(adapter).to receive(:users).and_return([])
+    end
+
+    it 'attempts to bind using credentials' do
+      stub_ldap_config(has_auth?: true)
+
+      expect(ldap).to receive(:bind)
+
+      run_rake_task('gitlab:ldap:generate_avatars')
+    end
+
+    it 'searches for all LDAP users' do
+      stub_ldap_config(uid: 'uid')
+
+      expect(adapter).to receive(:users).with('uid', '*')
+
+      run_rake_task('gitlab:ldap:generate_avatars')
+    end
+  end
+end


### PR DESCRIPTION
Add gitlab:ldap:generate_avatars rake task to use and generate avatar file from LDAP for all users

See issue #14459