### PR TITLE
Bump git version requirement for compilation

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -93,9 +93,9 @@ Is the system packaged Git too old? Remove it and compile from source.
 
     # Download and compile from source
     cd /tmp
-    curl --remote-name --progress https://www.kernel.org/pub/software/scm/git/git-2.8.4.tar.gz
-    echo '626e319f8a24fc0866167ea5f6bf3e2f38f69d6cb2e59e150f13709ca3ebf301  git-2.8.4.tar.gz' | shasum -a256 -c - && tar -xzf git-2.8.4.tar.gz
-    cd git-2.8.4/
+    curl --remote-name --progress https://www.kernel.org/pub/software/scm/git/git-2.13.5.tar.gz
+    echo 'b2bdabe9ebe1043bc37cf2ca2a1c5847dc2d933884708c670bc691d027791ad0  git-2.13.5.tar.gz' | shasum -a256 -c - && tar -xzf git-2.13.5.tar.gz
+    cd git-2.13.5/
     ./configure
     make prefix=/usr/local all
 


### PR DESCRIPTION
Following work from these commits:
https://github.com/gitlabhq/gitlabhq/commit/5a26948d774aecb4bcf8d7f0b67efb5b9502dca2
https://github.com/gitlabhq/gitlabhq/commit/86f726a5e969fd69c82c94713bc25bd0f0bba598

Maybe next person will use the latest version of git (`2.14.1`) now.

Thank you for taking the time to contribute back to GitLab!

Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests), we look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.
