### PR TITLE
Add required approvals before merge for free tier

### DIFF
--- a/app/models/merge_request.rb
+++ b/app/models/merge_request.rb
@@ -1661,6 +1661,7 @@ class MergeRequest < ApplicationRecord
         ::MergeRequests::Mergeability::CheckMergeTimeService
       ],
       heavy: [
+        ::MergeRequests::Mergeability::CheckApprovedStatusService,
         ::MergeRequests::Mergeability::CheckLfsFileLocksService,
         ::MergeRequests::Mergeability::CheckDiscussionsStatusService,
         ::MergeRequests::Mergeability::CheckCiStatusService,
@@ -2052,6 +2053,18 @@ class MergeRequest < ApplicationRecord
 
   def only_allow_merge_if_all_discussions_are_resolved?
     project.only_allow_merge_if_all_discussions_are_resolved?(inherit_group_setting: true)
+  end
+
+  def requires_approvals?
+    project.approvals_before_merge.to_i > 0
+  end
+
+  def approvals_required
+    project.approvals_before_merge.to_i
+  end
+
+  def approvals_given
+    approvals.count
   end
 
   # We use a heuristic of if there are pipeline created, being created, or a ci integration is setup

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -689,6 +689,7 @@ class Project < ApplicationRecord
   validates :variables, nested_attributes_duplicates: { scope: :environment_scope }
   validates :bfg_object_map, file_size: { maximum: :max_attachment_size }
   validates :max_artifacts_size, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+  validates :approvals_before_merge, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :suggestion_commit_message, length: { maximum: MAX_SUGGESTIONS_TEMPLATE_LENGTH }
 
   validate :path_availability, if: :path_changed?

--- a/app/services/merge_requests/mergeability/check_approved_status_service.rb
+++ b/app/services/merge_requests/mergeability/check_approved_status_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module MergeRequests
+  module Mergeability
+    class CheckApprovedStatusService < CheckBaseService
+      set_identifier :not_approved
+      set_description 'Checks whether the merge request has the required approvals'
+
+      def execute
+        return inactive unless merge_request.requires_approvals?
+
+        if merge_request.approvals_given >= merge_request.approvals_required
+          success
+        else
+          failure
+        end
+      end
+
+      def skip?
+        params[:skip_approved_check].present?
+      end
+
+      def cacheable?
+        false
+      end
+    end
+  end
+end

--- a/lib/api/entities/project.rb
+++ b/lib/api/entities/project.rb
@@ -160,6 +160,7 @@ module API
         SharedGroupWithProject.represent(project.visible_group_links(for_user: user), options)
       end
 
+      expose :approvals_before_merge, documentation: { type: 'Integer', example: 0 }
       expose :only_allow_merge_if_pipeline_succeeds, documentation: { type: 'Boolean' }
       expose :allow_merge_on_skipped_pipeline, documentation: { type: 'Boolean' }
       expose :request_access_enabled, documentation: { type: 'Boolean' }

--- a/lib/api/helpers/projects_helpers.rb
+++ b/lib/api/helpers/projects_helpers.rb
@@ -64,6 +64,7 @@ module API
         optional :public_builds, type: Boolean, desc: 'Deprecated: Use public_jobs instead.'
         optional :public_jobs, type: Boolean, desc: 'Perform public builds'
         optional :request_access_enabled, type: Boolean, desc: 'Allow users to request member access'
+        optional :approvals_before_merge, type: Integer, desc: 'How many approvals are required before an MR can be merged'
         optional :only_allow_merge_if_pipeline_succeeds, type: Boolean, desc: 'Only allow to merge if builds succeed'
         optional :allow_merge_on_skipped_pipeline, type: Boolean, desc: 'Allow to merge if pipeline is skipped'
         optional :only_allow_merge_if_all_discussions_are_resolved, type: Boolean, desc: 'Only allow to merge if all threads are resolved'
@@ -186,6 +187,7 @@ module API
           :merge_trains_enabled,
           :merge_method,
           :name,
+          :approvals_before_merge,
           :only_allow_merge_if_all_discussions_are_resolved,
           :only_allow_merge_if_pipeline_succeeds,
           :package_registry_access_level,

--- a/spec/services/merge_requests/mergeability/check_approved_status_service_spec.rb
+++ b/spec/services/merge_requests/mergeability/check_approved_status_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MergeRequests::Mergeability::CheckApprovedStatusService, feature_category: :code_review_workflow do
+  subject(:check_approved_status) { described_class.new(merge_request: merge_request, params: params) }
+
+  let_it_be(:project) { build(:project) }
+  let_it_be(:merge_request) { build(:merge_request, source_project: project) }
+  let(:params) { { skip_approved_check: skip_check } }
+  let(:skip_check) { false }
+
+  it_behaves_like 'mergeability check service', :not_approved,
+    'Checks whether the merge request has the required approvals'
+
+  describe '#execute' do
+    let(:result) { check_approved_status.execute }
+
+    before do
+      allow(merge_request).to receive(:requires_approvals?).and_return(requires_approvals)
+    end
+
+    context 'when the project does not require approvals' do
+      let(:requires_approvals) { false }
+
+      it 'returns a check result with inactive status' do
+        expect(result.status).to eq Gitlab::MergeRequests::Mergeability::CheckResult::INACTIVE_STATUS
+      end
+    end
+
+    context 'when the project requires approvals' do
+      let(:requires_approvals) { true }
+
+      before do
+        allow(merge_request).to receive(:approvals_required).and_return(2)
+        allow(merge_request).to receive(:approvals_given).and_return(approvals_given)
+      end
+
+      context 'when sufficient approvals have been given' do
+        let(:approvals_given) { 2 }
+
+        it 'returns a check result with status success' do
+          expect(result.status).to eq Gitlab::MergeRequests::Mergeability::CheckResult::SUCCESS_STATUS
+        end
+      end
+
+      context 'when more approvals than required have been given' do
+        let(:approvals_given) { 3 }
+
+        it 'returns a check result with status success' do
+          expect(result.status).to eq Gitlab::MergeRequests::Mergeability::CheckResult::SUCCESS_STATUS
+        end
+      end
+
+      context 'when insufficient approvals have been given' do
+        let(:approvals_given) { 1 }
+
+        it 'returns a check result with status failed' do
+          expect(result.status).to eq Gitlab::MergeRequests::Mergeability::CheckResult::FAILED_STATUS
+          expect(result.payload[:identifier]).to eq(:not_approved)
+        end
+      end
+
+      context 'when no approvals have been given' do
+        let(:approvals_given) { 0 }
+
+        it 'returns a check result with status failed' do
+          expect(result.status).to eq Gitlab::MergeRequests::Mergeability::CheckResult::FAILED_STATUS
+          expect(result.payload[:identifier]).to eq(:not_approved)
+        end
+      end
+    end
+  end
+
+  describe '#skip?' do
+    context 'when skip check is true' do
+      let(:skip_check) { true }
+
+      it 'returns true' do
+        expect(check_approved_status.skip?).to eq true
+      end
+    end
+
+    context 'when skip check is false' do
+      let(:skip_check) { false }
+
+      it 'returns false' do
+        expect(check_approved_status.skip?).to eq false
+      end
+    end
+  end
+
+  describe '#cacheable?' do
+    it 'returns false' do
+      expect(check_approved_status.cacheable?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Wire the existing `approvals_before_merge` project column into the CE mergeability pipeline so any project can block merging until enough approvals are collected, without requiring an EE licence.

- Add CheckApprovedStatusService mergeability check that returns failure when approvals_given < approvals_required
- Register the check in MergeRequest.mergeable_state_checks_by_tier
- Expose requires_approvals?, approvals_required, approvals_given helpers on MergeRequest
- Validate approvals_before_merge >= 0 in Project model
- Expose approvals_before_merge via the projects REST API (GET/PUT)

Thank you for taking the time to contribute back to GitLab!

Please open a merge request [on GitLab.com](https://gitlab.com/gitlab-org/gitlab/merge_requests), we look forward to reviewing your contribution! You can log into GitLab.com using your GitHub account.
