### PR TITLE
enabled word breaking of card title

### DIFF
--- a/app/assets/stylesheets/pages/boards.scss
+++ b/app/assets/stylesheets/pages/boards.scss
@@ -318,6 +318,7 @@
     color: $gl-text-color;
     word-wrap: break-word;
     margin-right: 2px;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
Enabled word breaking of card title as it gets overlapped by the assignee's icon when its a single long line with no spaces.