### PR TITLE
Update 20160610201627_migrate_users_notification_level.rb

### DIFF
--- a/db/migrate/20160610201627_migrate_users_notification_level.rb
+++ b/db/migrate/20160610201627_migrate_users_notification_level.rb
@@ -4,8 +4,6 @@ class MigrateUsersNotificationLevel < ActiveRecord::Migration
   # Migrates only users who changed their default notification level :participating
   # creating a new record on notification settings table
 
-  DOWNTIME = false
-
   def up
     execute(%Q{
       INSERT INTO notification_settings


### PR DESCRIPTION
Hey i hope all is well,
While i reading Gitlab migrations files to learn what is the best practice to migrate new changes on old schema i noticed that in this file 20160610201627_migrate_users_notification_level DOWNTIME is duplicated without any reasons !! Why ?!

Thank you for taking the time to contribute back to GitLab!

Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests), we look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.
