### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitLab
 
+[![gitcgr](https://gitcgr.com/badge/gitlabhq/gitlabhq.svg)](https://gitcgr.com/gitlabhq/gitlabhq)
+
 ## Canonical source
 
 The canonical source of GitLab where all development takes place is [hosted on GitLab.com](https://gitlab.com/gitlab-org/gitlab).


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/gitlabhq/gitlabhq.svg)](https://gitcgr.com/gitlabhq/gitlabhq)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).