### PR TITLE
Add skip_password_expiration boolean when doing PUT on users

### DIFF
--- a/doc/api/users.md
+++ b/doc/api/users.md
@@ -298,6 +298,7 @@ Parameters:
 - `admin` (optional)            - User is admin - true or false (default)
 - `can_create_group` (optional) - User can create groups - true or false
 - `skip_reconfirmation` (optional) - Skip reconfirmation - true or false (default)
+- `skip_password_expiration` (optional) - Do not ask user to change his password at next login - true or false (default)
 - `external` (optional)         - Flags the user as external - true or false(default)
 - `avatar` (optional)           - Image file for user's avatar
 

--- a/lib/api/users.rb
+++ b/lib/api/users.rb
@@ -137,6 +137,7 @@ module API
         optional :email, type: String, desc: 'The email of the user'
         optional :password, type: String, desc: 'The password of the new user'
         optional :skip_reconfirmation, type: Boolean, desc: 'Flag indicating the account skips the confirmation by email'
+        optional :skip_password_expiration, type: Boolean, default: false, desc: 'Flag indicating the account skips the password change at next login'
         optional :name, type: String, desc: 'The name of the user'
         optional :username, type: String, desc: 'The username of the user'
         use :optional_attributes
@@ -169,9 +170,11 @@ module API
           end
         end
 
-        user_params[:password_expires_at] = Time.now if user_params[:password].present?
+        if !user_params[:skip_password_expiration]
+          user_params[:password_expires_at] = Time.now if user_params[:password].present?
+        end
 
-        result = ::Users::UpdateService.new(current_user, user_params.except(:extern_uid, :provider).merge(user: user)).execute
+        result = ::Users::UpdateService.new(current_user, user_params.except(:extern_uid, :provider, :skip_password_expiration).merge(user: user)).execute
 
         if result[:status] == :success
           present user, with: Entities::UserPublic


### PR DESCRIPTION
Hello,

We're synchronizing users's password using admin API key and recent GitLab CE releases broke this behavior by adding an "already-expired-password" feature when a user's password is being changed throught the API. That leads to an unexpected password change prompt when the users logs in.

Altough I understand this feature I think our usage makes sense too and both should be allowed.

This pull request adds a boolean to override password expiration to the API.
