### PR TITLE
Wrong method call on notify_post_receive.

### DIFF
--- a/changelogs/unreleased/fix-notify-post-receive.yml
+++ b/changelogs/unreleased/fix-notify-post-receive.yml
@@ -1,0 +1,4 @@
+---
+title: Fixed wrong method call on notify_post_receive
+merge_request:
+author: Luigi Leoni

--- a/lib/api/internal.rb
+++ b/lib/api/internal.rb
@@ -140,7 +140,7 @@ module API
         begin
           Gitlab::GitalyClient::Notifications.new(project.repository).post_receive
         rescue GRPC::Unavailable => e
-          render_api_error(e, 500)
+          render_api_error!(e, 500)
         end
       end
     end


### PR DESCRIPTION
GitLab upgrade to 9.0 or 9.1 cause an error on notify_post_receive invocation.
 Every push gives the following error : 

**application.log** stack trace
```Started GET "/api/v3/internal/merge_request_urls?project=/xxx/xxxxx/xxxx.git&changes=1681e6b94a5a995cb22c0c92da3a18de1ae2cb6d%205fcf55298feb6512dc09b9253675e222c16528bd%20refs/heads/master%0A" for 127.0.0.1 at 2017-04-27 07:52:39 +0200
Started POST "/api/v4/internal/notify_post_receive" for 127.0.0.1 at 2017-04-27 07:52:39 +0200

NoMethodError (undefined method 'render_api_error' for #<#<Class:0x007fce2edf76f0>:0x007fce1d030758>
Did you mean?  render_api_error!
               render_spam_error!):
/opt/gitlab/embedded/service/gitlab-rails/lib/api/internal.rb:143:in  'rescue in block (2 levels) in <class:Internal>'
```



File **lib/api/internal.rb** contains wrong method call 
```
 begin
     Gitlab::GitalyClient::Notifications.new(project.repository).post_receive
       rescue GRPC::Unavailable => e
         render_api_error(e, 500)
 end
```
instead of 
```
  begin
      Gitlab::GitalyClient::Notifications.new(project.repository).post_receive
        rescue GRPC::Unavailable => e
          render_api_error!(e, 500)
  end
```