### PR TITLE
update set_table_owner_statement

### DIFF
--- a/lib/gitlab/database/partitioning/replace_table.rb
+++ b/lib/gitlab/database/partitioning/replace_table.rb
@@ -118,7 +118,7 @@ module Gitlab
 
         def set_table_owner_statement(table_name, new_owner)
           <<~SQL.chomp
-            ALTER TABLE #{quote_table_name(table_name)} OWNER TO #{new_owner}
+            ALTER TABLE #{quote_table_name(table_name)} OWNER TO "#{new_owner}"
           SQL
         end
 


### PR DESCRIPTION
In this improved version, #{new_owner} is surrounded by double quotes inside the interpolation. This will ensure that the owner name is always quoted in the generated SQL query, which is especially important when the name contains special characters such as hyphens

Thank you for taking the time to contribute back to GitLab!

Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab/merge_requests), we look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.
