### PR TITLE
Update _piwik.html.haml

### DIFF
--- a/app/views/layouts/_piwik.html.haml
+++ b/app/views/layouts/_piwik.html.haml
@@ -6,10 +6,10 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="//#{extra_config.piwik_url}/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setTrackerUrl', u+'js/']);
     _paq.push(['setSiteId', #{extra_config.piwik_site_id}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'js/'; s.parentNode.insertBefore(g,s);
   })();
-<noscript><p><img src="//#{extra_config.piwik_url}/piwik.php?idsite=#{extra_config.piwik_site_id}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="//#{extra_config.piwik_url}/js/?idsite=#{extra_config.piwik_site_id}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->


### PR DESCRIPTION
Matomo core developers  are recommended to use "js/" instead of "piwik.js" and "piwik.php":
- js/index.php (or implicitly as "js/") can be used to serve up the minified piwik.js;
- it supports conditional-GET and Last-Modified, so piwik.js can be cached by the browser;
- it supports deflate/gzip compression if your web server (e.g., Apache without mod_deflate or mod_gzip), shrinking the data transfer to 8K;
- js/index.php (or implicitly as "js/") can also act as a proxy to piwik.php;
- If you are concerned about the impact of browser-based privacy filters which attempt to block tracking, you can change your tracking code to use "js/" instead of "piwik.js" and "piwik.php", respectively.

https://github.com/matomo-org/matomo/blob/3.x-dev/js/README.md

Thank you for taking the time to contribute back to GitLab!

Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests), we look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.
